### PR TITLE
Allow Tag::new types to be independent

### DIFF
--- a/ddprof-exporter/src/tag.rs
+++ b/ddprof-exporter/src/tag.rs
@@ -135,7 +135,7 @@ mod tests {
         // slide.
         let bytes = &[32, 0b1111_0111];
         let key = String::from_utf8_lossy(bytes);
-        let t = Tag::new(key.as_ref(), "value").unwrap();
+        let t = Tag::new(key, "value").unwrap();
         assert_eq!(" \u{FFFD}:value", t.to_string());
     }
 
@@ -151,11 +151,8 @@ mod tests {
         // that profile tags will then differ or cause failures compared to
         // trace tags. These require cross-team, cross-language collaboration.
         let cases = [
-            (" begins with non-letter".to_string(), "value".to_owned()),
-            (
-                "the-tag-length-is-over-200-characters".repeat(6),
-                "value".to_owned(),
-            ),
+            (" begins with non-letter".to_string(), "value"),
+            ("the-tag-length-is-over-200-characters".repeat(6), "value"),
         ];
 
         for case in cases {


### PR DESCRIPTION
# What does this PR do?

Before, you couldn't pass `(&str, String)`, even though both are
`AsRef<str>`, because they weren't the same type. This change allows
them to be unique types, both of which are `AsRef<str>`, which allows
for something like:

```rust
Tag::new("process_id", std::process::id().to_string())
```

# Motivation

I started working on adding `process_id` and realized this edge is
pointlessly sharp, and this was one way to solve it.

# Additional Notes

It could be solved instead by taking `Cow<str>` instead, but that would
have more API breaks. I didn't have to change the tests, but simplified
them to show that it actually works to have mismatched types where both
implement `AsRef<str>` now.

# How to test the change?

All existing code is fine, but you can create keys now where the key is
a `&str` and the value is a `String`, like this:

```rust
Tag::new("process_id", std::process::id().to_string())
```
