### PR TITLE
Rename `libddprof` to `libdatadog` in docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -26,5 +26,5 @@ If possible, add logs and screenshots to help explain your problem, or even bett
 **Additional context**
 Add any other context about the problem here.
 
-**How does `libddprof` help you?**
-Optionally, tell us why you're using `libddprof`, and what your overall experience with it is!
+**How does `libdatadog` help you?**
+Optionally, tell us why you're using `libdatadog`, and what your overall experience with it is!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 # Contributing
 
-Community contributions to `libddprof` are welcome 😃! See below for some basic guidelines.
+Community contributions to `libdatadog` are welcome 😃! See below for some basic guidelines.
 
 ## Want to request a new feature?
 
 Many great ideas for new features come from the community, and we'd be happy to consider yours!
 
-To share your request, you can [open a Github issue](https://github.com/datadog/libddprof/issues/new) with the details
+To share your request, you can [open a Github issue](https://github.com/datadog/libdatadog/issues/new) with the details
 about what you'd like to see. At a minimum, please provide:
 
 * The goal of the new feature
@@ -26,8 +26,8 @@ Additionally, if you can, include:
 For any urgent matters (such as outages) or issues concerning the Datadog service or UI, contact our support team via
 https://docs.datadoghq.com/help/ for direct, faster assistance.
 
-You can submit bug reports concerning `libddprof` by
-[opening a Github issue](https://github.com/datadog/libddprof/issues/new). At a minimum, please provide:
+You can submit bug reports concerning `libdatadog` by
+[opening a Github issue](https://github.com/datadog/libdatadog/issues/new). At a minimum, please provide:
 
 * A description of the problem
 * Steps to reproduce
@@ -38,7 +38,7 @@ You can submit bug reports concerning `libddprof` by
 
 If at all possible, also provide:
 
-* Logs (from the profiler/application/agent) or other diagnostics
+* Logs (from the library/profiler/application/agent) or other diagnostics
 * Screenshots, links, or other visual aids that are publicly accessible
 * Code sample or test that reproduces the problem
 * An explanation of what causes the bug and/or how it can be fixed
@@ -48,15 +48,15 @@ Reports that include rich detail are better, and ones with code that reproduce t
 ## Have a patch?
 
 We welcome code contributions to the library, which you can
-[submit as a pull request](https://github.com/datadog/libddprof/pull/new/main).
+[submit as a pull request](https://github.com/datadog/libdatadog/pull/new/main).
 To create a pull request:
 
-1. **Fork the repository** from <https://github.com/datadog/libddprof>
+1. **Fork the repository** from <https://github.com/datadog/libdatadog>
 2. **Make any changes** for your patch
 3. **Write tests** that demonstrate how the feature works or how the bug is fixed
 4. **Update any documentation** especially for new features.
 5. **Submit the pull request** from your fork back to the latest revision of the `main` branch on
-   <https://github.com/datadog/libddprof>
+   <https://github.com/datadog/libdatadog>
 
 The pull request will be run through our CI pipeline, and a project member will review the changes with you.
 At a minimum, to be accepted and merged, pull requests must:

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Datadog libddprof
-Copyright 2021 Datadog, Inc.
+Datadog libdatadog
+Copyright 2021-2022 Datadog, Inc.
 
 This product includes software developed at Datadog (<https://www.datadoghq.com/>).

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-# libddprof
+# `libdatadog`
 
-`libddprof` provides a shared library containing common code used in the implementation of Datadog's
-[Continuous Profilers](https://docs.datadoghq.com/tracing/profiler/).
+`libdatadog` provides a shared library containing common code used in the implementation of Datadog's libraries,
+including [Continuous Profilers](https://docs.datadoghq.com/tracing/profiler/).
 
+(In a past life, `libdatadog` was known as [`libddprof`](https://github.com/DataDog/libddprof) but it was renamed when
+we decided to increase its scope).
 
-**NOTE**: If you're building a new profiler or want to contribute to Datadog's existing profilers, you've come to the
+**NOTE**: If you're building a new Datadog library/profiler or want to contribute to Datadog's existing tools, you've come to the
 right place!
 Otherwise, this is possibly not the droid you were looking for.
 
@@ -16,11 +18,11 @@ See <CONTRIBUTING.md>.
 
 ### Building
 
-Build libddprof as usual with `cargo build`. To package a release with the generated ffi header and CMake module,
-use the `ffi-build.sh` helper script. To stick the output in `/opt/libddprof`, you would do:
+Build `libdatadog` as usual with `cargo build`. To package a release with the generated ffi header and CMake module,
+use the `ffi-build.sh` helper script. To stick the output in `/opt/libdatadog`, you would do:
 
 ```bash
-bash ffi-build.sh /opt/libddprof
+bash ffi-build.sh /opt/libdatadog
 ```
 
 #### Build Dependencies


### PR DESCRIPTION
# What does this PR do?

I've gone through all our docs and updated/renamed them to the new project name.

Note that I did not fix any other places (such as scripts) where we still use the old name.

# Motivation

Get to first release / be able to set the repo as public.

# Additional Notes

I really like chocolate cake.

# How to test the change?

Use 👀 to check content; grep project for `libddprof` strings and check that none are in the documentation.