### PR TITLE
Rename Ruby packaging scripts (libddprof to libdatadog) and package 0.7.0-rc.1 release for Ruby

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,10 +1,13 @@
-# libddprof Ruby gem
+# libdatadog Ruby gem
 
-`libddprof` provides a shared library containing common code used in the implementation of Datadog's
-[Continuous Profilers](https://docs.datadoghq.com/tracing/profiler/).
+`libdatadog` provides a shared library containing common code used in the implementation of Datadog's libraries,
+including [Continuous Profilers](https://docs.datadoghq.com/tracing/profiler/).
 
-**NOTE**: If you're building a new profiler or want to contribute to Datadog's existing profilers,
-you've come to the right place!
+(In a past life, `libdatadog` was known as [`libddprof`](https://github.com/datadog/libddprof) but it was renamed when
+we decided to increase its scope).
+
+**NOTE**: If you're building a new Datadog library/profiler or want to contribute to Datadog's existing tools, you've come to the
+right place!
 Otherwise, this is possibly not the droid you were looking for.
 
 ## Development
@@ -18,13 +21,13 @@ Note: No Ruby needed to run this! It all runs inside docker :)
 
 Note: Publishing new releases to rubygems.org can only be done by Datadog employees.
 
-1. [ ] Locate the new libddprof release on GitHub: <https://github.com/DataDog/libddprof/releases>
+1. [ ] Locate the new libdatadog release on GitHub: <https://github.com/datadog/libdatadog/releases>
 2. [ ] Update the `LIB_GITHUB_RELEASES` section of the <Rakefile> with the new version
-3. [ ] Update the <lib/libddprof/version.rb> file with the `LIB_VERSION` and `VERSION` to use
+3. [ ] Update the <lib/libdatadog/version.rb> file with the `LIB_VERSION` and `VERSION` to use
 4. [ ] Commit change, open PR, get it merged
 5. [ ] Release by running `docker-compose run push_to_rubygems`.
     (When asked for rubygems credentials, check your local friendly Datadog 1Password.)
-6. [ ] Verify that release shows up correctly on: <https://rubygems.org/gems/libddprof>
+6. [ ] Verify that release shows up correctly on: <https://rubygems.org/gems/libdatadog>
 
 ## Contributing
 

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -45,7 +45,7 @@ task default: [
 desc "Download lib release from github"
 task :fetch do
   Helpers.each_github_release_variant do |file:, sha256:, target_directory:, target_file:, **_|
-    target_url = "https://github.com/DataDog/libddprof/releases/download/v#{Libddprof::LIB_VERSION}/#{file}"
+    target_url = "https://github.com/datadog/libdatadog/releases/download/v#{Libdatadog::LIB_VERSION}/#{file}"
 
     if File.exist?(target_file)
       target_file_hash = Digest::SHA256.hexdigest(File.read(target_file))
@@ -88,13 +88,13 @@ task package: [
   (:'standard:fix' unless RUBY_VERSION < "2.6"),
   :extract
 ] do
-  gemspec = eval(File.read("libddprof.gemspec"), nil, "libddprof.gemspec") # standard:disable Security/Eval
+  gemspec = eval(File.read("libdatadog.gemspec"), nil, "libdatadog.gemspec") # standard:disable Security/Eval
   FileUtils.mkdir_p("pkg")
 
   # Fallback package with all binaries
   # This package will get used by (1) platforms that have no matching `ruby_platform` or (2) that have set
   # "BUNDLE_FORCE_RUBY_PLATFORM" (or its equivalent via code) to avoid precompiled gems.
-  # In a previous version of libddprof, this package had no binaries, but that could mean that we broke customers in case (2).
+  # In a previous version of libdatadog, this package had no binaries, but that could mean that we broke customers in case (2).
   # For customers in case (1), this package is a no-op, and dd-trace-rb will correctly detect and warn that
   # there are no valid binaries for the platform.
   Helpers.package_for(gemspec, ruby_platform: nil, files: Helpers.files_for("x86_64-linux", "x86_64-linux-musl", "aarch64-linux", "aarch64-linux-musl"))
@@ -105,7 +105,7 @@ task package: [
   Helpers.package_for(gemspec, ruby_platform: "aarch64-linux", files: Helpers.files_for("aarch64-linux", "aarch64-linux-musl"))
 
   # Experimental macOS package, not published to rubygems.org at the moment
-  if ENV["LIBDDPROF_PACKAGE_MACOS"] == "true"
+  if ENV["LIBDATADOG_PACKAGE_MACOS"] == "true"
     Helpers.package_for(gemspec, ruby_platform: "x86_64-darwin-19", files: Helpers.files_for("x86_64-darwin-19"))
   end
 end
@@ -117,22 +117,22 @@ task push_to_rubygems: [
 ] do
   system("gem signout") # make sure there are no existing credentials in use
 
-  system("gem push pkg/libddprof-#{Libddprof::VERSION}.gem")
-  system("gem push pkg/libddprof-#{Libddprof::VERSION}-x86_64-linux.gem")
-  system("gem push pkg/libddprof-#{Libddprof::VERSION}-aarch64-linux.gem")
+  system("gem push pkg/libdatadog-#{Libdatadog::VERSION}.gem")
+  system("gem push pkg/libdatadog-#{Libdatadog::VERSION}-x86_64-linux.gem")
+  system("gem push pkg/libdatadog-#{Libdatadog::VERSION}-aarch64-linux.gem")
 
   system("gem signout") # leave no credentials behind
 end
 
 module Helpers
-  def self.each_github_release_variant(version: Libddprof::LIB_VERSION)
+  def self.each_github_release_variant(version: Libdatadog::LIB_VERSION)
     LIB_GITHUB_RELEASES.fetch(version).each do |variant|
       file = variant.fetch(:file)
       sha256 = variant.fetch(:sha256)
       ruby_platform = variant.fetch(:ruby_platform)
 
       # These two are so common that we just centralize them here
-      target_directory = "vendor/libddprof-#{version}/#{ruby_platform}"
+      target_directory = "vendor/libdatadog-#{version}/#{ruby_platform}"
       target_file = "#{target_directory}/#{file}"
 
       FileUtils.mkdir_p(target_directory)
@@ -156,7 +156,7 @@ module Helpers
 
   def self.files_for(
     *included_platforms,
-    version: Libddprof::LIB_VERSION,
+    version: Libdatadog::LIB_VERSION,
     excluded_files: [
       "ddprof_ffi.pc", # we use the ddprof_ffi_with_rpath.pc variant
       "libddprof_ffi.a", "ddprof_ffi-static.pc", # We don't use the static library

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -11,31 +11,34 @@ require "rubygems/package"
 
 RSpec::Core::RakeTask.new(:spec)
 
-LIB_GITHUB_RELEASES = {
-  # This should match the version in the version.rb file
-  "0.6.0" => [
-    {
-      file: "libddprof-aarch64-alpine-linux-musl.tar.gz",
-      sha256: "7501d26ed9b2607c2bca79b3fd39971efa4dbb6949226d7d123f095e47ca541c",
-      ruby_platform: "aarch64-linux-musl"
-    },
-    {
-      file: "libddprof-aarch64-unknown-linux-gnu.tar.gz",
-      sha256: "c18351882fdb4b64df76f4cd49dbf567d8871349fa444144aa9a8ddf0532bad2",
-      ruby_platform: "aarch64-linux"
-    },
-    {
-      file: "libddprof-x86_64-alpine-linux-musl.tar.gz",
-      sha256: "ca5e49636465ee977943d64815442d4bff2de2b74678b1376e6368280534f909",
-      ruby_platform: "x86_64-linux-musl"
-    },
-    {
-      file: "libddprof-x86_64-unknown-linux-gnu.tar.gz",
-      sha256: "8eaec92d14bcfa8839843ba2ddfeae254804e087a4984985132a508d6f841645",
-      ruby_platform: "x86_64-linux"
-    }
-  ]
-}
+LIB_VERSION_TO_PACKAGE = "0.7.0-rc.1"
+unless LIB_VERSION_TO_PACKAGE.start_with?(Libdatadog::LIB_VERSION)
+  raise "`LIB_VERSION_TO_PACKAGE` setting in <Rakefile> (#{LIB_VERSION_TO_PACKAGE}) does not match " \
+    "`LIB_VERSION` setting in <lib/libdatadog/version.rb> (#{Libdatadog::LIB_VERSION})"
+end
+
+LIB_GITHUB_RELEASES = [
+  {
+    file: "libdatadog-aarch64-alpine-linux-musl.tar.gz",
+    sha256: "d3a6d71f45ce0f95978dcb31525389ee3ea02ea0170f00be466ff6ce1a1f6047",
+    ruby_platform: "aarch64-linux-musl"
+  },
+  {
+    file: "libdatadog-aarch64-unknown-linux-gnu.tar.gz",
+    sha256: "e792c923d5cdc6d581da87d12ab789ae578fa588fb2a220f72660f8d25df6de8",
+    ruby_platform: "aarch64-linux"
+  },
+  {
+    file: "libdatadog-x86_64-alpine-linux-musl.tar.gz",
+    sha256: "402a1f40b55e1bad022d1391793a4ed79c8b41bfd9265cad721960be77c12f1e",
+    ruby_platform: "x86_64-linux-musl"
+  },
+  {
+    file: "libdatadog-x86_64-unknown-linux-gnu.tar.gz",
+    sha256: "9b43711b23e42e76684eeced9e8d25183d350060d087d755622fa6748fa79aa5",
+    ruby_platform: "x86_64-linux"
+  }
+]
 
 task default: [
   :spec,
@@ -45,7 +48,7 @@ task default: [
 desc "Download lib release from github"
 task :fetch do
   Helpers.each_github_release_variant do |file:, sha256:, target_directory:, target_file:, **_|
-    target_url = "https://github.com/datadog/libdatadog/releases/download/v#{Libdatadog::LIB_VERSION}/#{file}"
+    target_url = "https://github.com/datadog/libdatadog/releases/download/v#{LIB_VERSION_TO_PACKAGE}/#{file}"
 
     if File.exist?(target_file)
       target_file_hash = Digest::SHA256.hexdigest(File.read(target_file))
@@ -125,14 +128,14 @@ task push_to_rubygems: [
 end
 
 module Helpers
-  def self.each_github_release_variant(version: Libdatadog::LIB_VERSION)
-    LIB_GITHUB_RELEASES.fetch(version).each do |variant|
+  def self.each_github_release_variant
+    LIB_GITHUB_RELEASES.each do |variant|
       file = variant.fetch(:file)
       sha256 = variant.fetch(:sha256)
       ruby_platform = variant.fetch(:ruby_platform)
 
       # These two are so common that we just centralize them here
-      target_directory = "vendor/libdatadog-#{version}/#{ruby_platform}"
+      target_directory = "vendor/libdatadog-#{Libdatadog::LIB_VERSION}/#{ruby_platform}"
       target_file = "#{target_directory}/#{file}"
 
       FileUtils.mkdir_p(target_directory)
@@ -156,7 +159,6 @@ module Helpers
 
   def self.files_for(
     *included_platforms,
-    version: Libdatadog::LIB_VERSION,
     excluded_files: [
       "ddprof_ffi.pc", # we use the ddprof_ffi_with_rpath.pc variant
       "libddprof_ffi.a", "ddprof_ffi-static.pc", # We don't use the static library
@@ -166,7 +168,7 @@ module Helpers
   )
     files = []
 
-    each_github_release_variant(version: version) do |ruby_platform:, target_directory:, target_file:, **_|
+    each_github_release_variant do |ruby_platform:, target_directory:, target_file:, **_|
       next unless included_platforms.include?(ruby_platform)
 
       downloaded_release_tarball = target_file

--- a/ruby/docker-compose.yml
+++ b/ruby/docker-compose.yml
@@ -5,9 +5,9 @@ services:
     platform: linux/x86_64
     stdin_open: true
     tty: true
-    command: bash -c 'cd /libddprof/ruby && bundle install && bundle exec rake push_to_rubygems'
+    command: bash -c 'cd /libdatadog/ruby && bundle install && bundle exec rake push_to_rubygems'
     volumes:
-      - ..:/libddprof
+      - ..:/libdatadog
       - bundle-3.1:/usr/local/bundle
 
 volumes:

--- a/ruby/gems.rb
+++ b/ruby/gems.rb
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in libddprof.gemspec
+# Specify your gem's dependencies in libdatadog.gemspec
 gemspec
 
 gem "rake", ">= 12.0", "< 14"

--- a/ruby/lib/libdatadog.rb
+++ b/ruby/lib/libdatadog.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require_relative "libddprof/version"
+require_relative "libdatadog/version"
 
-module Libddprof
+module Libdatadog
   # This should only be used for debugging/logging
   def self.available_binaries
     File.directory?(vendor_directory) ? (Dir.entries(vendor_directory) - [".", ".."]) : []
@@ -21,6 +21,6 @@ module Libddprof
   end
 
   private_class_method def self.vendor_directory
-    ENV["LIBDDPROF_VENDOR_OVERRIDE"] || "#{__dir__}/../vendor/libddprof-#{Libddprof::LIB_VERSION}/"
+    ENV["LIBDATADOG_VENDOR_OVERRIDE"] || "#{__dir__}/../vendor/libdatadog-#{Libdatadog::LIB_VERSION}/"
   end
 end

--- a/ruby/lib/libdatadog/version.rb
+++ b/ruby/lib/libdatadog/version.rb
@@ -2,11 +2,11 @@
 
 module Libdatadog
   # Current libdatadog version
-  LIB_VERSION = "0.6.0"
+  LIB_VERSION = "0.7.0"
 
   GEM_MAJOR_VERSION = "1"
   GEM_MINOR_VERSION = "0"
-  GEM_PRERELEASE_VERSION = "" # remember to include dot prefix, if needed!
+  GEM_PRERELEASE_VERSION = ".rc1" # remember to include dot prefix, if needed!
   private_constant :GEM_MAJOR_VERSION, :GEM_MINOR_VERSION, :GEM_PRERELEASE_VERSION
 
   # The gem version scheme is lib_version.gem_major.gem_minor[.prerelease].

--- a/ruby/lib/libdatadog/version.rb
+++ b/ruby/lib/libdatadog/version.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-module Libddprof
-  # Current libddprof version
+module Libdatadog
+  # Current libdatadog version
   LIB_VERSION = "0.6.0"
 
   GEM_MAJOR_VERSION = "1"
@@ -10,7 +10,7 @@ module Libddprof
   private_constant :GEM_MAJOR_VERSION, :GEM_MINOR_VERSION, :GEM_PRERELEASE_VERSION
 
   # The gem version scheme is lib_version.gem_major.gem_minor[.prerelease].
-  # This allows a version constraint such as ~> 0.2.0.1.0 in the consumer (ddtrace), in essence pinning the libddprof to
+  # This allows a version constraint such as ~> 0.2.0.1.0 in the consumer (ddtrace), in essence pinning libdatadog to
   # a specific version like = 0.2.0, but still allow a) introduction of a gem-level breaking change by bumping gem_major
   # and b) allow to push automatically picked up bugfixes by bumping gem_minor.
   VERSION = "#{LIB_VERSION}.#{GEM_MAJOR_VERSION}.#{GEM_MINOR_VERSION}#{GEM_PRERELEASE_VERSION}"

--- a/ruby/libdatadog.gemspec
+++ b/ruby/libdatadog.gemspec
@@ -2,25 +2,25 @@
 
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "libddprof/version"
+require "libdatadog/version"
 
 Gem::Specification.new do |spec|
-  spec.name = "libddprof"
-  spec.version = Libddprof::VERSION
+  spec.name = "libdatadog"
+  spec.version = Libdatadog::VERSION
   spec.authors = ["Datadog, Inc."]
   spec.email = ["dev@datadoghq.com"]
 
   spec.summary = "Library of common code used by Datadog Continuous Profiler for Ruby"
   spec.description =
-    "libddprof contains implementation bits used by Datadog's ddtrace gem as part of its Continuous Profiler feature."
-  spec.homepage = "https://docs.datadoghq.com/tracing/profiler/"
+    "libdatadog is a Rust-based utility library for Datadog's ddtrace gem."
+  spec.homepage = "https://docs.datadoghq.com/tracing/"
   spec.license = "Apache-2.0"
   spec.required_ruby_version = ">= 2.1.0"
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/DataDog/libddprof/tree/main/ruby"
+  spec.metadata["source_code_uri"] = "https://github.com/datadog/libdatadog/tree/main/ruby"
 
   # Require releases on rubygems.org to be coming from multi-factor-auth-authenticated accounts
   spec.metadata["rubygems_mfa_required"] = "true"

--- a/ruby/spec/libdatadog_spec.rb
+++ b/ruby/spec/libdatadog_spec.rb
@@ -3,14 +3,14 @@
 require "tmpdir"
 require "fileutils"
 
-RSpec.describe Libddprof do
+RSpec.describe Libdatadog do
   describe "version constants" do
     it "has a version number" do
-      expect(Libddprof::VERSION).to_not be nil
+      expect(Libdatadog::VERSION).to_not be nil
     end
 
-    it "has an upstream libddprof version number" do
-      expect(Libddprof::LIB_VERSION).to_not be nil
+    it "has an upstream libdatadog version number" do
+      expect(Libdatadog::LIB_VERSION).to_not be nil
     end
   end
 
@@ -19,7 +19,7 @@ RSpec.describe Libddprof do
 
     before do
       allow(ENV).to receive(:[]).and_call_original
-      allow(ENV).to receive(:[]).with("LIBDDPROF_VENDOR_OVERRIDE").and_return(temporary_directory)
+      allow(ENV).to receive(:[]).with("LIBDATADOG_VENDOR_OVERRIDE").and_return(temporary_directory)
     end
 
     after do
@@ -32,11 +32,11 @@ RSpec.describe Libddprof do
 
     context "when no binaries are available in the vendor directory" do
       describe ".available_binaries" do
-        it { expect(Libddprof.available_binaries).to be_empty }
+        it { expect(Libdatadog.available_binaries).to be_empty }
       end
 
       describe ".pkgconfig_folder" do
-        it { expect(Libddprof.pkgconfig_folder).to be nil }
+        it { expect(Libdatadog.pkgconfig_folder).to be nil }
       end
     end
 
@@ -44,11 +44,11 @@ RSpec.describe Libddprof do
       let(:temporary_directory) { "does/not/exist" }
 
       describe ".available_binaries" do
-        it { expect(Libddprof.available_binaries).to be_empty }
+        it { expect(Libdatadog.available_binaries).to be_empty }
       end
 
       describe ".pkgconfig_folder" do
-        it { expect(Libddprof.pkgconfig_folder).to be nil }
+        it { expect(Libdatadog.pkgconfig_folder).to be nil }
       end
     end
 
@@ -59,7 +59,7 @@ RSpec.describe Libddprof do
       end
 
       describe ".available_binaries" do
-        it { expect(Libddprof.available_binaries).to contain_exactly("386-freedos", "mipsel-linux") }
+        it { expect(Libdatadog.available_binaries).to contain_exactly("386-freedos", "mipsel-linux") }
       end
 
       context "for the current platform" do
@@ -72,14 +72,14 @@ RSpec.describe Libddprof do
 
         describe ".pkgconfig_folder" do
           it "returns the folder containing the pkgconfig file" do
-            expect(Libddprof.pkgconfig_folder).to eq pkgconfig_folder
+            expect(Libdatadog.pkgconfig_folder).to eq pkgconfig_folder
           end
         end
       end
 
       context "but not for the current platform" do
         describe ".pkgconfig_folder" do
-          it { expect(Libddprof.pkgconfig_folder).to be nil }
+          it { expect(Libdatadog.pkgconfig_folder).to be nil }
         end
       end
     end

--- a/ruby/spec/spec_helper.rb
+++ b/ruby/spec/spec_helper.rb
@@ -2,7 +2,7 @@
 
 require "pry"
 
-require "libddprof"
+require "libdatadog"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
# What does this PR do?

* Rename Ruby packaging scripts (libddprof to libdatadog)
* Package 0.7.0-rc.1 release for Ruby

# Motivation

Use `libdatadog` in [dd-trace-rb](https://github.com/datadog/dd-trace-rb)

# Additional Notes

Since this was the first release, as an exception, I've already pushed it on rubygems.org (<https://rubygems.org/gems/libdatadog>) to reserve the name for our use.

# How to test the change?

1. Check the new release hashes match those on https://github.com/DataDog/libdatadog/releases/tag/v0.7.0-rc.1
2. Validate release shows up on https://rubygems.org/gems/libdatadog
3. Observe that CI is green in this downstream dd-trace-rb PR that picks up this new version for use https://github.com/DataDog/dd-trace-rb/pull/2061 