### PR TITLE
Fix clippy errors - including clippy::significant_drop_in_scrutinee

### DIFF
--- a/ddprof-ffi/src/vec.rs
+++ b/ddprof-ffi/src/vec.rs
@@ -124,6 +124,7 @@ impl<T> Default for Vec<T> {
     }
 }
 
+#[allow(clippy::get_first)]
 #[cfg(test)]
 mod test {
     use crate::vec::*;

--- a/ddtelemetry/src/worker.rs
+++ b/ddtelemetry/src/worker.rs
@@ -256,6 +256,8 @@ impl TelemetryWorker {
         let mut series = Vec::new();
         for (context_key, extra_tags, points) in self.data.metric_buckets.flush_series() {
             let context_guard = self.data.metric_contexts.get_context(context_key);
+
+            #[allow(clippy::significant_drop_in_scrutinee)]
             let context = match context_guard.read() {
                 Some(context) => context,
                 None => {
@@ -268,6 +270,7 @@ impl TelemetryWorker {
                     continue;
                 }
             };
+
             let mut tags = extra_tags;
             tags.extend(context.tags.iter().cloned());
             series.push(data::metrics::Serie {


### PR DESCRIPTION
# What does this PR do?

Clippy found a potential unexpected deadlock related to unexpected late drops in match block.
This PR fixes it

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
