### PR TITLE
Bump Rust version to 1.60

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
     name: "clippy #${{ matrix.version }}"
     strategy:
       matrix:
-        version: [nightly, "1.56.1"] 
+        version: [nightly, "1.60"]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         rust_version: [""]
         include:
           - platform: "ubuntu-latest"
-            rust_version: "1.56.1"
+            rust_version: "1.60"
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ bash ffi-build.sh /opt/libdatadog
 
 #### Build Dependencies
 
-Rust 1.56 or newer with cargo. Some platforms may need protoc; others have it shipped in prost-build.
+Rust 1.60 or newer with cargo. Some platforms may need protoc; others have it shipped in prost-build.


### PR DESCRIPTION
# What does this PR do?

Alpine released a new version including rust 1.60. We no longer need to build with rust 1.56.

# Motivation

Build with newer version

# Additional Notes

N/A

# How to test the change?

CI
