### PR TITLE
Bump version from 0.7.0-rc.1 to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,7 +115,7 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "ddcommon"
-version = "0.7.0-rc.1"
+version = "0.7.0"
 dependencies = [
  "lazy_static",
  "maplit",
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "ddprof"
-version = "0.7.0-rc.1"
+version = "0.7.0"
 dependencies = [
  "ddprof-exporter",
  "ddprof-profiles",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "ddprof-exporter"
-version = "0.7.0-rc.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "ddprof-ffi"
-version = "0.7.0-rc.1"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "ddcommon",
@@ -175,7 +175,7 @@ dependencies = [
 
 [[package]]
 name = "ddprof-profiles"
-version = "0.7.0-rc.1"
+version = "0.7.0"
 dependencies = [
  "indexmap",
  "libc",
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry"
-version = "0.7.0-rc.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "ddcommon",

--- a/ddcommon/Cargo.toml
+++ b/ddcommon/Cargo.toml
@@ -5,7 +5,7 @@
 edition = "2018"
 license = "Apache-2.0"
 name = "ddcommon"
-version = "0.7.0-rc.1"
+version = "0.7.0"
 
 [lib]
 crate-type = ["lib"]

--- a/ddprof-exporter/Cargo.toml
+++ b/ddprof-exporter/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ddprof-exporter"
-version = "0.7.0-rc.1"
+version = "0.7.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/ddprof-ffi/Cargo.toml
+++ b/ddprof-ffi/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ddprof-ffi"
-version = "0.7.0-rc.1"
+version = "0.7.0"
 edition = "2021"
 license = "Apache-2.0"
 
@@ -14,9 +14,9 @@ crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
 chrono = "0.4"
-ddprof-exporter = { path = "../ddprof-exporter", version = "0.7.0-rc.1" }
-ddprof-profiles = { path = "../ddprof-profiles", version = "0.7.0-rc.1" }
-ddcommon = { path = "../ddcommon", version = "0.7.0-rc.1" }
+ddprof-exporter = { path = "../ddprof-exporter", version = "0.7.0" }
+ddprof-profiles = { path = "../ddprof-profiles", version = "0.7.0" }
+ddcommon = { path = "../ddcommon", version = "0.7.0" }
 libc = "0.2"
 hyper = { version = "0.14", default-features = false }
 tokio-util = "0.7.1"

--- a/ddprof-profiles/Cargo.toml
+++ b/ddprof-profiles/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ddprof-profiles"
-version = "0.7.0-rc.1"
+version = "0.7.0"
 edition = "2021"
 build = "build.rs"
 license = "Apache-2.0"

--- a/ddprof/Cargo.toml
+++ b/ddprof/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ddprof"
-version = "0.7.0-rc.1"
+version = "0.7.0"
 edition = "2018"
 license = "Apache-2.0"
 

--- a/ddtelemetry/Cargo.toml
+++ b/ddtelemetry/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2018"
 license = "Apache 2.0"
 name = "ddtelemetry"
-version = "0.7.0-rc.1"
+version = "0.7.0"
 
 [dependencies]
 anyhow = {version = "1.0"}


### PR DESCRIPTION
# What does this PR do?

Bump version number in preparation for releasing 0.7.0-rc.1 as 0.7.0.

# Motivation

Have a stable release of libdatadog out, so the Ruby profiler can switch over to use it.

# Additional Notes

Because "master" is already ahead of what we shipped in 0.7.0-rc.1, I've created a new branch (`release-0.7`) from the original 0.7.0-rc.1 tag, and this PR is on top of that branch.

# How to test the change?

Compile and check that version is correct in generated output.
