### PR TITLE
Fix or work around clippy lints

### DIFF
--- a/ddprof-ffi/src/exporter.rs
+++ b/ddprof-ffi/src/exporter.rs
@@ -235,7 +235,7 @@ fn unwrap_cancellation_token<'a>(
 ) -> Option<&'a tokio_util::sync::CancellationToken> {
     cancel.map(|c| {
         let wrapped_reference: &CancellationToken = unsafe { c.as_ref() };
-        let unwrapped_reference: &tokio_util::sync::CancellationToken = &(*wrapped_reference).0;
+        let unwrapped_reference: &tokio_util::sync::CancellationToken = &(wrapped_reference.0);
 
         unwrapped_reference
     })

--- a/ddprof-ffi/src/tags.rs
+++ b/ddprof-ffi/src/tags.rs
@@ -54,6 +54,9 @@ pub struct ParseTagsResult {
     error_message: Option<Box<crate::Vec<u8>>>,
 }
 
+/// # Safety
+/// The `string`'s .ptr must point to a valid object at least as large as its
+/// .len property.
 #[must_use]
 #[no_mangle]
 pub unsafe extern "C" fn ddprof_ffi_Vec_tag_parse(string: CharSlice) -> ParseTagsResult {

--- a/ddprof-ffi/src/vec.rs
+++ b/ddprof-ffi/src/vec.rs
@@ -124,7 +124,6 @@ impl<T> Default for Vec<T> {
     }
 }
 
-#[allow(clippy::get_first)]
 #[cfg(test)]
 mod test {
     use crate::vec::*;
@@ -155,10 +154,9 @@ mod test {
         assert!(ffi_vec.capacity >= 2);
 
         let slice = unsafe { ffi_vec.as_slice().as_slice() };
-        let first = slice.get(0).unwrap();
-        let second = slice.get(1).unwrap();
-        assert_eq!(first, &1);
-        assert_eq!(second, &2);
+        let [first, second]: [_; 2] = slice.try_into().expect("slice to have 2 items");
+        assert_eq!(first, 1);
+        assert_eq!(second, 2);
     }
 
     #[test]

--- a/ddprof-profiles/src/lib.rs
+++ b/ddprof-profiles/src/lib.rs
@@ -656,7 +656,8 @@ mod api_test {
 
     #[test]
     fn impl_from_profile_for_pprof_profile() {
-        let profile: pprof::Profile = (&provide_distinct_locations()).into();
+        let locations = provide_distinct_locations();
+        let profile = pprof::Profile::from(&locations);
 
         assert_eq!(profile.sample.len(), 2);
         assert_eq!(profile.mapping.len(), 1);

--- a/ddtelemetry/src/worker.rs
+++ b/ddtelemetry/src/worker.rs
@@ -256,9 +256,8 @@ impl TelemetryWorker {
         let mut series = Vec::new();
         for (context_key, extra_tags, points) in self.data.metric_buckets.flush_series() {
             let context_guard = self.data.metric_contexts.get_context(context_key);
-
-            #[allow(clippy::significant_drop_in_scrutinee)]
-            let context = match context_guard.read() {
+            let maybe_context = context_guard.read();
+            let context = match maybe_context {
                 Some(context) => context,
                 None => {
                     telemetry_worker_log!(


### PR DESCRIPTION
# What does this PR do?

This fixes or works around clippy lints that exist on nightly.

# Motivation

I didn't like having a broken CI job as well as a broken clippy checker if I ran it locally.

# Additional Notes

Nightly is annoying but helpful.

# How to test the change?

Regular tests should work.
