### PR TITLE
Drop "V3" suffix from exporter APIs

### DIFF
--- a/ddprof-exporter/src/lib.rs
+++ b/ddprof-exporter/src/lib.rs
@@ -29,12 +29,12 @@ pub struct Exporter {
     runtime: Runtime,
 }
 
-pub struct FieldsV3 {
+pub struct Fields {
     pub start: DateTime<Utc>,
     pub end: DateTime<Utc>,
 }
 
-pub struct ProfileExporterV3 {
+pub struct ProfileExporter {
     exporter: Exporter,
     endpoint: Endpoint,
     family: Cow<'static, str>,
@@ -103,12 +103,12 @@ impl Request {
     }
 }
 
-impl ProfileExporterV3 {
+impl ProfileExporter {
     pub fn new<IntoCow: Into<Cow<'static, str>>>(
         family: IntoCow,
         tags: Option<Vec<Tag>>,
         endpoint: Endpoint,
-    ) -> Result<ProfileExporterV3, Box<dyn Error>> {
+    ) -> Result<ProfileExporter, Box<dyn Error>> {
         Ok(Self {
             exporter: Exporter::new()?,
             endpoint,

--- a/ddprof-exporter/tests/form.rs
+++ b/ddprof-exporter/tests/form.rs
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
 
-use ddprof_exporter::{File, ProfileExporterV3, Request};
+use ddprof_exporter::{File, ProfileExporter, Request};
 use std::error::Error;
 use std::io::Read;
 use std::ops::Sub;
@@ -16,7 +16,7 @@ fn open<P: AsRef<Path>>(path: P) -> Result<Vec<u8>, Box<dyn Error>> {
     Ok(buffer)
 }
 
-fn multipart(exporter: &ProfileExporterV3) -> Request {
+fn multipart(exporter: &ProfileExporter) -> Request {
     let small_pprof_name = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/profile.pprof");
     let buffer = open(small_pprof_name).expect("to open file and read its bytes");
 
@@ -57,7 +57,7 @@ mod tests {
     fn multipart_agent() {
         let base_url = "http://localhost:8126".parse().expect("url to parse");
         let endpoint = config::agent(base_url).expect("endpoint to construct");
-        let exporter = ProfileExporterV3::new("php", Some(default_tags()), endpoint)
+        let exporter = ProfileExporter::new("php", Some(default_tags()), endpoint)
             .expect("exporter to construct");
 
         let request = multipart(&exporter);
@@ -75,7 +75,7 @@ mod tests {
     fn multipart_agentless() {
         let api_key = "1234567890123456789012";
         let endpoint = config::agentless("datadoghq.com", api_key).expect("endpoint to construct");
-        let exporter = ProfileExporterV3::new("php", Some(default_tags()), endpoint)
+        let exporter = ProfileExporter::new("php", Some(default_tags()), endpoint)
             .expect("exporter to construct");
 
         let request = multipart(&exporter);


### PR DESCRIPTION
# What does this PR do?

Drop the "V3" suffix from exporter APIs. Does not otherwise change the behavior in any way.

# Motivation

As discussed in <https://github.com/DataDog/libdatadog/pull/24#discussion_r921924120> having the "V3" suffix on APIs doesn't seem that useful because:

1. We're still iterating on APIs all the time. We just broke the API again by changing the prefixes to `ddog_` so it seems a bit too early to version things. We never supported more than a version at a time!

2. Since the datadog agent just proxies profiling requests, we probably don't need to support more than one API version at a time.

3. The new intake format (internally called v2.4, whereas the old v3 was renamed to v1.3) does not need extensive API changes, so it's quite possible that we can move profilers to use v2.4 without changing the libdatadog APIs. So having v3 in the API names would force us to break the API even if not needed.

For these reasons, I decided to ride the wave of #24 already breaking all our APIs and also dropping the V3 suffix. Let me know your thoughts :)

# How to test the change?

Validate that profiles are still being reported with example apps/downstream profilers.
