### PR TITLE
Add ddprof_ffi_Profile_set_endpoint

### DIFF
--- a/ddprof-ffi/src/profiles.rs
+++ b/ddprof-ffi/src/profiles.rs
@@ -340,6 +340,18 @@ pub extern "C" fn ddprof_ffi_Profile_add(
     }
 }
 
+#[no_mangle]
+pub unsafe extern "C" fn ddprof_ffi_Profile_set_endpoint<'a>(
+    profile: &mut ddprof_profiles::Profile,
+    local_root_span_id: CharSlice<'a>,
+    endpoint: CharSlice<'a>
+) {
+    let local_root_span_id = local_root_span_id.to_utf8_lossy();
+    let endpoint = endpoint.to_utf8_lossy();
+
+    profile.add_endpoint(local_root_span_id, endpoint);
+}
+
 #[repr(C)]
 pub struct EncodedProfile {
     start: Timespec,
@@ -391,6 +403,7 @@ pub unsafe extern "C" fn ddprof_ffi_Profile_serialize(
         Some(x) if *x < 0 => None,
         Some(x) => Some(Duration::from_nanos((*x) as u64)),
     };
+
     match || -> Result<_, Box<dyn Error>> { Ok(profile.serialize(end_time, duration)?) }() {
         Ok(ok) => SerializeResult::Ok(ok.into()),
         Err(err) => SerializeResult::Err(err.into()),

--- a/ddprof-ffi/src/profiles.rs
+++ b/ddprof-ffi/src/profiles.rs
@@ -340,6 +340,22 @@ pub extern "C" fn ddprof_ffi_Profile_add(
     }
 }
 
+/// Associate an endpoint to a given local root span id.
+/// During the serialization of the profile, an endpoint label will be added
+/// to all samples that contain a matching local root span id label.
+///
+/// Note: calling this API causes the "trace endpoint" and "local root span id" strings
+/// to be interned, even if no matching sample is found.
+///
+/// # Arguments
+/// * `profile` - a reference to the profile that will contain the samples.
+/// * `local_root_span_id` - the value of the local root span id label to look for.
+/// * `endpoint` - the value of the endpoint label to add for matching samples.
+///
+/// # Safety
+/// The `profile` ptr must point to a valid Profile object created by this
+/// module.
+/// This call is _NOT_ thread-safe.
 #[no_mangle]
 pub unsafe extern "C" fn ddprof_ffi_Profile_set_endpoint<'a>(
     profile: &mut ddprof_profiles::Profile,

--- a/ddprof-ffi/src/profiles.rs
+++ b/ddprof-ffi/src/profiles.rs
@@ -344,7 +344,7 @@ pub extern "C" fn ddprof_ffi_Profile_add(
 pub unsafe extern "C" fn ddprof_ffi_Profile_set_endpoint<'a>(
     profile: &mut ddprof_profiles::Profile,
     local_root_span_id: CharSlice<'a>,
-    endpoint: CharSlice<'a>
+    endpoint: CharSlice<'a>,
 ) {
     let local_root_span_id = local_root_span_id.to_utf8_lossy();
     let endpoint = endpoint.to_utf8_lossy();
@@ -403,7 +403,6 @@ pub unsafe extern "C" fn ddprof_ffi_Profile_serialize(
         Some(x) if *x < 0 => None,
         Some(x) => Some(Duration::from_nanos((*x) as u64)),
     };
-
     match || -> Result<_, Box<dyn Error>> { Ok(profile.serialize(end_time, duration)?) }() {
         Ok(ok) => SerializeResult::Ok(ok.into()),
         Err(err) => SerializeResult::Err(err.into()),

--- a/ddprof-profiles/src/lib.rs
+++ b/ddprof-profiles/src/lib.rs
@@ -15,7 +15,6 @@ use indexmap::{IndexMap, IndexSet};
 use pprof::{Function, Label, Line, Location, ValueType};
 use prost::{EncodeError, Message};
 
-
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[repr(transparent)]
 pub struct PProfId(usize);
@@ -90,7 +89,7 @@ pub struct Profile {
 pub struct Endpoints {
     mappings: IndexMap<i64, i64>,
     local_root_span_id_label: i64,
-    endpoint_label: i64
+    endpoint_label: i64,
 }
 
 pub struct ProfileBuilder<'a> {
@@ -216,7 +215,7 @@ impl Endpoints {
         Self {
             mappings: Default::default(),
             local_root_span_id_label: Default::default(),
-            endpoint_label: Default::default()
+            endpoint_label: Default::default(),
         }
     }
 }
@@ -423,7 +422,9 @@ impl Profile {
         let interned_span_id = self.intern(local_root_span_id.as_ref());
         let interned_endpoint = self.intern(endpoint.as_ref());
 
-        self.endpoints.mappings.insert(interned_span_id, interned_endpoint);
+        self.endpoints
+            .mappings
+            .insert(interned_span_id, interned_endpoint);
     }
 
     /// Serialize the aggregated profile, adding the end time and duration.
@@ -471,7 +472,7 @@ impl From<&Profile> for pprof::Profile {
             None => (0, None),
         };
 
-        let mut samples : Vec<pprof::Sample> = profile
+        let mut samples: Vec<pprof::Sample> = profile
             .samples
             .iter()
             .map(|(sample, values)| pprof::Sample {
@@ -483,7 +484,7 @@ impl From<&Profile> for pprof::Profile {
 
         if profile.endpoints.mappings.len() > 0 {
             for sample in samples.iter_mut() {
-                let mut endpoint : Option<&i64> = None;
+                let mut endpoint: Option<&i64> = None;
 
                 for label in &sample.label {
                     if label.key == profile.endpoints.local_root_span_id_label {
@@ -497,7 +498,7 @@ impl From<&Profile> for pprof::Profile {
                         key: profile.endpoints.endpoint_label,
                         str: *endpoint_value,
                         num: 0,
-                        num_unit: 0
+                        num_unit: 0,
                     });
                 }
             }
@@ -558,8 +559,8 @@ impl From<&Profile> for pprof::Profile {
 
 #[cfg(test)]
 mod api_test {
-    use std::borrow::Cow;
     use crate::{api, pprof, PProfId, Profile, ValueType};
+    use std::borrow::Cow;
 
     #[test]
     fn interning() {
@@ -845,27 +846,27 @@ mod api_test {
             ..Default::default()
         };
 
-        let mut profile : Profile = Profile::builder().sample_types(sample_types).build();
+        let mut profile: Profile = Profile::builder().sample_types(sample_types).build();
 
         let id_label = api::Label {
             key: "local root span id",
             str: Some("10"),
             num: 0,
-            num_unit: None
+            num_unit: None,
         };
 
         let id2_label = api::Label {
             key: "local root span id",
             str: Some("11"),
             num: 0,
-            num_unit: None
+            num_unit: None,
         };
 
         let other_label = api::Label {
             key: "other",
             str: Some("test"),
             num: 0,
-            num_unit: None
+            num_unit: None,
         };
 
         let sample1 = api::Sample {
@@ -880,11 +881,9 @@ mod api_test {
             labels: vec![id2_label, other_label],
         };
 
-        profile.add(sample1)
-            .expect("add to success");
+        profile.add(sample1).expect("add to success");
 
-        profile.add(sample2)
-            .expect("add to success");
+        profile.add(sample2).expect("add to success");
 
         profile.add_endpoint(Cow::from("10"), Cow::from("my endpoint"));
 
@@ -899,18 +898,54 @@ mod api_test {
 
         let l1 = s1.label.get(0).expect("label");
 
-        assert_eq!(serialized_profile.string_table.get(l1.key as usize).unwrap(), "local root span id");
-        assert_eq!(serialized_profile.string_table.get(l1.str as usize).unwrap(), "10");
+        assert_eq!(
+            serialized_profile
+                .string_table
+                .get(l1.key as usize)
+                .unwrap(),
+            "local root span id"
+        );
+        assert_eq!(
+            serialized_profile
+                .string_table
+                .get(l1.str as usize)
+                .unwrap(),
+            "10"
+        );
 
         let l2 = s1.label.get(1).expect("label");
 
-        assert_eq!(serialized_profile.string_table.get(l2.key as usize).unwrap(), "other");
-        assert_eq!(serialized_profile.string_table.get(l2.str as usize).unwrap(), "test");
+        assert_eq!(
+            serialized_profile
+                .string_table
+                .get(l2.key as usize)
+                .unwrap(),
+            "other"
+        );
+        assert_eq!(
+            serialized_profile
+                .string_table
+                .get(l2.str as usize)
+                .unwrap(),
+            "test"
+        );
 
         let l3 = s1.label.get(2).expect("label");
 
-        assert_eq!(serialized_profile.string_table.get(l3.key as usize).unwrap(), "trace endpoint");
-        assert_eq!(serialized_profile.string_table.get(l3.str as usize).unwrap(), "my endpoint");
+        assert_eq!(
+            serialized_profile
+                .string_table
+                .get(l3.key as usize)
+                .unwrap(),
+            "trace endpoint"
+        );
+        assert_eq!(
+            serialized_profile
+                .string_table
+                .get(l3.str as usize)
+                .unwrap(),
+            "my endpoint"
+        );
 
         let s2 = serialized_profile.sample.get(1).expect("sample");
 

--- a/ddprof-profiles/src/lib.rs
+++ b/ddprof-profiles/src/lib.rs
@@ -220,6 +220,12 @@ impl Endpoints {
     }
 }
 
+impl Default for Endpoints {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Profile {
     /// Creates a profile with `start_time`. Initializes the string table to
     /// include the empty string. All other fields are default.
@@ -414,7 +420,7 @@ impl Profile {
     }
 
     pub fn add_endpoint(&mut self, local_root_span_id: Cow<str>, endpoint: Cow<str>) {
-        if self.endpoints.mappings.len() == 0 {
+        if self.endpoints.mappings.is_empty() {
             self.endpoints.local_root_span_id_label = self.intern("local root span id");
             self.endpoints.endpoint_label = self.intern("trace endpoint");
         }
@@ -482,7 +488,7 @@ impl From<&Profile> for pprof::Profile {
             })
             .collect();
 
-        if profile.endpoints.mappings.len() > 0 {
+        if !profile.endpoints.mappings.is_empty() {
             for sample in samples.iter_mut() {
                 let mut endpoint: Option<&i64> = None;
 
@@ -835,16 +841,6 @@ mod api_test {
                 unit: "nanoseconds",
             },
         ];
-
-        let mapping = api::Mapping {
-            filename: "php",
-            ..Default::default()
-        };
-
-        let index = api::Function {
-            filename: "index.php",
-            ..Default::default()
-        };
 
         let mut profile: Profile = Profile::builder().sample_types(sample_types).build();
 

--- a/ddprof-profiles/src/lib.rs
+++ b/ddprof-profiles/src/lib.rs
@@ -242,7 +242,7 @@ impl Profile {
             strings: Default::default(),
             start_time,
             period: None,
-            endpoints: Endpoints::new(),
+            endpoints: Default::default(),
         };
 
         profile.intern("");


### PR DESCRIPTION
# What does this PR do?

This PR implements and exposes a `ddprof_ffi_Profile_set_endpoint` function, that is used to lazily associate endpoints to spans.

# Motivation

The goal is to help profilers support endpoint profiling.

