### PR TITLE
Cleanup socket APIs for other Rust consumers

### DIFF
--- a/ddcommon/src/connector/uds.rs
+++ b/ddcommon/src/connector/uds.rs
@@ -9,11 +9,11 @@ use std::path::{Path, PathBuf};
 /// encoded as a hex string, to prevent special characters in the url authority
 pub fn socket_path_to_uri(path: &Path) -> Result<hyper::Uri, hyper::http::Error> {
     let path = hex::encode(path.as_os_str().as_bytes());
-    Ok(hyper::Uri::builder()
+    hyper::Uri::builder()
         .scheme("unix")
         .authority(path)
         .path_and_query("")
-        .build()?)
+        .build()
 }
 
 pub fn socket_path_from_uri(uri: &hyper::Uri) -> anyhow::Result<PathBuf> {

--- a/ddcommon/src/connector/uds.rs
+++ b/ddcommon/src/connector/uds.rs
@@ -1,14 +1,13 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
 
-use std::error::Error;
 use std::ffi::OsString;
 use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::path::{Path, PathBuf};
 
 /// Creates a new Uri, with the `unix` scheme, and the path to the socket
 /// encoded as a hex string, to prevent special characters in the url authority
-pub fn socket_path_to_uri(path: &Path) -> Result<hyper::Uri, Box<dyn Error>> {
+pub fn socket_path_to_uri(path: &Path) -> Result<hyper::Uri, hyper::http::Error> {
     let path = hex::encode(path.as_os_str().as_bytes());
     Ok(hyper::Uri::builder()
         .scheme("unix")

--- a/ddprof-ffi/src/exporter.rs
+++ b/ddprof-ffi/src/exporter.rs
@@ -94,9 +94,7 @@ unsafe fn try_to_url(slice: CharSlice) -> Result<hyper::Uri, Box<dyn Error>> {
     }
 }
 
-unsafe fn try_to_endpoint(
-    endpoint: Endpoint,
-) -> Result<exporter::Endpoint, Box<dyn Error>> {
+unsafe fn try_to_endpoint(endpoint: Endpoint) -> Result<exporter::Endpoint, Box<dyn Error>> {
     // convert to utf8 losslessly -- URLs and API keys should all be ASCII, so
     // a failed result is likely to be an error.
     match endpoint {

--- a/ddprof-ffi/src/exporter.rs
+++ b/ddprof-ffi/src/exporter.rs
@@ -82,11 +82,11 @@ pub extern "C" fn endpoint_agentless<'a>(
     Endpoint::Agentless(site, api_key)
 }
 
-unsafe fn try_to_url(slice: CharSlice) -> Result<hyper::Uri, Box<dyn std::error::Error>> {
+unsafe fn try_to_url(slice: CharSlice) -> Result<hyper::Uri, Box<dyn Error>> {
     let str: &str = slice.try_to_utf8()?;
     #[cfg(unix)]
     if let Some(path) = str.strip_prefix("unix://") {
-        return exporter::socket_path_to_uri(path.as_ref());
+        return Ok(exporter::socket_path_to_uri(path.as_ref())?);
     }
     match hyper::Uri::from_str(str) {
         Ok(url) => Ok(url),
@@ -96,7 +96,7 @@ unsafe fn try_to_url(slice: CharSlice) -> Result<hyper::Uri, Box<dyn std::error:
 
 unsafe fn try_to_endpoint(
     endpoint: Endpoint,
-) -> Result<exporter::Endpoint, Box<dyn std::error::Error>> {
+) -> Result<exporter::Endpoint, Box<dyn Error>> {
     // convert to utf8 losslessly -- URLs and API keys should all be ASCII, so
     // a failed result is likely to be an error.
     match endpoint {

--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -20,7 +20,7 @@ mod errors;
 pub use ddcommon::Endpoint;
 
 #[cfg(unix)]
-pub use connector::uds::socket_path_to_uri;
+pub use connector::uds::{socket_path_from_uri, socket_path_to_uri};
 
 const DURATION_ZERO: std::time::Duration = std::time::Duration::from_millis(0);
 


### PR DESCRIPTION
# Description and Motivation

We should probably do a pass on this at some point, but consumers of
the Rust API should not have to deal with a boxed error generally so
that we avoid allocations and retain information about errors. We
would still have boxed errors in a few cases, most likely:

 1. The errors on FFI boundaries will need boxed for ABI stability.
 2. Having multiple errors from different crates in the same function.
    Although it's possible to make error types to serve this case, it
    does take effort that's probably better spent elsewhere for now.

Anyway, in this case, there is only one error type and the boxing is
unnecessary for Rust callers.

# Additional Notes

I also changed some usages of `std::error::Error` to just `Error` because
it's already imported.

I also exported `socket_path_from_uri` in `exporter` to match
`socket_path_to_uri`.

# How to test the change?

Most things will Just Work, but you may need to wrap the error in
`Ok(...?)` to get a conversion to another error type.
