### PR TITLE
Fix issue with old rubygems not detecting musl linux properly

### DIFF
--- a/ruby/lib/libdatadog.rb
+++ b/ruby/lib/libdatadog.rb
@@ -11,6 +11,23 @@ module Libdatadog
   def self.pkgconfig_folder(pkgconfig_file_name = "ddprof_ffi_with_rpath.pc")
     current_platform = Gem::Platform.local.to_s
 
+    if RbConfig::CONFIG["arch"].include?("-musl") && !current_platform.include?("-musl")
+      # Fix/workaround for https://github.com/DataDog/dd-trace-rb/issues/2222
+      #
+      # Old versions of rubygems (for instance 3.0.3) don't properly detect alternative libc implementations on Linux;
+      # in particular for our case, they don't detect musl. (For reference, Rubies older than 2.7 may have shipped with
+      # an affected version of rubygems).
+      # In such cases, we fall back to use RbConfig::CONFIG['arch'] instead.
+      #
+      # Why not use RbConfig::CONFIG['arch'] always? Because Gem::Platform.local.to_s does some normalization we want
+      # in other situations -- for instance, it turns `x86_64-linux-gnu` to `x86_64-linux`. So for now we only add this
+      # workaround in a specific situation where we actually know it is wrong.
+      #
+      # See also https://github.com/rubygems/rubygems/pull/2922 and https://github.com/rubygems/rubygems/pull/4082
+
+      current_platform = RbConfig::CONFIG["arch"]
+    end
+
     return unless available_binaries.include?(current_platform)
 
     pkgconfig_file = Dir.glob("#{vendor_directory}/#{current_platform}/**/#{pkgconfig_file_name}").first

--- a/ruby/lib/libdatadog/version.rb
+++ b/ruby/lib/libdatadog/version.rb
@@ -5,7 +5,7 @@ module Libdatadog
   LIB_VERSION = "0.7.0"
 
   GEM_MAJOR_VERSION = "1"
-  GEM_MINOR_VERSION = "0"
+  GEM_MINOR_VERSION = "1"
   GEM_PRERELEASE_VERSION = "" # remember to include dot prefix, if needed!
   private_constant :GEM_MAJOR_VERSION, :GEM_MINOR_VERSION, :GEM_PRERELEASE_VERSION
 

--- a/ruby/spec/libdatadog_spec.rb
+++ b/ruby/spec/libdatadog_spec.rb
@@ -70,8 +70,13 @@ RSpec.describe Libdatadog do
         end
 
         def create_dummy_pkgconfig_file(pkgconfig_folder)
-          FileUtils.mkdir_p(pkgconfig_folder)
-          File.open("#{pkgconfig_folder}/ddprof_ffi_with_rpath.pc", "w") {}
+          begin
+            FileUtils.mkdir_p(pkgconfig_folder)
+          rescue Errno::EEXIST
+            # No problem, a few specs try to create the same folder
+          end
+
+          File.open("#{pkgconfig_folder}/ddprof_ffi_with_rpath.pc", "w+") {}
         end
 
         describe ".pkgconfig_folder" do

--- a/ruby/spec/libdatadog_spec.rb
+++ b/ruby/spec/libdatadog_spec.rb
@@ -93,7 +93,6 @@ RSpec.describe Libdatadog do
             allow(Gem::Platform).to receive(:local).and_return("x86_64-linux")
 
             ["x86_64-linux", "x86_64-linux-musl"].each do |arch|
-              Dir.mkdir("#{temporary_directory}/#{arch}")
               create_dummy_pkgconfig_file("#{temporary_directory}/#{arch}/some/folder/containing/the/pkgconfig/file")
             end
           end


### PR DESCRIPTION
# What does this PR do?

Fix issue with old rubygems not detecting musl linux properly.

Old versions of rubygems (for instance 3.0.3) don't properly detect alternative libc implementations on Linux; in particular for our case, they don't detect musl.

(For reference, Rubies older than 2.7 may have shipped with an affected version of rubygems).

In such cases, we fall back to use RbConfig::CONFIG['arch'] instead.

Why not use `RbConfig::CONFIG['arch']` always? Because `Gem::Platform.local.to_s` does some normalization we want in other situations -- for instance, it turns `x86_64-linux-gnu` to
`x86_64-linux`. So for now we only add this workaround in a specific situation where we actually know it is wrong.

See also https://github.com/rubygems/rubygems/pull/2922 and https://github.com/rubygems/rubygems/pull/4082

Fixes https://github.com/DataDog/dd-trace-rb/issues/2222

# Motivation

Fix https://github.com/DataDog/dd-trace-rb/issues/2222; customers can manually upgrade to a non-buggy rubygems, but having this fixed on our side provides a better user experience.

# Additional Notes

I'll ask someone working on Ruby to review this change, since it's very Ruby-specific.

# How to test the change?

The `ruby:2.5.9-alpine3.13` docker image ships with an affected version of Rubygems 3.0.3. Without this fix, the following command will print the wrong (non-musl) path for libdatadog:

```
$ docker run --network=host -ti -v `pwd`:/working ruby:2.5.9-alpine3.13 /bin/sh
/ # gem -v
3.0.3
/ # gem install libdatadog
Fetching libdatadog-0.7.0.1.0-x86_64-linux.gem
Successfully installed libdatadog-0.7.0.1.0-x86_64-linux
1 gem installed
/ # ruby -e "require 'libdatadog'; pp Libdatadog.pkgconfig_folder"
"/usr/local/bundle/gems/libdatadog-0.7.0.1.0-x86_64-linux/vendor/libdatadog-0.7.0/x86_64-linux/libdatadog-x86_64-unknown-linux-gnu/lib/pkgconfig"
```

with the new libdatadog (here I install it manually -- you can run `bundle exec rake package` to replicate locally), the correct version gets used:

```
/ # gem install working/libdatadog-0.7.0.1.1-x86_64-linux.gem
Successfully installed libdatadog-0.7.0.1.1-x86_64-linux
1 gem installed
/ # gem -v
3.0.3
/ # ruby -e "require 'libdatadog'; pp Libdatadog.pkgconfig_folder"
"/usr/local/bundle/gems/libdatadog-0.7.0.1.1-x86_64-linux/vendor/libdatadog-0.7.0/x86_64-linux-musl/libdatadog-x86_64-alpine-linux-musl/lib/pkgconfig"
```
