### PR TITLE
Release v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,7 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "datadog-profiling"
-version = "0.8.0-alpha.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -149,7 +149,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-ffi"
-version = "0.8.0-alpha.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -163,7 +163,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon"
-version = "0.8.0-alpha.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -186,7 +186,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon-ffi"
-version = "0.8.0-alpha.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "ddcommon",
@@ -194,7 +194,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry"
-version = "0.8.0-alpha.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "ddcommon",

--- a/ddcommon-ffi/Cargo.toml
+++ b/ddcommon-ffi/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ddcommon-ffi"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/ddcommon/Cargo.toml
+++ b/ddcommon/Cargo.toml
@@ -5,7 +5,7 @@
 edition = "2021"
 license = "Apache-2.0"
 name = "ddcommon"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 
 [lib]
 crate-type = ["lib"]

--- a/ddtelemetry/Cargo.toml
+++ b/ddtelemetry/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 license = "Apache 2.0"
 name = "ddtelemetry"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 
 [dependencies]
 anyhow = {version = "1.0"}

--- a/profiling-ffi/Cargo.toml
+++ b/profiling-ffi/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "datadog-profiling-ffi"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "datadog-profiling"
-version = "0.8.0-rc.1"
+version = "0.8.0"
 edition = "2021"
 build = "build.rs"
 license = "Apache-2.0"


### PR DESCRIPTION
# What does this PR do?

Bumps versions to 0.8.0 from 0.8.0-rc.1. Adjusts Cargo.lock accordingly.

# Motivation

I want to use a non-prerelease of libdatadog for the next PHP profiler release.

# Additional Notes

Nope.

# How to test the change?

No changes necessary.
