### PR TITLE
Add support for Windows Named Pipe

### DIFF
--- a/ddcommon/src/connector/conn_stream.rs
+++ b/ddcommon/src/connector/conn_stream.rs
@@ -38,10 +38,10 @@ pub type ConnStreamError = Box<dyn std::error::Error + Send + Sync>;
 
 use hyper::{client::HttpConnector, service::Service};
 impl ConnStream {
-    pub async fn from_uds_uri(uri: hyper::Uri) -> Result<ConnStream, ConnStreamError> {
+    pub async fn from_uds_uri(_uri: hyper::Uri) -> Result<ConnStream, ConnStreamError> {
         #[cfg(unix)]
         {
-            let path = super::uds::socket_path_from_uri(&uri)?;
+            let path = super::uds::socket_path_from_uri(&_uri)?;
             Ok(ConnStream::Udp {
                 transport: tokio::net::UnixStream::connect(path).await?,
             })
@@ -52,10 +52,10 @@ impl ConnStream {
         }
     }
 
-    pub async fn from_named_pipe_uri(uri: hyper::Uri) -> Result<ConnStream, ConnStreamError> {
+    pub async fn from_named_pipe_uri(_uri: hyper::Uri) -> Result<ConnStream, ConnStreamError> {
         #[cfg(windows)]
         {
-            let path = super::named_pipe::socket_path_from_uri(&uri)?;
+            let path = super::named_pipe::named_pipe_path_from_uri(&_uri)?;
             Ok(ConnStream::NamedPipe {
                 transport: tokio::net::windows::named_pipe::ClientOptions::new().open(path)?,
             })

--- a/ddcommon/src/connector/conn_stream.rs
+++ b/ddcommon/src/connector/conn_stream.rs
@@ -58,6 +58,10 @@ impl ConnStream {
             let path = super::named_pipe::socket_path_from_uri(&uri)?;
             Ok(ConnStream::NamedPipe { transport: tokio::net::windows::named_pipe::ClientOptions::new().open(path)? })
         }
+        #[cfg(not(windows))]
+        {
+            Err(super::errors::Error::WindowsNamedPipeUnsupported.into())
+        }
     }
 
     pub fn from_http_connector_with_uri(

--- a/ddcommon/src/connector/conn_stream.rs
+++ b/ddcommon/src/connector/conn_stream.rs
@@ -52,11 +52,13 @@ impl ConnStream {
         }
     }
 
-    pub async fn from_namedpipe_uri(uri : hyper::Uri) -> Result<ConnStream, ConnStreamError> {
+    pub async fn from_named_pipe_uri(uri: hyper::Uri) -> Result<ConnStream, ConnStreamError> {
         #[cfg(windows)]
         {
             let path = super::named_pipe::socket_path_from_uri(&uri)?;
-            Ok(ConnStream::NamedPipe { transport: tokio::net::windows::named_pipe::ClientOptions::new().open(path)? })
+            Ok(ConnStream::NamedPipe {
+                transport: tokio::net::windows::named_pipe::ClientOptions::new().open(path)?,
+            })
         }
         #[cfg(not(windows))]
         {
@@ -142,7 +144,7 @@ impl tokio::io::AsyncWrite for ConnStream {
             #[cfg(unix)]
             ConnStreamProj::Udp { transport } => transport.poll_write(cx, buf),
             #[cfg(windows)]
-            ConnStreamProj::NamedPipe { transport } =>  transport.poll_write(cx, buf)
+            ConnStreamProj::NamedPipe { transport } => transport.poll_write(cx, buf),
         }
     }
 

--- a/ddcommon/src/connector/conn_stream.rs
+++ b/ddcommon/src/connector/conn_stream.rs
@@ -38,30 +38,32 @@ pub type ConnStreamError = Box<dyn std::error::Error + Send + Sync>;
 
 use hyper::{client::HttpConnector, service::Service};
 impl ConnStream {
-    pub async fn from_uds_uri(_uri: hyper::Uri) -> Result<ConnStream, ConnStreamError> {
+    pub async fn from_uds_uri(uri: hyper::Uri) -> Result<ConnStream, ConnStreamError> {
         #[cfg(unix)]
         {
-            let path = super::uds::socket_path_from_uri(&_uri)?;
+            let path = super::uds::socket_path_from_uri(&uri)?;
             Ok(ConnStream::Udp {
                 transport: tokio::net::UnixStream::connect(path).await?,
             })
         }
         #[cfg(not(unix))]
         {
+            let _ = uri;
             Err(super::errors::Error::UnixSocketUnsupported.into())
         }
     }
 
-    pub async fn from_named_pipe_uri(_uri: hyper::Uri) -> Result<ConnStream, ConnStreamError> {
+    pub async fn from_named_pipe_uri(uri: hyper::Uri) -> Result<ConnStream, ConnStreamError> {
         #[cfg(windows)]
         {
-            let path = super::named_pipe::named_pipe_path_from_uri(&_uri)?;
+            let path = super::named_pipe::named_pipe_path_from_uri(&uri)?;
             Ok(ConnStream::NamedPipe {
                 transport: tokio::net::windows::named_pipe::ClientOptions::new().open(path)?,
             })
         }
         #[cfg(not(windows))]
         {
+            let _ = uri;
             Err(super::errors::Error::WindowsNamedPipeUnsupported.into())
         }
     }

--- a/ddcommon/src/connector/errors.rs
+++ b/ddcommon/src/connector/errors.rs
@@ -11,6 +11,7 @@ pub enum Error {
     UnixSocketUnsupported,
     CannotEstablishTlsConnection,
     NoValidCertifacteRootsFound,
+    WindowsNamedPipeUnsupported,
 }
 
 impl fmt::Display for Error {
@@ -25,6 +26,7 @@ impl fmt::Display for Error {
             Self::NoValidCertifacteRootsFound => {
                 "missing or not valid system HTTPS/TLS certificate roots"
             }
+            Self::WindowsNamedPipeUnsupported => "windows named pipes unsupported",
         })
     }
 }

--- a/ddcommon/src/connector/mod.rs
+++ b/ddcommon/src/connector/mod.rs
@@ -13,6 +13,9 @@ use std::task::{Context, Poll};
 #[cfg(unix)]
 pub mod uds;
 
+#[cfg(windows)]
+pub mod named_pipe;
+
 pub mod errors;
 
 mod conn_stream;
@@ -102,6 +105,7 @@ impl hyper::service::Service<hyper::Uri> for Connector {
     fn call(&mut self, uri: hyper::Uri) -> Self::Future {
         match uri.scheme_str() {
             Some("unix") => conn_stream::ConnStream::from_uds_uri(uri).boxed(),
+            Some("windows") => conn_stream::ConnStream::from_namedpipe_uri(uri).boxed(),
             Some("https") => self.build_conn_stream(uri, true),
             _ => self.build_conn_stream(uri, false),
         }

--- a/ddcommon/src/connector/mod.rs
+++ b/ddcommon/src/connector/mod.rs
@@ -105,7 +105,7 @@ impl hyper::service::Service<hyper::Uri> for Connector {
     fn call(&mut self, uri: hyper::Uri) -> Self::Future {
         match uri.scheme_str() {
             Some("unix") => conn_stream::ConnStream::from_uds_uri(uri).boxed(),
-            Some("windows") => conn_stream::ConnStream::from_namedpipe_uri(uri).boxed(),
+            Some("windows") => conn_stream::ConnStream::from_named_pipe_uri(uri).boxed(),
             Some("https") => self.build_conn_stream(uri, true),
             _ => self.build_conn_stream(uri, false),
         }

--- a/ddcommon/src/connector/named_pipe.rs
+++ b/ddcommon/src/connector/named_pipe.rs
@@ -1,54 +1,51 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
 
-use std::ffi::OsString;
-use std::os::unix::ffi::{OsStrExt, OsStringExt};
 use std::path::{Path, PathBuf};
 
-/// Creates a new Uri, with the `unix` scheme, and the path to the socket
-/// encoded as a hex string, to prevent special characters in the url authority
 pub fn socket_path_to_uri(path: &Path) -> Result<hyper::Uri, hyper::http::Error> {
-    let path = hex::encode(path.as_os_str().as_bytes());
+    let path = hex::encode(path.as_os_str().to_str().unwrap());
     hyper::Uri::builder()
-        .scheme("unix")
+        .scheme("windows")
         .authority(path)
         .path_and_query("")
         .build()
 }
 
 pub fn socket_path_from_uri(uri: &hyper::Uri) -> anyhow::Result<PathBuf> {
-    if uri.scheme_str() != Some("unix") {
+    if uri.scheme_str() != Some("windows") {
         return Err(super::errors::Error::InvalidUrl.into());
-    }
-    
+    } 
+
     let path = hex::decode(
         uri.authority()
             .ok_or(super::errors::Error::InvalidUrl)?
             .as_str(),
     )
     .map_err(|_| super::errors::Error::InvalidUrl)?;
-    Ok(PathBuf::from(OsString::from_vec(path)))
+    
+    return match String::from_utf8(path) {
+        Ok(s) => Ok(PathBuf::from(s.as_str())),
+        _ => Err(super::errors::Error::InvalidUrl.into()),
+    };
 }
 
 #[test]
-fn test_encode_unix_socket_path_absolute() {
-    let expected_path = "/path/to/a/socket.sock".as_ref();
+fn test_encode_named_pipe_for_local_server() {
+    let expected_path = r"\\.\pipe\pipename".as_ref();
     let uri = socket_path_to_uri(expected_path).unwrap();
-    assert_eq!(uri.scheme_str(), Some("unix"));
+    assert_eq!(uri.scheme_str(), Some("windows"));
 
     let actual_path = socket_path_from_uri(&uri).unwrap();
     assert_eq!(actual_path.as_path(), Path::new(expected_path))
 }
 
 #[test]
-fn test_encode_unix_socket_relative_path() {
-    let expected_path = "relative/path/to/a/socket.sock".as_ref();
+fn test_encode_named_pipe_for_remote_server() {
+    let expected_path = r"\\servername\pipe\pipename".as_ref();
     let uri = socket_path_to_uri(expected_path).unwrap();
-    let actual_path = socket_path_from_uri(&uri).unwrap();
-    assert_eq!(actual_path.as_path(), Path::new(expected_path));
-
-    let expected_path = "./relative/path/to/a/socket.sock".as_ref();
-    let uri = socket_path_to_uri(expected_path).unwrap();
+    assert_eq!(uri.scheme_str(), Some("windows"));
+    
     let actual_path = socket_path_from_uri(&uri).unwrap();
     assert_eq!(actual_path.as_path(), Path::new(expected_path));
 }

--- a/ddcommon/src/connector/named_pipe.rs
+++ b/ddcommon/src/connector/named_pipe.rs
@@ -3,7 +3,17 @@
 
 use std::path::{Path, PathBuf};
 
-pub fn socket_path_to_uri(path: &Path) -> Result<hyper::Uri, hyper::http::Error> {
+/// Windows Named Pipe
+/// https://docs.microsoft.com/en-us/windows/win32/ipc/named-pipes
+///
+/// The form a windows named pipe path is either local to the computer:
+/// \\.\pipe\pipename
+/// or targeting a remote server
+/// \\ServerName\pipe\pipename
+///
+/// Build a URI from a Path representing a named pipe
+/// `path` - named pipe path. ex: \\.\pipe\pipename
+pub fn named_pipe_path_to_uri(path: &Path) -> Result<hyper::Uri, hyper::http::Error> {
     let path = hex::encode(path.as_os_str().to_str().unwrap());
     hyper::Uri::builder()
         .scheme("windows")
@@ -12,7 +22,7 @@ pub fn socket_path_to_uri(path: &Path) -> Result<hyper::Uri, hyper::http::Error>
         .build()
 }
 
-pub fn socket_path_from_uri(uri: &hyper::Uri) -> anyhow::Result<PathBuf> {
+pub fn named_pipe_path_from_uri(uri: &hyper::Uri) -> anyhow::Result<PathBuf> {
     if uri.scheme_str() != Some("windows") {
         return Err(super::errors::Error::InvalidUrl.into());
     }
@@ -33,19 +43,19 @@ pub fn socket_path_from_uri(uri: &hyper::Uri) -> anyhow::Result<PathBuf> {
 #[test]
 fn test_encode_named_pipe_for_local_server() {
     let expected_path = r"\\.\pipe\pipename".as_ref();
-    let uri = socket_path_to_uri(expected_path).unwrap();
+    let uri = named_pipe_path_to_uri(expected_path).unwrap();
     assert_eq!(uri.scheme_str(), Some("windows"));
 
-    let actual_path = socket_path_from_uri(&uri).unwrap();
+    let actual_path = named_pipe_path_from_uri(&uri).unwrap();
     assert_eq!(actual_path.as_path(), Path::new(expected_path))
 }
 
 #[test]
 fn test_encode_named_pipe_for_remote_server() {
     let expected_path = r"\\servername\pipe\pipename".as_ref();
-    let uri = socket_path_to_uri(expected_path).unwrap();
+    let uri = named_pipe_path_to_uri(expected_path).unwrap();
     assert_eq!(uri.scheme_str(), Some("windows"));
 
-    let actual_path = socket_path_from_uri(&uri).unwrap();
+    let actual_path = named_pipe_path_from_uri(&uri).unwrap();
     assert_eq!(actual_path.as_path(), Path::new(expected_path));
 }

--- a/ddcommon/src/connector/named_pipe.rs
+++ b/ddcommon/src/connector/named_pipe.rs
@@ -15,7 +15,7 @@ pub fn socket_path_to_uri(path: &Path) -> Result<hyper::Uri, hyper::http::Error>
 pub fn socket_path_from_uri(uri: &hyper::Uri) -> anyhow::Result<PathBuf> {
     if uri.scheme_str() != Some("windows") {
         return Err(super::errors::Error::InvalidUrl.into());
-    } 
+    }
 
     let path = hex::decode(
         uri.authority()
@@ -23,7 +23,7 @@ pub fn socket_path_from_uri(uri: &hyper::Uri) -> anyhow::Result<PathBuf> {
             .as_str(),
     )
     .map_err(|_| super::errors::Error::InvalidUrl)?;
-    
+
     return match String::from_utf8(path) {
         Ok(s) => Ok(PathBuf::from(s.as_str())),
         _ => Err(super::errors::Error::InvalidUrl.into()),
@@ -45,7 +45,7 @@ fn test_encode_named_pipe_for_remote_server() {
     let expected_path = r"\\servername\pipe\pipename".as_ref();
     let uri = socket_path_to_uri(expected_path).unwrap();
     assert_eq!(uri.scheme_str(), Some("windows"));
-    
+
     let actual_path = socket_path_from_uri(&uri).unwrap();
     assert_eq!(actual_path.as_path(), Path::new(expected_path));
 }

--- a/ddcommon/src/connector/uds.rs
+++ b/ddcommon/src/connector/uds.rs
@@ -20,7 +20,7 @@ pub fn socket_path_from_uri(uri: &hyper::Uri) -> anyhow::Result<PathBuf> {
     if uri.scheme_str() != Some("unix") {
         return Err(super::errors::Error::InvalidUrl.into());
     }
-    
+
     let path = hex::decode(
         uri.authority()
             .ok_or(super::errors::Error::InvalidUrl)?

--- a/profiling-ffi/src/exporter.rs
+++ b/profiling-ffi/src/exporter.rs
@@ -87,6 +87,10 @@ unsafe fn try_to_url(slice: CharSlice) -> anyhow::Result<hyper::Uri> {
     if let Some(path) = str.strip_prefix("unix://") {
         return Ok(exporter::socket_path_to_uri(path.as_ref())?);
     }
+    #[cfg(windows)]
+    if let Some(path) = str.strip_prefix("windows:") {
+        return Ok(exporter::socket_path_to_uri(path.as_ref())?);
+    }
     Ok(hyper::Uri::from_str(str)?)
 }
 

--- a/profiling-ffi/src/exporter.rs
+++ b/profiling-ffi/src/exporter.rs
@@ -89,7 +89,7 @@ unsafe fn try_to_url(slice: CharSlice) -> anyhow::Result<hyper::Uri> {
     }
     #[cfg(windows)]
     if let Some(path) = str.strip_prefix("windows:") {
-        return Ok(exporter::socket_path_to_uri(path.as_ref())?);
+        return Ok(exporter::named_pipe_path_to_uri(path.as_ref())?);
     }
     Ok(hyper::Uri::from_str(str)?)
 }

--- a/profiling/src/exporter/config.rs
+++ b/profiling/src/exporter/config.rs
@@ -2,8 +2,12 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
 
 #[cfg(unix)]
-use ddcommon::connector::uds;
+use ddcommon::connector::uds ;
 use ddcommon::Endpoint;
+
+#[cfg(windows)]
+use ddcommon::connector::named_pipe;
+
 
 use http::Uri;
 use std::borrow::Cow;
@@ -35,6 +39,16 @@ pub fn agent(base_url: Uri) -> anyhow::Result<Endpoint> {
 #[cfg(unix)]
 pub fn agent_uds(path: &std::path::Path) -> anyhow::Result<Endpoint> {
     let base_url = uds::socket_path_to_uri(path)?;
+    agent(base_url)
+}
+
+/// Createsan Endpoint for talking to the Datadog agent though a windows named pipe.
+///
+/// # Arguments
+/// * `path` - file system path to the named pipe 
+#[cfg(windows)]
+pub fn agent_named_pipe(path: &std::path::Path) -> anyhow::Result<Endpoint> {
+    let base_url = named_pipe::socket_path_to_uri(path)?;
     agent(base_url)
 }
 

--- a/profiling/src/exporter/config.rs
+++ b/profiling/src/exporter/config.rs
@@ -47,7 +47,7 @@ pub fn agent_uds(path: &std::path::Path) -> anyhow::Result<Endpoint> {
 /// * `path` - file system path to the named pipe
 #[cfg(windows)]
 pub fn agent_named_pipe(path: &std::path::Path) -> anyhow::Result<Endpoint> {
-    let base_url = named_pipe::socket_path_to_uri(path)?;
+    let base_url = named_pipe::named_pipe_path_to_uri(path)?;
     agent(base_url)
 }
 

--- a/profiling/src/exporter/config.rs
+++ b/profiling/src/exporter/config.rs
@@ -2,12 +2,11 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
 
 #[cfg(unix)]
-use ddcommon::connector::uds ;
+use ddcommon::connector::uds;
 use ddcommon::Endpoint;
 
 #[cfg(windows)]
 use ddcommon::connector::named_pipe;
-
 
 use http::Uri;
 use std::borrow::Cow;
@@ -42,10 +41,10 @@ pub fn agent_uds(path: &std::path::Path) -> anyhow::Result<Endpoint> {
     agent(base_url)
 }
 
-/// Createsan Endpoint for talking to the Datadog agent though a windows named pipe.
+/// Creates an Endpoint for talking to the Datadog agent though a windows named pipe.
 ///
 /// # Arguments
-/// * `path` - file system path to the named pipe 
+/// * `path` - file system path to the named pipe
 #[cfg(windows)]
 pub fn agent_named_pipe(path: &std::path::Path) -> anyhow::Result<Endpoint> {
     let base_url = named_pipe::socket_path_to_uri(path)?;

--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -22,7 +22,7 @@ pub use ddcommon::Endpoint;
 pub use connector::uds::{socket_path_from_uri, socket_path_to_uri};
 
 #[cfg(windows)]
-pub use connector::named_pipe::{socket_path_to_uri, socket_path_from_uri};
+pub use connector::named_pipe::{socket_path_from_uri, socket_path_to_uri};
 
 const DURATION_ZERO: std::time::Duration = std::time::Duration::from_millis(0);
 

--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -21,6 +21,9 @@ pub use ddcommon::Endpoint;
 #[cfg(unix)]
 pub use connector::uds::{socket_path_from_uri, socket_path_to_uri};
 
+#[cfg(windows)]
+pub use connector::named_pipe::{socket_path_to_uri, socket_path_from_uri};
+
 const DURATION_ZERO: std::time::Duration = std::time::Duration::from_millis(0);
 
 pub struct Exporter {

--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -22,7 +22,7 @@ pub use ddcommon::Endpoint;
 pub use connector::uds::{socket_path_from_uri, socket_path_to_uri};
 
 #[cfg(windows)]
-pub use connector::named_pipe::{socket_path_from_uri, socket_path_to_uri};
+pub use connector::named_pipe::{named_pipe_path_from_uri, named_pipe_path_to_uri};
 
 const DURATION_ZERO: std::time::Duration = std::time::Duration::from_millis(0);
 


### PR DESCRIPTION
# What does this PR do?

This PR adds support for the  Windows Named Pipe.

# Motivation

The .NET tracer currently runs in environment (AAS) where traces are sent to the agent through windows named pipe. The customers that have their apps in that environment are waiting for the profiler to work there too.

# Additional Notes

Not on top of my head

# How to test the change?

* I build a custom version of libdatadog, linked it to the compiler.
* Implement support for named pipe in the profiler
* Setup the datadog agent to listen on windows named pipe by setting the environment variable `DD_APM_WINDOWS_PIPE_NAME` to `\\.\pipe\datadogpipe\mypipe`
* Run the application

I check the profiler log and I saw the agent url is the named pipe:
`[2022-08-23 22:01:41.691 | info | PId: 421300 | TId: 411900] Using agent endpoint windows:\\.\pipe\datadogpipe\mypipe`

And saw in the dashboard my profiles:
![image (16)](https://user-images.githubusercontent.com/17292193/186380178-5dd8dbba-35da-416b-8811-79cc854e8fa2.png)

