### PR TITLE
Fix `build-profiling-ffi.sh` script not working with relative paths + Fix incorrect placeholder for version

### DIFF
--- a/build-profiling-ffi.sh
+++ b/build-profiling-ffi.sh
@@ -63,24 +63,23 @@ case "$target" in
 esac
 
 echo "Recognized platform '${target}'. Adding libs: ${native_static_libs}"
-cd profiling-ffi
-sed < datadog_profiling.pc.in "s/@Datadog_VERSION@/${version}/g" \
+# cd profiling-ffi
+sed < profiling-ffi/datadog_profiling.pc.in "s/@Datadog_VERSION@/${version}/g" \
     > "$destdir/lib/pkgconfig/datadog_profiling.pc"
 
-sed < datadog_profiling_with_rpath.pc.in "s/@Datadog_VERSION@/${version}/g" \
+sed < profiling-ffi/datadog_profiling_with_rpath.pc.in "s/@Datadog_VERSION@/${version}/g" \
     > "$destdir/lib/pkgconfig/datadog_profiling_with_rpath.pc"
 
-sed < datadog_profiling-static.pc.in "s/@Datadog_VERSION@/${version}/g" \
+sed < profiling-ffi/datadog_profiling-static.pc.in "s/@Datadog_VERSION@/${version}/g" \
     | sed "s/@Datadog_LIBRARIES@/${native_static_libs}/g" \
     > "$destdir/lib/pkgconfig/datadog_profiling-static.pc"
 
 # strip leading white space as per CMake policy CMP0004.
 ffi_libraries="$(echo "${native_static_libs}" | sed -e 's/^[[:space:]]*//')"
 
-sed < ../cmake/DatadogConfig.cmake.in \
+sed < cmake/DatadogConfig.cmake.in \
     > "$destdir/cmake/DatadogConfig.cmake" \
     "s/@Datadog_LIBRARIES@/${ffi_libraries}/g"
-cd -
 
 cp -v LICENSE LICENSE-3rdparty.yml NOTICE "$destdir/"
 

--- a/build-profiling-ffi.sh
+++ b/build-profiling-ffi.sh
@@ -63,7 +63,6 @@ case "$target" in
 esac
 
 echo "Recognized platform '${target}'. Adding libs: ${native_static_libs}"
-# cd profiling-ffi
 sed < profiling-ffi/datadog_profiling.pc.in "s/@Datadog_VERSION@/${version}/g" \
     > "$destdir/lib/pkgconfig/datadog_profiling.pc"
 

--- a/profiling-ffi/datadog_profiling_with_rpath.pc.in
+++ b/profiling-ffi/datadog_profiling_with_rpath.pc.in
@@ -10,7 +10,7 @@ includedir=${prefix}/include
 
 Name: datadog_profiling
 Description: Contains common code used to implement Datadog's Continuous Profilers. (Dynamic linking variant, sets rpath)
-Version: @DDog_VERSION@
+Version: @Datadog_VERSION@
 Requires:
 Libs: -L${libdir} -ldatadog_profiling -Wl,-rpath,${libdir}
 Libs.private:


### PR DESCRIPTION
# What does this PR do?

* Fix `build-profiling-ffi.sh` script not working with relative paths
* Fix incorrect placeholder for version

# Motivation

See individual commit messages for details.

# How to test the change?

* Check that `build-profiling-ffi.sh` still produces the same output as before, as well as working now with relative paths
* Check that `datadog_profiling_with_rpath.pc` gets templated correctly with the version