### PR TITLE
Fix compilation error for old version of GCC

### DIFF
--- a/ddcommon-ffi/cbindgen.toml
+++ b/ddcommon-ffi/cbindgen.toml
@@ -22,12 +22,23 @@ after_includes = """
 /* NOTE: Compilation fails if you pass in a char* instead of a literal */ ((ddog_CharSlice){ .ptr = "" string, .len = sizeof(string) - 1 })
 #endif
 
+#if defined __GNUC__
+#  define DDOG_GNUC_VERSION(major) __GNUC__ >= 4
+#else
+#  define DDOG_GNUC_VERSION(major) (0)
+#endif
+
+#if defined __has_attribute
+#  define DDOG_HAS_ATTRIBUTE(attribute, major) __has_attribute(attribute)
+#else
+#  define DDOG_HAS_ATTRIBUTE(attribute, major) DDOG_GNUC_VERSION(major)
+#endif
+
 #if defined(__cplusplus) && (__cplusplus >= 201703L)
 #  define DDOG_CHECK_RETURN [[nodiscard]]
 #elif defined(_Check_return_) /* SAL */
 #  define DDOG_CHECK_RETURN _Check_return_
-#elif (defined(__has_attribute) && __has_attribute(warn_unused_result)) || \\
-      (defined(__GNUC__) && (__GNUC__ >= 4))
+#elif DDOG_HAS_ATTRIBUTE(warn_unused_result, 4)
 #  define DDOG_CHECK_RETURN __attribute__((__warn_unused_result__))
 #else
 #  define DDOG_CHECK_RETURN

--- a/ddcommon-ffi/cbindgen.toml
+++ b/ddcommon-ffi/cbindgen.toml
@@ -23,7 +23,7 @@ after_includes = """
 #endif
 
 #if defined __GNUC__
-#  define DDOG_GNUC_VERSION(major) __GNUC__ >= 4
+#  define DDOG_GNUC_VERSION(major) __GNUC__ >= major
 #else
 #  define DDOG_GNUC_VERSION(major) (0)
 #endif


### PR DESCRIPTION
# What does this PR do?

This PR fixes the C/C++ macro in the common.h file.

# Motivation

This PR fixes the issue https://github.com/DataDog/libdatadog/issues/47 for old GCC version.


# How to test the change?

What I have done to validate the fix:
- Followed the steps from https://github.com/DataDog/libdatadog/issues/47 and checked that for this old version 4.9.2 the issue was fixed.
- Compiled the .NET profiler on Linux with Clang 11.
- Compiled a little C code which includes a modified version of `common.h` with a newer version of GCC (10.2.1)
- Compiled the .NET profiler with a modified version of `common.h` (what you have in the fix)
