### PR TITLE
fix nightly lints surprise build breakage

### DIFF
--- a/.github/actions/cache/action.yaml
+++ b/.github/actions/cache/action.yaml
@@ -16,8 +16,12 @@ runs:
       uses: actions/cache@v3
       with:
         path: |
-          ~/.cargo/registry/
           ~/.cargo/git/db/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
           ~/.cargo/bin/
           target/
-        key: v1-${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}-${{ inputs.rust_version }}-${{ inputs.build_profile }}
+        key: v1-${{ runner.os }}-cargo-${{ inputs.rust_version }}-${{ hashFiles('**/Cargo.toml') }}-${{ inputs.build_profile }}
+        restore-keys: |
+          v1-${{ runner.os }}-cargo-${{ inputs.rust_version }}-${{ hashFiles('**/Cargo.toml') }}-
+          v1-${{ runner.os }}-cargo-${{ inputs.rust_version }}-

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,6 +30,7 @@ jobs:
     name: "clippy #${{ matrix.rust_version }}"
     needs: setup-clippy-matrix
     strategy:
+      fail-fast: false
       matrix:
         rust_version: ${{ fromJson(needs.setup-clippy-matrix.outputs.versions) }}
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -80,8 +80,9 @@ jobs:
             ~/.cargo/registry/
             ~/.cargo/git/db/
             ~/.cargo/bin/
-          key: v0.5.0
-      - run: cargo install --force cargo-bundle-licenses
+            ~/.cargo/.crates.toml
+          key: "v1-0.5.0"
+      - run: cargo install cargo-bundle-licenses 
       - name: "Generate new LICENSE-3rdparty.yml and check against the previous" 
         env: 
           CARGO_HOME: "/tmp/dd-cargo"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,8 +2,6 @@ name: Lint
 on: [push]
 env: 
   CARGO_TERM_COLOR: always
-  PINNED_NIGHTLY_VERSION: nightly-2022-08-25
-  RUST_VERSION: "1.60.0"
 
 jobs:
   rustfmt:
@@ -16,23 +14,12 @@ jobs:
       - name: Install latest nightly toolchain and rustfmt
         run: rustup update nightly && rustup default nightly && rustup component add rustfmt
       - run: cargo fmt --all -- --check
-  setup-clippy-matrix:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup matrix combinations
-        id: setup-clippy-matrix
-        run: 
-          echo ::set-output name=versions::[\"nightly\", \"${{ env.PINNED_NIGHTLY_VERSION }}\", \"${{ env.RUST_VERSION }}\"]
-    outputs:
-      versions: ${{ steps.setup-clippy-matrix.outputs.versions }}
- 
   clippy:
     name: "clippy #${{ matrix.rust_version }}"
-    needs: setup-clippy-matrix
     strategy:
       fail-fast: false
       matrix:
-        rust_version: ${{ fromJson(needs.setup-clippy-matrix.outputs.versions) }}
+        rust_version: ["nightly", "1.60.0", "nightly-2022-09-19"]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust_version: ["nightly", "1.60.0", "nightly-2022-09-19"]
+        rust_version: ["nightly", "1.60.0", "stable"]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -73,7 +73,15 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
       - run: stat LICENSE-3rdparty.yml
-      - run: cargo install cargo-bundle-licenses
+      - name: Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry/
+            ~/.cargo/git/db/
+            ~/.cargo/bin/
+          key: v0.5.0
+      - run: cargo install --force cargo-bundle-licenses
       - name: "Generate new LICENSE-3rdparty.yml and check against the previous" 
         env: 
           CARGO_HOME: "/tmp/dd-cargo"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,8 @@ name: Lint
 on: [push]
 env: 
   CARGO_TERM_COLOR: always
+  PINNED_NIGHTLY_VERSION: nightly-2022-08-25
+  RUST_VERSION: "1.60.0"
 
 jobs:
   rustfmt:
@@ -14,19 +16,32 @@ jobs:
       - name: Install latest nightly toolchain and rustfmt
         run: rustup update nightly && rustup default nightly && rustup component add rustfmt
       - run: cargo fmt --all -- --check
+  setup-clippy-matrix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup matrix combinations
+        id: setup-clippy-matrix
+        run: 
+          echo ::set-output name=versions::[\"nightly\", \"${{ env.PINNED_NIGHTLY_VERSION }}\", \"${{ env.RUST_VERSION }}\"]
+    outputs:
+      versions: ${{ steps.setup-clippy-matrix.outputs.versions }}
+ 
   clippy:
-    name: "clippy #${{ matrix.version }}"
+    name: "clippy #${{ matrix.rust_version }}"
+    needs: setup-clippy-matrix
     strategy:
       matrix:
-        version: [nightly, "1.60"]
+        rust_version: ${{ fromJson(needs.setup-clippy-matrix.outputs.versions) }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
       - name: Cache
         uses: ./.github/actions/cache
+        with:
+          rust_version: ${{ matrix.rust_version }}
       - name: Install ${{ matrix.version }} toolchain and clippy
-        run: rustup install ${{ matrix.version }} && rustup default ${{ matrix.version }} && rustup component add clippy
+        run: rustup install ${{ matrix.rust_version }} && rustup default ${{ matrix.rust_version }} && rustup component add clippy
       - run: cargo clippy --all-targets --all-features -- -D warnings
   licensecheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,6 +69,8 @@ jobs:
             ~/.cargo/git/db/
             ~/.cargo/bin/
             ~/.cargo/.crates.toml
+          # cache key contains current version of cargo-bundle-licenses
+          # when upstream version is updated we can bump the cache key version, to cache the latest version of the tool
           key: "v1-0.5.0"
       - run: cargo install cargo-bundle-licenses 
       - name: "Generate new LICENSE-3rdparty.yml and check against the previous" 


### PR DESCRIPTION
Nightly builds that pull in latest lints daily, often cause us to chase broken tests.
In a few cases it turned out that the clippy checks were later removed - while we've lost time fixing code to keep the tests up to date. 

This PR introduces adds latest "stable" clippy to be used as reference against latest nightly - and allows other builds in the matrix to finish if one of them fails.

Additionally it improves the caching on lints, and should reduce their execution time to seconds, instead of minutes