### PR TITLE
Change Tag to hold a String instead of Cow<str>

### DIFF
--- a/ddcommon/src/tag.rs
+++ b/ddcommon/src/tag.rs
@@ -18,6 +18,12 @@ impl Debug for Tag {
     }
 }
 
+impl AsRef<str> for Tag {
+    fn as_ref(&self) -> &str {
+        self.value.as_ref()
+    }
+}
+
 // Any type which implements Display automatically has to_string.
 impl Display for Tag {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {

--- a/ddcommon/src/tag.rs
+++ b/ddcommon/src/tag.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 #[derive(Clone, Eq, PartialEq, Hash, Serialize)]
 #[serde(transparent)]
 pub struct Tag {
-    value: Cow<'static, str>,
+    value: String,
 }
 
 impl Debug for Tag {
@@ -28,9 +28,10 @@ impl Display for Tag {
 impl Tag {
     /// It's recommended to use Tag::new when possible, as tags that are in
     /// the <KEY>:<VALUE> format are preferred.
-    pub fn from_value<'a, IntoCow: Into<Cow<'a, str>>>(
-        chunk: IntoCow,
-    ) -> Result<Self, Cow<'static, str>> {
+    pub fn from_value<'a, IntoCow>(chunk: IntoCow) -> Result<Self, Cow<'static, str>>
+    where
+        IntoCow: Into<Cow<'a, str>>,
+    {
         let chunk = chunk.into();
 
         /* The docs have various rules, which we are choosing not to enforce:
@@ -55,7 +56,7 @@ impl Tag {
         }
 
         Ok(Tag {
-            value: chunk.into_owned().into(),
+            value: chunk.into_owned(),
         })
     }
 
@@ -68,11 +69,6 @@ impl Tag {
         let value = value.as_ref();
 
         Tag::from_value(format!("{}:{}", key, value))
-    }
-
-    pub fn into_owned(mut self) -> Self {
-        self.value = self.value.to_owned();
-        self
     }
 }
 

--- a/profiling-ffi/src/exporter.rs
+++ b/profiling-ffi/src/exporter.rs
@@ -123,7 +123,7 @@ pub extern "C" fn profile_exporter_new(
     match || -> anyhow::Result<ProfileExporter> {
         let family = unsafe { family.to_utf8_lossy() }.into_owned();
         let converted_endpoint = unsafe { try_to_endpoint(endpoint)? };
-        let tags = tags.map(|tags| tags.iter().map(|tag| tag.clone().into_owned()).collect());
+        let tags = tags.map(|tags| tags.iter().map(Tag::clone).collect());
         ProfileExporter::new(family, tags, converted_endpoint)
     }() {
         Ok(exporter) => NewProfileExporterResult::Ok(Box::into_raw(Box::new(exporter))),

--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -122,8 +122,8 @@ impl ProfileExporter {
     /// Build a Request object representing the profile information provided.
     pub fn build(
         &self,
-        start: chrono::DateTime<chrono::Utc>,
-        end: chrono::DateTime<chrono::Utc>,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
         files: &[File],
         additional_tags: Option<&Vec<Tag>>,
         timeout: std::time::Duration,
@@ -133,7 +133,7 @@ impl ProfileExporter {
         form.add_text("version", "3");
         form.add_text("start", start.format("%Y-%m-%dT%H:%M:%S%.9fZ").to_string());
         form.add_text("end", end.format("%Y-%m-%dT%H:%M:%S%.9fZ").to_string());
-        form.add_text("family", self.family.to_owned());
+        form.add_text("family", self.family.as_ref());
 
         for tags in self.tags.as_ref().iter().chain(additional_tags.iter()) {
             for tag in tags.iter() {


### PR DESCRIPTION
# What does this PR do?

Change `Tag` to hold a `String` instead of `Cow<str>`.

I also implemented `AsRef<str>` for `Tag`. 

# Motivation

This originated from a lint on nightly which didn't like `Cow::to_owned`
being called, and instead callers should use `Cow::clone` or
`Cow::into_owned`. However, while inspecting the code with fresh eyes, we
saw that we're always holding a `Cow::Owned` variant, so just hold the
`String` instead.

Simultaneously, I got a crash report in Rust for the PHP profiler. I
don't support forking, and they forked. Anyway, for this particular
crash it's not much harder to support `fork` (well, it leaks
technically but works) than to disable everything on a fork. As part of
supporting fork, I need to fixup the `process_id` tag to have the new
pid after a fork, and `Tag::as_ref` will help with that.

# Additional Notes

I also noticed that we were fully qualifying two usages of `DateTime` and
`Utc` even though we're publicly using those, so I shortened them.

# How to test the change?

If your code is calling `Tag::to_owned` then it will break. It should be
reworked into using a `Tag::clone` or call `.to_string` on it or similar.
