### PR TITLE
Add `initialize_before_fork` functions

### DIFF
--- a/profiling-ffi/src/exporter.rs
+++ b/profiling-ffi/src/exporter.rs
@@ -113,6 +113,25 @@ unsafe fn try_to_endpoint(endpoint: Endpoint) -> anyhow::Result<exporter::Endpoi
     }
 }
 
+#[repr(C)]
+pub enum ProfileExporterInitializeBeforeForkResult {
+    Ok,
+    Err(ddcommon_ffi::Vec<u8>),
+}
+
+/// On Apple platforms in particular, some things need to be initialized
+/// before a fork, and ideally before threads are created. This function
+/// initializes these things for the exporter. This only needs to be called
+/// once.
+#[no_mangle]
+pub extern "C" fn ddog_ProfileExporter_initialize_before_fork(
+) -> ProfileExporterInitializeBeforeForkResult {
+    match exporter::initialize_before_fork() {
+        Ok(_) => ProfileExporterInitializeBeforeForkResult::Ok,
+        Err(err) => ProfileExporterInitializeBeforeForkResult::Err(err.into()),
+    }
+}
+
 #[must_use]
 #[export_name = "ddog_ProfileExporter_new"]
 pub extern "C" fn profile_exporter_new(

--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -1,14 +1,15 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
 
+pub mod config;
+mod errors;
+
 use std::borrow::Cow;
 use std::future;
 use std::io::Cursor;
 
 use bytes::Bytes;
-pub use chrono::{DateTime, Utc};
-pub use ddcommon::tag::Tag;
-pub use hyper::Uri;
+use ddcommon::{azure_app_services, connector, HttpClient, HttpResponse};
 use hyper_multipart_rfc7578::client::multipart;
 use lz4_flex::frame::FrameEncoder;
 use mime;
@@ -17,11 +18,9 @@ use std::io::Write;
 use tokio::runtime::Runtime;
 use tokio_util::sync::CancellationToken;
 
-use ddcommon::{azure_app_services, connector, HttpClient, HttpResponse};
-
-pub mod config;
-mod errors;
-pub use ddcommon::Endpoint;
+pub use chrono::{DateTime, Utc};
+pub use ddcommon::{connector::initialize_before_fork, tag::Tag, Endpoint};
+pub use hyper::Uri;
 
 #[cfg(unix)]
 pub use connector::uds::{socket_path_from_uri, socket_path_to_uri};


### PR DESCRIPTION
# What does this PR do?

Adds `initialize_before_fork()` functions.

Also re-organizes the includes and mods section a bit to group things a bit more.

# Motivation

From one of the function's documentation:

```rs
/// On Apple platforms in particular, some things need to be initialized
/// before a fork, and ideally before threads are created.
/// Users may run into errors like the following if they do not:
/// > objc[25938]: +[__NSCFConstantString initialize] may have been in
/// > progress in another thread when fork() was called. We cannot safely
/// > call it or ignore it in the fork() child process. Crashing instead. Set
/// > a breakpoint on objc_initializeAfterForkError to debug.
```

# Additional Notes

If the codebase using libdatadog might fork, then this should be called before forking, at least on Apple platforms.

The `profiling::exporter` module re-exports the `ddcommon::connector`'s function, and the `profiling-ffi::exporter` uses the `profiling::exporter` version. This organization made sense to me at the time but I am having trouble defending it so I'm happy to hear your thoughts.

# How to test the change?

Call one of the `initialize_before_fork` functions on an Apple platform, then fork, and note that you don't crash, whereas on older versions of libdatadog you might (depends potentially on if anything else has fully initialized the Apple frameworks). Note that you don't need to use the return value for this use case, though you could if you were interested in logging failures.