### PR TITLE
Improve ProfileExporter API docs

### DIFF
--- a/profiling-ffi/src/exporter.rs
+++ b/profiling-ffi/src/exporter.rs
@@ -113,6 +113,16 @@ unsafe fn try_to_endpoint(endpoint: Endpoint) -> anyhow::Result<exporter::Endpoi
     }
 }
 
+/// Creates a new exporter to be used to report profiling data.
+/// # Arguments
+/// * `profiling_library_name` - Profiling library name, usually dd-trace-something, e.g. "dd-trace-rb". See
+///   https://datadoghq.atlassian.net/wiki/spaces/PROF/pages/1538884229/Client#Header-values (Datadog internal link)
+///   for a list of common values.
+/// * `profliling_library_version` - Version used when publishing the profiling library to a package manager
+/// * `family` - Profile family, e.g. "ruby"
+/// * `tags` - Tags to include with every profile reported by this exporter. It's also possible to include
+///   profile-specific tags, see `additional_tags` on `profile_exporter_build`.
+/// * `endpoint` - Configuration for reporting data
 #[must_use]
 #[export_name = "ddog_ProfileExporter_new"]
 pub extern "C" fn profile_exporter_new(

--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -113,6 +113,16 @@ impl Request {
 }
 
 impl ProfileExporter {
+    /// Creates a new exporter to be used to report profiling data.
+    /// # Arguments
+    /// * `profiling_library_name` - Profiling library name, usually dd-trace-something, e.g. "dd-trace-rb". See
+    ///   https://datadoghq.atlassian.net/wiki/spaces/PROF/pages/1538884229/Client#Header-values (Datadog internal link)
+    ///   for a list of common values.
+    /// * `profliling_library_version` - Version used when publishing the profiling library to a package manager
+    /// * `family` - Profile family, e.g. "ruby"
+    /// * `tags` - Tags to include with every profile reported by this exporter. It's also possible to include
+    ///   profile-specific tags, see `additional_tags` on `build`.
+    /// * `endpoint` - Configuration for reporting data
     pub fn new<F, N, V>(
         profiling_library_name: N,
         profiling_library_version: V,


### PR DESCRIPTION
# What does this PR do?

After some discussion on the expected values for `profiling_library_name` on slack, I've decided to go ahead and document the current expectations alongside the API.

# Motivation

Avoid confusion over expected values for `profiling_library_name`.

# Additional Notes

(None)

# How to test the change?

(This is a documentation change only)