### PR TITLE
Profiling Breakdown API

### DIFF
--- a/examples/ffi/exporter.cpp
+++ b/examples/ffi/exporter.cpp
@@ -26,14 +26,11 @@ static struct ddog_Timespec systemtime_now(void) {
   int base = timespec_get(&ts, TIME_UTC);
   assert(base == TIME_UTC);
 
-  return (struct ddog_Timespec) {
-      .seconds = (int64_t)ts.tv_sec,
-      .nanoseconds = (uint32_t)ts.tv_nsec,
-  };
+  return {static_cast<int64_t>(ts.tv_sec), static_cast<uint32_t>(ts.tv_nsec)};
 }
 
 static int64_t timespec_to_i64(struct ddog_Timespec ts) {
-  return ts.seconds * INT64_C(1000000000) + (int64_t)ts.nanoseconds;
+  return ts.seconds * INT64_C(1000000000) + static_cast<int64_t>(ts.nanoseconds);
 }
 
 int main(int argc, char *argv[]) {

--- a/examples/ffi/profiles.c
+++ b/examples/ffi/profiles.c
@@ -6,57 +6,100 @@
 #include <assert.h>
 #include <datadog/common.h>
 #include <datadog/profiling.h>
+#include <inttypes.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <time.h>
 
-/* Creates a profile with one sample type "wall-time" with period of
- * "wall-time" with unit 60 "nanoseconds". Adds one sample with a string label
- * "language".
+/* The profile built doesn't match the same format as the PHP profiler, but
+ * it is similar and should make sense.
  */
 int main(void) {
-  const struct ddog_ValueType wall_time = {
-      .type_ = DDOG_CHARSLICE_C("wall-time"),
-      .unit = DDOG_CHARSLICE_C("nanoseconds"),
+  const struct ddog_ValueType sample_types_data[] = {
+      {
+          .type_ = DDOG_CHARSLICE_C("wall-time"),
+          .unit = DDOG_CHARSLICE_C("nanoseconds"),
+      },
+      {
+          .type_ = DDOG_CHARSLICE_C("cpu-time"),
+          .unit = DDOG_CHARSLICE_C("nanoseconds"),
+      },
   };
-  const struct ddog_Slice_value_type sample_types = {&wall_time, 1};
-  const struct ddog_Period period = {wall_time, 60};
+
+  const struct ddog_Slice_value_type sample_types = {sample_types_data, 2};
+  const struct ddog_Period period = {sample_types_data[0], INT64_C(60000000000)};
 
   ddog_Profile *profile = ddog_Profile_new(sample_types, &period, NULL);
 
-  struct ddog_Line root_line = {
-      .function =
-          (struct ddog_Function){
-              .name = DDOG_CHARSLICE_C("{main}"),
-              .filename = DDOG_CHARSLICE_C("/srv/example/index.php"),
-          },
-      .line = 0,
+  struct ddog_Line lines[] = {
+      {
+          .function =
+              (struct ddog_Function){
+                  .name = DDOG_CHARSLICE_C("sleep"),
+              },
+          .line = 0,
+      },
+      {
+          .function =
+              (struct ddog_Function){
+                  .name = DDOG_CHARSLICE_C("<?php"),
+                  .filename = DDOG_CHARSLICE_C("/srv/example.org/index.php"),
+              },
+          .line = 3,
+      },
   };
 
-  struct ddog_Location root_location = {
-      // yes, a zero-initialized mapping is valid
-      .mapping = (struct ddog_Mapping){0},
-      .lines = (struct ddog_Slice_line){&root_line, 1},
+  struct ddog_Location locations[] = {
+      {
+          .mapping = (struct ddog_Mapping){.filename = DDOG_CHARSLICE_C("[ext/standard]")},
+          .lines = (struct ddog_Slice_line){&lines[0], 1},
+      },
+      {
+          // yes, a zero-initialized mapping is valid
+          .mapping = (struct ddog_Mapping){0},
+          .lines = (struct ddog_Slice_line){&lines[1], 1},
+      },
   };
-  int64_t value = 10;
+  int64_t values[] = {10000, 73};
   const struct ddog_Label label = {
-      .key = DDOG_CHARSLICE_C("language"),
-      .str = DDOG_CHARSLICE_C("php"),
+      .key = DDOG_CHARSLICE_C("process_id"),
+      .str = DDOG_CHARSLICE_C("12345"),
   };
 
   struct timespec now;
-  int result = timespec_get(&now, TIME_UTC);
-  assert(result == TIME_UTC);
+  int timespec_get_result = timespec_get(&now, TIME_UTC);
+  assert(timespec_get_result == TIME_UTC);
 
-  int64_t tick =
-      ((int64_t)now.tv_sec) * INT64_C(1000000000) + (int64_t)now.tv_nsec;
+  int64_t tick = ((int64_t)now.tv_sec) * INT64_C(1000000000) + (int64_t)now.tv_nsec;
 
   struct ddog_Sample sample = {
-      .locations = {&root_location, 1},
-      .values = {&value, 1},
+      .locations = {locations, 2},
+      .values = {values, 2},
       .labels = {&label, 1},
       .tick = tick,
   };
-  ddog_Profile_add(profile, sample);
+  uint64_t sample_id1 = ddog_Profile_add(profile, sample);
+  uint64_t sample_id2 = ddog_Profile_add(profile, sample);
+  if (sample_id1 != sample_id2) {
+    fprintf(stderr, "Sample ids did not match: %" PRIu64 " != %" PRIu64, sample_id1, sample_id2);
+  }
+
+  int exit_code = 0;
+  struct ddog_SerializeResult result = ddog_Profile_serialize(profile, NULL, NULL);
+  if (result.tag == DDOG_SERIALIZE_RESULT_OK) {
+    struct ddog_EncodedProfile encoded_profile = result.ok;
+    struct ddog_Vec_u8 buffer = encoded_profile.buffer;
+    size_t bytes_written = fwrite(buffer.ptr, 1, buffer.len, stdout);
+    if (bytes_written != buffer.len) {
+      fprintf(stderr, "Only wrote %zu of %zu bytes.\n", bytes_written, buffer.len);
+      exit_code = 1;
+    }
+  } else {
+    struct ddog_Vec_u8 err = result.err;
+    fprintf(stderr, "Failed to serialize profile: %*s.\n", (int)err.len, (const char *)err.ptr);
+    exit_code = 1;
+  }
+  ddog_SerializeResult_drop(result);
   ddog_Profile_free(profile);
-  return 0;
+  return exit_code;
 }

--- a/examples/ffi/profiles.c
+++ b/examples/ffi/profiles.c
@@ -3,12 +3,15 @@
 // developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
 // Datadog, Inc.
 
+#include <assert.h>
 #include <datadog/common.h>
 #include <datadog/profiling.h>
 #include <stdint.h>
+#include <time.h>
 
-/* Creates a profile with one sample type "wall-time" with period of "wall-time"
- * with unit 60 "nanoseconds". Adds one sample with a string label "language".
+/* Creates a profile with one sample type "wall-time" with period of
+ * "wall-time" with unit 60 "nanoseconds". Adds one sample with a string label
+ * "language".
  */
 int main(void) {
   const struct ddog_ValueType wall_time = {
@@ -39,10 +42,19 @@ int main(void) {
       .key = DDOG_CHARSLICE_C("language"),
       .str = DDOG_CHARSLICE_C("php"),
   };
+
+  struct timespec now;
+  int result = timespec_get(&now, TIME_UTC);
+  assert(result == TIME_UTC);
+
+  int64_t tick =
+      ((int64_t)now.tv_sec) * INT64_C(1000000000) + (int64_t)now.tv_nsec;
+
   struct ddog_Sample sample = {
       .locations = {&root_location, 1},
       .values = {&value, 1},
       .labels = {&label, 1},
+      .tick = tick,
   };
   ddog_Profile_add(profile, sample);
   ddog_Profile_free(profile);

--- a/examples/ffi/profiles.c
+++ b/examples/ffi/profiles.c
@@ -11,10 +11,26 @@
 #include <stdio.h>
 #include <time.h>
 
+static struct ddog_Timespec systemtime_now(void) {
+  struct timespec ts;
+  int base = timespec_get(&ts, TIME_UTC);
+  assert(base == TIME_UTC);
+
+  return (struct ddog_Timespec) {
+      .seconds = (int64_t)ts.tv_sec,
+      .nanoseconds = (uint32_t)ts.tv_nsec,
+  };
+}
+
+static int64_t timespec_to_i64(struct ddog_Timespec ts) {
+  return ts.seconds * INT64_C(1000000000) + (int64_t)ts.nanoseconds;
+}
+
 /* The profile built doesn't match the same format as the PHP profiler, but
  * it is similar and should make sense.
  */
 int main(void) {
+  struct ddog_Timespec start_time = systemtime_now();
   const struct ddog_ValueType sample_types_data[] = {
       {
           .type_ = DDOG_CHARSLICE_C("wall-time"),
@@ -29,7 +45,7 @@ int main(void) {
   const struct ddog_Slice_value_type sample_types = {sample_types_data, 2};
   const struct ddog_Period period = {sample_types_data[0], INT64_C(60000000000)};
 
-  ddog_Profile *profile = ddog_Profile_new(sample_types, &period, NULL);
+  ddog_Profile *profile = ddog_Profile_new(sample_types, &period, &start_time);
 
   struct ddog_Line lines[] = {
       {
@@ -66,26 +82,25 @@ int main(void) {
       .str = DDOG_CHARSLICE_C("12345"),
   };
 
-  struct timespec now;
-  int timespec_get_result = timespec_get(&now, TIME_UTC);
-  assert(timespec_get_result == TIME_UTC);
-
-  int64_t tick = ((int64_t)now.tv_sec) * INT64_C(1000000000) + (int64_t)now.tv_nsec;
-
   struct ddog_Sample sample = {
       .locations = {locations, 2},
       .values = {values, 2},
       .labels = {&label, 1},
-      .tick = tick,
+      .unix_timestamp_ns = timespec_to_i64(systemtime_now()),
   };
   uint64_t sample_id1 = ddog_Profile_add(profile, sample);
+
+  sample.unix_timestamp_ns = timespec_to_i64(systemtime_now());
   uint64_t sample_id2 = ddog_Profile_add(profile, sample);
   if (sample_id1 != sample_id2) {
     fprintf(stderr, "Sample ids did not match: %" PRIu64 " != %" PRIu64, sample_id1, sample_id2);
   }
 
   int exit_code = 0;
-  struct ddog_SerializeResult result = ddog_Profile_serialize(profile, NULL, NULL);
+
+  struct ddog_Timespec end_time = systemtime_now();
+  struct ddog_SerializeResult result = ddog_Profile_serialize(profile, &end_time, NULL);
+
   if (result.tag == DDOG_SERIALIZE_RESULT_OK) {
     struct ddog_EncodedProfile encoded_profile = result.ok;
     struct ddog_Vec_u8 buffer = encoded_profile.buffer;
@@ -94,11 +109,13 @@ int main(void) {
       fprintf(stderr, "Only wrote %zu of %zu bytes.\n", bytes_written, buffer.len);
       exit_code = 1;
     }
+
   } else {
     struct ddog_Vec_u8 err = result.err;
     fprintf(stderr, "Failed to serialize profile: %*s.\n", (int)err.len, (const char *)err.ptr);
     exit_code = 1;
   }
+
   ddog_SerializeResult_drop(result);
   ddog_Profile_free(profile);
   return exit_code;

--- a/profiling-ffi/src/profiles.rs
+++ b/profiling-ffi/src/profiles.rs
@@ -148,7 +148,7 @@ pub struct Sample<'a> {
     /// things like a thread id, allocation size, etc
     pub labels: Slice<'a, Label<'a>>,
 
-    /// Nanoseconds since the UNIX epoch.
+    /// The timestamp of the sample in nanoseconds since the UNIX epoch.
     pub unix_timestamp_ns: i64,
 }
 

--- a/profiling/examples/profiles.rs
+++ b/profiling/examples/profiles.rs
@@ -57,6 +57,7 @@ fn main() {
         ],
         values: vec![1, 10000],
         labels: vec![],
+        tick: 0,
     };
 
     // Not setting .start_time intentionally to use the current time.

--- a/profiling/examples/profiles.rs
+++ b/profiling/examples/profiles.rs
@@ -4,7 +4,6 @@
 use datadog_profiling::profile::{api, Profile};
 use std::io::Write;
 use std::time::SystemTime;
-use tokio::time::Instant;
 
 /* The profile built doesn't match the same format as the PHP profiler, but
  * it is similar and should make sense.
@@ -12,7 +11,6 @@ use tokio::time::Instant;
  */
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let start_time = SystemTime::now();
-    let started_at = Instant::now();
 
     let wall_time = api::ValueType {
         r#type: "wall-time",
@@ -66,11 +64,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             num: 0,
             num_unit: None,
         }],
-        tick: started_at
-            .elapsed()
-            .as_nanos()
-            .try_into()
-            .unwrap_or(i64::MAX),
+        timestamp: SystemTime::now(),
     };
 
     let mut profile: Profile = Profile::builder()
@@ -81,11 +75,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let sample_id1 = profile.add(sample.clone())?;
 
-    sample.tick = started_at
-        .elapsed()
-        .as_nanos()
-        .try_into()
-        .unwrap_or(i64::MAX);
+    sample.timestamp = SystemTime::now();
     let sample_id2 = profile.add(sample)?;
 
     assert_eq!(sample_id1, sample_id2, "Sample ids should match");

--- a/profiling/src/profile/api.rs
+++ b/profiling/src/profile/api.rs
@@ -1,12 +1,13 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
 
-#[derive(Copy, Clone)]
+#[derive(Clone, Copy)]
 pub struct ValueType<'a> {
     pub r#type: &'a str,
     pub unit: &'a str,
 }
 
+#[derive(Clone, Copy)]
 pub struct Period<'a> {
     pub r#type: ValueType<'a>,
     pub value: i64,
@@ -97,10 +98,10 @@ pub struct Label<'a> {
     /// Should only be present when num is present.
     /// Specifies the units of num.
     /// Use arbitrary string (for example, "requests") as a custom count unit.
-    /// If no unit is specified, consumer may apply heuristic to deduce the unit.
-    /// Consumers may also  interpret units like "bytes" and "kilobytes" as memory
-    /// units and units like "seconds" and "nanoseconds" as time units,
-    /// and apply appropriate unit conversions to these.
+    /// If no unit is specified, consumer may apply heuristic to deduce the
+    /// unit. Consumers may also interpret units like "bytes" and "kilobytes"
+    /// as memory units and units like "seconds" and "nanoseconds" as time
+    /// units, and apply appropriate unit conversions to these.
     pub num_unit: Option<&'a str>,
 }
 
@@ -108,15 +109,19 @@ pub struct Sample<'a> {
     /// The leaf is at locations[0].
     pub locations: Vec<Location<'a>>,
 
-    /// The type and unit of each value is defined by the corresponding
-    /// entry in Profile.sample_type. All samples must have the same
-    /// number of values, the same as the length of Profile.sample_type.
-    /// When aggregating multiple samples into a single sample, the
-    /// result has a list of values that is the element-wise sum of the
-    /// lists of the originals.
-    pub values: Vec<i64>,
+    /// The type and unit of each value is defined by the corresponding entry
+    /// in Profile.sample_type. All samples must have the same number of
+    /// values, the same as the length of Profile.sample_type. When
+    /// aggregating multiple samples into a single sample, the result has a
+    /// list of values that is the element-wise sum of the lists of the
+    /// originals.
+    pub values: Vec<i64>, // [0, 0, 40, 1]
 
     /// label includes additional context for this sample. It can include
     /// things like a thread id, allocation size, etc
     pub labels: Vec<Label<'a>>,
+
+    /// Nanoseconds since the beginning of the profile, which may be negative
+    /// due to async collection of samples.
+    pub tick: i64,
 }

--- a/profiling/src/profile/api.rs
+++ b/profiling/src/profile/api.rs
@@ -1,6 +1,8 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
 
+use std::time::SystemTime;
+
 #[derive(Clone, Copy)]
 pub struct ValueType<'a> {
     pub r#type: &'a str,
@@ -123,7 +125,6 @@ pub struct Sample<'a> {
     /// things like a thread id, allocation size, etc
     pub labels: Vec<Label<'a>>,
 
-    /// Nanoseconds since the beginning of the profile, which may be negative
-    /// due to async collection of samples.
-    pub tick: i64,
+    /// The timestamp of when the sample was taken.
+    pub timestamp: SystemTime,
 }

--- a/profiling/src/profile/api.rs
+++ b/profiling/src/profile/api.rs
@@ -51,6 +51,7 @@ pub struct Function<'a> {
     pub start_line: i64,
 }
 
+#[derive(Clone)]
 pub struct Line<'a> {
     /// The corresponding profile.Function for this line.
     pub function: Function<'a>,
@@ -59,7 +60,7 @@ pub struct Line<'a> {
     pub line: i64,
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct Location<'a> {
     pub mapping: Mapping<'a>,
 
@@ -87,7 +88,7 @@ pub struct Location<'a> {
     pub is_folded: bool,
 }
 
-#[derive(Copy, Clone, Default)]
+#[derive(Clone, Copy, Default)]
 pub struct Label<'a> {
     pub key: &'a str,
 
@@ -105,6 +106,7 @@ pub struct Label<'a> {
     pub num_unit: Option<&'a str>,
 }
 
+#[derive(Clone)]
 pub struct Sample<'a> {
     /// The leaf is at locations[0].
     pub locations: Vec<Location<'a>>,

--- a/profiling/src/profile/pprof.rs
+++ b/profiling/src/profile/pprof.rs
@@ -34,6 +34,10 @@ pub struct Profile {
     pub comment: Vec<i64>,
     #[prost(int64, tag = "14")]
     pub default_sample_type: i64,
+    #[prost(int64, tag = "15")]
+    pub tick_unit: i64, // Index into the string table.
+    #[prost(message, repeated, tag = "16")]
+    pub label_sets: Vec<LabelSet>,
 }
 
 impl Profile {
@@ -60,6 +64,34 @@ pub struct Sample {
     /// label includes additional context for this sample. It can include
     /// things like a thread id, allocation size, etc
     #[prost(message, repeated, tag = "3")]
+    pub labels: Vec<Label>,
+    /// Breakdown can hold the individual timestamps and values for a sample
+    /// that has aggregated values. The type and unit of each breakdown is
+    /// defined by the corresponding entry in Profile.sample_type. It's
+    /// acceptable to have less, but not more, breakdown entries than
+    /// Profile.sample_type entries.
+    #[prost(message, repeated, tag = "4")]
+    pub breakdowns: Vec<Breakdown>,
+}
+
+#[derive(Clone, Eq, Hash, PartialEq, ::prost::Message)]
+pub struct Breakdown {
+    #[prost(int64, repeated, tag = "1")]
+    pub ticks: Vec<i64>,
+    #[prost(int64, repeated, tag = "2")]
+    pub values: Vec<i64>,
+    #[prost(uint64, repeated, tag = "3")]
+    pub label_set_ids: Vec<u64>,
+}
+
+#[derive(Derivative)]
+#[derivative(Eq, PartialEq, Hash)]
+#[derive(Clone, ::prost::Message)]
+pub struct LabelSet {
+    #[derivative(PartialEq = "ignore", Hash = "ignore")]
+    #[prost(uint64, tag = "1")]
+    pub id: u64,
+    #[prost(message, repeated, tag = "2")]
     pub labels: Vec<Label>,
 }
 
@@ -240,11 +272,13 @@ mod test {
                     location_ids: vec![main_location.id],
                     values: vec![1],
                     labels: vec![],
+                    breakdowns: vec![],
                 },
                 Sample {
                     location_ids: vec![test_location.id, main_location.id],
                     values: vec![1],
                     labels: vec![],
+                    breakdowns: vec![],
                 },
             ],
             mappings: vec![php_mapping],

--- a/profiling/src/profile/profile.proto
+++ b/profiling/src/profile/profile.proto
@@ -66,13 +66,13 @@ message Profile {
   // regexp will be dropped from the samples, along with their successors.
   int64 drop_frames = 7;   // Index into string table.
   // frames with Function.function_name fully matching the following
-  // regexp will be kept, even if it matches drop_functions.
+  // regexp will be kept, even if it matches drop_frames.
   int64 keep_frames = 8;  // Index into string table.
 
   // The following fields are informational, do not affect
   // interpretation of results.
 
-  // Time of collection (UTC) represented as nanoseconds past the epoch.
+  // Time the collection started (UTC) represented as nanoseconds past the epoch.
   int64 time_nanos = 9;
   // Duration of the profile, if a duration makes sense.
   int64 duration_nanos = 10;
@@ -86,6 +86,11 @@ message Profile {
   // Index into the string table of the type of the preferred sample
   // value. If unset, clients should default to the last sample value.
   int64 default_sample_type = 14;
+  // Index into the string table that defines the resolution of
+  // Breakdown.ticks, e.g. "nanoseconds" or "microseconds".
+  int64 tick_unit = 15;
+  // Labels referenced by Breakdown.
+  repeated LabelSet label_set = 16;
 }
 
 // ValueType describes the semantics and measurement units of a value.
@@ -106,12 +111,42 @@ message Sample {
   // entry in Profile.sample_type. All samples must have the same
   // number of values, the same as the length of Profile.sample_type.
   // When aggregating multiple samples into a single sample, the
-  // result has a list of values that is the elemntwise sum of the
+  // result has a list of values that is the element-wise sum of the
   // lists of the originals.
   repeated int64 value = 2;
   // label includes additional context for this sample. It can include
   // things like a thread id, allocation size, etc
   repeated Label label = 3;
+  // Breakdown can hold the individual timestamps and values for a sample that
+  // has aggregated values. The type and unit of each breakdown is defined by
+  // the corresponding entry in Profile.sample_type. It's acceptable to have
+  // less, but not more, breakdown entries than Profile.sample_type entries.
+  repeated Breakdown breakdown = 4;
+}
+
+// Breakdown stores data about the individual events that have been aggregated
+// into a Sample. There can be one breakdown for each Profile.sample_type.
+//
+// TODO: Figure out if this can also be used for the exemplar UC from alexey:
+// https://github.com/google/pprof/pull/725#issuecomment-1264841904
+message Breakdown {
+  // A list of timestamps at which the values of the associated sample were
+  // collected. The time is given in Profile.tick_unit resolution relative to
+  // Profile.time_nanos and values are delta encoded. So for three events
+  // captured at 100, 110 and 150 ticks after the profile start, this list should
+  // hold the values [100, 10, 40].
+  //
+  // TODO: Is delta encoding going to safe enough space to justify the
+  // complexity?
+  repeated int64 ticks = 1;
+  // A list that is either empty or holding exactly the same number of elements
+  // as Breakdown.ticks, associating each point in time with a recorded value.
+  // For cumulative sample types the sum of these values should add up to the
+  // corresponding Sample.value.
+  repeated int64 value = 2;
+  // A list that is either empty or holding exactly the same number of elements
+  // as Breakdown.ticks, associating each point in time with a LabelSet.
+  repeated uint64 label_set_id = 3;
 }
 
 message Label {
@@ -129,6 +164,17 @@ message Label {
   // units and units like "seconds" and "nanoseconds" as time units,
   // and apply appropriate unit conversions to these.
   int64 num_unit = 4;  // Index into string table
+}
+
+// A group of labels that can be referenced multiple times in order to reduce
+// overhead. Example use cases for reusable label sets:
+//
+// - Tracing IDs (e.g. trace_id=123, span_id=345)
+// - Thread/Process IDs (e.g. process_id=123, thread_id=456)
+message LabelSet {
+  // Unique nonzero id for the LabelSet.
+  uint64 id = 1;
+  repeated Label label = 2;
 }
 
 message Mapping {


### PR DESCRIPTION
# What does this PR do?

Adds timestamp information to profiling samples for both the Rust and C APIs. The pprof alterations come from this PR: felixge/pprof#3. Note that when encoded, it's possible for the `ticks` values to be negative as samples can be collected from different sources asynchronously and end up happening before the start time of the profile. I am unsure if this is a problem.

Updates the `profiles.c` and `profiles.rs` examples to be more interesting in general, but also to use breakdowns. They both write a mostly hard-coded profile to stdout, which you can feed into protoc to explore.

# Motivation

I want to move the timeline UI project forward, and my recent R&D week was spent in these parts of libdatadog, so I could quickly make these changes.

# Additional Notes

This particularly PR would force everyone to send a timestamp for the sample. Maybe it would be prudent to make the timestamp optional. Can you think of any reason to do so?

# How to test the change?

In both the C and Rust APIs, you need to send the timestamp of the sample, which in C is the number of nanoseconds since the UNIX epoch and in Rust this is a `SystemTime`. These will encoded in the pprof as offsets since the start time of the profile. 
