### PR TITLE
Allow setting cgroup path for integration testing purposes

### DIFF
--- a/ddtelemetry-ffi/Cargo.toml
+++ b/ddtelemetry-ffi/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 [lib]
 # LTO is ignored if "lib" is added as crate type
 # cf. https://github.com/rust-lang/rust/issues/51009
-crate-type = ["staticlib", "cdylib"]
+crate-type = ["lib", "staticlib", "cdylib"]
 
 [dependencies]
 ddtelemetry = { path = "../ddtelemetry", version = "0.9.0" }

--- a/ddtelemetry-ffi/Cargo.toml
+++ b/ddtelemetry-ffi/Cargo.toml
@@ -7,8 +7,6 @@ version = "0.9.1"
 edition = "2021"
 
 [lib]
-# LTO is ignored if "lib" is added as crate type
-# cf. https://github.com/rust-lang/rust/issues/51009
 crate-type = ["lib", "staticlib", "cdylib"]
 
 [dependencies]

--- a/ddtelemetry-ffi/cbindgen.toml
+++ b/ddtelemetry-ffi/cbindgen.toml
@@ -11,7 +11,7 @@ style = "both"
 
 no_includes = true
 sys_includes = ["stdbool.h", "stddef.h", "stdint.h"]
-includes = ["datadog/common.h"]
+includes = ["common.h"]
 
 [export]
 prefix = "ddog_"

--- a/ddtelemetry-ffi/cbindgen.toml
+++ b/ddtelemetry-ffi/cbindgen.toml
@@ -11,7 +11,7 @@ style = "both"
 
 no_includes = true
 sys_includes = ["stdbool.h", "stddef.h", "stdint.h"]
-includes = ["common.h"]
+includes = ["datadog/common.h"]
 
 [export]
 prefix = "ddog_"

--- a/profiling-ffi/cbindgen.toml
+++ b/profiling-ffi/cbindgen.toml
@@ -11,7 +11,7 @@ style = "both"
 
 no_includes = true
 sys_includes = ["stdbool.h", "stddef.h", "stdint.h"]
-includes = ["datadog/common.h"]
+includes = ["common.h"]
 
 [export]
 prefix = "ddog_"


### PR DESCRIPTION
# What does this PR do?

Currently Cgroup path is rightfully hardcoded in the source, however this makes it impossible to perform end-to-end tests on stubbed values of the file, as `/proc/groups/self` file is not overridable on linux systems

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
