### PR TITLE
Add AAS metadata in event.json file

### DIFF
--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -187,15 +187,12 @@ impl ProfileExporter {
                     ("aas.site.type", aas_metadata.get_site_type()),
                     ("aas.subscription.id", aas_metadata.get_subscription_id()),
                 ];
-                aas_tags
-                    .into_iter()
-                    .for_each(|(name, value)| match Tag::new(name, value) {
-                        Ok(tag) => {
-                            tags_profiler.push_str(tag.as_ref());
-                            tags_profiler.push(',');
-                        }
-                        _ => (),
-                    });
+                aas_tags.into_iter().for_each(|(name, value)| {
+                    if let Ok(tag) = Tag::new(name, value) {
+                        tags_profiler.push_str(tag.as_ref());
+                        tags_profiler.push(',');
+                    }
+                });
             }
             None => (),
         }

--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -187,10 +187,15 @@ impl ProfileExporter {
                     ("aas.site.type", aas_metadata.get_site_type()),
                     ("aas.subscription.id", aas_metadata.get_subscription_id()),
                 ];
-                aas_tags.into_iter().for_each(|(name, value)| {
-                    tags_profiler.push_str(Tag::new(name, value).unwrap().as_ref());
-                    tags_profiler.push(',');
-                });
+                aas_tags
+                    .into_iter()
+                    .for_each(|(name, value)| match Tag::new(name, value) {
+                        Ok(tag) => {
+                            tags_profiler.push_str(tag.as_ref());
+                            tags_profiler.push(',');
+                        }
+                        _ => (),
+                    });
             }
             None => (),
         }

--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -163,28 +163,6 @@ impl ProfileExporter {
             tags_profiler.push_str(tag.as_ref());
             tags_profiler.push(',');
         }
-        tags_profiler.pop(); // clean up the trailing comma
-
-        let attachments: Vec<String> = files.iter().map(|file| file.name.to_owned()).collect();
-
-        let event = json!({
-            "attachments": attachments,
-            "tags_profiler": tags_profiler,
-            "start": start.format("%Y-%m-%dT%H:%M:%S%.9fZ").to_string(),
-            "end": end.format("%Y-%m-%dT%H:%M:%S%.9fZ").to_string(),
-            "family": self.family.as_ref(),
-            "version": "4",
-        })
-        .to_string();
-
-        form.add_reader_file_with_mime(
-            // Intake does not look for filename=event.json, it looks for name=event.
-            "event",
-            // this one shouldn't be compressed
-            Cursor::new(event),
-            "event.json",
-            mime::APPLICATION_JSON,
-        );
 
         match azure_app_services::get_metadata() {
             Some(aas_metadata) => {
@@ -209,12 +187,36 @@ impl ProfileExporter {
                     ("aas.site.type", aas_metadata.get_site_type()),
                     ("aas.subscription.id", aas_metadata.get_subscription_id()),
                 ];
-                aas_tags
-                    .into_iter()
-                    .for_each(|(name, value)| form.add_text(name, value));
+                aas_tags.into_iter().for_each(|(name, value)| {
+                    tags_profiler.push_str(Tag::new(name, value).unwrap().as_ref());
+                    tags_profiler.push(',');
+                });
             }
             None => (),
         }
+
+        tags_profiler.pop(); // clean up the trailing comma
+
+        let attachments: Vec<String> = files.iter().map(|file| file.name.to_owned()).collect();
+
+        let event = json!({
+            "attachments": attachments,
+            "tags_profiler": tags_profiler,
+            "start": start.format("%Y-%m-%dT%H:%M:%S%.9fZ").to_string(),
+            "end": end.format("%Y-%m-%dT%H:%M:%S%.9fZ").to_string(),
+            "family": self.family.as_ref(),
+            "version": "4",
+        })
+        .to_string();
+
+        form.add_reader_file_with_mime(
+            // Intake does not look for filename=event.json, it looks for name=event.
+            "event",
+            // this one shouldn't be compressed
+            Cursor::new(event),
+            "event.json",
+            mime::APPLICATION_JSON,
+        );
 
         for file in files {
             let mut encoder = FrameEncoder::new(Vec::new());


### PR DESCRIPTION
# What does this PR do?

This PR adds AAS metadata as tags in the `event.json` file instead of adding them in the form body.

# Motivation

In a previous https://github.com/DataDog/libdatadog/pull/50, the metadata were added in the form body but with the 2.4 endpoint version, tags are added in the `event.json` file.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Same as the previous PR (https://github.com/DataDog/libdatadog/pull/50)
