### PR TITLE
Rename FFI types, functions and enums in preparation for 1.0

### DIFF
--- a/ddcommon-ffi/cbindgen.toml
+++ b/ddcommon-ffi/cbindgen.toml
@@ -4,10 +4,10 @@
 language = "C"
 tab_width = 2
 header = """// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
-"""
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc."""
 include_guard = "DDOG_COMMON_H"
 style = "both"
+pragma_once = true
 
 no_includes = true
 sys_includes = ["stdbool.h", "stddef.h", "stdint.h"]
@@ -46,9 +46,14 @@ after_includes = """
 
 [export]
 prefix = "ddog_"
+renaming_overrides_prefixing = true
 
 [export.mangle]
-rename_types="SnakeCase"
+rename_types = "PascalCase"
+
+[export.rename]
+"ParseTagsResult" = "ddog_Vec_Tag_ParseResult"
+"PushTagResult" = "ddog_Vec_Tag_PushResult"
 
 [enum]
 prefix_with_name = true

--- a/ddcommon-ffi/src/tags.rs
+++ b/ddcommon-ffi/src/tags.rs
@@ -6,12 +6,12 @@ use ddcommon::tag::{parse_tags, Tag};
 
 #[must_use]
 #[no_mangle]
-pub extern "C" fn ddog_Vec_tag_new() -> crate::Vec<Tag> {
+pub extern "C" fn ddog_Vec_Tag_new() -> crate::Vec<Tag> {
     crate::Vec::default()
 }
 
 #[no_mangle]
-pub extern "C" fn ddog_Vec_tag_drop(_: crate::Vec<Tag>) {}
+pub extern "C" fn ddog_Vec_Tag_drop(_: crate::Vec<Tag>) {}
 
 #[repr(C)]
 pub enum PushTagResult {
@@ -20,7 +20,7 @@ pub enum PushTagResult {
 }
 
 #[no_mangle]
-pub extern "C" fn ddog_PushTagResult_drop(_: PushTagResult) {}
+pub extern "C" fn ddog_Vec_Tag_PushResult_drop(_: PushTagResult) {}
 
 /// Creates a new Tag from the provided `key` and `value` by doing a utf8
 /// lossy conversion, and pushes into the `vec`. The strings `key` and `value`
@@ -32,7 +32,7 @@ pub extern "C" fn ddog_PushTagResult_drop(_: PushTagResult) {}
 /// `.len` properties claim.
 #[must_use]
 #[no_mangle]
-pub unsafe extern "C" fn ddog_Vec_tag_push(
+pub unsafe extern "C" fn ddog_Vec_Tag_push(
     vec: &mut crate::Vec<Tag>,
     key: CharSlice,
     value: CharSlice,
@@ -59,7 +59,7 @@ pub struct ParseTagsResult {
 /// .len property.
 #[must_use]
 #[no_mangle]
-pub unsafe extern "C" fn ddog_Vec_tag_parse(string: CharSlice) -> ParseTagsResult {
+pub unsafe extern "C" fn ddog_Vec_Tag_parse(string: CharSlice) -> ParseTagsResult {
     let string = string.to_utf8_lossy();
     let (tags, error) = parse_tags(string.as_ref());
     ParseTagsResult {
@@ -75,21 +75,21 @@ mod tests {
     #[test]
     fn empty_tag_name() {
         unsafe {
-            let mut tags = ddog_Vec_tag_new();
-            let result = ddog_Vec_tag_push(&mut tags, CharSlice::from(""), CharSlice::from("woof"));
+            let mut tags = ddog_Vec_Tag_new();
+            let result = ddog_Vec_Tag_push(&mut tags, CharSlice::from(""), CharSlice::from("woof"));
             assert!(!matches!(result, PushTagResult::Ok));
         }
     }
 
     #[test]
     fn test_lifetimes() {
-        let mut tags = ddog_Vec_tag_new();
+        let mut tags = ddog_Vec_Tag_new();
         unsafe {
             // make a string here so it has a scoped lifetime
             let key = String::from("key1");
             {
                 let value = String::from("value1");
-                let result = ddog_Vec_tag_push(
+                let result = ddog_Vec_Tag_push(
                     &mut tags,
                     CharSlice::from(key.as_str()),
                     CharSlice::from(value.as_str()),
@@ -105,9 +105,9 @@ mod tests {
     #[test]
     fn test_get() {
         unsafe {
-            let mut tags = ddog_Vec_tag_new();
+            let mut tags = ddog_Vec_Tag_new();
             let result =
-                ddog_Vec_tag_push(&mut tags, CharSlice::from("sound"), CharSlice::from("woof"));
+                ddog_Vec_Tag_push(&mut tags, CharSlice::from("sound"), CharSlice::from("woof"));
             assert!(matches!(result, PushTagResult::Ok));
             assert_eq!(1, tags.len());
             assert_eq!("sound:woof", tags.get(0).unwrap().to_string());
@@ -119,7 +119,7 @@ mod tests {
         let dd_tags = "env:staging:east, tags:, env_staging:east"; // contains an error
 
         // SAFETY: CharSlices from Rust strings are safe.
-        let result = unsafe { ddog_Vec_tag_parse(CharSlice::from(dd_tags)) };
+        let result = unsafe { ddog_Vec_Tag_parse(CharSlice::from(dd_tags)) };
         assert_eq!(2, result.tags.len());
         assert_eq!("env:staging:east", result.tags.get(0).unwrap().to_string());
         assert_eq!("env_staging:east", result.tags.get(1).unwrap().to_string());

--- a/ddcommon-ffi/src/vec.rs
+++ b/ddcommon-ffi/src/vec.rs
@@ -10,8 +10,8 @@ use std::mem::ManuallyDrop;
 
 /// Holds the raw parts of a Rust Vec; it should only be created from Rust,
 /// never from C.
-/// The names ptr and len were chosen to minimize conversion from a previous
-/// Buffer type which this has replaced to become more general.
+// The names ptr and len were chosen to minimize conversion from a previous
+// Buffer type which this has replaced to become more general.
 #[repr(C)]
 #[derive(Debug)]
 pub struct Vec<T: Sized> {

--- a/examples/ffi/exporter.cpp
+++ b/examples/ffi/exporter.cpp
@@ -1,6 +1,6 @@
 extern "C" {
-#include <datadog/common.h>
-#include <datadog/profiling.h>
+  #include <datadog/common.h>
+  #include <datadog/profiling.h>
 }
 #include <cstdint>
 #include <cstdio>
@@ -9,10 +9,10 @@ extern "C" {
 #include <memory>
 #include <thread>
 
-static ddog_Slice_c_char to_slice_c_char(const char *s) { return {.ptr = s, .len = strlen(s)}; }
+static ddog_CharSlice to_slice_c_char(const char *s) { return {.ptr = s, .len = strlen(s)}; }
 
 struct Deleter {
-  void operator()(ddog_Profile *object) { ddog_Profile_free(object); }
+  void operator()(ddog_prof_Profile *object) { ddog_prof_Profile_drop(object); }
 };
 
 template <typename T> void print_error(const char *s, const T &err) {
@@ -32,16 +32,16 @@ int main(int argc, char *argv[]) {
 
   const auto service = argv[1];
 
-  const ddog_ValueType wall_time = {
+  const ddog_prof_ValueType wall_time = {
       .type_ = DDOG_CHARSLICE_C("wall-time"),
       .unit = DDOG_CHARSLICE_C("nanoseconds"),
   };
 
-  const ddog_Slice_value_type sample_types = {&wall_time, 1};
-  const ddog_Period period = {wall_time, 60};
-  std::unique_ptr<ddog_Profile, Deleter> profile{ddog_Profile_new(sample_types, &period, nullptr)};
+  const ddog_prof_Slice_ValueType sample_types = {&wall_time, 1};
+  const ddog_prof_Period period = {wall_time, 60};
+  std::unique_ptr<ddog_prof_Profile, Deleter> profile{ ddog_prof_Profile_new(sample_types, &period, nullptr) };
 
-  ddog_Line root_line = {
+  ddog_prof_Line root_line = {
       .function =
           {
               .name = DDOG_CHARSLICE_C("{main}"),
@@ -50,71 +50,71 @@ int main(int argc, char *argv[]) {
       .line = 0,
   };
 
-  ddog_Location root_location = {
+  ddog_prof_Location root_location = {
       // yes, a zero-initialized mapping is valid
       .mapping = {},
       .lines = {&root_line, 1},
   };
 
   int64_t value = 10;
-  const ddog_Label label = {
+  const ddog_prof_Label label = {
       .key = DDOG_CHARSLICE_C("language"),
       .str = DDOG_CHARSLICE_C("php"),
   };
-  ddog_Sample sample = {
+  ddog_prof_Sample sample = {
       .locations = {&root_location, 1},
       .values = {&value, 1},
       .labels = {&label, 1},
   };
-  ddog_Profile_add(profile.get(), sample);
+  ddog_prof_Profile_add(profile.get(), sample);
 
-  ddog_SerializeResult serialize_result = ddog_Profile_serialize(profile.get(), nullptr, nullptr);
-  if (serialize_result.tag == DDOG_SERIALIZE_RESULT_ERR) {
+  ddog_prof_Profile_SerializeResult serialize_result = ddog_prof_Profile_serialize(profile.get(), nullptr, nullptr);
+  if (serialize_result.tag == DDOG_PROF_PROFILE_SERIALIZE_RESULT_ERR) {
     print_error("Failed to serialize profile: ", serialize_result.err);
     return 1;
   }
 
-  ddog_EncodedProfile *encoded_profile = &serialize_result.ok;
+  ddog_prof_EncodedProfile *encoded_profile = &serialize_result.ok;
 
   ddog_Endpoint endpoint =
       ddog_Endpoint_agentless(DDOG_CHARSLICE_C("datad0g.com"), to_slice_c_char(api_key));
 
-  ddog_Vec_tag tags = ddog_Vec_tag_new();
-  ddog_PushTagResult tag_result =
-      ddog_Vec_tag_push(&tags, DDOG_CHARSLICE_C("service"), to_slice_c_char(service));
-  if (tag_result.tag == DDOG_PUSH_TAG_RESULT_ERR) {
+  ddog_Vec_Tag tags = ddog_Vec_Tag_new();
+  ddog_Vec_Tag_PushResult tag_result =
+      ddog_Vec_Tag_push(&tags, DDOG_CHARSLICE_C("service"), to_slice_c_char(service));
+  if (tag_result.tag == DDOG_VEC_TAG_PUSH_RESULT_ERR) {
     print_error("Failed to push tag: ", tag_result.err);
-    ddog_PushTagResult_drop(tag_result);
+    ddog_Vec_Tag_PushResult_drop(tag_result);
     return 1;
   }
 
-  ddog_PushTagResult_drop(tag_result);
+  ddog_Vec_Tag_PushResult_drop(tag_result);
 
-  ddog_NewProfileExporterResult exporter_new_result = ddog_ProfileExporter_new(
+  ddog_prof_Exporter_NewResult exporter_new_result = ddog_prof_Exporter_new(
       DDOG_CHARSLICE_C("exporter-example"),
       DDOG_CHARSLICE_C("1.2.3"),
       DDOG_CHARSLICE_C("native"),
       &tags,
       endpoint
   );
-  ddog_Vec_tag_drop(tags);
+  ddog_Vec_Tag_drop(tags);
 
-  if (exporter_new_result.tag == DDOG_NEW_PROFILE_EXPORTER_RESULT_ERR) {
+  if (exporter_new_result.tag == DDOG_PROF_EXPORTER_NEW_RESULT_ERR) {
     print_error("Failed to create exporter: ", exporter_new_result.err);
-    ddog_NewProfileExporterResult_drop(exporter_new_result);
+    ddog_prof_Exporter_NewResult_drop(exporter_new_result);
     return 1;
   }
 
   auto exporter = exporter_new_result.ok;
 
-  ddog_File files_[] = {{
+  ddog_prof_Exporter_File files_[] = {{
       .name = DDOG_CHARSLICE_C("auto.pprof"),
-      .file = ddog_Vec_u8_as_slice(&encoded_profile->buffer),
+      .file = ddog_Vec_U8_as_slice(&encoded_profile->buffer),
   }};
 
-  ddog_Slice_file files = {.ptr = files_, .len = sizeof files_ / sizeof *files_};
+  ddog_prof_Exporter_Slice_File files = {.ptr = files_, .len = sizeof files_ / sizeof *files_};
 
-  ddog_Request *request = ddog_ProfileExporter_build(
+  ddog_prof_Exporter_Request *request = ddog_prof_Exporter_Request_build(
     exporter,
     encoded_profile->start,
     encoded_profile->end,
@@ -145,16 +145,16 @@ int main(int argc, char *argv[]) {
   trigger_cancel_if_request_takes_too_long_thread.detach();
 
   int exit_code = 0;
-  ddog_SendResult send_result = ddog_ProfileExporter_send(exporter, request, cancel);
-  if (send_result.tag == DDOG_SEND_RESULT_ERR) {
+  ddog_prof_Exporter_SendResult send_result = ddog_prof_Exporter_send(exporter, request, cancel);
+  if (send_result.tag == DDOG_PROF_EXPORTER_SEND_RESULT_ERR) {
     print_error("Failed to send profile: ", send_result.err);
     exit_code = 1;
   } else {
     printf("Response code: %d\n", send_result.http_response.code);
   }
 
-  ddog_NewProfileExporterResult_drop(exporter_new_result);
-  ddog_SendResult_drop(send_result);
+  ddog_prof_Exporter_NewResult_drop(exporter_new_result);
+  ddog_prof_Exporter_SendResult_drop(send_result);
   ddog_CancellationToken_drop(cancel);
   return exit_code;
 }

--- a/examples/ffi/profiles.c
+++ b/examples/ffi/profiles.c
@@ -11,40 +11,40 @@
  * with unit 60 "nanoseconds". Adds one sample with a string label "language".
  */
 int main(void) {
-  const struct ddog_ValueType wall_time = {
+  const ddog_prof_ValueType wall_time = {
       .type_ = DDOG_CHARSLICE_C("wall-time"),
       .unit = DDOG_CHARSLICE_C("nanoseconds"),
   };
-  const struct ddog_Slice_value_type sample_types = {&wall_time, 1};
-  const struct ddog_Period period = {wall_time, 60};
+  const ddog_prof_Slice_ValueType sample_types = {&wall_time, 1};
+  const ddog_prof_Period period = {wall_time, 60};
 
-  ddog_Profile *profile = ddog_Profile_new(sample_types, &period, NULL);
+  ddog_prof_Profile *profile = ddog_prof_Profile_new(sample_types, &period, NULL);
 
-  struct ddog_Line root_line = {
+  ddog_prof_Line root_line = {
       .function =
-          (struct ddog_Function){
+          (struct ddog_prof_Function) {
               .name = DDOG_CHARSLICE_C("{main}"),
               .filename = DDOG_CHARSLICE_C("/srv/example/index.php"),
           },
       .line = 0,
   };
 
-  struct ddog_Location root_location = {
+  ddog_prof_Location root_location = {
       // yes, a zero-initialized mapping is valid
-      .mapping = (struct ddog_Mapping){0},
-      .lines = (struct ddog_Slice_line){&root_line, 1},
+      .mapping = (ddog_prof_Mapping) {0},
+      .lines = (ddog_prof_Slice_Line) {&root_line, 1},
   };
   int64_t value = 10;
-  const struct ddog_Label label = {
+  const ddog_prof_Label label = {
       .key = DDOG_CHARSLICE_C("language"),
       .str = DDOG_CHARSLICE_C("php"),
   };
-  struct ddog_Sample sample = {
+  const ddog_prof_Sample sample = {
       .locations = {&root_location, 1},
       .values = {&value, 1},
       .labels = {&label, 1},
   };
-  ddog_Profile_add(profile, sample);
-  ddog_Profile_free(profile);
+  ddog_prof_Profile_add(profile, sample);
+  ddog_prof_Profile_drop(profile);
   return 0;
 }

--- a/profiling-ffi/cbindgen.toml
+++ b/profiling-ffi/cbindgen.toml
@@ -4,20 +4,42 @@
 language = "C"
 tab_width = 2
 header = """// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
-"""
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc."""
 include_guard = "DDOG_PROFILING_H"
 style = "both"
+pragma_once = true
 
 no_includes = true
 sys_includes = ["stdbool.h", "stddef.h", "stdint.h"]
 includes = ["common.h"]
 
 [export]
-prefix = "ddog_"
+prefix = "ddog_prof_"
+renaming_overrides_prefixing = true
+
+[export.rename]
+"ByteSlice" = "ddog_ByteSlice"
+"CancellationToken" = "ddog_CancellationToken"
+"CharSlice" = "ddog_CharSlice"
+"Endpoint" = "ddog_Endpoint"
+"HttpStatus" = "ddog_HttpStatus"
+"Slice_CChar" = "ddog_Slice_CChar"
+"Slice_I64" = "ddog_Slice_I64"
+"Slice_U8" = "ddog_Slice_U8"
+"Tag" = "ddog_Tag"
+"Timespec" = "ddog_Timespec"
+"Vec_Tag" = "ddog_Vec_Tag"
+
+"File" = "ddog_prof_Exporter_File"
+"NewProfileExporterResult" = "ddog_prof_Exporter_NewResult"
+"ProfileExporter" = "ddog_prof_Exporter"
+"Request" = "ddog_prof_Exporter_Request"
+"SendResult" = "ddog_prof_Exporter_SendResult"
+"SerializeResult" = "ddog_prof_Profile_SerializeResult"
+"Slice_File" = "ddog_prof_Exporter_Slice_File"
 
 [export.mangle]
-rename_types="SnakeCase"
+rename_types = "PascalCase"
 
 [enum]
 prefix_with_name = true

--- a/profiling-ffi/src/profiles.rs
+++ b/profiling-ffi/src/profiles.rs
@@ -286,7 +286,7 @@ impl<'a> TryFrom<Sample<'a>> for profiles::api::Sample<'a> {
 }
 
 /// Create a new profile with the given sample types. Must call
-/// `ddog_Profile_free` when you are done with the profile.
+/// `ddog_prof_Profile_drop` when you are done with the profile.
 ///
 /// # Arguments
 /// * `sample_types`
@@ -299,7 +299,7 @@ impl<'a> TryFrom<Sample<'a>> for profiles::api::Sample<'a> {
 /// and must have the correct number of elements for the slice.
 #[no_mangle]
 #[must_use]
-pub unsafe extern "C" fn ddog_Profile_new(
+pub unsafe extern "C" fn ddog_prof_Profile_new(
     sample_types: Slice<ValueType>,
     period: Option<&Period>,
     start_time: Option<&Timespec>,
@@ -319,7 +319,10 @@ pub unsafe extern "C" fn ddog_Profile_new(
 /// # Safety
 /// The `profile` must point to an object created by another FFI routine in this
 /// module, such as `ddog_Profile_with_sample_types`.
-pub unsafe extern "C" fn ddog_Profile_free(_profile: Box<datadog_profiling::profile::Profile>) {}
+pub unsafe extern "C" fn ddog_prof_Profile_drop(
+    _profile: Box<datadog_profiling::profile::Profile>,
+) {
+}
 
 #[no_mangle]
 /// # Safety
@@ -327,7 +330,7 @@ pub unsafe extern "C" fn ddog_Profile_free(_profile: Box<datadog_profiling::prof
 /// module. All pointers inside the `sample` need to be valid for the duration
 /// of this call.
 /// This call is _NOT_ thread-safe.
-pub extern "C" fn ddog_Profile_add(
+pub extern "C" fn ddog_prof_Profile_add(
     profile: &mut datadog_profiling::profile::Profile,
     sample: Sample,
 ) -> u64 {
@@ -357,7 +360,7 @@ pub extern "C" fn ddog_Profile_add(
 /// module.
 /// This call is _NOT_ thread-safe.
 #[no_mangle]
-pub unsafe extern "C" fn ddog_Profile_set_endpoint<'a>(
+pub unsafe extern "C" fn ddog_prof_Profile_set_endpoint<'a>(
     profile: &mut datadog_profiling::profile::Profile,
     local_root_span_id: CharSlice<'a>,
     endpoint: CharSlice<'a>,
@@ -391,7 +394,7 @@ pub enum SerializeResult {
 }
 
 /// Serialize the aggregated profile. Don't forget to clean up the result by
-/// calling ddog_SerializeResult_drop.
+/// calling ddog_prof_Profile_SerializeResult_drop.
 ///
 /// # Arguments
 /// * `profile` - a reference to the profile being serialized.
@@ -408,7 +411,7 @@ pub enum SerializeResult {
 /// The `end_time` must be null or otherwise point to a valid TimeSpec object.
 /// The `duration_nanos` must be null or otherwise point to a valid i64.
 #[no_mangle]
-pub unsafe extern "C" fn ddog_Profile_serialize(
+pub unsafe extern "C" fn ddog_prof_Profile_serialize(
     profile: &datadog_profiling::profile::Profile,
     end_time: Option<&Timespec>,
     duration_nanos: Option<&i64>,
@@ -428,11 +431,11 @@ pub unsafe extern "C" fn ddog_Profile_serialize(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn ddog_SerializeResult_drop(_result: SerializeResult) {}
+pub unsafe extern "C" fn ddog_prof_Profile_SerializeResult_drop(_result: SerializeResult) {}
 
 #[must_use]
 #[no_mangle]
-pub unsafe extern "C" fn ddog_Vec_u8_as_slice(vec: &ddcommon_ffi::Vec<u8>) -> Slice<u8> {
+pub unsafe extern "C" fn ddog_Vec_U8_as_slice(vec: &ddcommon_ffi::Vec<u8>) -> Slice<u8> {
     vec.as_slice()
 }
 
@@ -449,7 +452,7 @@ pub unsafe extern "C" fn ddog_Vec_u8_as_slice(vec: &ddcommon_ffi::Vec<u8>) -> Sl
 /// can be called across an FFI boundary, the compiler cannot enforce this.
 /// If `time` is not null, it must point to a valid Timespec object.
 #[no_mangle]
-pub unsafe extern "C" fn ddog_Profile_reset(
+pub unsafe extern "C" fn ddog_prof_Profile_reset(
     profile: &mut datadog_profiling::profile::Profile,
     start_time: Option<&Timespec>,
 ) -> bool {
@@ -465,8 +468,8 @@ mod test {
     fn ctor_and_dtor() {
         unsafe {
             let sample_type: *const ValueType = &ValueType::new("samples", "count");
-            let profile = ddog_Profile_new(Slice::new(sample_type, 1), None, None);
-            ddog_Profile_free(profile);
+            let profile = ddog_prof_Profile_new(Slice::new(sample_type, 1), None, None);
+            ddog_prof_Profile_drop(profile);
         }
     }
 
@@ -474,7 +477,7 @@ mod test {
     fn aggregate_samples() {
         unsafe {
             let sample_type: *const ValueType = &ValueType::new("samples", "count");
-            let mut profile = ddog_Profile_new(Slice::new(sample_type, 1), None, None);
+            let mut profile = ddog_prof_Profile_new(Slice::new(sample_type, 1), None, None);
 
             let lines = &vec![Line {
                 function: Function {
@@ -511,19 +514,19 @@ mod test {
 
             let aggregator = &mut *profile;
 
-            let sample_id1 = ddog_Profile_add(aggregator, sample);
+            let sample_id1 = ddog_prof_Profile_add(aggregator, sample);
             assert_eq!(sample_id1, 1);
 
-            let sample_id2 = ddog_Profile_add(aggregator, sample);
+            let sample_id2 = ddog_prof_Profile_add(aggregator, sample);
             assert_eq!(sample_id1, sample_id2);
 
-            ddog_Profile_free(profile);
+            ddog_prof_Profile_drop(profile);
         }
     }
 
     unsafe fn provide_distinct_locations_ffi() -> datadog_profiling::profile::Profile {
         let sample_type: *const ValueType = &ValueType::new("samples", "count");
-        let mut profile = ddog_Profile_new(Slice::new(sample_type, 1), None, None);
+        let mut profile = ddog_prof_Profile_new(Slice::new(sample_type, 1), None, None);
 
         let main_lines = vec![Line {
             function: Function {
@@ -582,10 +585,10 @@ mod test {
 
         let aggregator = &mut *profile;
 
-        let sample_id1 = ddog_Profile_add(aggregator, main_sample);
+        let sample_id1 = ddog_prof_Profile_add(aggregator, main_sample);
         assert_eq!(sample_id1, 1);
 
-        let sample_id2 = ddog_Profile_add(aggregator, test_sample);
+        let sample_id2 = ddog_prof_Profile_add(aggregator, test_sample);
         assert_eq!(sample_id2, 2);
 
         *profile


### PR DESCRIPTION
 # What does this PR do?

This PR updates the names used in the libdatadog API as discussed in the 1.0 discussion meeting.

In particular, the following concerns were addressed:

* Namespace names -- `ddog_` for common-ffi, `ddog_prof_` for profiling-ffi. This avoids having something like `ddog_Line` which is very specific to profiling be at the top of the namespace.

* Fixed inconsistency in destructors: we had `free`, `delete` and `drop`. We now use `drop` everywhere.

* Updated namespacing for nested things. E.g. the result of `ddog_prof_Exporter_new` is a `ddog_prof_Exporter_NewResult`.

* Used case to separate structs (CamelCase) from methods (snake_case)

One departure from what was discussed in the meeting is how containers/generics are named. I had proposed `ddog_VecTag` and `ddog_SliceU8` but cbindgen really doesn't like it. Rather than fight cbindigen about it, I settled for `ddog_Vec_tag` and `ddog_Slice_U8`. Hopefully that is acceptable.

 # Motivation

As our API grows, having a more consistent naming will hopefully help people navigate it. We still have a bit of a weird mix of what goes on `common.h` vs `profiling.h`, but I'll leave changing that for a later PR.

Furthermore, it looked to me like 0.9-to-1.0 was a good time to address these concerns.

 # Additional Notes

To the best of my knowledge, here's the complete list of all types changed:

| **Kind** | **0.9**                              | **1.0**                                      |
|:--------:|--------------------------------------|----------------------------------------------|
|     Type | ddog_Endpoint_ddog_Agentless_Body    | ddog_Endpoint_ddog_prof_Agentless_Body       |
|     Type | ddog_Slice_c_char                    | ddog_Slice_CChar                             |
|     Type | ddog_Slice_i64                       | ddog_Slice_I64                               |
|     Type | ddog_Slice_u8                        | ddog_Slice_U8                                |
|     Type | ddog_Vec_tag                         | ddog_Vec_Tag                                 |
| Function | ddog_Vec_tag_drop                    | ddog_Vec_Tag_drop                            |
| Function | ddog_Vec_tag_new                     | ddog_Vec_Tag_new                             |
| Function | ddog_Vec_tag_parse                   | ddog_Vec_Tag_parse                           |
|     Type | ddog_ParseTagsResult                 | ddog_Vec_Tag_ParseResult                      |
| Function | ddog_Vec_tag_push                    | ddog_Vec_Tag_push                            |
|     Enum | DDOG_PUSH_TAG_RESULT_ERR             | DDOG_VEC_TAG_PUSH_RESULT_ERR                 |
|     Enum | DDOG_PUSH_TAG_RESULT_OK              | DDOG_VEC_TAG_PUSH_RESULT_OK                  |
|     Type | ddog_PushTagResult                   | ddog_Vec_Tag_PushResult                      |
| Function | ddog_PushTagResult_drop              | ddog_Vec_Tag_PushResult_drop                 |
|     Type | ddog_PushTagResult_Tag               | ddog_Vec_Tag_PushResult_Tag                  |
|     Type | ddog_Vec_u8                          | ddog_Vec_U8                                  |
| Function | ddog_Vec_u8_as_slice                 | ddog_Vec_U8_as_slice                         |
|     Type | ddog_EncodedProfile                  | ddog_prof_EncodedProfile                     |
|     Type | ddog_ProfileExporter                 | ddog_prof_Exporter                           |
| Function | ddog_ProfileExporter_delete          | ddog_prof_Exporter_drop                      |
|     Type | ddog_File                            | ddog_prof_Exporter_File                      |
| Function | ddog_ProfileExporter_new             | ddog_prof_Exporter_new                       |
|     Enum | DDOG_NEW_PROFILE_EXPORTER_RESULT_ERR | DDOG_PROF_EXPORTER_NEW_RESULT_ERR            |
|     Enum | DDOG_NEW_PROFILE_EXPORTER_RESULT_OK  | DDOG_PROF_EXPORTER_NEW_RESULT_OK             |
|     Type | ddog_NewProfileExporterResult        | ddog_prof_Exporter_NewResult                 |
| Function | ddog_NewProfileExporterResult_drop   | ddog_prof_Exporter_NewResult_drop            |
|     Type | ddog_NewProfileExporterResult_Tag    | ddog_prof_Exporter_NewResult_Tag             |
|     Type | ddog_Request                         | ddog_prof_Exporter_Request                   |
| Function | ddog_ProfileExporter_build           | ddog_prof_Exporter_Request_build             |
| Function | ddog_Request_drop                    | ddog_prof_Exporter_Request_drop              |
| Function | ddog_ProfileExporter_send            | ddog_prof_Exporter_send                      |
|     Enum | DDOG_SEND_RESULT_ERR                 | DDOG_PROF_EXPORTER_SEND_RESULT_ERR           |
|     Enum | DDOG_SEND_RESULT_HTTP_RESPONSE       | DDOG_PROF_EXPORTER_SEND_RESULT_HTTP_RESPONSE |
|     Type | ddog_SendResult                      | ddog_prof_Exporter_SendResult                |
| Function | ddog_SendResult_drop                 | ddog_prof_Exporter_SendResult_drop           |
|     Type | ddog_SendResult_Tag                  | ddog_prof_Exporter_SendResult_Tag            |
|     Type | ddog_Slice_file                      | ddog_prof_Exporter_Slice_File                |
|     Type | ddog_Function                        | ddog_prof_Function                           |
|     Type | ddog_Label                           | ddog_prof_Label                              |
|     Type | ddog_Line                            | ddog_prof_Line                               |
|     Type | ddog_Location                        | ddog_prof_Location                           |
|     Type | ddog_Mapping                         | ddog_prof_Mapping                            |
|     Type | ddog_Period                          | ddog_prof_Period                             |
|     Type | ddog_Profile                         | ddog_prof_Profile                            |
| Function | ddog_Profile_add                     | ddog_prof_Profile_add                        |
| Function | ddog_Profile_free                    | ddog_prof_Profile_drop                       |
| Function | ddog_Profile_new                     | ddog_prof_Profile_new                        |
| Function | ddog_Profile_reset                   | ddog_prof_Profile_reset                      |
| Function | ddog_Profile_serialize               | ddog_prof_Profile_serialize                  |
|     Enum | DDOG_SERIALIZE_RESULT_ERR            | DDOG_PROF_PROFILE_SERIALIZE_RESULT_ERR       |
|     Enum | DDOG_SERIALIZE_RESULT_OK             | DDOG_PROF_PROFILE_SERIALIZE_RESULT_OK        |
|     Type | ddog_SerializeResult                 | ddog_prof_Profile_SerializeResult            |
| Function | ddog_SerializeResult_drop            | ddog_prof_Profile_SerializeResult_drop       |
|     Type | ddog_SerializeResult_Tag             | ddog_prof_Profile_SerializeResult_Tag        |
| Function | ddog_Profile_set_endpoint            | ddog_prof_Profile_set_endpoint               |
|     Type | ddog_Sample                          | ddog_prof_Sample                             |
|     Type | ddog_Slice_label                     | ddog_prof_Slice_Label                        |
|     Type | ddog_Slice_line                      | ddog_prof_Slice_Line                         |
|     Type | ddog_Slice_location                  | ddog_prof_Slice_Location                     |
|     Type | ddog_Slice_value_type                | ddog_prof_Slice_ValueType                    |
|     Type | ddog_ValueType                       | ddog_prof_ValueType                          |

 # How to test the change?

The ffi example apps have been updated and should still compile/work fine.

Profilers using libdatadog will need to be updated to use the new names, but otherwise should remain working as before.