### PR TITLE
Change `endpoints_count` into `endpoint_counts`

### DIFF
--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -154,7 +154,7 @@ impl ProfileExporter {
         end: DateTime<Utc>,
         files: &[File],
         additional_tags: Option<&Vec<Tag>>,
-        endpoints_count: Option<&ProfiledEndpointsStats>,
+        endpoint_counts: Option<&ProfiledEndpointsStats>,
         timeout: std::time::Duration,
     ) -> anyhow::Result<Request> {
         let mut form = multipart::Form::default();
@@ -211,7 +211,7 @@ impl ProfileExporter {
             "end": end.format("%Y-%m-%dT%H:%M:%S%.9fZ").to_string(),
             "family": self.family.as_ref(),
             "version": "4",
-            "endpoints_count" : endpoints_count,
+            "endpoint_counts" : endpoint_counts,
         })
         .to_string();
 

--- a/profiling/src/profile/mod.rs
+++ b/profiling/src/profile/mod.rs
@@ -976,7 +976,7 @@ mod api_test {
     }
 
     #[test]
-    fn endpoints_count_empty_test() {
+    fn endpoint_counts_empty_test() {
         let sample_types = vec![
             api::ValueType {
                 r#type: "samples",
@@ -999,7 +999,7 @@ mod api_test {
     }
 
     #[test]
-    fn endpoints_count_test() {
+    fn endpoint_counts_test() {
         let sample_types = vec![
             api::ValueType {
                 r#type: "samples",


### PR DESCRIPTION
# What does this PR do?

Rename the field `endpoints_count` into `endpoint_counts`.

# Motivation

This field is used in the backend, but the name expected by the backend is not the one I used.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Did the same test for the previous PR: run a .NET application with the Tracer and check what's inside the HTTP request.
