### PR TITLE
Convert local root span id to u64, fix clippy lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,7 +283,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-ffi"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -327,7 +327,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -351,7 +351,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon-ffi"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "ddcommon",
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry-ffi"
-version = "1.0.1"
+version = "2.0.0"
 dependencies = [
  "ddcommon-ffi",
  "ddtelemetry",

--- a/ddcommon-ffi/Cargo.toml
+++ b/ddcommon-ffi/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ddcommon-ffi"
-version = "1.0.1"
+version = "2.0.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/ddcommon-ffi/src/vec.rs
+++ b/ddcommon-ffi/src/vec.rs
@@ -59,7 +59,7 @@ impl<T> From<alloc::vec::Vec<T>> for Vec<T> {
 impl From<anyhow::Error> for Vec<u8> {
     fn from(err: anyhow::Error) -> Self {
         let mut vec = vec![];
-        write!(vec, "{}", err).expect("write to vec to always succeed");
+        write!(vec, "{err}").expect("write to vec to always succeed");
         Self::from(vec)
     }
 }

--- a/ddcommon/Cargo.toml
+++ b/ddcommon/Cargo.toml
@@ -5,7 +5,7 @@
 edition = "2021"
 license = "Apache-2.0"
 name = "ddcommon"
-version = "1.0.1"
+version = "2.0.0"
 
 [lib]
 crate-type = ["lib"]

--- a/ddcommon/src/tag.rs
+++ b/ddcommon/src/tag.rs
@@ -55,10 +55,10 @@ impl Tag {
 
         let mut chars = chunk.chars();
         if chars.next() == Some(':') {
-            return Err(format!("tag '{}' begins with a colon", chunk).into());
+            return Err(format!("tag '{chunk}' begins with a colon").into());
         }
         if chars.last() == Some(':') {
-            return Err(format!("tag '{}' ends with a colon", chunk).into());
+            return Err(format!("tag '{chunk}' ends with a colon").into());
         }
 
         Ok(Tag {
@@ -74,7 +74,7 @@ impl Tag {
         let key = key.as_ref();
         let value = value.as_ref();
 
-        Tag::from_value(format!("{}:{}", key, value))
+        Tag::from_value(format!("{key}:{value}"))
     }
 }
 

--- a/ddtelemetry-ffi/Cargo.toml
+++ b/ddtelemetry-ffi/Cargo.toml
@@ -3,14 +3,14 @@
 
 [package]
 name = "ddtelemetry-ffi"
-version = "1.0.1"
+version = "2.0.0"
 edition = "2021"
 
 [lib]
 crate-type = ["lib", "staticlib", "cdylib"]
 
 [dependencies]
-ddtelemetry = { path = "../ddtelemetry", version = "1.0.1" }
-ddcommon-ffi = { path = "../ddcommon-ffi", version = "1.0.1" }
+ddtelemetry = { path = "../ddtelemetry" }
+ddcommon-ffi = { path = "../ddcommon-ffi" }
 paste = "1"
 libc = "0.2"

--- a/ddtelemetry/Cargo.toml
+++ b/ddtelemetry/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 license = "Apache 2.0"
 name = "ddtelemetry"
-version = "1.0.1"
+version = "2.0.0"
 
 [dependencies]
 anyhow = {version = "1.0"}

--- a/ddtelemetry/benches/ipc.rs
+++ b/ddtelemetry/benches/ipc.rs
@@ -47,7 +47,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         _ => panic!("shouldn't happen"),
     };
 
-    println!("Total requests handled: {}", requests_received);
+    println!("Total requests handled: {requests_received}");
 
     drop(transport);
     worker.join().unwrap();

--- a/ddtelemetry/src/config.rs
+++ b/ddtelemetry/src/config.rs
@@ -50,7 +50,7 @@ impl FromEnv {
         let agent_host =
             env::var(DD_AGENT_HOST).unwrap_or_else(|_| String::from(DEFAULT_AGENT_HOST));
 
-        format!("http://{}:{}", agent_host, agent_port)
+        format!("http://{agent_host}:{agent_port}")
     }
 
     fn get_intake_base_url() -> String {
@@ -63,9 +63,9 @@ impl FromEnv {
 
         if let Ok(dd_site) = env::var(DD_SITE) {
             if dd_site.is_empty() {
-                format!("{}.{}", PROD_INTAKE_FORMAT_PREFIX, DEFAULT_DD_SITE)
+                format!("{PROD_INTAKE_FORMAT_PREFIX}.{DEFAULT_DD_SITE}")
             } else {
-                format!("{}.{}", PROD_INTAKE_FORMAT_PREFIX, dd_site)
+                format!("{PROD_INTAKE_FORMAT_PREFIX}.{dd_site}")
             }
         } else {
             String::from(STAGING_INTAKE)
@@ -77,9 +77,9 @@ impl FromEnv {
 
         let telemetry_url = if api_key.is_some() {
             let telemetry_intake_base_url = Self::get_intake_base_url();
-            format!("{}{}", telemetry_intake_base_url, DIRECT_TELEMETRY_URL_PATH)
+            format!("{telemetry_intake_base_url}{DIRECT_TELEMETRY_URL_PATH}")
         } else {
-            format!("{}{}", &agent_url, AGENT_TELEMETRY_URL_PATH)
+            format!("{}{AGENT_TELEMETRY_URL_PATH}", &agent_url)
         };
 
         let telemetry_uri = Uri::from_str(&telemetry_url).ok()?;

--- a/ddtelemetry/src/fork.rs
+++ b/ddtelemetry/src/fork.rs
@@ -142,7 +142,7 @@ pub mod tests {
         sock_a.read_to_string(&mut out).unwrap();
 
         assert_child_exit!(pid);
-        assert_eq!(format!("child-{}", pid), out);
+        assert_eq!(format!("child-{pid}"), out);
     }
 
     #[test]

--- a/ddtelemetry/src/ipc/platform/unix/mod.rs
+++ b/ddtelemetry/src/ipc/platform/unix/mod.rs
@@ -23,7 +23,6 @@ mod tests {
         fs::File,
         io::{self, Read, Seek, Write},
         os::unix::prelude::{AsRawFd, RawFd},
-        path::Path,
     };
 
     use crate::ipc::platform::{metadata::ChannelMetadata, unix::message::MAX_FDS};

--- a/ddtelemetry/src/ipc/platform/unix/mod.rs
+++ b/ddtelemetry/src/ipc/platform/unix/mod.rs
@@ -52,7 +52,7 @@ mod tests {
             .map(|p| format!("{}", p))
             .unwrap_or_else(|| "self".into());
 
-        let fds_path = Path::new("/proc").join(proc).join("fd");
+        let fds_path = std::path::Path::new("/proc").join(proc).join("fd");
         let fds = std::fs::read_dir(fds_path)?
             .filter_map(|r| r.ok())
             .filter_map(|r| {

--- a/ddtelemetry/src/metrics.rs
+++ b/ddtelemetry/src/metrics.rs
@@ -212,14 +212,14 @@ mod test {
             for (i, &a) in assertions.iter().enumerate() {
                 if a(e) {
                     if used[i] {
-                        panic!("Assertion {} has been used multiple times", i);
+                        panic!("Assertion {i} has been used multiple times");
                     }
                     found = true;
                     break;
                 }
             }
             if !found {
-                panic!("No assertion found for elem {:?}", e)
+                panic!("No assertion found for elem {e:?}")
             }
         }
     }

--- a/profiling-ffi/Cargo.toml
+++ b/profiling-ffi/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "datadog-profiling-ffi"
-version = "1.0.1"
+version = "2.0.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/profiling-ffi/src/profiles.rs
+++ b/profiling-ffi/src/profiles.rs
@@ -353,7 +353,7 @@ pub extern "C" fn ddog_prof_Profile_add(
 ///
 /// # Arguments
 /// * `profile` - a reference to the profile that will contain the samples.
-/// * `local_root_span_id` - the value of the local root span id label to look for.
+/// * `local_root_span_id`
 /// * `endpoint` - the value of the endpoint label to add for matching samples.
 ///
 /// # Safety
@@ -361,14 +361,12 @@ pub extern "C" fn ddog_prof_Profile_add(
 /// module.
 /// This call is _NOT_ thread-safe.
 #[no_mangle]
-pub unsafe extern "C" fn ddog_prof_Profile_set_endpoint<'a>(
+pub unsafe extern "C" fn ddog_prof_Profile_set_endpoint(
     profile: &mut datadog_profiling::profile::Profile,
-    local_root_span_id: CharSlice<'a>,
-    endpoint: CharSlice<'a>,
+    local_root_span_id: u64,
+    endpoint: CharSlice,
 ) {
-    let local_root_span_id = local_root_span_id.to_utf8_lossy();
     let endpoint = endpoint.to_utf8_lossy();
-
     profile.add_endpoint(local_root_span_id, endpoint);
 }
 

--- a/profiling-ffi/src/profiles.rs
+++ b/profiling-ffi/src/profiles.rs
@@ -449,9 +449,7 @@ pub unsafe extern "C" fn ddog_prof_Profile_serialize(
         Some(x) if *x < 0 => None,
         Some(x) => Some(Duration::from_nanos((*x) as u64)),
     };
-    match || -> anyhow::Result<datadog_profiling::profile::EncodedProfile> {
-        Ok(profile.serialize(end_time, duration)?)
-    }() {
+    match profile.serialize(end_time, duration) {
         Ok(ok) => SerializeResult::Ok(ok.into()),
         Err(err) => SerializeResult::Err(err.into()),
     }

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "datadog-profiling"
-version = "1.0.1"
+version = "2.0.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/profiling/src/exporter/config.rs
+++ b/profiling/src/exporter/config.rs
@@ -23,7 +23,7 @@ pub fn agent(base_url: Uri) -> anyhow::Result<Endpoint> {
         Some(pq) => {
             let path = pq.path();
             let path = path.strip_suffix('/').unwrap_or(path);
-            Some(format!("{}/profiling/v1/input", path).parse()?)
+            Some(format!("{path}/profiling/v1/input").parse()?)
         }
     };
     parts.path_and_query = p_q;

--- a/profiling/src/profile/mod.rs
+++ b/profiling/src/profile/mod.rs
@@ -523,10 +523,11 @@ impl Profile {
          */
         let local_root_span_id: u64 = unsafe { std::intrinsics::transmute(label.num) };
 
-        Ok(match self.endpoints.mappings.get(&local_root_span_id) {
-            None => None,
-            Some(endpoint_string_id) => Some(*endpoint_string_id),
-        })
+        Ok(self
+            .endpoints
+            .mappings
+            .get(&local_root_span_id)
+            .map(i64::clone))
     }
 }
 

--- a/profiling/src/profile/mod.rs
+++ b/profiling/src/profile/mod.rs
@@ -1121,10 +1121,14 @@ mod api_test {
             num_unit: None,
         };
 
+        let large_span_id = u64::MAX;
+        // Safety: a u64 can fit into an i64, and we're testing that it's not mis-handled.
+        let large_num: i64 = unsafe { std::intrinsics::transmute(large_span_id) };
+
         let id2_label = api::Label {
             key: "local root span id",
             str: None,
-            num: 11,
+            num: large_num,
             num_unit: None,
         };
 
@@ -1144,7 +1148,7 @@ mod api_test {
         profile.add(sample2).expect("add to success");
 
         profile.add_endpoint(10, Cow::from("endpoint 10"));
-        profile.add_endpoint(11, Cow::from("endpoint 11"));
+        profile.add_endpoint(large_span_id, Cow::from("large endpoint"));
 
         let serialized_profile = pprof::Profile::try_from(&profile).unwrap();
         assert_eq!(serialized_profile.samples.len(), 2);
@@ -1184,10 +1188,10 @@ mod api_test {
                 pprof::Label {
                     key: local_root_span_id,
                     str: 0,
-                    num: 11,
+                    num: large_num,
                     num_unit: 0,
                 },
-                pprof::Label::str(trace_endpoint, locate_string("endpoint 11")),
+                pprof::Label::str(trace_endpoint, locate_string("large endpoint")),
             ],
         ];
 


### PR DESCRIPTION
# What does this PR do?

- Fix `clippy::uninlined_format_args` lints.
- Fix unused import `std::path::Path` in `cfg(test)`.
- Converts `local_root_span_id` in `add_endpoint` and related functions to be `u64` instead of a string.
- Removes unnecessary `Cow<str>` for `str` in label.
- Bumps version to v2.0.0.

# Motivation

The profiling backend can now accept numeric labels. This PR converts "local root span id" related parameters to use numbers in the endpoint API.

# Additional Notes

This should have been multiple PRs. I'm sorry.

# How to test the change?

- Change `add_endpoint` to use `u64` instead of a string.
- Change your `local root span id` labels to use the `.num` variant instead of `.str`. Transmute from `u64` to `i64` as necessary. If they aren't changed, then `profile.add` will fail.

And then test as normal. Double-check that Code Hotspots and Endpoint Profiling both work.
