### PR TITLE
Add metrics.json support

### DIFF
--- a/ddcommon-ffi/cbindgen.toml
+++ b/ddcommon-ffi/cbindgen.toml
@@ -54,6 +54,7 @@ rename_types = "PascalCase"
 [export.rename]
 "ParseTagsResult" = "ddog_Vec_Tag_ParseResult"
 "PushTagResult" = "ddog_Vec_Tag_PushResult"
+"PushMetricResult" = "ddog_Vec_Metric_PushResult"
 
 [enum]
 prefix_with_name = true

--- a/ddcommon-ffi/src/lib.rs
+++ b/ddcommon-ffi/src/lib.rs
@@ -1,6 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
 
+pub mod metrics;
 pub mod option;
 pub mod slice;
 pub mod tags;

--- a/ddcommon-ffi/src/metrics.rs
+++ b/ddcommon-ffi/src/metrics.rs
@@ -1,0 +1,76 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022-Present Datadog, Inc.
+
+use crate::{slice::AsBytes, slice::CharSlice};
+use ddcommon::metric::Metric;
+
+#[must_use]
+#[no_mangle]
+pub extern "C" fn ddog_Vec_Metric_new() -> crate::Vec<Metric> {
+    crate::Vec::default()
+}
+
+#[no_mangle]
+pub extern "C" fn ddog_Vec_Metric_drop(_: crate::Vec<Metric>) {}
+
+#[repr(C)]
+pub enum PushMetricResult {
+    Ok,
+    Err(crate::Vec<u8>),
+}
+
+#[no_mangle]
+pub extern "C" fn ddog_Vec_Metric_PushResult_drop(_: PushMetricResult) {}
+
+/// Creates a new Tag from the provided `key` and `value` by doing a utf8
+/// lossy conversion, and pushes into the `vec`. The strings `key` and `value`
+/// are cloned to avoid FFI lifetime issues.
+///
+/// # Safety
+/// The `vec` must be a valid reference.
+/// The CharSlices `key` and `value` must point to at least many bytes as their
+/// `.len` properties claim.
+#[no_mangle]
+pub unsafe extern "C" fn ddog_Vec_Metric_push(
+    vec: &mut crate::Vec<Metric>,
+    key: CharSlice,
+    value: f32,
+) -> PushMetricResult {
+    let name = key.to_utf8_lossy().into_owned();
+    match Metric::new(name, value) {
+        Ok(metric) => {
+            vec.push(metric);
+            PushMetricResult::Ok
+        }
+        Err(err) => PushMetricResult::Err(err.as_bytes().to_vec().into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::metrics::*;
+
+    #[test]
+    fn empty_metric_name() {
+        unsafe {
+            let mut metrics = ddog_Vec_Metric_new();
+            let result = ddog_Vec_Metric_push(&mut metrics, CharSlice::from(""), 42.);
+            assert_eq!(metrics.len(), 0);
+            assert!(!matches!(result, PushMetricResult::Ok));
+        }
+    }
+
+    #[test]
+    fn test_get() {
+        unsafe {
+            let mut metrics = ddog_Vec_Metric_new();
+            let metric_name = "my_metric_name";
+            let result = ddog_Vec_Metric_push(&mut metrics, CharSlice::from(metric_name), 42.);
+            assert!(matches!(result, PushMetricResult::Ok));
+            assert_eq!(1, metrics.len());
+            let metric = metrics.get(0).unwrap();
+            let expected = Metric::new(metric_name.to_string(), 42.).unwrap();
+            assert_eq!(metric, &expected);
+        }
+    }
+}

--- a/ddcommon-ffi/src/metrics.rs
+++ b/ddcommon-ffi/src/metrics.rs
@@ -34,7 +34,7 @@ pub extern "C" fn ddog_Vec_Metric_PushResult_drop(_: PushMetricResult) {}
 pub unsafe extern "C" fn ddog_Vec_Metric_push(
     vec: &mut crate::Vec<Metric>,
     key: CharSlice,
-    value: f32,
+    value: f64,
 ) -> PushMetricResult {
     let name = key.to_utf8_lossy().into_owned();
     match Metric::new(name, value) {

--- a/ddcommon/src/lib.rs
+++ b/ddcommon/src/lib.rs
@@ -8,6 +8,7 @@ use hyper::header::HeaderValue;
 pub mod azure_app_services;
 pub mod connector;
 pub mod container_id;
+pub mod metric;
 pub mod tag;
 
 pub mod header {

--- a/ddcommon/src/metric.rs
+++ b/ddcommon/src/metric.rs
@@ -3,7 +3,7 @@
 
 use core::fmt::Debug;
 use serde::{Deserialize, Serialize};
-use std::{borrow::Cow, fmt::Formatter};
+use std::fmt::Formatter;
 
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct Metric {
@@ -23,7 +23,7 @@ impl Debug for Metric {
 impl Metric {
     pub fn new(name: String, value: f64) -> Result<Self, &'static str> {
         if name.is_empty() {
-            Err("empty metric name is not valid".into())
+            Err("empty metric name is not valid")
         } else {
             Ok(Metric { name, value })
         }

--- a/ddcommon/src/metric.rs
+++ b/ddcommon/src/metric.rs
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+
+use core::fmt::Debug;
+use serde::{Deserialize, Serialize};
+use std::{borrow::Cow, fmt::Formatter};
+
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
+pub struct Metric {
+    name: String,
+    value: f32,
+}
+
+impl Debug for Metric {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Metric")
+            .field("name", &self.name)
+            .field("value", &self.value)
+            .finish()
+    }
+}
+
+impl Metric {
+    pub fn new(name: String, value: f32) -> Result<Self, Cow<'static, str>> {
+        if name.is_empty() {
+            Err("empty metric name is not valid".into())
+        } else {
+            Ok(Metric { name, value })
+        }
+    }
+}

--- a/ddcommon/src/metric.rs
+++ b/ddcommon/src/metric.rs
@@ -8,7 +8,7 @@ use std::{borrow::Cow, fmt::Formatter};
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct Metric {
     name: String,
-    value: f32,
+    value: f64,
 }
 
 impl Debug for Metric {
@@ -21,7 +21,7 @@ impl Debug for Metric {
 }
 
 impl Metric {
-    pub fn new(name: String, value: f32) -> Result<Self, Cow<'static, str>> {
+    pub fn new(name: String, value: f64) -> Result<Self, &'static str> {
         if name.is_empty() {
             Err("empty metric name is not valid".into())
         } else {

--- a/examples/ffi/exporter.cpp
+++ b/examples/ffi/exporter.cpp
@@ -105,6 +105,15 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
+  ddog_Vec_Metric metrics = ddog_Vec_Metric_new();
+  ddog_Vec_Metric_PushResult metric_result =
+      ddog_Vec_Metric_push(&metrics, DDOG_CHARSLICE_C("my_metric"), 42.0f);
+  if (metric_result.tag == DDOG_VEC_METRIC_PUSH_RESULT_ERR) {
+    print_error("Failed to push metric: ", metric_result.err);
+    ddog_Vec_Metric_PushResult_drop(metric_result);
+    return 1;
+  }
+
   auto exporter = exporter_new_result.ok;
 
   ddog_prof_Exporter_File files_[] = {{
@@ -121,8 +130,11 @@ int main(int argc, char *argv[]) {
     files,
     nullptr,
     nullptr,
+    &metrics,
     30000
   );
+  
+  ddog_Vec_Metric_drop(metrics);
 
   ddog_CancellationToken *cancel = ddog_CancellationToken_new();
   ddog_CancellationToken *cancel_for_background_thread = ddog_CancellationToken_clone(cancel);

--- a/profiling-ffi/cbindgen.toml
+++ b/profiling-ffi/cbindgen.toml
@@ -29,6 +29,8 @@ renaming_overrides_prefixing = true
 "Tag" = "ddog_Tag"
 "Timespec" = "ddog_Timespec"
 "Vec_Tag" = "ddog_Vec_Tag"
+"Metric" = "ddog_Metric"
+"Vec_Metric" = "ddog_Vec_Metric"
 
 "File" = "ddog_prof_Exporter_File"
 "NewProfileExporterResult" = "ddog_prof_Exporter_NewResult"

--- a/profiling/tests/form.rs
+++ b/profiling/tests/form.rs
@@ -32,7 +32,7 @@ fn multipart(exporter: &ProfileExporter) -> Request {
     let timeout = std::time::Duration::from_secs(10);
 
     let request = exporter
-        .build(start, end, files, None, None, timeout)
+        .build(start, end, files, None, None, None, timeout)
         .expect("request to be built");
 
     let actual_timeout = request.timeout().expect("timeout to exist");
@@ -59,6 +59,7 @@ mod tests {
         let profiling_library_version = "1.2.3";
         let base_url = "http://localhost:8126".parse().expect("url to parse");
         let endpoint = config::agent(base_url).expect("endpoint to construct");
+
         let exporter = ProfileExporter::new(
             profiling_library_name,
             profiling_library_version,


### PR DESCRIPTION
# What does this PR do?

This PR adds support for `metrics.json` file.

# Motivation

In the .NET profiler, we would like to send `metrics.json` file to the backend. The goal is to unlock this capability for other profilers too.


# How to test the change?

To be done with the .NET profiler.
