### PR TITLE
Remove unused optional `time` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,6 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time",
  "winapi",
 ]
 
@@ -1508,16 +1507,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]

--- a/profiling-ffi/Cargo.toml
+++ b/profiling-ffi/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
 anyhow = "1.0"
-chrono = "0.4"
+chrono = {version = "0.4", default-features = false}
 datadog-profiling = { path = "../profiling"}
 hyper = {version = "0.14", default-features = false}
 ddcommon = { path = "../ddcommon"}

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["lib"]
 [dependencies]
 anyhow = "1.0"
 bytes = "1.1"
-chrono = "0.4"
+chrono = {version = "0.4", default-features = false, features = ["std", "clock"]}
 ddcommon = {path = "../ddcommon"}
 derivative = "2.2.0"
 futures = "0.3"


### PR DESCRIPTION
**What does this PR do?**:

This PR tweaks the optional features of the `chrono` crate to avoid pulling in the `time` crate.

**Motivation**:

We got warned by dependabot that the version of `time` pulled in by `chrono` is a deprecated version that should no longer be used.

Since we were not actually making use of any of the features provided by it, we can just remove it.

**Additional Notes**:

(N/A)

**How to test the change?**:

Validate that all tests still pass.