### PR TITLE
Minor: Document expected result of `ddog_prof_Profile_add`

### DIFF
--- a/profiling-ffi/src/profiles.rs
+++ b/profiling-ffi/src/profiles.rs
@@ -330,6 +330,11 @@ pub unsafe extern "C" fn ddog_prof_Profile_drop(
 /// The `profile` ptr must point to a valid Profile object created by this
 /// module. All pointers inside the `sample` need to be valid for the duration
 /// of this call.
+//// Returns the internal id of the sample (> 0) if successful, and 0 on error.
+///
+/// # Safety
+/// The `profile` ptr must point to a valid Profile object created by this
+/// module.
 /// This call is _NOT_ thread-safe.
 pub extern "C" fn ddog_prof_Profile_add(
     profile: &mut datadog_profiling::profile::Profile,


### PR DESCRIPTION
**What does this PR do?**:

Documents the expected result of the `ddog_prof_Profile_add` API.

**Motivation**:

While validating #80 on Ruby, I called `add` in a way that should've triggered an error, but saw none.

On closer inspection, I had no error handling for `add` because it wasn't clear to me that its result could indicate an error.

Thus, I decided to document that fact.

**Additional Notes**:

At some point we could change `add` to return an actual result, allowing us to pass the error message back to the caller, but for now I decided to just document it.

**How to test the change?**:

Documentation change only.