### PR TITLE
feat(profiling)!: send media type with files

### DIFF
--- a/examples/ffi/exporter.cpp
+++ b/examples/ffi/exporter.cpp
@@ -109,6 +109,7 @@ int main(int argc, char *argv[]) {
 
   ddog_prof_Exporter_File files_[] = {{
       .name = DDOG_CHARSLICE_C("auto.pprof"),
+      .mime = DDOG_CHARSLICE_C("application/octet-stream"),
       .file = ddog_Vec_U8_as_slice(&encoded_profile->buffer),
   }};
 

--- a/profiling/tests/form.rs
+++ b/profiling/tests/form.rs
@@ -22,6 +22,7 @@ fn multipart(exporter: &ProfileExporter) -> Request {
 
     let files: &[File] = &[File {
         name: "profile.pprof",
+        mime: mime::APPLICATION_OCTET_STREAM,
         bytes: buffer.as_slice(),
     }];
 


### PR DESCRIPTION
# What does this PR do?

Change the profiling `File` types to have a media type aka mime. This allows sending files like `metrics.json` with the right content type.

# Motivation

There was discussion on PR #81 and on Slack around the idea that it might be nicer for current users to send `metrics.json` in the `File` slice. However, there isn't support today for media types, which this fixes.

# Additional Notes

I like working with Grégory :)

# How to test the change?

All `File` objects now have a `mime` field which needs to be added. For encoded profiles, use type `mime::APPLICATION_OCTET_STREAM` or `"application/octet-stream"` as appropriate for which `File` type is being used.