### PR TITLE
refactor(profiling)!: create FFI Error type and remove `*Result_drop` methods

### DIFF
--- a/ddcommon-ffi/src/error.rs
+++ b/ddcommon-ffi/src/error.rs
@@ -62,7 +62,7 @@ impl From<Box<&dyn std::error::Error>> for Error {
 }
 
 /// # Safety
-/// Only pass null or a valid reference to an Error.
+/// Only pass null or a valid reference to a `ddog_Error`.
 #[no_mangle]
 pub unsafe extern "C" fn ddog_Error_drop(error: Option<&mut Error>) {
     if let Some(err) = error {
@@ -76,7 +76,7 @@ pub unsafe extern "C" fn ddog_Error_drop(error: Option<&mut Error>) {
 /// Returns a CharSlice of the error's message that is valid until the error
 /// is dropped.
 /// # Safety
-/// Only pass null or a valid reference to an Error.
+/// Only pass null or a valid reference to a `ddog_Error`.
 #[no_mangle]
 pub unsafe extern "C" fn ddog_Error_message(error: Option<&Error>) -> CharSlice {
     match error {

--- a/ddcommon-ffi/src/error.rs
+++ b/ddcommon-ffi/src/error.rs
@@ -1,0 +1,86 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+
+use crate::slice::CharSlice;
+use crate::vec::Vec;
+use std::fmt::{Display, Formatter};
+
+/// Please treat this as opaque; do not reach into it, and especially don't
+/// write into it!
+#[derive(Debug)]
+#[repr(C)]
+pub struct Error {
+    /// This is a String stuffed into the vec.
+    message: Vec<u8>,
+}
+
+impl AsRef<str> for Error {
+    fn as_ref(&self) -> &str {
+        // Safety: .message is a String (just FFI safe).
+        unsafe { std::str::from_utf8_unchecked(self.message.as_slice().as_slice()) }
+    }
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_ref())
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl From<String> for Error {
+    fn from(value: String) -> Self {
+        let message = Vec::from(value.into_bytes());
+        Self { message }
+    }
+}
+
+impl From<Error> for String {
+    fn from(value: Error) -> String {
+        // Safety: .message is a String (just FFI safe).
+        unsafe { String::from_utf8_unchecked(value.message.into()) }
+    }
+}
+
+impl From<&str> for Error {
+    fn from(value: &str) -> Self {
+        Self::from(value.to_string())
+    }
+}
+
+impl From<anyhow::Error> for Error {
+    fn from(value: anyhow::Error) -> Self {
+        Self::from(value.to_string())
+    }
+}
+
+impl From<Box<&dyn std::error::Error>> for Error {
+    fn from(value: Box<&dyn std::error::Error>) -> Self {
+        Self::from(value.to_string())
+    }
+}
+
+/// # Safety
+/// Only pass null or a valid reference to an Error.
+#[no_mangle]
+pub unsafe extern "C" fn ddog_Error_drop(error: Option<&mut Error>) {
+    if let Some(err) = error {
+        // Leave an empty String in place to help with double-free issues.
+        let mut tmp = Error::from(String::new());
+        std::mem::swap(&mut tmp, err);
+        drop(tmp)
+    }
+}
+
+/// Returns a CharSlice of the error's message that is valid until the error
+/// is dropped.
+/// # Safety
+/// Only pass null or a valid reference to an Error.
+#[no_mangle]
+pub unsafe extern "C" fn ddog_Error_message(error: Option<&Error>) -> CharSlice {
+    match error {
+        None => CharSlice::default(),
+        Some(err) => CharSlice::from(err.as_ref()),
+    }
+}

--- a/ddcommon-ffi/src/lib.rs
+++ b/ddcommon-ffi/src/lib.rs
@@ -1,10 +1,14 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
 
+mod error;
+
 pub mod option;
 pub mod slice;
 pub mod tags;
 pub mod vec;
+
+pub use error::*;
 
 pub use option::Option;
 pub use slice::{CharSlice, Slice};

--- a/ddcommon-ffi/src/tags.rs
+++ b/ddcommon-ffi/src/tags.rs
@@ -20,9 +20,6 @@ pub enum PushTagResult {
     Err(Error),
 }
 
-#[no_mangle]
-pub extern "C" fn ddog_Vec_Tag_PushResult_drop(_: PushTagResult) {}
-
 /// Creates a new Tag from the provided `key` and `value` by doing a utf8
 /// lossy conversion, and pushes into the `vec`. The strings `key` and `value`
 /// are cloned to avoid FFI lifetime issues.

--- a/ddcommon-ffi/src/tags.rs
+++ b/ddcommon-ffi/src/tags.rs
@@ -1,7 +1,8 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022-Present Datadog, Inc.
 
-use crate::{slice::AsBytes, slice::CharSlice};
+use crate::slice::{AsBytes, CharSlice};
+use crate::Error;
 use ddcommon::tag::{parse_tags, Tag};
 
 #[must_use]
@@ -16,7 +17,7 @@ pub extern "C" fn ddog_Vec_Tag_drop(_: crate::Vec<Tag>) {}
 #[repr(C)]
 pub enum PushTagResult {
     Ok,
-    Err(crate::Vec<u8>),
+    Err(Error),
 }
 
 #[no_mangle]
@@ -44,14 +45,14 @@ pub unsafe extern "C" fn ddog_Vec_Tag_push(
             vec.push(tag);
             PushTagResult::Ok
         }
-        Err(err) => PushTagResult::Err(err.as_bytes().to_vec().into()),
+        Err(err) => PushTagResult::Err(Error::from(err.as_ref())),
     }
 }
 
 #[repr(C)]
 pub struct ParseTagsResult {
     tags: crate::Vec<Tag>,
-    error_message: Option<Box<crate::Vec<u8>>>,
+    error_message: Option<Box<Error>>,
 }
 
 /// # Safety
@@ -64,7 +65,7 @@ pub unsafe extern "C" fn ddog_Vec_Tag_parse(string: CharSlice) -> ParseTagsResul
     let (tags, error) = parse_tags(string.as_ref());
     ParseTagsResult {
         tags: tags.into(),
-        error_message: error.map(|message| Box::new(crate::Vec::from(message.into_bytes()))),
+        error_message: error.map(Error::from).map(Box::new),
     }
 }
 
@@ -126,10 +127,11 @@ mod tests {
 
         // 'tags:' cannot end in a semi-colon, so expect an error.
         assert!(result.error_message.is_some());
-        let error_message: Vec<u8> = (*result.error_message.unwrap()).into();
+        let error = *result.error_message.unwrap();
+        let error_message = error.as_ref();
         assert!(!error_message.is_empty());
 
-        let expected_error_message = b"Errors while parsing tags: tag 'tags:' ends with a colon";
-        assert_eq!(expected_error_message, error_message.as_slice())
+        let expected_error_message = "Errors while parsing tags: tag 'tags:' ends with a colon";
+        assert_eq!(expected_error_message, error_message)
     }
 }

--- a/examples/ffi/exporter.cpp
+++ b/examples/ffi/exporter.cpp
@@ -128,6 +128,7 @@ int main(int argc, char *argv[]) {
     nullptr,
     30000
   );
+  ddog_prof_EncodedProfile_drop(encoded_profile);
 
   if (build_result.tag == DDOG_PROF_EXPORTER_REQUEST_BUILD_RESULT_ERR) {
     print_error("Failed to build request: ", build_result.err);

--- a/examples/ffi/exporter.cpp
+++ b/examples/ffi/exporter.cpp
@@ -169,6 +169,8 @@ int main(int argc, char *argv[]) {
     printf("Response code: %d\n", send_result.http_response.code);
   }
 
+  // no ddog_prof_Exporter_Request_drop(request) since it was sent to Exporter_send
+
   ddog_prof_Exporter_drop(exporter);
   ddog_CancellationToken_drop(cancel);
   return exit_code;

--- a/examples/ffi/exporter.cpp
+++ b/examples/ffi/exporter.cpp
@@ -15,8 +15,9 @@ struct Deleter {
   void operator()(ddog_prof_Profile *object) { ddog_prof_Profile_drop(object); }
 };
 
-template <typename T> void print_error(const char *s, const T &err) {
-  printf("%s (%.*s)\n", s, static_cast<int>(err.len), err.ptr);
+void print_error(const char *s, const ddog_Error &err) {
+  auto charslice = ddog_Error_message(&err);
+  printf("%s (%.*s)\n", s, static_cast<int>(charslice.len), charslice.ptr);
 }
 
 int main(int argc, char *argv[]) {

--- a/examples/ffi/exporter.cpp
+++ b/examples/ffi/exporter.cpp
@@ -70,14 +70,14 @@ int main(int argc, char *argv[]) {
   auto add_result = ddog_prof_Profile_add(profile.get(), sample);
   if (add_result.tag != DDOG_PROF_PROFILE_ADD_RESULT_OK) {
     print_error("Failed to add sample to profile: ", add_result.err);
-    ddog_prof_Profile_AddResult_drop(add_result);
+    ddog_Error_drop(&add_result.err);
     return 1;
   }
 
   ddog_prof_Profile_SerializeResult serialize_result = ddog_prof_Profile_serialize(profile.get(), nullptr, nullptr);
   if (serialize_result.tag == DDOG_PROF_PROFILE_SERIALIZE_RESULT_ERR) {
     print_error("Failed to serialize profile: ", serialize_result.err);
-    ddog_prof_Profile_SerializeResult_drop(serialize_result);
+    ddog_Error_drop(&serialize_result.err);
     return 1;
   }
 
@@ -91,11 +91,9 @@ int main(int argc, char *argv[]) {
       ddog_Vec_Tag_push(&tags, DDOG_CHARSLICE_C("service"), to_slice_c_char(service));
   if (tag_result.tag == DDOG_VEC_TAG_PUSH_RESULT_ERR) {
     print_error("Failed to push tag: ", tag_result.err);
-    ddog_Vec_Tag_PushResult_drop(tag_result);
+    ddog_Error_drop(&tag_result.err);
     return 1;
   }
-
-  ddog_Vec_Tag_PushResult_drop(tag_result);
 
   ddog_prof_Exporter_NewResult exporter_new_result = ddog_prof_Exporter_new(
       DDOG_CHARSLICE_C("exporter-example"),
@@ -108,7 +106,7 @@ int main(int argc, char *argv[]) {
 
   if (exporter_new_result.tag == DDOG_PROF_EXPORTER_NEW_RESULT_ERR) {
     print_error("Failed to create exporter: ", exporter_new_result.err);
-    ddog_prof_Exporter_NewResult_drop(exporter_new_result);
+    ddog_Error_drop(&exporter_new_result.err);
     return 1;
   }
 
@@ -133,7 +131,7 @@ int main(int argc, char *argv[]) {
 
   if (build_result.tag == DDOG_PROF_EXPORTER_REQUEST_BUILD_RESULT_ERR) {
     print_error("Failed to build request: ", build_result.err);
-    ddog_prof_Exporter_Request_BuildResult_drop(build_result);
+    ddog_Error_drop(&build_result.err);
     return 1;
   }
 
@@ -165,12 +163,12 @@ int main(int argc, char *argv[]) {
   if (send_result.tag == DDOG_PROF_EXPORTER_SEND_RESULT_ERR) {
     print_error("Failed to send profile: ", send_result.err);
     exit_code = 1;
+    ddog_Error_drop(&send_result.err);
   } else {
     printf("Response code: %d\n", send_result.http_response.code);
   }
 
-  ddog_prof_Exporter_NewResult_drop(exporter_new_result);
-  ddog_prof_Exporter_SendResult_drop(send_result);
+  ddog_prof_Exporter_drop(exporter);
   ddog_CancellationToken_drop(cancel);
   return exit_code;
 }

--- a/examples/ffi/profiles.c
+++ b/examples/ffi/profiles.c
@@ -48,7 +48,8 @@ int main(void) {
 
   ddog_prof_Profile_AddResult add_result = ddog_prof_Profile_add(profile, sample);
   if (add_result.tag != DDOG_PROF_PROFILE_ADD_RESULT_OK) {
-    fprintf(stderr, "%*s", (int)add_result.err.len, add_result.err.ptr);
+    ddog_CharSlice message = ddog_Error_message(&add_result.err);
+    fprintf(stderr, "%*s", (int)message.len, message.ptr);
     ddog_prof_Profile_AddResult_drop(add_result);
   }
 

--- a/examples/ffi/profiles.c
+++ b/examples/ffi/profiles.c
@@ -50,7 +50,7 @@ int main(void) {
   if (add_result.tag != DDOG_PROF_PROFILE_ADD_RESULT_OK) {
     ddog_CharSlice message = ddog_Error_message(&add_result.err);
     fprintf(stderr, "%*s", (int)message.len, message.ptr);
-    ddog_prof_Profile_AddResult_drop(add_result);
+    ddog_Error_drop(&add_result.err);
   }
 
 

--- a/profiling-ffi/README.md
+++ b/profiling-ffi/README.md
@@ -1,0 +1,28 @@
+# Datadog Profiling FFI Notes
+
+## \#[must_use] on functions
+
+Many FFI functions should use `#[must_use]`. As an example, there are many
+Result types which need to be used for correctness reasons:
+
+```rust
+#[repr(C)]
+pub enum ProfileAddResult {
+    Ok(u64),
+    Err(Error),
+}
+```
+
+Then on `ddog_prof_Profile_add` which returns a `ProfileAddResult`, there is a
+`#[must_use]`. If the C user of this API doesn't touch the return value, then
+they'll get a warning, something like:
+
+> warning: ignoring return value of function declared with
+> 'warn_unused_result' attribute [-Wunused-result]
+
+Additionally, many types (including Error types) have memory that needs to
+be dropped. If the user doesn't use the result, then they definitely leak.
+
+It would be nice if we could put `#[must_use]` directly on the type, rather
+than on the functions which return them. At the moment, cbindgen doesn't
+handle this case, so we have to put `#[must_use]` on functions.

--- a/profiling-ffi/cbindgen.toml
+++ b/profiling-ffi/cbindgen.toml
@@ -22,6 +22,7 @@ renaming_overrides_prefixing = true
 "CancellationToken" = "ddog_CancellationToken"
 "CharSlice" = "ddog_CharSlice"
 "Endpoint" = "ddog_Endpoint"
+"Error" = "ddog_Error"
 "HttpStatus" = "ddog_HttpStatus"
 "Slice_CChar" = "ddog_Slice_CChar"
 "Slice_I64" = "ddog_Slice_I64"

--- a/profiling-ffi/src/exporter.rs
+++ b/profiling-ffi/src/exporter.rs
@@ -230,7 +230,7 @@ pub unsafe extern "C" fn ddog_prof_Exporter_Request_drop(request: *mut Request) 
 /// # Arguments
 /// * `exporter` - Borrows the exporter for sending the request.
 /// * `request` - Takes ownership of the request. Do not call
-///               `ddog_prof_Exporter_Request` on `request` after calling
+///               `ddog_prof_Exporter_Request_drop` on `request` after calling
 ///               `ddog_prof_Exporter_send` on it.
 /// * `cancel` - Borrows the cancel, if any.
 ///

--- a/profiling-ffi/src/profiles.rs
+++ b/profiling-ffi/src/profiles.rs
@@ -22,12 +22,6 @@ pub enum SerializeResult {
     Err(Error),
 }
 
-#[no_mangle]
-pub extern "C" fn ddog_prof_Profile_AddResult_drop(_result: ProfileAddResult) {}
-
-#[no_mangle]
-pub unsafe extern "C" fn ddog_prof_Profile_SerializeResult_drop(_result: SerializeResult) {}
-
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct ValueType<'a> {

--- a/profiling-ffi/src/profiles.rs
+++ b/profiling-ffi/src/profiles.rs
@@ -429,6 +429,11 @@ pub struct EncodedProfile {
     endpoints_stats: Box<profiled_endpoints::ProfiledEndpointsStats>,
 }
 
+#[no_mangle]
+pub extern "C" fn ddog_prof_EncodedProfile_drop(profile: EncodedProfile) {
+    drop(profile)
+}
+
 impl From<datadog_profiling::profile::EncodedProfile> for EncodedProfile {
     fn from(value: datadog_profiling::profile::EncodedProfile) -> Self {
         let start = value.start.into();
@@ -445,8 +450,9 @@ impl From<datadog_profiling::profile::EncodedProfile> for EncodedProfile {
     }
 }
 
-/// Serialize the aggregated profile. Don't forget to clean up the result by
-/// calling ddog_prof_Profile_SerializeResult_drop.
+/// Serialize the aggregated profile.
+///
+/// Don't forget to clean up the ok or error variant once you are done with it!
 ///
 /// # Arguments
 /// * `profile` - a reference to the profile being serialized.


### PR DESCRIPTION
# What does this PR do?

This extracts an FFI `Error` type aka `ddog_Error` and it contains an FFI Vec internally.

```rust
/// Please treat this as opaque; do not reach into it, and especially don't
/// write into it!
#[derive(Debug)]
#[repr(C)]
pub struct Error {
    /// This is a String stuffed into the vec.
    message: Vec<u8>,
}
```

Then, the FFI error types use this in their `Err` field, instead of `ddcommon_ffi::Vec<u8>`:

```rust
#[repr(C)]
pub enum SendResult {
    HttpResponse(HttpStatus),
    Err(Error),
}
```

The `*Result_drop` methods have been removed:

- ddog_prof_Exporter_NewResult_drop
- ddog_prof_Exporter_Request_BuildResult_drop
- ddog_prof_Exporter_SendResult_drop
- ddog_prof_Profile_AddResult_drop
- ddog_prof_Profile_SerializeResult_drop
- ddog_Vec_Tag_PushResult_drop

And these were added instead:

- ddog_Error_drop (+ ddog_Error_message to get the message)
- ddog_prof_EncodedProfile_drop
- ddog_prof_Exporter_Request_drop

# Motivation

I thought it was a bit nicer this way to not have to reach into the guts, and instead have an API.

Additionally, we realized that with the `*Result_drop` APIs it was a bit easy to get into double-free scenarios, so we removed them.

# Additional Notes

I wish we could also extract a generic `Result` type, but the cbindgen output leaves a bad API. Maybe once some PRs land. The idea would be to hard-code the error type to always be the FFI Error:

```rust
#[repr(C)]
enum Result<T> {
    Ok(T),
    Err(Error), // the Error type being the one introduced here
};
```

# How to test the change?

Use the new `ddog_Error_message` and `ddog_Error_drop` APIs:

```c
/**
 * # Safety
 * Only pass null or a valid reference to an Error.
 */
void ddog_Error_drop(struct ddog_Error *error);

/**
 * Returns a CharSlice of the error's message that is valid until the error
 * is dropped.
 * # Safety
 * Only pass null or a valid reference to an Error.
 */
ddog_CharSlice ddog_Error_message(const struct ddog_Error *error);
```

As well as adjust your dropping as the `*Result_drop` APIs have been removed. You need to drop each case, if necessary (don't need to drop a uint64_t, obviously).