### PR TITLE
fix: clippy lints from Rust v1.67.0 release

### DIFF
--- a/ddcommon/src/azure_app_services.rs
+++ b/ddcommon/src/azure_app_services.rs
@@ -104,10 +104,7 @@ impl AzureMetadata {
     ) -> Option<String> {
         match (subscription_id, site_name, resource_group) {
             (Some(id_sub), Some(sitename), Some(res_grp)) => Some(
-                format!(
-                    "/subscriptions/{}/resourcegroups/{}/providers/microsoft.web/sites/{}",
-                    id_sub, res_grp, sitename
-                )
+                format!("/subscriptions/{id_sub}/resourcegroups/{res_grp}/providers/microsoft.web/sites/{sitename}")
                 .to_lowercase(),
             ),
             _ => None,

--- a/ddcommon/src/container_id.rs
+++ b/ddcommon/src/container_id.rs
@@ -51,8 +51,7 @@ const TASK_SOURCE: &str = r"[0-9a-f]{32}-\d+";
 lazy_static! {
     static ref LINE_REGEX: Regex = Regex::new(r"^\d+:[^:]*:(.+)$").unwrap();
     static ref CONTAINER_REGEX: Regex = Regex::new(&format!(
-        r"({}|{}|{})(?:.scope)? *$",
-        UUID_SOURCE, CONTAINER_SOURCE, TASK_SOURCE
+        r"({UUID_SOURCE}|{CONTAINER_SOURCE}|{TASK_SOURCE})(?:.scope)? *$"
     ))
     .unwrap();
 }
@@ -209,8 +208,7 @@ mod tests {
             assert_eq!(
                 extract_container_id(&test_root_dir.join(filename)).ok(),
                 expected_result.map(String::from),
-                "testing file {}",
-                filename
+                "testing file {filename}"
             );
         }
     }

--- a/ddtelemetry/src/ipc/platform/unix/mod.rs
+++ b/ddtelemetry/src/ipc/platform/unix/mod.rs
@@ -48,9 +48,7 @@ mod tests {
     fn get_open_file_descriptors(
         pid: Option<libc::pid_t>,
     ) -> Result<BTreeMap<RawFd, String>, io::Error> {
-        let proc = pid
-            .map(|p| format!("{}", p))
-            .unwrap_or_else(|| "self".into());
+        let proc = pid.map(|p| format!("{p}")).unwrap_or_else(|| "self".into());
 
         let fds_path = std::path::Path::new("/proc").join(proc).join("fd");
         let fds = std::fs::read_dir(fds_path)?

--- a/profiling/tests/wordpress.rs
+++ b/profiling/tests/wordpress.rs
@@ -203,8 +203,7 @@ fn compare_sample(a: api::Sample, b: &api::Sample) {
     for (offset, (a, b)) in a.locations.iter().zip(b.locations.iter()).enumerate() {
         assert_eq!(
             a, b,
-            "Sample location offsets {} differ:\n{:#?}\n{:#?}",
-            offset, a, b
+            "Sample location offsets {offset} differ:\n{a:#?}\n{b:#?}"
         );
     }
 }

--- a/tools/src/bin/dedup_headers.rs
+++ b/tools/src/bin/dedup_headers.rs
@@ -30,7 +30,7 @@ fn read(f: &mut BufReader<&File>) -> String {
 
 fn write_parts(writer: &mut BufWriter<&File>, parts: &[&str]) -> io::Result<()> {
     writer.get_ref().set_len(0)?;
-    writer.seek(io::SeekFrom::Start(0))?;
+    writer.rewind()?;
     for part in parts {
         writer.write_all(part.as_bytes())?;
     }


### PR DESCRIPTION
# What does this PR do?

Fixes some `clippy::uninlined_format_args` lints and also a `clippy::seek_to_start_instead_of_rewind` lint and that appeared on `stable` aka 1.67.0.

# Motivation

An unrelated PR started failing :)

# Additional Notes

Nope.

# How to test the change?

No change, regular tests apply.
