### PR TITLE
fix link to contribution guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Otherwise, this is possibly not the droid you were looking for.
 
 ### Contributing
 
-See <CONTRIBUTING.md>.
+See [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ### Building
 


### PR DESCRIPTION
# What does this PR do?

Links to the `CONTRIBUTING.md` file

# Motivation

I could not click, had to scroll back to the top and then click on the `CONTRIBUTING.md` 😉 

# Additional Notes

Clippy will be pleased in #99 

# How to test the change?

Go to https://github.com/DataDog/libdatadog/tree/florian/fix-readme#contributing and see that `CONTRIBUTING.md` is now linked, click on the link, see the contribution guide, profit 🚀 