### PR TITLE
refactor(profiling)!: less chance of request double free

### DIFF
--- a/examples/ffi/exporter.cpp
+++ b/examples/ffi/exporter.cpp
@@ -136,7 +136,7 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
-  ddog_prof_Exporter_Request *request = build_result.ok;
+  auto &request = build_result.ok;
 
   ddog_CancellationToken *cancel = ddog_CancellationToken_new();
   ddog_CancellationToken *cancel_for_background_thread = ddog_CancellationToken_clone(cancel);
@@ -160,7 +160,7 @@ int main(int argc, char *argv[]) {
   trigger_cancel_if_request_takes_too_long_thread.detach();
 
   int exit_code = 0;
-  ddog_prof_Exporter_SendResult send_result = ddog_prof_Exporter_send(exporter, request, cancel);
+  ddog_prof_Exporter_SendResult send_result = ddog_prof_Exporter_send(exporter, &request, cancel);
   if (send_result.tag == DDOG_PROF_EXPORTER_SEND_RESULT_ERR) {
     print_error("Failed to send profile: ", send_result.err);
     exit_code = 1;
@@ -169,7 +169,7 @@ int main(int argc, char *argv[]) {
     printf("Response code: %d\n", send_result.http_response.code);
   }
 
-  // no ddog_prof_Exporter_Request_drop(request) since it was sent to Exporter_send
+  ddog_prof_Exporter_Request_drop(request);
 
   ddog_prof_Exporter_drop(exporter);
   ddog_CancellationToken_drop(cancel);


### PR DESCRIPTION
# What does this PR do?

This refactors `ddog_prof_Exporter_send` to use a double-pointer for request `ddog_prof_Exporter_Request **request` instead of a single one. This allows it to replace the `*request` of the caller with a null-pointer, reducing the opportunity to double-free it by mistake.

Also does some lifetime refactoring around cancellation tokens. There weren't bugs before as far as I can tell, but now the lifetimes are more obviously bounded.

# Motivation

It bothered me that we kept calling out "don't double-free the request object." We should just make a better API, right?

# Additional Notes

Nope.

# How to test the change?

Handling of the request object is a bit different, it should now look a bit more like this C++ pseudo-code:

```cpp
auto build_result = ddog_prof_Exporter_Request_build(build, ...);
// handle err

auto &request = build_result.ok;
auto send_result = ddog_prof_Exporter_send(exporter, &request, nullptr);

// The build_result.ok now has null, so you can do this drop.
// Or, don't. Whatever you think is cleaner with your specific code.
ddog_prof_Exporter_Request_drop(request);

// handle send_result
```
