### PR TITLE
Trace Normalizer: add service + env tag normalization

### DIFF
--- a/trace-normalization/src/normalize_utils.rs
+++ b/trace-normalization/src/normalize_utils.rs
@@ -127,8 +127,10 @@ pub(crate) fn is_normalized_ascii_tag(tag: &str) -> bool {
         None => return false,
     }
 
-    for mut i in 0..tag.len() {
-        let cur_char = match tag.chars().nth(i) {
+    let mut tag_iter = tag.chars().peekable();
+
+    while tag_iter.peek().is_some() {
+        let cur_char = match tag_iter.next() {
             Some(c) => c,
             None => return false,
         };
@@ -137,8 +139,7 @@ pub(crate) fn is_normalized_ascii_tag(tag: &str) -> bool {
         }
         if cur_char == '_' {
             // an underscore is only okay if followed by a valid non-underscore character
-            i += 1;
-            match tag.chars().nth(i) {
+            match tag_iter.next() {
                 Some(c) => {
                     if !is_valid_ascii_tag_char(c) {
                         return false;

--- a/trace-normalization/src/normalize_utils.rs
+++ b/trace-normalization/src/normalize_utils.rs
@@ -44,11 +44,7 @@ pub(crate) fn fallback_service() -> String {
 pub(crate) fn normalize_service(svc: &str) -> anyhow::Result<String> {
     anyhow::ensure!(!svc.is_empty(), "Normalizer Error: Empty service name.");
 
-    let truncated_service = if svc.len() > MAX_SERVICE_LEN {
-        truncate_utf8(svc, MAX_SERVICE_LEN)
-    } else {
-        svc
-    };
+    let truncated_service = truncate_utf8(svc, MAX_SERVICE_LEN);
 
     normalize_tag(truncated_service)
 }

--- a/trace-normalization/src/normalize_utils.rs
+++ b/trace-normalization/src/normalize_utils.rs
@@ -118,7 +118,10 @@ pub(crate) fn is_normalized_ascii_tag(tag: &str) -> bool {
     if tag.len() > MAX_TAG_LEN {
         return false;
     }
-    match tag.chars().next() {
+
+    let mut tag_iter = tag.chars();
+
+    match tag_iter.next() {
         Some(c) => {
             if !is_valid_ascii_start_char(c) {
                 return false;
@@ -126,8 +129,6 @@ pub(crate) fn is_normalized_ascii_tag(tag: &str) -> bool {
         }
         None => return false,
     }
-
-    let mut tag_iter = tag.chars();
 
     while let Some(cur_char) = tag_iter.next() {
         if is_valid_ascii_tag_char(cur_char) {

--- a/trace-normalization/src/normalize_utils.rs
+++ b/trace-normalization/src/normalize_utils.rs
@@ -34,17 +34,12 @@ pub(crate) fn truncate_utf8(s: &str, limit: usize) -> &str {
 
 // fallbackService returns the fallback service name for a service
 // belonging to language lang.
-pub(crate) fn fallback_service(lang: &str) -> String {
+pub(crate) fn fallback_service() -> String {
     if lang.is_empty() {
         return DEFAULT_SERVICE_NAME.to_string();
     }
-    let mut service_name = String::new();
-    service_name.push_str("unnamed-");
-    service_name.push_str(lang);
-    service_name.push_str("-service");
-    // TODO: the original golang implementation uses a map to cache previously created
-    // service names. Implement that here.
-    service_name
+    // In the go agent implementation, if a lang was specified in TagStats
+    // (extracted from the payload header) the fallback_service name would be "unnamed-{lang}-service". 
 }
 
 // NormalizeService normalizes a span service and returns an error describing the reason

--- a/trace-normalization/src/normalize_utils.rs
+++ b/trace-normalization/src/normalize_utils.rs
@@ -34,14 +34,13 @@ pub(crate) fn truncate_utf8(s: &str, limit: usize) -> &str {
 
 // fallback_service returns the fallback service name for a service
 // belonging to language lang.
+// In the go agent implementation, if a lang was specified in TagStats
+// (extracted from the payload header) the fallback_service name would be "unnamed-{lang}-service".
 pub(crate) fn fallback_service() -> String {
-    // In the go agent implementation, if a lang was specified in TagStats
-    // (extracted from the payload header) the fallback_service name would be "unnamed-{lang}-service".
     DEFAULT_SERVICE_NAME.to_string()
 }
 
-// normalize_service normalizes a span service and returns an error describing the reason
-// (if any) why the name was modified.
+// normalize_service normalizes a span service
 pub(crate) fn normalize_service(svc: &str) -> anyhow::Result<String> {
     anyhow::ensure!(!svc.is_empty(), "Normalizer Error: Empty service name.");
 

--- a/trace-normalization/src/normalize_utils.rs
+++ b/trace-normalization/src/normalize_utils.rs
@@ -36,8 +36,8 @@ pub(crate) fn truncate_utf8(s: &str, limit: usize) -> &str {
 // belonging to language lang.
 pub(crate) fn fallback_service(lang: String) -> String {
     if lang.is_empty() {
-		return DEFAULT_SERVICE_NAME.to_string();
-	}
+        return DEFAULT_SERVICE_NAME.to_string();
+    }
     let mut service_name = String::new();
     service_name.push_str("unnamed-");
     service_name.push_str(&lang);
@@ -52,7 +52,7 @@ pub(crate) fn fallback_service(lang: String) -> String {
 pub(crate) fn normalize_service(svc: &str) -> anyhow::Result<String> {
     anyhow::ensure!(!svc.is_empty(), "Normalizer Error: Empty service name.");
 
-    let truncated_service = if svc.len() > MAX_SERVICE_LEN as usize {
+    let truncated_service = if svc.len() > MAX_SERVICE_LEN {
         truncate_utf8(svc, MAX_SERVICE_LEN)
     } else {
         svc
@@ -64,10 +64,10 @@ pub(crate) fn normalize_service(svc: &str) -> anyhow::Result<String> {
 // NormalizeTag applies some normalization to ensure the tags match the backend requirements.
 pub(crate) fn normalize_tag(tag: &str) -> anyhow::Result<String> {
     // Fast path: Check if the tag is valid and only contains ASCII characters,
-	// if yes return it as-is right away. For most use-cases this reduces CPU usage.
-	if is_normalized_ascii_tag(tag) {
-		return Ok(tag.to_string());
-	}
+    // if yes return it as-is right away. For most use-cases this reduces CPU usage.
+    if is_normalized_ascii_tag(tag) {
+        return Ok(tag.to_string());
+    }
 
     anyhow::ensure!(!tag.is_empty(), "Normalizer Error: Empty tag name.");
 
@@ -79,7 +79,7 @@ pub(crate) fn normalize_tag(tag: &str) -> anyhow::Result<String> {
     let char_vec: Vec<char> = tag.chars().collect();
 
     for cur_char in char_vec {
-        if result.len() == MAX_TAG_LEN as usize {
+        if result.len() == MAX_TAG_LEN {
             break;
         }
         if cur_char.is_lowercase() {
@@ -106,7 +106,9 @@ pub(crate) fn normalize_tag(tag: &str) -> anyhow::Result<String> {
             last_char = cur_char;
             continue;
         }
-        if !result.is_empty() && (cur_char.is_ascii_digit() || cur_char == '.' || cur_char == '/' || cur_char == '-') {
+        if !result.is_empty()
+            && (cur_char.is_ascii_digit() || cur_char == '.' || cur_char == '/' || cur_char == '-')
+        {
             result.push(cur_char);
             last_char = cur_char;
             continue;
@@ -128,7 +130,7 @@ pub(crate) fn is_normalized_ascii_tag(tag: &str) -> bool {
     if tag.is_empty() {
         return true;
     }
-    if tag.len() > MAX_TAG_LEN as usize {
+    if tag.len() > MAX_TAG_LEN {
         return false;
     }
     if !is_valid_ascii_start_char(tag.chars().next().unwrap()) {
@@ -141,10 +143,10 @@ pub(crate) fn is_normalized_ascii_tag(tag: &str) -> bool {
         }
         if b == '_' {
             // an underscore is only okay if followed by a valid non-underscore character
-			i+=1;
-			if i == tag.len() || !is_valid_ascii_tag_char(tag.chars().nth(i).unwrap()) {
-				return false;
-			}
+            i += 1;
+            if i == tag.len() || !is_valid_ascii_tag_char(tag.chars().nth(i).unwrap()) {
+                return false;
+            }
         } else {
             return false;
         }
@@ -269,7 +271,7 @@ mod tests {
             Ok(val) => {
                 assert_eq!(expected_err, "");
                 assert_eq!(val, expected)
-            },
+            }
             Err(err) => {
                 assert_eq!(format!("{err}"), expected_err);
             }

--- a/trace-normalization/src/normalize_utils.rs
+++ b/trace-normalization/src/normalize_utils.rs
@@ -34,13 +34,13 @@ pub(crate) fn truncate_utf8(s: &str, limit: usize) -> &str {
 
 // fallbackService returns the fallback service name for a service
 // belonging to language lang.
-pub(crate) fn fallback_service(lang: String) -> String {
+pub(crate) fn fallback_service(lang: &str) -> String {
     if lang.is_empty() {
         return DEFAULT_SERVICE_NAME.to_string();
     }
     let mut service_name = String::new();
     service_name.push_str("unnamed-");
-    service_name.push_str(&lang);
+    service_name.push_str(lang);
     service_name.push_str("-service");
     // TODO: the original golang implementation uses a map to cache previously created
     // service names. Implement that here.

--- a/trace-normalization/src/normalize_utils.rs
+++ b/trace-normalization/src/normalize_utils.rs
@@ -132,7 +132,10 @@ pub(crate) fn is_normalized_ascii_tag(tag: &str) -> bool {
     }
 
     for mut i in 0..tag.len() {
-        let Some(cur_char) = tag.chars().nth(i) else { return false; };
+        let cur_char = match tag.chars().nth(i) {
+            Some(c) => c,
+            None => return false,
+        };
         if is_valid_ascii_tag_char(cur_char) {
             continue;
         }

--- a/trace-normalization/src/normalize_utils.rs
+++ b/trace-normalization/src/normalize_utils.rs
@@ -35,11 +35,9 @@ pub(crate) fn truncate_utf8(s: &str, limit: usize) -> &str {
 // fallbackService returns the fallback service name for a service
 // belonging to language lang.
 pub(crate) fn fallback_service() -> String {
-    if lang.is_empty() {
-        return DEFAULT_SERVICE_NAME.to_string();
-    }
     // In the go agent implementation, if a lang was specified in TagStats
-    // (extracted from the payload header) the fallback_service name would be "unnamed-{lang}-service". 
+    // (extracted from the payload header) the fallback_service name would be "unnamed-{lang}-service".
+    DEFAULT_SERVICE_NAME.to_string()
 }
 
 // NormalizeService normalizes a span service and returns an error describing the reason

--- a/trace-normalization/src/normalize_utils.rs
+++ b/trace-normalization/src/normalize_utils.rs
@@ -127,13 +127,9 @@ pub(crate) fn is_normalized_ascii_tag(tag: &str) -> bool {
         None => return false,
     }
 
-    let mut tag_iter = tag.chars().peekable();
+    let mut tag_iter = tag.chars();
 
-    while tag_iter.peek().is_some() {
-        let cur_char = match tag_iter.next() {
-            Some(c) => c,
-            None => return false,
-        };
+    while let Some(cur_char) = tag_iter.next() {
         if is_valid_ascii_tag_char(cur_char) {
             continue;
         }

--- a/trace-normalization/src/normalize_utils.rs
+++ b/trace-normalization/src/normalize_utils.rs
@@ -4,14 +4,14 @@
 // Datadog, Inc.
 
 // DEFAULT_SERVICE_NAME is the default name we assign a service if it's missing and we have no reasonable fallback
-pub(crate) const DEFAULT_SERVICE_NAME: &str = "unnamed-service";
+const DEFAULT_SERVICE_NAME: &str = "unnamed-service";
 
 // MAX_NAME_LEN the maximum length a name can have
 pub(crate) const MAX_NAME_LEN: usize = 100;
 // MAX_SERVICE_LEN the maximum length a service can have
-pub(crate) const MAX_SERVICE_LEN: usize = 100;
+const MAX_SERVICE_LEN: usize = 100;
 // MAX_SERVICE_LEN the maximum length a tag can have
-pub(crate) const MAX_TAG_LEN: usize = 200;
+const MAX_TAG_LEN: usize = 200;
 
 // truncate_utf8 truncates the given string to make sure it uses less than limit bytes.
 // If the last character is a utf8 character that would be split, it removes it
@@ -69,9 +69,7 @@ pub(crate) fn normalize_tag(tag: &str) -> anyhow::Result<String> {
 
     let mut result = String::with_capacity(tag.len());
 
-    let char_vec: Vec<char> = tag.chars().collect();
-
-    for cur_char in char_vec {
+    for cur_char in tag.chars() {
         if result.len() == MAX_TAG_LEN {
             break;
         }
@@ -135,10 +133,7 @@ pub(crate) fn is_normalized_ascii_tag(tag: &str) -> bool {
     }
 
     for mut i in 0..tag.len() {
-        let cur_char: char = match tag.chars().nth(i) {
-            Some(c) => c,
-            None => return false,
-        };
+        let Some(cur_char) = tag.chars().nth(i) else { return false; };
         if is_valid_ascii_tag_char(cur_char) {
             continue;
         }

--- a/trace-normalization/src/normalizer.rs
+++ b/trace-normalization/src/normalizer.rs
@@ -21,9 +21,12 @@ pub fn normalize(s: &mut pb::Span) -> anyhow::Result<()> {
     anyhow::ensure!(s.trace_id != 0, "TraceID is zero (reason:trace_id_zero)");
     anyhow::ensure!(s.span_id != 0, "SpanID is zero (reason:span_id_zero)");
 
-    // TODO: Implement service name normalizer in future PR
-    // let (svc, _) = normalize_utils::normalize_service(s.service.clone(), "".to_string());
-    // s.service = svc;
+    let normalized_service = match normalize_utils::normalize_service(&s.service) {
+        Ok(service) => service,
+        Err(_) => normalize_utils::fallback_service("".to_string())
+    };
+
+    s.service = normalized_service;
 
     // TODO: check for a feature flag to determine the component tag to become the span name
     // https://github.com/DataDog/datadog-agent/blob/dc88d14851354cada1d15265220a39dce8840dcc/pkg/trace/agent/normalizer.go#L64
@@ -76,14 +79,18 @@ pub fn normalize(s: &mut pb::Span) -> anyhow::Result<()> {
         s.r#type = normalize_utils::truncate_utf8(&s.r#type, MAX_TYPE_LEN).to_string();
     }
 
-    // TODO: Implement tag normalization in future PR
-    // if s.meta.contains_key("env") {
-    //     let env_tag: String = s.meta.get("env").unwrap().to_string();
-    //     s.meta.insert("env".to_string(), normalize_utils::normalize_tag(env_tag));
-    // }
+    if s.meta.contains_key("env") {
+        let env_tag: &str = s.meta.get("env").unwrap();
+        match normalize_utils::normalize_tag(env_tag) {
+            Ok(normalized_tag) => {
+                s.meta.insert("env".to_string(), normalized_tag);
+            },
+            Err(_) => {}
+        }
+    };
 
     if let Some(code) = s.meta.get("http.status_code") {
-        if !is_valid_status_code(code.to_string()) {
+        if !is_valid_status_code(code) {
             s.meta.remove("http.status_code");
         }
     };
@@ -91,7 +98,7 @@ pub fn normalize(s: &mut pb::Span) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub(crate) fn is_valid_status_code(sc: String) -> bool {
+pub(crate) fn is_valid_status_code(sc: &str) -> bool {
     if let Ok(code) = sc.parse::<i64>() {
         return (100..600).contains(&code);
     }
@@ -100,12 +107,12 @@ pub(crate) fn is_valid_status_code(sc: String) -> bool {
 
 #[cfg(test)]
 mod tests {
-
     use crate::normalize_utils;
     use crate::normalizer;
     use crate::pb;
     use rand::Rng;
     use std::collections::HashMap;
+    use std::time::SystemTime;
 
     pub fn new_test_span() -> pb::Span {
         let mut rng = rand::thread_rng();
@@ -197,5 +204,226 @@ mod tests {
         test_span.resource = "".to_string();
         assert!(normalizer::normalize(&mut test_span).is_ok());
         assert_eq!(test_span.resource, test_span.name);
+    }
+
+    #[test]
+    pub fn test_normalize_trace_id_passes() {
+        let mut test_span = new_test_span();
+        let before_trace_id = test_span.trace_id;
+        assert!(normalizer::normalize(&mut test_span).is_ok());
+        assert_eq!(before_trace_id, test_span.trace_id);
+    }
+
+    #[test]
+    pub fn test_normalize_no_trace_id() {
+        let mut test_span = new_test_span();
+        test_span.trace_id = 0;
+        assert!(normalizer::normalize(&mut test_span).is_err());
+    }
+
+    #[test]
+    pub fn test_normalize_component_to_name() {
+        let mut test_span = new_test_span();
+        let before_trace_id = test_span.trace_id;
+        assert!(normalizer::normalize(&mut test_span).is_ok());
+        assert_eq!(before_trace_id, test_span.trace_id);
+    }
+
+    // TODO: Add a unit test for testing Component2Name, one that is 
+    //       implemented within the normalize function.
+
+    #[test]
+    pub fn test_normalize_span_id_passes() {
+        let mut test_span = new_test_span();
+        let before_span_id = test_span.span_id;
+        assert!(normalizer::normalize(&mut test_span).is_ok());
+        assert_eq!(before_span_id, test_span.span_id);
+    }
+
+    #[test]
+    pub fn test_normalize_no_span_id() {
+        let mut test_span = new_test_span();
+        test_span.span_id = 0;
+        assert!(normalizer::normalize(&mut test_span).is_err());
+    }
+
+    #[test]
+    pub fn test_normalize_start_passes() {
+        let mut test_span = new_test_span();
+        let before_start = test_span.start;
+        assert!(normalizer::normalize(&mut test_span).is_ok());
+        assert_eq!(before_start, test_span.start);
+    }
+
+    fn get_current_time() -> i64 {
+        SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_nanos() as i64
+    }
+
+    #[test]
+    pub fn test_normalize_start_too_small() {
+        let mut test_span = new_test_span();
+
+        test_span.start = 42;
+        let min_start = get_current_time() - test_span.duration;
+
+        assert!(normalizer::normalize(&mut test_span).is_ok());
+        assert!(test_span.start >= min_start);
+        assert!(test_span.start <= get_current_time());
+    }
+
+    #[test]
+    pub fn test_normalize_start_too_small_with_large_duration() {
+        let mut test_span = new_test_span();
+        
+        test_span.start = 42;
+        test_span.duration = get_current_time() * 2;
+        let min_start = get_current_time();
+        
+        assert!(normalizer::normalize(&mut test_span).is_ok());
+        assert!(test_span.start >= min_start); // start should have been reset to current time
+        assert!(test_span.start <= get_current_time()); //start should have been reset to current time
+    }
+
+    #[test]
+    pub fn test_normalize_duration_passes() {
+        let mut test_span = new_test_span();
+        let before_duration = test_span.duration;
+
+        assert!(normalizer::normalize(&mut test_span).is_ok());
+        assert_eq!(before_duration, test_span.duration);
+    }
+
+    #[test]
+    pub fn test_normalize_empty_duration() {
+        let mut test_span = new_test_span();
+        test_span.duration = 0;
+
+        assert!(normalizer::normalize(&mut test_span).is_ok());
+        assert_eq!(test_span.duration, 0);
+    }
+
+    #[test]
+    pub fn test_normalize_negative_duration() {
+        let mut test_span = new_test_span();
+        test_span.duration = -50;
+
+        assert!(normalizer::normalize(&mut test_span).is_ok());
+        assert_eq!(test_span.duration, 0);
+    }
+
+    #[test]
+    pub fn test_normalize_large_duration() {
+        let mut test_span = new_test_span();
+        test_span.duration = std::i64::MAX;
+
+        assert!(normalizer::normalize(&mut test_span).is_ok());
+        assert_eq!(test_span.duration, 0);
+    }
+
+    #[test]
+    pub fn test_normalize_error_passes() {
+        let mut test_span = new_test_span();
+        let before_error = test_span.error;
+
+        assert!(normalizer::normalize(&mut test_span).is_ok());
+        assert_eq!(before_error, test_span.error);
+    }
+
+    #[test]
+    pub fn test_normalize_metrics_passes() {
+        let mut test_span = new_test_span();
+        let before_metrics = test_span.metrics.clone();
+
+        assert!(normalizer::normalize(&mut test_span).is_ok());
+        assert_eq!(before_metrics, test_span.metrics);
+    }
+
+    #[test]
+    pub fn test_normalize_meta_passes() {
+        let mut test_span = new_test_span();
+        let before_meta = test_span.meta.clone();
+
+        assert!(normalizer::normalize(&mut test_span).is_ok());
+        assert_eq!(before_meta, test_span.meta);
+    }
+
+    #[test]
+    pub fn test_normalize_parent_id_passes() {
+        let mut test_span = new_test_span();
+        let before_parent_id = test_span.parent_id;
+
+        assert!(normalizer::normalize(&mut test_span).is_ok());
+        assert_eq!(before_parent_id, test_span.parent_id);
+    }
+
+    #[test]
+    pub fn test_normalize_type_passes() {
+        let mut test_span = new_test_span();
+        let before_type = test_span.r#type.clone();
+
+        assert!(normalizer::normalize(&mut test_span).is_ok());
+        assert_eq!(before_type, test_span.r#type);
+    }
+
+    #[test]
+    pub fn test_normalize_type_too_long() {
+        let mut test_span = new_test_span();
+        test_span.r#type = "sql".repeat(1000);
+
+        assert!(normalizer::normalize(&mut test_span).is_ok());
+        assert_eq!(test_span.r#type.len(), normalizer::MAX_TYPE_LEN as usize);
+    }
+
+    #[test]
+    pub fn test_normalize_service_tag() {
+        let mut test_span = new_test_span();
+        test_span.service = "retargeting(api-Staging ".to_string();
+
+        assert!(normalizer::normalize(&mut test_span).is_ok());
+        assert_eq!(test_span.service, "retargeting_api-staging");
+    }
+
+    #[test]
+    pub fn test_normalize_env() {
+        let mut test_span = new_test_span();
+        test_span.meta.insert("env".to_string(), "DEVELOPMENT".to_string());
+
+        assert!(normalizer::normalize(&mut test_span).is_ok());
+        assert_eq!("development", test_span.meta.get("env").unwrap());
+    }
+
+    #[test]
+    pub fn test_special_zipkin_root_span() {
+        let mut test_span = new_test_span();
+        test_span.parent_id = 42;
+        test_span.trace_id = 42;
+        test_span.span_id = 42;
+
+        let before_trace_id = test_span.trace_id;
+        let before_span_id = test_span.span_id;
+
+        assert!(normalizer::normalize(&mut test_span).is_ok());
+        assert_eq!(test_span.parent_id, 0);
+        assert_eq!(test_span.trace_id, before_trace_id);
+        assert_eq!(test_span.span_id, before_span_id);
+
+    }
+
+    #[test]
+    pub fn test_normalize_trace_empty() {
+        let mut test_span = new_test_span();
+        test_span.meta.insert("env".to_string(), "DEVELOPMENT".to_string());
+
+        assert!(normalizer::normalize(&mut test_span).is_ok());
+        assert_eq!("development", test_span.meta.get("env").unwrap());
+    }
+
+    #[test]
+    pub fn test_is_valid_status_code() {
+        assert!(normalizer::is_valid_status_code("100"));
+        assert!(normalizer::is_valid_status_code("599"));
+        assert!(!normalizer::is_valid_status_code("99"));
+        assert!(!normalizer::is_valid_status_code("600"));
+        assert!(!normalizer::is_valid_status_code("Invalid status code"));
     }
 }

--- a/trace-normalization/src/normalizer.rs
+++ b/trace-normalization/src/normalizer.rs
@@ -113,7 +113,7 @@ mod tests {
     use std::collections::HashMap;
     use std::time::SystemTime;
 
-    pub fn new_test_span() -> pb::Span {
+    fn new_test_span() -> pb::Span {
         let mut rng = rand::thread_rng();
 
         pb::Span {
@@ -137,7 +137,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_normalize_name_passes() {
+    fn test_normalize_name_passes() {
         let mut test_span = new_test_span();
         let before_name = test_span.name.clone();
         assert!(normalizer::normalize(&mut test_span).is_ok());
@@ -145,7 +145,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_normalize_empty_name() {
+    fn test_normalize_empty_name() {
         let mut test_span = new_test_span();
         test_span.name = "".to_string();
         assert!(normalizer::normalize(&mut test_span).is_ok());
@@ -153,7 +153,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_normalize_long_name() {
+    fn test_normalize_long_name() {
         let mut test_span = new_test_span();
         test_span.name = "CAMEMBERT".repeat(100);
         assert!(normalizer::normalize(&mut test_span).is_ok());
@@ -161,7 +161,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_normalize_name_no_alphanumeric() {
+    fn test_normalize_name_no_alphanumeric() {
         let mut test_span = new_test_span();
         test_span.name = "/".to_string();
         assert!(normalizer::normalize(&mut test_span).is_ok());
@@ -169,7 +169,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_normalize_name_for_metrics() {
+    fn test_normalize_name_for_metrics() {
         let expected_names = HashMap::from([
             (
                 "pylons.controller".to_string(),
@@ -190,7 +190,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_normalize_resource_passes() {
+    fn test_normalize_resource_passes() {
         let mut test_span = new_test_span();
         let before_resource = test_span.resource.clone();
         assert!(normalizer::normalize(&mut test_span).is_ok());
@@ -198,7 +198,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_normalize_empty_resource() {
+    fn test_normalize_empty_resource() {
         let mut test_span = new_test_span();
         test_span.resource = "".to_string();
         assert!(normalizer::normalize(&mut test_span).is_ok());
@@ -206,7 +206,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_normalize_trace_id_passes() {
+    fn test_normalize_trace_id_passes() {
         let mut test_span = new_test_span();
         let before_trace_id = test_span.trace_id;
         assert!(normalizer::normalize(&mut test_span).is_ok());
@@ -214,14 +214,14 @@ mod tests {
     }
 
     #[test]
-    pub fn test_normalize_no_trace_id() {
+    fn test_normalize_no_trace_id() {
         let mut test_span = new_test_span();
         test_span.trace_id = 0;
         assert!(normalizer::normalize(&mut test_span).is_err());
     }
 
     #[test]
-    pub fn test_normalize_component_to_name() {
+    fn test_normalize_component_to_name() {
         let mut test_span = new_test_span();
         let before_trace_id = test_span.trace_id;
         assert!(normalizer::normalize(&mut test_span).is_ok());
@@ -232,7 +232,7 @@ mod tests {
     //       implemented within the normalize function.
 
     #[test]
-    pub fn test_normalize_span_id_passes() {
+    fn test_normalize_span_id_passes() {
         let mut test_span = new_test_span();
         let before_span_id = test_span.span_id;
         assert!(normalizer::normalize(&mut test_span).is_ok());
@@ -240,14 +240,14 @@ mod tests {
     }
 
     #[test]
-    pub fn test_normalize_no_span_id() {
+    fn test_normalize_no_span_id() {
         let mut test_span = new_test_span();
         test_span.span_id = 0;
         assert!(normalizer::normalize(&mut test_span).is_err());
     }
 
     #[test]
-    pub fn test_normalize_start_passes() {
+    fn test_normalize_start_passes() {
         let mut test_span = new_test_span();
         let before_start = test_span.start;
         assert!(normalizer::normalize(&mut test_span).is_ok());
@@ -262,7 +262,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_normalize_start_too_small() {
+    fn test_normalize_start_too_small() {
         let mut test_span = new_test_span();
 
         test_span.start = 42;
@@ -274,7 +274,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_normalize_start_too_small_with_large_duration() {
+    fn test_normalize_start_too_small_with_large_duration() {
         let mut test_span = new_test_span();
 
         test_span.start = 42;
@@ -287,7 +287,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_normalize_duration_passes() {
+    fn test_normalize_duration_passes() {
         let mut test_span = new_test_span();
         let before_duration = test_span.duration;
 
@@ -296,7 +296,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_normalize_empty_duration() {
+    fn test_normalize_empty_duration() {
         let mut test_span = new_test_span();
         test_span.duration = 0;
 
@@ -305,7 +305,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_normalize_negative_duration() {
+    fn test_normalize_negative_duration() {
         let mut test_span = new_test_span();
         test_span.duration = -50;
 
@@ -314,7 +314,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_normalize_large_duration() {
+    fn test_normalize_large_duration() {
         let mut test_span = new_test_span();
         test_span.duration = std::i64::MAX;
 
@@ -323,7 +323,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_normalize_error_passes() {
+    fn test_normalize_error_passes() {
         let mut test_span = new_test_span();
         let before_error = test_span.error;
 
@@ -332,7 +332,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_normalize_metrics_passes() {
+    fn test_normalize_metrics_passes() {
         let mut test_span = new_test_span();
         let before_metrics = test_span.metrics.clone();
 
@@ -341,7 +341,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_normalize_meta_passes() {
+    fn test_normalize_meta_passes() {
         let mut test_span = new_test_span();
         let before_meta = test_span.meta.clone();
 
@@ -350,7 +350,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_normalize_parent_id_passes() {
+    fn test_normalize_parent_id_passes() {
         let mut test_span = new_test_span();
         let before_parent_id = test_span.parent_id;
 
@@ -359,7 +359,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_normalize_type_passes() {
+    fn test_normalize_type_passes() {
         let mut test_span = new_test_span();
         let before_type = test_span.r#type.clone();
 
@@ -368,7 +368,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_normalize_type_too_long() {
+    fn test_normalize_type_too_long() {
         let mut test_span = new_test_span();
         test_span.r#type = "sql".repeat(1000);
 
@@ -377,7 +377,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_normalize_service_tag() {
+    fn test_normalize_service_tag() {
         let mut test_span = new_test_span();
         test_span.service = "retargeting(api-Staging ".to_string();
 
@@ -386,7 +386,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_normalize_env() {
+    fn test_normalize_env() {
         let mut test_span = new_test_span();
         test_span
             .meta
@@ -397,7 +397,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_special_zipkin_root_span() {
+    fn test_special_zipkin_root_span() {
         let mut test_span = new_test_span();
         test_span.parent_id = 42;
         test_span.trace_id = 42;
@@ -413,7 +413,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_normalize_trace_empty() {
+    fn test_normalize_trace_empty() {
         let mut test_span = new_test_span();
         test_span
             .meta
@@ -424,7 +424,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_is_valid_status_code() {
+    fn test_is_valid_status_code() {
         assert!(normalizer::is_valid_status_code("100"));
         assert!(normalizer::is_valid_status_code("599"));
         assert!(!normalizer::is_valid_status_code("99"));

--- a/trace-normalization/src/normalizer.rs
+++ b/trace-normalization/src/normalizer.rs
@@ -23,7 +23,7 @@ pub fn normalize(s: &mut pb::Span) -> anyhow::Result<()> {
 
     let normalized_service = match normalize_utils::normalize_service(&s.service) {
         Ok(service) => service,
-        Err(_) => normalize_utils::fallback_service(""),
+        Err(_) => normalize_utils::fallback_service(),
     };
 
     s.service = normalized_service;

--- a/trace-normalization/src/normalizer.rs
+++ b/trace-normalization/src/normalizer.rs
@@ -23,7 +23,7 @@ pub fn normalize(s: &mut pb::Span) -> anyhow::Result<()> {
 
     let normalized_service = match normalize_utils::normalize_service(&s.service) {
         Ok(service) => service,
-        Err(_) => normalize_utils::fallback_service("".to_string()),
+        Err(_) => normalize_utils::fallback_service(""),
     };
 
     s.service = normalized_service;

--- a/trace-normalization/src/normalizer.rs
+++ b/trace-normalization/src/normalizer.rs
@@ -28,7 +28,7 @@ pub fn normalize(s: &mut pb::Span) -> anyhow::Result<()> {
 
     s.service = normalized_service;
 
-    // TODO: check for a feature flag to determine the component tag to become the span name
+    // TODO: component2name: check for a feature flag to determine the component tag to become the span name
     // https://github.com/DataDog/datadog-agent/blob/dc88d14851354cada1d15265220a39dce8840dcc/pkg/trace/agent/normalizer.go#L64
 
     let normalized_name = match normalize_utils::normalize_name(&s.name) {
@@ -107,6 +107,7 @@ pub(crate) fn is_valid_status_code(sc: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+
     use crate::normalize_utils;
     use crate::normalizer;
     use crate::pb;

--- a/trace-normalization/src/normalizer.rs
+++ b/trace-normalization/src/normalizer.rs
@@ -80,9 +80,10 @@ pub fn normalize(s: &mut pb::Span) -> anyhow::Result<()> {
     }
 
     if s.meta.contains_key("env") {
-        let env_tag: &str = s.meta.get("env").unwrap();
-        if let Ok(normalized_tag) = normalize_utils::normalize_tag(env_tag) {
-            s.meta.insert("env".to_string(), normalized_tag);
+        if let Some(env_tag) = s.meta.get("env") {
+            if let Ok(normalized_tag) = normalize_utils::normalize_tag(env_tag) {
+                s.meta.insert("env".to_string(), normalized_tag);
+            }
         }
     };
 


### PR DESCRIPTION
# What does this PR do?

Adds service tag and env tag normalization to the normalizer + associated unit tests.

This normalizer is modeled very closely after the existing agent trace normalizer, which can be found [here](https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/agent/normalizer.go).

The next PR will cover:
- `normalize_trace`
- `normalize_chunk`

These two last functions in the normalizer are much shorter than `normalize`

# Motivation

The trace normalizer will be used in our serverless agentless POC, which will use it to normalize traces before being sent directly to the datadog trace intake.

See: [the serverless branch](https://github.com/DataDog/libdatadog/tree/serverless)

# Additional Notes

- Tags allow non ascii alpha characters, while metrics names don't

# How to test the change?

Describe here in detail how the change can be validated.

The changes have been manually tested using the agentless POC, normalizing span names and verifying the normalization works as expected. Unit tests have been copied/translated from the agent normalizer unit tests written in go.
