### PR TITLE
Remove unneeded "gem signout" step from Ruby release

### DIFF
--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -118,8 +118,6 @@ task push_to_rubygems: [
   :package,
   :"release:guard_clean"
 ] do
-  system("gem signout") # make sure there are no existing credentials in use
-
   puts "Please input 'libdatadog ruby release key' from 'Profiling - Falcon' Datadog 1Password:"
   input = $stdin.gets.strip
 
@@ -128,8 +126,6 @@ task push_to_rubygems: [
   system("gem push pkg/libdatadog-#{Libdatadog::VERSION}.gem")
   system("gem push pkg/libdatadog-#{Libdatadog::VERSION}-x86_64-linux.gem")
   system("gem push pkg/libdatadog-#{Libdatadog::VERSION}-aarch64-linux.gem")
-
-  system("gem signout") # leave no credentials behind
 end
 
 module Helpers


### PR DESCRIPTION
**What does this PR do?**:

This PR removes the now-unneeded "gem signout" steps during the Ruby release process.

**Motivation**:

In #85, we changed the way that we authenticate with rubygems.org when pushing a new libdatadog release.

I just did a release with this new code, and noticed that because we no longer log in, but just use a limited API key, the "gem signout" does not do anything and emits an error.

Here's what I saw when I ran `docker-compose run push_to_rubygems`:

```
... preparation of packages goes here...

ERROR:  You are not currently signed in.
Please input 'libdatadog ruby release key' from 'Profiling - Falcon' Datadog 1Password:
(...key...)
Pushing gem to https://rubygems.org...
You have enabled multi-factor authentication. Please enter OTP code.
Code:   (...)
Successfully registered gem: libdatadog (2.0.0.1.0)
Pushing gem to https://rubygems.org...
You have enabled multi-factor authentication. Please enter OTP code.
Code:   (...)
Successfully registered gem: libdatadog (2.0.0.1.0-x86_64-linux)
Pushing gem to https://rubygems.org...
You have enabled multi-factor authentication. Please enter OTP code.
Code:   (...)
Successfully registered gem: libdatadog (2.0.0.1.0-aarch64-linux)
ERROR:  You are not currently signed in.
```

Those two "ERROR:  You are not currently signed in" come from the "gem signout" steps, and what's why I'm removing them.

**Additional Notes**:

(N/A)

**How to test the change?**:

You can run `docker-compose run push_to_rubygems` and validate the errors will not show up again. This is safe because Rubygems does not allow re-releasing the same packages.