### PR TITLE
Trace Normalizer: add trace & trace chunk normalization

### DIFF
--- a/trace-normalization/src/normalizer.rs
+++ b/trace-normalization/src/normalizer.rs
@@ -5,6 +5,7 @@
 
 use crate::normalize_utils;
 use crate::pb;
+use std::collections::HashSet;
 use std::time::SystemTime;
 
 const MAX_TYPE_LEN: usize = 100;
@@ -102,6 +103,36 @@ pub(crate) fn is_valid_status_code(sc: &str) -> bool {
     }
     false
 }
+
+// normalize_trace takes a trace and
+// * rejects the trace if there is a trace ID discrepancy between 2 spans
+// * rejects the trace if two spans have the same span_id
+// * rejects empty traces
+// * rejects traces where at least one span cannot be normalized
+// * return the normalized trace and an error:
+//   - nil if the trace can be accepted
+//   - a reason tag explaining the reason the traces failed normalization
+// pub fn normalize_trace(t: &mut [pb::Span]) -> anyhow::Result<()> {
+//     if t.is_empty() {
+//        anyhow::bail!("Normalize Trace Error: Trace is empty.");
+//     }
+
+//     let mut span_ids = HashSet::new();
+
+//     let first_span = &t[0];
+
+//     for i in 1..t.len() {
+//         if t[i].trace_id != first_span.trace_id {
+//             anyhow::bail!(format!("Normalize Trace Error: Trace has foreign span: {:?}", t[i]));
+//         }
+//         match normalize(t[i]) {
+//             Ok(_) => {}
+//             Err(e) => return Err(e)
+//         }
+//         span_ids.insert(&span.span_id);
+//     }
+//     Ok(())
+// }
 
 #[cfg(test)]
 mod tests {

--- a/trace-normalization/src/normalizer.rs
+++ b/trace-normalization/src/normalizer.rs
@@ -113,9 +113,9 @@ pub(crate) fn is_valid_status_code(sc: &str) -> bool {
     false
 }
 
-// normalize_trace takes a trace and
-// * returns an error if there is a trace ID discrepancy between 2 spans
-// * returns an error if at least one span cannot be normalized
+/// normalize_trace takes a trace and
+/// * returns an error if there is a trace ID discrepancy between 2 spans
+/// * returns an error if at least one span cannot be normalized
 pub fn normalize_trace(trace: &mut [pb::Span]) -> anyhow::Result<()> {
     if trace.is_empty() {
         anyhow::bail!("Normalize Trace Error: Trace is empty.");

--- a/trace-normalization/src/normalizer.rs
+++ b/trace-normalization/src/normalizer.rs
@@ -130,10 +130,7 @@ pub fn normalize_trace(trace: &mut [pb::Span]) -> anyhow::Result<()> {
                 span
             ));
         }
-        match normalize_span(span) {
-            Ok(_) => {}
-            Err(e) => anyhow::bail!(e),
-        }
+        normalize_span(span)?;
     }
     Ok(())
 }


### PR DESCRIPTION
# What does this PR do?

This PR adds the public functions `normalize_trace` and `normalize_chunk` to the normalizer, as well as associated unit tests.

# Motivation

# Additional Notes

in the go agent trace normalizer, the `normalize_chunk` function takes in the chunk, and a pointer to the root span ([see here](https://github.com/DataDog/datadog-agent/blob/85f2ce92c3d71988a1cf4693a9b472b25dacdd49/pkg/trace/agent/normalizer.go#L148)). Because of the fact that in rust the root span will have been moved into the spans vec of the trace chunk itself, I've opted to pass the index of the root span within the trace chunk spans vec instead

# How to test the change?

unit tests cover these additions (unit tests are translated/copied from the go agent normalizer)
