### PR TITLE
Add scripts to builds artifacts on windows

### DIFF
--- a/windows/build-artifacts.ps1
+++ b/windows/build-artifacts.ps1
@@ -1,0 +1,38 @@
+function Invoke-Call {
+    param (
+        [scriptblock]$ScriptBlock
+    )
+    & @ScriptBlock
+    if ($lastexitcode -ne 0) {
+        exit $lastexitcode
+    }
+}
+
+$output_dir = $args[0]
+
+if ([string]::IsNullOrEmpty($output_dir)) {
+    throw "You must specify an output directory. Ex: $($myInvocation.InvocationName) my_rust_project/ bin"
+}
+
+if (![System.IO.Path]::IsPathRooted($output_dir)) {
+    $output_dir = [System.IO.Path]::Combine($(Get-Location), $output_dir)
+}
+
+Write-Host "Building project into $($output_dir)" -ForegroundColor Magenta
+
+Invoke-Call -ScriptBlock { cargo build --target i686-pc-windows-msvc --release --target-dir $output_dir }
+Invoke-Call -ScriptBlock { cargo build --target i686-pc-windows-msvc --target-dir $output_dir }
+Invoke-Call -ScriptBlock { cargo build --target x86_64-pc-windows-msvc --release --target-dir $output_dir }
+Invoke-Call -ScriptBlock { cargo build --target x86_64-pc-windows-msvc --target-dir $output_dir }
+
+Write-Host "Building tools" -ForegroundColor Magenta
+Set-Location tools
+Invoke-Call -ScriptBlock { cargo build --release }
+Set-Location ..
+
+Write-Host "Generating headers" -ForegroundColor Magenta
+Invoke-Call -ScriptBlock { cbindgen --crate ddcommon-ffi --config ddcommon-ffi/cbindgen.toml --output $output_dir\common.h }
+Invoke-Call -ScriptBlock { cbindgen --crate datadog-profiling-ffi --config profiling-ffi/cbindgen.toml --output $output_dir\profiling.h }
+Invoke-Call -ScriptBlock { .\target\release\dedup_headers $output_dir"\common.h"  $output_dir"\profiling.h" }
+
+Write-Host "Build finished"  -ForegroundColor Magenta

--- a/windows/libdatadog.csproj
+++ b/windows/libdatadog.csproj
@@ -1,0 +1,63 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <id>libdatadog</id>
+    <Company>Datadog</Company>
+    <Authors>Datadog</Authors>
+    <Title>Datadog libdatadog</Title>
+    <Version>$(LibdatadogVersion)</Version>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageProjectUrl>https://github.com/DataDog/libdatadog</PackageProjectUrl>
+    <Description>libdatadog provides a shared library containing common code used in the
+      implementation of Datadog's libraries, including Datadog Continuous Profilers</Description>
+    <PackageReleaseNotes>Release of libdatadog</PackageReleaseNotes>
+    <Copyright>Copyright 2022 Datadog, Inc.</Copyright>
+    <PackageTags>Datadog;native;</PackageTags>
+    <RepositoryType>git</RepositoryType>
+
+    <!-- NuGet packages -->
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="..\README.md" Pack="true" PackagePath="\" />
+    <None Include="..\LICENSE" Pack="true" PackagePath="\" />
+    <None Include="libdatadog.props" Pack="true" PackagePath="build\native\libdatadog.props" />
+
+    <None Include="$(LibDatadogBinariesOutputDir)\common.h" Pack="true"
+      PackagePath="include\native\datadog\common.h" />
+    <None Include="$(LibDatadogBinariesOutputDir)\profiling.h" Pack="true"
+      PackagePath="include\native\datadog\profiling.h" />
+
+    <None Include="$(LibDatadogBinariesOutputDir)\x86_64-pc-windows-msvc\debug\datadog_profiling_ffi.lib"
+      Pack="true" PackagePath="build\native\lib\x64\debug\datadog_profiling_ffi.lib" />
+    <None Include="$(LibDatadogBinariesOutputDir)\x86_64-pc-windows-msvc\debug\datadog_profiling_ffi.dll"
+      Pack="true" PackagePath="build\native\lib\x64\debug\datadog_profiling_ffi.dll" />
+    <None Include="$(LibDatadogBinariesOutputDir)\x86_64-pc-windows-msvc\debug\datadog_profiling_ffi.pdb"
+      Pack="true" PackagePath="build\native\lib\x64\debug\datadog_profiling_ffi.pdb" />
+
+    <None Include="$(LibDatadogBinariesOutputDir)\x86_64-pc-windows-msvc\release\datadog_profiling_ffi.lib"
+      Pack="true" PackagePath="build\native\lib\x64\release\datadog_profiling_ffi.lib" />
+    <None Include="$(LibDatadogBinariesOutputDir)\x86_64-pc-windows-msvc\release\datadog_profiling_ffi.dll"
+      Pack="true" PackagePath="build\native\lib\x64\release\datadog_profiling_ffi.dll" />
+    <None Include="$(LibDatadogBinariesOutputDir)\x86_64-pc-windows-msvc\release\datadog_profiling_ffi.pdb"
+      Pack="true" PackagePath="build\native\lib\x64\release\datadog_profiling_ffi.lpdb" />
+
+    <None Include="$(LibDatadogBinariesOutputDir)\i686-pc-windows-msvc\debug\datadog_profiling_ffi.lib"
+      Pack="true" PackagePath="build\native\lib\x86\debug\datadog_profiling_ffi.lib" />
+    <None Include="$(LibDatadogBinariesOutputDir)\i686-pc-windows-msvc\debug\datadog_profiling_ffi.dll"
+      Pack="true" PackagePath="build\native\lib\x86\debug\datadog_profiling_ffi.dll" />
+    <None Include="$(LibDatadogBinariesOutputDir)\i686-pc-windows-msvc\debug\datadog_profiling_ffi.pdb"
+      Pack="true" PackagePath="build\native\lib\x86\debug\datadog_profiling_ffi.pdb" />
+
+    <None Include="$(LibDatadogBinariesOutputDir)\i686-pc-windows-msvc\release\datadog_profiling_ffi.lib"
+      Pack="true" PackagePath="build\native\lib\x86\release\datadog_profiling_ffi.lib" />
+    <None Include="$(LibDatadogBinariesOutputDir)\i686-pc-windows-msvc\release\datadog_profiling_ffi.dll"
+      Pack="true" PackagePath="build\native\lib\x86\release\datadog_profiling_ffi.dll" />
+    <None Include="$(LibDatadogBinariesOutputDir)\i686-pc-windows-msvc\release\datadog_profiling_ffi.pdb"
+      Pack="true" PackagePath="build\native\lib\x86\release\datadog_profiling_ffi.pdb" />
+  </ItemGroup>
+</Project>

--- a/windows/libdatadog.props
+++ b/windows/libdatadog.props
@@ -2,23 +2,23 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"
         ToolsVersion="15.0">
   <PropertyGroup>
-    <LIBDDPROF-PLATFORM Condition="'$(Platform)'=='x64'">x64</LIBDDPROF-PLATFORM>
-    <LIBDDPROF-PLATFORM Condition="'$(Platform)'=='Win32' OR '$(Platform)'=='x86'">x86</LIBDDPROF-PLATFORM>
+    <LIBDATADOG-PLATFORM Condition="'$(Platform)'=='x64'">x64</LIBDATADOG-PLATFORM>
+    <LIBDATADOG-PLATFORM Condition="'$(Platform)'=='Win32' OR '$(Platform)'=='x86'">x86</LIBDATADOG-PLATFORM>
   </PropertyGroup>
   <ItemGroup>
-  <LibddprofLibs Include="$(MSBuildThisFileDirectory)..\..\build\native\lib\$(LIBDDPROF-PLATFORM)\$(Configuration)\*.lib" />
+  <LibdatadogLibs Include="$(MSBuildThisFileDirectory)..\..\build\native\lib\$(LIBDATADOG-PLATFORM)\$(Configuration)\*.lib" />
   </ItemGroup>
   <PropertyGroup>
     <!-- Expland the items to a property -->
-    <LibddprofLibraries>@(LibddprofLibs)</LibddprofLibraries>
-    <LibddprofDependencies>NtDll.lib;UserEnv.lib;Bcrypt.lib;crypt32.lib;wsock32.lib;ws2_32.lib;shlwapi.lib;Secur32.lib;Ncrypt.lib</LibddprofDependencies>
+    <LibdatadogLibraries>@(LibdatadogLibs)</LibdatadogLibraries>
+    <LibdatadogDependencies>NtDll.lib;UserEnv.lib;Bcrypt.lib;crypt32.lib;wsock32.lib;ws2_32.lib;shlwapi.lib;Secur32.lib;Ncrypt.lib</LibdatadogDependencies>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)..\..\include\native;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>$(LibddprofLibraries);$(LibddprofDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(LibdatadogLibraries);$(LibdatadogDependencies);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 </Project>

--- a/windows/libdatadog.props
+++ b/windows/libdatadog.props
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"
+        ToolsVersion="15.0">
+  <PropertyGroup>
+    <LIBDDPROF-PLATFORM Condition="'$(Platform)'=='x64'">x64</LIBDDPROF-PLATFORM>
+    <LIBDDPROF-PLATFORM Condition="'$(Platform)'=='Win32' OR '$(Platform)'=='x86'">x86</LIBDDPROF-PLATFORM>
+  </PropertyGroup>
+  <ItemGroup>
+  <LibddprofLibs Include="$(MSBuildThisFileDirectory)..\..\build\native\lib\$(LIBDDPROF-PLATFORM)\$(Configuration)\*.lib" />
+  </ItemGroup>
+  <PropertyGroup>
+    <!-- Expland the items to a property -->
+    <LibddprofLibraries>@(LibddprofLibs)</LibddprofLibraries>
+    <LibddprofDependencies>NtDll.lib;UserEnv.lib;Bcrypt.lib;crypt32.lib;wsock32.lib;ws2_32.lib;shlwapi.lib;Secur32.lib;Ncrypt.lib</LibddprofDependencies>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)..\..\include\native;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>$(LibddprofLibraries);$(LibddprofDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+</Project>


### PR DESCRIPTION
# What does this PR do?

Add scripts and files to build windows artifacts: libraries and nuget package

# Motivation

The goal is to allow developers to build libdatadog locally on windows and also in CI.

# Additional Notes

None

# How to test the change?

Run the tests locally
