### PR TITLE
Bump libdatadog version to 2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,7 +384,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "bitmaps",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-ffi"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon-ffi"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "ddcommon",
@@ -489,7 +489,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry-ffi"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "datadog-ipc",
  "ddcommon-ffi",

--- a/ddcommon-ffi/Cargo.toml
+++ b/ddcommon-ffi/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ddcommon-ffi"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/ddcommon/Cargo.toml
+++ b/ddcommon/Cargo.toml
@@ -5,7 +5,7 @@
 edition = "2021"
 license = "Apache-2.0"
 name = "ddcommon"
-version = "2.0.0"
+version = "2.1.0"
 
 [lib]
 crate-type = ["lib"]

--- a/ddtelemetry-ffi/Cargo.toml
+++ b/ddtelemetry-ffi/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ddtelemetry-ffi"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 
 [lib]

--- a/ddtelemetry/Cargo.toml
+++ b/ddtelemetry/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 license = "Apache 2.0"
 name = "ddtelemetry"
-version = "2.0.0"
+version = "2.1.0"
 
 [dependencies]
 anyhow = {version = "1.0"}

--- a/profiling-ffi/Cargo.toml
+++ b/profiling-ffi/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "datadog-profiling-ffi"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "datadog-profiling"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
# What does this PR do?

Bump libdatadog version to 2.1.0

# Motivation

Ship awaited features :) (upscaling for example)


