### PR TITLE
Move downstream repository to apm-reliability

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,6 @@ trigger_internal_build:
     LIBDATADOG_COMMIT_SHA: $CI_COMMIT_SHA
     LIBDATADOG_SHORT_COMMIT_SHA: ${CI_COMMIT_SHORT_SHA}
   trigger:
-    project: DataDog/libddprof-build
+    project: DataDog/apm-reliability/libddprof-build
     strategy: depend
     branch: $DOWNSTREAM_BRANCH


### PR DESCRIPTION
# What does this PR do?

Move downstream repository to apm-reliability

# Motivation

- This is required to fix CI
- This is to allow libdatadog to run benchmarks
