### PR TITLE
Fix ddtelemetry generated cbindgen headers

### DIFF
--- a/ddtelemetry-ffi/cbindgen.toml
+++ b/ddtelemetry-ffi/cbindgen.toml
@@ -34,4 +34,4 @@ must_use = "DDOG_CHECK_RETURN"
 
 [parse]
 parse_deps = true
-include = ["ddcommon", "ddtelemetry", "ddcommon-ffi"]
+include = ["ddcommon", "ddtelemetry", "ddcommon-ffi", "datadog-ipc"]

--- a/ipc/src/platform/unix/platform_handle.rs
+++ b/ipc/src/platform/unix/platform_handle.rs
@@ -19,7 +19,6 @@ use crate::handles::TransferHandles;
 /// PlatformHandle contains a valid reference counted FileDescriptor and associated Type information
 /// allowing safe transfer and sharing of file handles across processes, and threads
 #[derive(Serialize, Deserialize, Debug)]
-#[repr(C)]
 pub struct PlatformHandle<T> {
     fd: RawFd, // Just an fd number to be used as reference e.g. when serializing, not for accessing actual fd
     #[serde(skip)]


### PR DESCRIPTION
# What does this PR do?

* Add ipc crate to cbindgen config
* PlatformHandle is not ABI stable since it contains an Arc cell

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
