### PR TITLE
Mini Agent: Verify GCP Env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,6 +476,7 @@ dependencies = [
 name = "datadog-trace-mini-agent"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "datadog-trace-normalization",
  "datadog-trace-protobuf",
@@ -483,6 +484,7 @@ dependencies = [
  "hyper",
  "log",
  "rmp-serde",
+ "serde",
  "serde_json",
  "tokio",
 ]

--- a/serverless/src/main.rs
+++ b/serverless/src/main.rs
@@ -6,7 +6,8 @@ use log::{error, info};
 use std::sync::Arc;
 
 use datadog_trace_mini_agent::{
-    config, env_verifier, mini_agent, stats_flusher, stats_processor, trace_flusher, trace_processor,
+    config, env_verifier, mini_agent, stats_flusher, stats_processor, trace_flusher,
+    trace_processor,
 };
 
 pub fn main() {

--- a/serverless/src/main.rs
+++ b/serverless/src/main.rs
@@ -6,7 +6,7 @@ use log::{error, info};
 use std::sync::Arc;
 
 use datadog_trace_mini_agent::{
-    config, mini_agent, stats_flusher, stats_processor, trace_flusher, trace_processor,
+    config, env_verifier, mini_agent, stats_flusher, stats_processor, trace_flusher, trace_processor,
 };
 
 pub fn main() {
@@ -14,6 +14,8 @@ pub fn main() {
     Builder::from_env(env).target(Target::Stdout).init();
 
     info!("Starting serverless trace mini agent");
+
+    let env_verifier = Arc::new(env_verifier::ServerlessEnvVerifier {});
 
     let trace_flusher = Arc::new(trace_flusher::ServerlessTraceFlusher {});
     let trace_processor = Arc::new(trace_processor::ServerlessTraceProcessor {});
@@ -31,6 +33,7 @@ pub fn main() {
 
     let mini_agent = Box::new(mini_agent::MiniAgent {
         config: Arc::new(config),
+        env_verifier,
         trace_processor,
         trace_flusher,
         stats_processor,

--- a/trace-mini-agent/Cargo.toml
+++ b/trace-mini-agent/Cargo.toml
@@ -4,10 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+anyhow = "1.0"
 hyper = { version = "0.14", default-features = false, features = ["server"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"]}
 async-trait = "0.1.64"
 log = "0.4"
+serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0"
 datadog-trace-protobuf = { path = "../trace-protobuf" }
 datadog-trace-utils = { path = "../trace-utils" }

--- a/trace-mini-agent/src/config.rs
+++ b/trace-mini-agent/src/config.rs
@@ -12,6 +12,8 @@ pub struct Config {
     pub trace_flush_interval: u64,
     /// how often to flush stats, in seconds
     pub stats_flush_interval: u64,
+    /// timeout for environment verification, in milliseconds
+    pub verify_env_timeout: u64,
 }
 
 impl Config {
@@ -33,6 +35,7 @@ impl Config {
             max_request_content_length: 10 * 1024 * 1024, // 10MB in Bytes
             trace_flush_interval: 3,
             stats_flush_interval: 3,
+            verify_env_timeout: 100,
         })
     }
 }

--- a/trace-mini-agent/src/env_verifier.rs
+++ b/trace-mini-agent/src/env_verifier.rs
@@ -89,14 +89,14 @@ impl EnvVerifier for ServerlessEnvVerifier {
 /// This function extracts just the region (us-east1) from this GCP region string.
 /// If the string does not have 4 parts (separated by "/") or extraction fails, return "unknown"
 fn get_region_from_gcp_region_string(str: String) -> String {
-    let split_str = str.split("/").collect::<Vec<&str>>();
+    let split_str = str.split('/').collect::<Vec<&str>>();
     if split_str.len() != 4 {
         return "unknown".to_string();
     }
     match split_str.last() {
-        Some(res) => return res.to_string(),
-        None => return "unknown".to_string(),
-    };
+        Some(res) => res.to_string(),
+        None => "unknown".to_string(),
+    }
 }
 
 /// GoogleMetadataClient trait is used so we can mock a google metadata server response in unit tests

--- a/trace-mini-agent/src/env_verifier.rs
+++ b/trace-mini-agent/src/env_verifier.rs
@@ -30,7 +30,8 @@ pub struct GCPProject {
 
 #[async_trait]
 pub trait EnvVerifier {
-    /// verifies the mini agent is running in the intended environment. if not, exit the process.
+    /// Verifies the mini agent is running in the intended environment. if not, exit the process.
+    /// Returns MiniAgentMetadata, a struct of metadata collected from the environment.
     async fn verify_environment(&self) -> trace_utils::MiniAgentMetadata;
 }
 
@@ -90,7 +91,8 @@ impl GoogleMetadataClient for GoogleMetadataClientWrapper {
 }
 
 /// Checks if we are running in a Google Cloud Function environment.
-/// if not, returns an error with the verification failure reason.
+/// If true, returns Metadata from the Google Cloud environment.
+/// Otherwise, returns an error with the verification failure reason.
 async fn ensure_gcp_function_environment(
     metadata_client: Box<dyn GoogleMetadataClient + Send + Sync>,
 ) -> anyhow::Result<GCPMetadata> {

--- a/trace-mini-agent/src/env_verifier.rs
+++ b/trace-mini-agent/src/env_verifier.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use hyper::{Body, Client, Method, Request, Response};
 use log::{debug, error};
 use serde::{Deserialize, Serialize};
-use std::process;
+use std::{process, time::Duration};
 
 use datadog_trace_utils::trace_utils;
 
@@ -16,48 +16,87 @@ pub struct GCPMetadata {
     pub project: GCPProject,
 }
 
-#[derive(Default, Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct GCPInstance {
-    pub region: Option<String>,
+    pub region: String,
+}
+impl Default for GCPInstance {
+    fn default() -> Self {
+        Self {
+            region: "unknown".to_string(),
+        }
+    }
 }
 
-#[derive(Clone, Default, Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GCPProject {
-    pub numeric_project_id: Option<u64>,
-    pub project_id: Option<String>,
+    pub project_id: String,
+}
+impl Default for GCPProject {
+    fn default() -> Self {
+        Self {
+            project_id: "unknown".to_string(),
+        }
+    }
 }
 
 #[async_trait]
 pub trait EnvVerifier {
     /// Verifies the mini agent is running in the intended environment. if not, exit the process.
     /// Returns MiniAgentMetadata, a struct of metadata collected from the environment.
-    async fn verify_environment(&self) -> trace_utils::MiniAgentMetadata;
+    async fn verify_environment(&self, verify_env_timeout: u64) -> trace_utils::MiniAgentMetadata;
 }
 
 pub struct ServerlessEnvVerifier {}
 
 #[async_trait]
 impl EnvVerifier for ServerlessEnvVerifier {
-    async fn verify_environment(&self) -> trace_utils::MiniAgentMetadata {
-        let gcp_metadata = match ensure_gcp_function_environment(Box::new(
-            GoogleMetadataClientWrapper {},
-        ))
+    async fn verify_environment(&self, verify_env_timeout: u64) -> trace_utils::MiniAgentMetadata {
+        let gcp_metadata_request =
+            ensure_gcp_function_environment(Box::new(GoogleMetadataClientWrapper {}));
+        let gcp_metadata = match tokio::time::timeout(
+            Duration::from_millis(verify_env_timeout),
+            gcp_metadata_request,
+        )
         .await
         {
-            Ok(res) => res,
-            Err(e) => {
-                error!("Google Cloud Function environment verification failed. The Mini Agent cannot be run in a non cloud function environment. Error: {e}. Shutting down now.");
-                process::exit(1);
+            Ok(result) => match result {
+                Ok(res) => {
+                    debug!("Successfully fetched Google Metadata.");
+                    res
+                }
+                Err(e) => {
+                    error!("The Mini Agent cannot be run in a non Google Cloud Function environment. Verification has failed, error: {e}. Shutting down now.");
+                    process::exit(1);
+                }
+            },
+            Err(_) => {
+                error!("Google Metadata request timeout of {verify_env_timeout} ms exceeded. Using default values.");
+                GCPMetadata::default()
             }
         };
-        debug!("Google Cloud Function environment verification suceeded.");
         trace_utils::MiniAgentMetadata {
-            gcp_project_id: gcp_metadata.project.project_id,
-            gcp_numeric_project_id: gcp_metadata.project.numeric_project_id,
-            gcp_region: gcp_metadata.instance.region,
+            gcp_project_id: Some(gcp_metadata.project.project_id),
+            gcp_region: Some(get_region_from_gcp_region_string(
+                gcp_metadata.instance.region,
+            )),
         }
     }
+}
+
+/// The region found in GCP Metadata comes in the format: "projects/123123/regions/us-east1"
+/// This function extracts just the region (us-east1) from this GCP region string.
+/// If the string does not have 4 parts (separated by "/") or extraction fails, return "unknown"
+fn get_region_from_gcp_region_string(str: String) -> String {
+    let split_str = str.split("/").collect::<Vec<&str>>();
+    if split_str.len() != 4 {
+        return "unknown".to_string();
+    }
+    match split_str.last() {
+        Some(res) => return res.to_string(),
+        None => return "unknown".to_string(),
+    };
 }
 
 /// GoogleMetadataClient trait is used so we can mock a google metadata server response in unit tests
@@ -136,11 +175,14 @@ async fn get_gcp_metadata_from_body(body: hyper::Body) -> anyhow::Result<GCPMeta
 #[cfg(test)]
 mod tests {
     use async_trait::async_trait;
+    use datadog_trace_utils::trace_utils::MiniAgentMetadata;
     use hyper::{Body, Response, StatusCode};
 
-    use crate::env_verifier::{ensure_gcp_function_environment, GoogleMetadataClient};
+    use crate::env_verifier::{
+        ensure_gcp_function_environment, get_region_from_gcp_region_string, GoogleMetadataClient,
+    };
 
-    use super::GoogleMetadataClientWrapper;
+    use super::{EnvVerifier, GoogleMetadataClientWrapper, ServerlessEnvVerifier};
 
     #[tokio::test]
     async fn test_verify_env_false_if_metadata_server_unreachable() {
@@ -209,5 +251,36 @@ mod tests {
         }
         let res = ensure_gcp_function_environment(Box::new(MockGoogleMetadataClient {})).await;
         assert!(res.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_verify_environment_timeout_exceeded_gives_unknown_values() {
+        let env_verifier = ServerlessEnvVerifier {};
+        let res = env_verifier.verify_environment(0).await; // set the verify_env_timeout to timeout immediately
+        assert_eq!(
+            res,
+            MiniAgentMetadata {
+                gcp_project_id: Some("unknown".to_string()),
+                gcp_region: Some("unknown".to_string())
+            }
+        )
+    }
+
+    #[test]
+    fn test_gcp_region_string_extraction_valid_string() {
+        let res = get_region_from_gcp_region_string("projects/123123/regions/us-east1".to_string());
+        assert_eq!(res, "us-east1");
+    }
+
+    #[test]
+    fn test_gcp_region_string_extraction_wrong_number_of_parts() {
+        let res = get_region_from_gcp_region_string("invalid/parts/count".to_string());
+        assert_eq!(res, "unknown");
+    }
+
+    #[test]
+    fn test_gcp_region_string_extraction_empty_string() {
+        let res = get_region_from_gcp_region_string("".to_string());
+        assert_eq!(res, "unknown");
     }
 }

--- a/trace-mini-agent/src/env_verifier.rs
+++ b/trace-mini-agent/src/env_verifier.rs
@@ -4,7 +4,10 @@ use async_trait::async_trait;
 use hyper::{Body, Client, Method, Request, Response};
 use log::{debug, error};
 use serde::{Deserialize, Serialize};
-use std::{process, time::Duration};
+use std::time::Duration;
+
+#[cfg(not(test))]
+use std::process;
 
 use datadog_trace_utils::trace_utils;
 
@@ -68,7 +71,10 @@ impl EnvVerifier for ServerlessEnvVerifier {
                 }
                 Err(e) => {
                     error!("The Mini Agent cannot be run in a non Google Cloud Function environment. Verification has failed, error: {e}. Shutting down now.");
+                    #[cfg(not(test))]
                     process::exit(1);
+                    #[cfg(test)]
+                    GCPMetadata::default()
                 }
             },
             Err(_) => {

--- a/trace-mini-agent/src/lib.rs
+++ b/trace-mini-agent/src/lib.rs
@@ -2,6 +2,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
 
 pub mod config;
+pub mod env_verifier;
 pub mod http_utils;
 pub mod mini_agent;
 pub mod stats_flusher;

--- a/trace-mini-agent/src/mini_agent.rs
+++ b/trace-mini-agent/src/mini_agent.rs
@@ -1,6 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
 
+use datadog_trace_utils::trace_utils;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{http, Body, Method, Request, Response, Server, StatusCode};
 use log::{error, info};
@@ -9,9 +10,10 @@ use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::mpsc::{self, Receiver, Sender};
+use tokio::sync::Mutex;
 
 use crate::http_utils::log_and_create_http_response;
-use crate::{config, stats_flusher, stats_processor, trace_flusher, trace_processor};
+use crate::{config, env_verifier, stats_flusher, stats_processor, trace_flusher, trace_processor};
 use datadog_trace_protobuf::pb;
 
 const MINI_AGENT_PORT: usize = 8126;
@@ -27,11 +29,27 @@ pub struct MiniAgent {
     pub trace_flusher: Arc<dyn trace_flusher::TraceFlusher + Send + Sync>,
     pub stats_processor: Arc<dyn stats_processor::StatsProcessor + Send + Sync>,
     pub stats_flusher: Arc<dyn stats_flusher::StatsFlusher + Send + Sync>,
+    pub env_verifier: Arc<dyn env_verifier::EnvVerifier + Send + Sync>,
 }
 
 impl MiniAgent {
     #[tokio::main]
     pub async fn start_mini_agent(&self) -> Result<(), Box<dyn std::error::Error>> {
+        // verify we are in a google cloud funtion environment. if not, shut down the mini agent.
+        let mini_agent_metadata: Arc<Mutex<trace_utils::MiniAgentMetadata>> =
+            Arc::new(Mutex::new(trace_utils::MiniAgentMetadata::default()));
+
+        let mini_agent_metadata_producer = mini_agent_metadata.clone();
+        let mini_agent_metadata_consumer = mini_agent_metadata.clone();
+        let env_verifier = self.env_verifier.clone();
+        tokio::spawn(async move {
+            let env_verifier = env_verifier.clone();
+            let updated_metadata = env_verifier.verify_environment().await;
+
+            let mut mini_agent_metadata_mutex = mini_agent_metadata_producer.lock().await;
+            *mini_agent_metadata_mutex = updated_metadata;
+        });
+
         // setup a channel to send processed traces to our flusher. tx is passed through each endpoint_handler
         // to the trace processor, which uses it to send de-serialized processed trace payloads to our trace flusher.
         let (trace_tx, trace_rx): (Sender<pb::TracerPayload>, Receiver<pb::TracerPayload>) =
@@ -76,6 +94,7 @@ impl MiniAgent {
             let stats_tx = stats_tx.clone();
 
             let endpoint_config = endpoint_config.clone();
+            let mini_agent_metadata_consumer = mini_agent_metadata_consumer.clone();
 
             let service = service_fn(move |req| {
                 MiniAgent::trace_endpoint_handler(
@@ -85,6 +104,7 @@ impl MiniAgent {
                     trace_tx.clone(),
                     stats_processor.clone(),
                     stats_tx.clone(),
+                    mini_agent_metadata_consumer.clone(),
                 )
             });
 
@@ -101,7 +121,6 @@ impl MiniAgent {
         // start hyper http server
         if let Err(e) = server.await {
             error!("Server error: {e}");
-            return Err(e.into());
         }
 
         Ok(())
@@ -114,10 +133,14 @@ impl MiniAgent {
         trace_tx: Sender<pb::TracerPayload>,
         stats_processor: Arc<dyn stats_processor::StatsProcessor + Send + Sync>,
         stats_tx: Sender<pb::ClientStatsPayload>,
+        mini_agent_metadata: Arc<Mutex<trace_utils::MiniAgentMetadata>>,
     ) -> http::Result<Response<Body>> {
         match (req.method(), req.uri().path()) {
             (&Method::PUT, TRACE_ENDPOINT_PATH) => {
-                match trace_processor.process_traces(config, req, trace_tx).await {
+                match trace_processor
+                    .process_traces(config, req, trace_tx, mini_agent_metadata)
+                    .await
+                {
                     Ok(res) => Ok(res),
                     Err(err) => log_and_create_http_response(
                         &format!("Error processing traces: {err}"),

--- a/trace-mini-agent/src/mini_agent.rs
+++ b/trace-mini-agent/src/mini_agent.rs
@@ -1,7 +1,6 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
 
-use datadog_trace_utils::trace_utils;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{http, Body, Method, Request, Response, Server, StatusCode};
 use log::{error, info};
@@ -15,6 +14,7 @@ use tokio::sync::Mutex;
 use crate::http_utils::log_and_create_http_response;
 use crate::{config, env_verifier, stats_flusher, stats_processor, trace_flusher, trace_processor};
 use datadog_trace_protobuf::pb;
+use datadog_trace_utils::trace_utils;
 
 const MINI_AGENT_PORT: usize = 8126;
 const TRACE_ENDPOINT_PATH: &str = "/v0.4/traces";
@@ -121,6 +121,7 @@ impl MiniAgent {
         // start hyper http server
         if let Err(e) = server.await {
             error!("Server error: {e}");
+            return Err(e.into());
         }
 
         Ok(())

--- a/trace-mini-agent/src/trace_processor.rs
+++ b/trace-mini-agent/src/trace_processor.rs
@@ -201,7 +201,9 @@ mod tests {
         if is_top_level {
             span.metrics.insert("_top_level".to_string(), 1.0);
             span.meta
-                .insert("_dd.origin".to_string(), "gcp_function".to_string());
+                .insert("_dd.origin".to_string(), "cloudfunction".to_string());
+            span.meta
+                .insert("origin".to_string(), "cloudfunction".to_string());
             span.meta.insert(
                 "functionname".to_string(),
                 "dummy_function_name".to_string(),

--- a/trace-utils/src/trace_utils.rs
+++ b/trace-utils/src/trace_utils.rs
@@ -260,7 +260,9 @@ fn set_top_level_span(span: &mut pb::Span, is_top_level: bool) {
 pub fn set_serverless_root_span_tags(span: &mut pb::Span, gcp_function_name: Option<String>) {
     span.r#type = "serverless".to_string();
     span.meta
-        .insert("_dd.origin".to_string(), "gcp_function".to_string());
+        .insert("_dd.origin".to_string(), "cloudfunction".to_string());
+    span.meta
+        .insert("origin".to_string(), "cloudfunction".to_string());
     if let Some(function_name) = gcp_function_name {
         span.meta.insert("functionname".to_string(), function_name);
     }
@@ -272,29 +274,23 @@ pub fn update_tracer_top_level(span: &mut pb::Span) {
     }
 }
 
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Default, Debug, Eq, PartialEq)]
 pub struct MiniAgentMetadata {
     pub gcp_project_id: Option<String>,
-    pub gcp_numeric_project_id: Option<u64>,
     pub gcp_region: Option<String>,
 }
 
 pub fn enrich_span_with_mini_agent_metadata(
     span: &mut pb::Span,
-    mini_agent_metadata: MiniAgentMetadata,
+    mini_agent_metadata: &MiniAgentMetadata,
 ) {
-    if let Some(gcp_project_id) = mini_agent_metadata.gcp_project_id {
+    if let Some(gcp_project_id) = &mini_agent_metadata.gcp_project_id {
         span.meta
-            .insert("gcp_project_id".to_string(), gcp_project_id);
+            .insert("project_id".to_string(), gcp_project_id.to_string());
     }
-    if let Some(gcp_numeric_project_id) = mini_agent_metadata.gcp_numeric_project_id {
-        span.meta.insert(
-            "gcp_numeric_project_id".to_string(),
-            gcp_numeric_project_id.to_string(),
-        );
-    }
-    if let Some(gcp_region) = mini_agent_metadata.gcp_region {
-        span.meta.insert("gcp_region".to_string(), gcp_region);
+    if let Some(gcp_region) = &mini_agent_metadata.gcp_region {
+        span.meta
+            .insert("location".to_string(), gcp_region.to_string());
     }
 }
 

--- a/trace-utils/src/trace_utils.rs
+++ b/trace-utils/src/trace_utils.rs
@@ -272,6 +272,32 @@ pub fn update_tracer_top_level(span: &mut pb::Span) {
     }
 }
 
+#[derive(Clone, Default, Debug)]
+pub struct MiniAgentMetadata {
+    pub gcp_project_id: Option<String>,
+    pub gcp_numeric_project_id: Option<u64>,
+    pub gcp_region: Option<String>,
+}
+
+pub fn enrich_span_with_mini_agent_metadata(
+    span: &mut pb::Span,
+    mini_agent_metadata: MiniAgentMetadata,
+) {
+    if let Some(gcp_project_id) = mini_agent_metadata.gcp_project_id {
+        span.meta
+            .insert("gcp_project_id".to_string(), gcp_project_id);
+    }
+    if let Some(gcp_numeric_project_id) = mini_agent_metadata.gcp_numeric_project_id {
+        span.meta.insert(
+            "gcp_numeric_project_id".to_string(),
+            gcp_numeric_project_id.to_string(),
+        );
+    }
+    if let Some(gcp_region) = mini_agent_metadata.gcp_region {
+        span.meta.insert("gcp_region".to_string(), gcp_region);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use hyper::Request;


### PR DESCRIPTION
# What does this PR do?

Add an `env_verifier` field to the trace mini agent. The mini agent calls `env_verifier.verify_environment()` in a tokio async task during initialization. This function makes an HTTP call to `http://metadata.google.internal`, the Google metadata server.

This metadata server is only accessible within a Google Cloud VM, and will include the following header in the response, indicating a google cloud function environment:
`Server: Metadata Server for Serverless`

If the metadata server is not accessible or the correct header is not returned, exit the mini agent process.

# Motivation

In the node/python tracer, we only check for the presence of K_SERVICE or FUNCTION_NAME environment variables (which google cloud functions set) before spinning up the mini-agent.

To prevent the use of the mini agent in server-ful environments (thereby bypassing infrastructure/host billing), we want to shut down the mini agent if it's running in a non gcp function env.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
