### PR TITLE
Mini Agent: Support DD_SITE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,6 +384,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "datadog-ipc"
 version = "0.1.0"
 dependencies = [
@@ -472,11 +485,13 @@ dependencies = [
  "datadog-trace-normalization",
  "datadog-trace-protobuf",
  "datadog-trace-utils",
+ "duplicate",
  "hyper",
  "log",
  "rmp-serde",
  "serde",
  "serde_json",
+ "serial_test",
  "tokio",
 ]
 
@@ -1104,6 +1119,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
 
 [[package]]
+name = "lock_api"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1333,6 +1358,29 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-sys 0.45.0",
+]
 
 [[package]]
 name = "paste"
@@ -1924,6 +1972,31 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.11",
 ]
 
 [[package]]

--- a/trace-mini-agent/Cargo.toml
+++ b/trace-mini-agent/Cargo.toml
@@ -17,3 +17,5 @@ datadog-trace-normalization = { path = "../trace-normalization" }
 
 [dev-dependencies]
 rmp-serde = "1.1.1"
+serial_test = "2.0.0"
+duplicate = "0.4.1"

--- a/trace-mini-agent/src/config.rs
+++ b/trace-mini-agent/src/config.rs
@@ -24,12 +24,8 @@ pub struct Config {
 
 impl Config {
     pub fn new() -> Result<Config, Box<dyn std::error::Error>> {
-        let api_key = match env::var("DD_API_KEY") {
-            Ok(res) => res,
-            Err(_) => {
-                return Err(anyhow::anyhow!("DD_API_KEY environment variable is not set").into());
-            }
-        };
+        let api_key = env::var("DD_API_KEY")
+            .map_err(|_| anyhow::anyhow!("DD_API_KEY environment variable is not set"))?;
         let mut function_name = None;
 
         // Google cloud functions automatically sets either K_SERVICE or FUNCTION_NAME

--- a/trace-mini-agent/src/config.rs
+++ b/trace-mini-agent/src/config.rs
@@ -3,6 +3,9 @@
 
 use std::env;
 
+const TRACE_INTAKE_ROUTE: &str = "/api/v0.2/traces";
+const TRACE_STATS_INTAKE_ROUTE: &str = "/api/v0.2/stats";
+
 #[derive(Debug, Clone)]
 pub struct Config {
     pub api_key: String,
@@ -14,11 +17,19 @@ pub struct Config {
     pub stats_flush_interval: u64,
     /// timeout for environment verification, in milliseconds
     pub verify_env_timeout: u64,
+    pub trace_intake_url: String,
+    pub trace_stats_intake_url: String,
+    pub dd_site: String,
 }
 
 impl Config {
     pub fn new() -> Result<Config, Box<dyn std::error::Error>> {
-        let api_key = env::var("DD_API_KEY")?;
+        let api_key = match env::var("DD_API_KEY") {
+            Ok(res) => res,
+            Err(_) => {
+                return Err(anyhow::anyhow!("DD_API_KEY environment variable is not set").into());
+            }
+        };
         let mut function_name = None;
 
         // Google cloud functions automatically sets either K_SERVICE or FUNCTION_NAME
@@ -29,6 +40,12 @@ impl Config {
         } else if let Ok(res) = env::var("FUNCTION_NAME") {
             function_name = Some(res);
         }
+
+        let dd_site = env::var("DD_SITE").unwrap_or("datadoghq.com".to_string());
+
+        let trace_intake_url = construct_trace_intake_url(&dd_site, TRACE_INTAKE_ROUTE);
+        let trace_stats_intake_url = construct_trace_intake_url(&dd_site, TRACE_STATS_INTAKE_ROUTE);
+
         Ok(Config {
             api_key,
             gcp_function_name: function_name,
@@ -36,6 +53,73 @@ impl Config {
             trace_flush_interval: 3,
             stats_flush_interval: 3,
             verify_env_timeout: 100,
+            dd_site,
+            trace_intake_url,
+            trace_stats_intake_url,
         })
+    }
+}
+
+fn construct_trace_intake_url(prefix: &str, route: &str) -> String {
+    format!("https://trace.agent.{prefix}{route}")
+}
+
+#[cfg(test)]
+mod tests {
+    use duplicate::duplicate_item;
+    use serial_test::serial;
+    use std::env;
+
+    use crate::config;
+
+    #[test]
+    #[serial]
+    fn test_error_if_no_api_key_env_var() {
+        let config = config::Config::new();
+        assert!(config.is_err());
+        assert_eq!(
+            config.unwrap_err().to_string(),
+            "DD_API_KEY environment variable is not set"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_default_trace_and_trace_stats_urls() {
+        env::set_var("DD_API_KEY", "_not_a_real_key_");
+        let config_res = config::Config::new();
+        assert!(config_res.is_ok());
+        let config = config_res.unwrap();
+        assert_eq!(
+            config.trace_intake_url,
+            "https://trace.agent.datadoghq.com/api/v0.2/traces"
+        );
+        assert_eq!(
+            config.trace_stats_intake_url,
+            "https://trace.agent.datadoghq.com/api/v0.2/stats"
+        );
+        env::remove_var("DD_API_KEY");
+    }
+
+    #[duplicate_item(
+        test_name                       dd_site                 expected_url;
+        [test_us1_trace_intake_url]     ["datadoghq.com"]       ["https://trace.agent.datadoghq.com/api/v0.2/traces"];
+        [test_us3_trace_intake_url]     ["us3.datadoghq.com"]   ["https://trace.agent.us3.datadoghq.com/api/v0.2/traces"];
+        [test_us5_trace_intake_url]     ["us5.datadoghq.com"]   ["https://trace.agent.us5.datadoghq.com/api/v0.2/traces"];
+        [test_eu_trace_intake_url]      ["datadoghq.eu"]        ["https://trace.agent.datadoghq.eu/api/v0.2/traces"];
+        [test_ap1_trace_intake_url]     ["ap1.datadoghq.com"]   ["https://trace.agent.ap1.datadoghq.com/api/v0.2/traces"];
+        [test_gov_trace_intake_url]     ["ddog-gov.com"]        ["https://trace.agent.ddog-gov.com/api/v0.2/traces"];
+    )]
+    #[test]
+    #[serial]
+    fn test_name() {
+        env::set_var("DD_API_KEY", "_not_a_real_key_");
+        env::set_var("DD_SITE", dd_site);
+        let config_res = config::Config::new();
+        assert!(config_res.is_ok());
+        let config = config_res.unwrap();
+        assert_eq!(config.trace_intake_url, expected_url);
+        env::remove_var("DD_API_KEY");
+        env::remove_var("DD_SITE");
     }
 }

--- a/trace-mini-agent/src/config.rs
+++ b/trace-mini-agent/src/config.rs
@@ -122,4 +122,26 @@ mod tests {
         env::remove_var("DD_API_KEY");
         env::remove_var("DD_SITE");
     }
+
+    #[duplicate_item(
+        test_name                       dd_site                 expected_url;
+        [test_us1_trace_stats_intake_url]     ["datadoghq.com"]       ["https://trace.agent.datadoghq.com/api/v0.2/stats"];
+        [test_us3_trace_stats_intake_url]     ["us3.datadoghq.com"]   ["https://trace.agent.us3.datadoghq.com/api/v0.2/stats"];
+        [test_us5_trace_stats_intake_url]     ["us5.datadoghq.com"]   ["https://trace.agent.us5.datadoghq.com/api/v0.2/stats"];
+        [test_eu_trace_stats_intake_url]      ["datadoghq.eu"]        ["https://trace.agent.datadoghq.eu/api/v0.2/stats"];
+        [test_ap1_trace_stats_intake_url]     ["ap1.datadoghq.com"]   ["https://trace.agent.ap1.datadoghq.com/api/v0.2/stats"];
+        [test_gov_trace_stats_intake_url]     ["ddog-gov.com"]        ["https://trace.agent.ddog-gov.com/api/v0.2/stats"];
+    )]
+    #[test]
+    #[serial]
+    fn test_name() {
+        env::set_var("DD_API_KEY", "_not_a_real_key_");
+        env::set_var("DD_SITE", dd_site);
+        let config_res = config::Config::new();
+        assert!(config_res.is_ok());
+        let config = config_res.unwrap();
+        assert_eq!(config.trace_stats_intake_url, expected_url);
+        env::remove_var("DD_API_KEY");
+        env::remove_var("DD_SITE");
+    }
 }

--- a/trace-mini-agent/src/config.rs
+++ b/trace-mini-agent/src/config.rs
@@ -41,7 +41,7 @@ impl Config {
             function_name = Some(res);
         }
 
-        let dd_site = env::var("DD_SITE").unwrap_or("datadoghq.com".to_string());
+        let dd_site = env::var("DD_SITE").unwrap_or_else(|_| "datadoghq.com".to_string());
 
         let trace_intake_url = construct_trace_intake_url(&dd_site, TRACE_INTAKE_ROUTE);
         let trace_stats_intake_url = construct_trace_intake_url(&dd_site, TRACE_STATS_INTAKE_ROUTE);

--- a/trace-mini-agent/src/stats_flusher.rs
+++ b/trace-mini-agent/src/stats_flusher.rs
@@ -75,7 +75,13 @@ impl StatsFlusher for ServerlessStatsFlusher {
             }
         };
 
-        match stats_utils::send_stats_payload(serialized_stats_payload, &config.api_key).await {
+        match stats_utils::send_stats_payload(
+            serialized_stats_payload,
+            &config.trace_stats_intake_url,
+            &config.api_key,
+        )
+        .await
+        {
             Ok(_) => info!("Successfully flushed stats"),
             Err(e) => {
                 error!("Error sending stats: {e:?}")

--- a/trace-mini-agent/src/trace_flusher.rs
+++ b/trace-mini-agent/src/trace_flusher.rs
@@ -67,7 +67,13 @@ impl TraceFlusher for ServerlessTraceFlusher {
             }
         };
 
-        match trace_utils::send(serialized_agent_payload, &config.api_key).await {
+        match trace_utils::send(
+            serialized_agent_payload,
+            &config.trace_intake_url,
+            &config.api_key,
+        )
+        .await
+        {
             Ok(_) => info!("Successfully flushed traces"),
             Err(e) => {
                 error!("Error sending trace: {e:?}")

--- a/trace-mini-agent/src/trace_processor.rs
+++ b/trace-mini-agent/src/trace_processor.rs
@@ -251,6 +251,9 @@ mod tests {
             trace_flush_interval: 3,
             stats_flush_interval: 3,
             verify_env_timeout: 100,
+            trace_intake_url: "trace.agent.notdog.com/traces".to_string(),
+            trace_stats_intake_url: "trace.agent.notdog.com/stats".to_string(),
+            dd_site: "datadoghq.com".to_string(),
         }
     }
 

--- a/trace-utils/src/stats_utils.rs
+++ b/trace-utils/src/stats_utils.rs
@@ -9,8 +9,6 @@ use std::io::Write;
 
 use datadog_trace_protobuf::pb;
 
-const STATS_INTAKE_URL: &str = "https://trace.agent.datadoghq.com/api/v0.2/stats";
-
 pub async fn get_stats_from_request_body(body: Body) -> anyhow::Result<pb::ClientStatsPayload> {
     let buffer = hyper::body::aggregate(body).await?;
 
@@ -48,10 +46,10 @@ pub fn serialize_stats_payload(payload: pb::StatsPayload) -> anyhow::Result<Vec<
     }
 }
 
-pub async fn send_stats_payload(data: Vec<u8>, api_key: &str) -> anyhow::Result<()> {
+pub async fn send_stats_payload(data: Vec<u8>, url: &str, api_key: &str) -> anyhow::Result<()> {
     let req = Request::builder()
         .method(Method::POST)
-        .uri(STATS_INTAKE_URL)
+        .uri(url)
         .header("Content-Type", "application/msgpack")
         .header("Content-Encoding", "gzip")
         .header("DD-API-KEY", api_key)

--- a/trace-utils/src/trace_utils.rs
+++ b/trace-utils/src/trace_utils.rs
@@ -12,8 +12,6 @@ use std::str;
 use datadog_trace_normalization::normalizer;
 use datadog_trace_protobuf::pb;
 
-const TRACE_INTAKE_URL: &str = "https://trace.agent.datadoghq.com/api/v0.2/traces";
-
 /// Span metric the mini agent must set for the backend to recognize top level span
 const TOP_LEVEL_KEY: &str = "_top_level";
 /// Span metric the tracer sets to denote a top level span
@@ -145,10 +143,10 @@ pub fn serialize_agent_payload(payload: pb::AgentPayload) -> anyhow::Result<Vec<
     Ok(buf)
 }
 
-pub async fn send(data: Vec<u8>, api_key: &str) -> anyhow::Result<()> {
+pub async fn send(data: Vec<u8>, url: &str, api_key: &str) -> anyhow::Result<()> {
     let req = Request::builder()
         .method(Method::POST)
-        .uri(TRACE_INTAKE_URL)
+        .uri(url)
         .header("Content-type", "application/x-protobuf")
         .header("DD-API-KEY", api_key)
         .body(Body::from(data))?;


### PR DESCRIPTION
# What does this PR do?

Support `DD_SITE`, sending traces and trace stats to non-us1 intakes

# Motivation

Mini Agent mvp/closed beta with non-us1 customers

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

`config.rs` unit tests. Manually tested by sending traces and trace stats to each region (with the exception of `ddog-gov.com`), and verifying they show up in the UI
