### PR TITLE
Run metrics agent via LD_PRELOAD

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,7 +401,7 @@ dependencies = [
  "futures",
  "io-lifetimes",
  "libc",
- "nix",
+ "nix 0.24.3",
  "pin-project",
  "pretty_assertions",
  "sendfd",
@@ -589,7 +589,7 @@ dependencies = [
  "io-lifetimes",
  "lazy_static",
  "libc",
- "nix",
+ "nix 0.24.3",
  "pin-project",
  "rand",
  "regex",
@@ -1232,6 +1232,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "memoffset 0.7.1",
+ "pin-utils",
+ "static_assertions",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1815,6 +1829,9 @@ name = "serverless-preload"
 version = "0.0.1"
 dependencies = [
  "datadog-metrics",
+ "ddcommon",
+ "nix 0.26.2",
+ "spawn_worker",
  "tokio",
 ]
 
@@ -1869,7 +1886,7 @@ dependencies = [
  "cc_utils",
  "io-lifetimes",
  "memfd",
- "nix",
+ "nix 0.24.3",
  "rlimit",
  "tempfile",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1811,6 +1811,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "serverless-preload"
+version = "0.0.1"
+dependencies = [
+ "datadog-metrics",
+ "tokio",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
   "spawn_worker",
   "tests/spawn_from_lib",
   "serverless",
+  "serverless-preload",
   "metrics",
 ]
 # https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2

--- a/metrics/src/config.rs
+++ b/metrics/src/config.rs
@@ -3,6 +3,7 @@
 
 #[derive(Debug, Builder)]
 #[builder(build_fn(validate = "Self::validate"))]
+#[builder(setter(strip_option))]
 pub struct Config {
     pub api_key: String,
     #[builder(default = "String::from(\"datadoghq.com\")")]

--- a/serverless-preload/Cargo.toml
+++ b/serverless-preload/Cargo.toml
@@ -7,4 +7,14 @@ edition = "2021"
 
 [dependencies]
 datadog-metrics = { path = "../metrics" }
+ddcommon = { version = "2.1.0", path = "../ddcommon" }
+nix = "0.26.2"
+spawn_worker = { version = "0.0.1", path = "../spawn_worker" }
 tokio = { version = "1.27.0", features = ["net", "rt", "rt-multi-thread", "macros"] }
+
+[lib]
+crate-type = ["cdylib"]
+
+[[bin]]
+name = "metrics_agent"
+path = "src/metrics_agent.rs"

--- a/serverless-preload/Cargo.toml
+++ b/serverless-preload/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "serverless-preload"
+version = "0.0.1"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+datadog-metrics = { path = "../metrics" }
+tokio = { version = "1.27.0", features = ["net", "rt", "rt-multi-thread", "macros"] }

--- a/serverless-preload/src/lib.rs
+++ b/serverless-preload/src/lib.rs
@@ -1,0 +1,4 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+#[cfg(unix)]
+pub mod libc_start_main;

--- a/serverless-preload/src/libc_start_main.rs
+++ b/serverless-preload/src/libc_start_main.rs
@@ -1,0 +1,190 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+
+use std::{
+    ffi::{self, CStr},
+    process::Command,
+};
+
+use ddcommon::cstr;
+use nix::libc;
+
+type StartMainFn = extern "C" fn(
+    main: MainFn,
+    argc: ffi::c_int,
+    argv: *const *const ffi::c_char,
+    init: InitFn,
+    fini: FiniFn,
+    rtld_fini: FiniFn,
+    stack_end: *const ffi::c_void,
+);
+type MainFn = unsafe extern "C" fn(
+    ffi::c_int,
+    *const *const ffi::c_char,
+    *const *const ffi::c_char,
+) -> ffi::c_int;
+type InitFn = extern "C" fn(ffi::c_int, *const *const ffi::c_char, *const *const ffi::c_char);
+type FiniFn = extern "C" fn();
+
+/// # Safety
+///
+/// caller must ensure its safe to read `environ` global value
+pub unsafe fn environ() -> *mut *const *const ffi::c_char {
+    extern "C" {
+        static mut environ: *const *const ffi::c_char;
+    }
+    std::ptr::addr_of_mut!(environ)
+}
+
+pub struct CListMutPtr<'a> {
+    inner: &'a mut [*const ffi::c_char],
+    elements: usize,
+}
+
+impl<'a> CListMutPtr<'a> {
+    /// # Safety
+    ///
+    /// pointers passed to this method must remain valid for the lifetime of CListMutPtr object
+    pub unsafe fn from_raw_parts(ptr: *mut *const ffi::c_char) -> Self {
+        let mut len = 0;
+        while !(*ptr.add(len)).is_null() {
+            len += 1;
+        }
+        Self {
+            inner: std::slice::from_raw_parts_mut(ptr, len + 1),
+            elements: len,
+        }
+    }
+
+    pub fn as_ptr(&self) -> *const *const ffi::c_char {
+        self.inner.as_ptr()
+    }
+
+    /// # Safety
+    /// entries in self.inner must be valid null terminated c strings
+    pub unsafe fn to_cstr_vec(&self) -> Vec<&CStr> {
+        self.inner[0..self.elements]
+            .iter()
+            .map(|s| CStr::from_ptr(*s))
+            .collect()
+    }
+
+    /// remove entry from a slice, shifting other entries in its place
+    ///
+    /// # Safety
+    /// entries in self.inner must be valid null terminated c strings
+    pub unsafe fn remove_entry<F: Fn(&[u8]) -> bool>(
+        &mut self,
+        predicate: F,
+    ) -> Option<*const ffi::c_char> {
+        for i in (0..self.elements).rev() {
+            let elem = CStr::from_ptr(self.inner[i]);
+            if predicate(elem.to_bytes()) {
+                for src in i + 1..self.elements {
+                    self.inner[src - 1] = self.inner[src]
+                }
+                self.elements -= 1;
+                return Some(elem.as_ptr());
+            }
+        }
+
+        None
+    }
+}
+
+#[allow(dead_code)]
+unsafe extern "C" fn new_main(
+    argc: ffi::c_int,
+    argv: *const *const ffi::c_char,
+    _envp: *const *const ffi::c_char,
+) -> ffi::c_int {
+    println!("Sending stdout and stderr to Datadog");
+    let metrics_agent_cmd = "./metrics_agent";
+
+    Command::new(metrics_agent_cmd)
+        .spawn()
+        .expect("Failed to run metrics agent");
+
+    match unsafe { ORIGINAL_MAIN } {
+        Some(f) => f(argc, argv, _envp),
+        None => 0,
+    }
+}
+
+unsafe fn dlsym_fn(handle: *mut ffi::c_void, str: &CStr) -> Option<*mut ffi::c_void> {
+    let addr = libc::dlsym(handle, str.as_ptr());
+    if addr.is_null() {
+        return None;
+    }
+
+    Some(addr)
+}
+
+#[no_mangle]
+pub extern "C" fn __libc_start_main(
+    main: MainFn,
+    argc: ffi::c_int,
+    argv: *const *const ffi::c_char,
+    init: InitFn,
+    fini: FiniFn,
+    rtld_fini: FiniFn,
+    stack_end: *const ffi::c_void,
+) {
+    unsafe {
+        let libc_start_main = std::mem::transmute::<_, StartMainFn>(
+            dlsym_fn(libc::RTLD_NEXT, cstr!("__libc_start_main")).unwrap(),
+        ) as StartMainFn;
+
+        ORIGINAL_MAIN = Some(main);
+
+        if std::process::id() == 1 || std::process::id() == 7 {
+            println!("Skipping process ID 1 or 7");
+            libc_start_main(
+                ORIGINAL_MAIN.unwrap(),
+                argc,
+                argv,
+                init,
+                fini,
+                rtld_fini,
+                stack_end,
+            )
+        }
+        // the pointer to envp is the next integer after argv
+        // it's a null-terminated array of strings
+        // Note: for some reason setting a new env in new_main didn't work,
+        // as the subprocesses spawned by this process still contain LD_PRELOAD,
+        // but removing it here does indeed work
+        let envp_ptr = argv.offset(argc as isize + 1) as *mut *const ffi::c_char;
+        let mut env_vec = CListMutPtr::from_raw_parts(envp_ptr);
+        match env_vec.remove_entry(|e| e.starts_with("LD_PRELOAD=".as_bytes())) {
+            Some(preload_lib) => {
+                println!(
+                    "Found {} in process {}, starting bootstrap process",
+                    CStr::from_ptr(preload_lib as *const ffi::c_char)
+                        .to_str()
+                        .expect("Couldn't convert LD_PRELOAD lib to string"),
+                    std::process::id(),
+                );
+
+                libc_start_main(new_main, argc, argv, init, fini, rtld_fini, stack_end)
+            }
+            None => {
+                println!(
+                    "No LD_PRELOAD found in env of process {}",
+                    std::process::id()
+                );
+                libc_start_main(
+                    ORIGINAL_MAIN.unwrap(),
+                    argc,
+                    argv,
+                    init,
+                    fini,
+                    rtld_fini,
+                    stack_end,
+                )
+            }
+        }
+    }
+}
+
+static mut ORIGINAL_MAIN: Option<MainFn> = None;

--- a/serverless-preload/src/main.rs
+++ b/serverless-preload/src/main.rs
@@ -1,0 +1,17 @@
+use datadog_metrics::agent::*;
+use datadog_metrics::config::ConfigBuilder;
+
+#[tokio::main]
+async fn main() {
+    let api_key = std::env::var("DD_API_KEY").expect("Must provide DD_API_KEY");
+    let site = std::env::var("DD_SITE").unwrap_or(String::from("us1.datadoghq.com"));
+    let config = ConfigBuilder::default()
+        .api_key(api_key)
+        .site(site)
+        .build()
+        .expect("Error constructing metrics agent");
+
+    let metrics_agent = MetricsAgent::with_config(config);
+
+    metrics_agent.run().await;
+}

--- a/serverless-preload/src/metrics_agent.rs
+++ b/serverless-preload/src/metrics_agent.rs
@@ -1,3 +1,6 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+
 use datadog_metrics::agent::*;
 use datadog_metrics::config::ConfigBuilder;
 


### PR DESCRIPTION
# What does this PR do?

This code adds a `serverless-preload` crate, which does the following:

1. Builds a standalone metrics-agent (dogstatsd server) binary, to be ran as a subprocess.
2. Adds a `libserverless_preload` library, which includes a `__libc_start_main` symbol meant to be started via `LD_PRELOAD`.

# Motivation

We're adding this so we can support a metrics agent being spawned via LD_PRELOAD. 

# Additional Notes

# How to test the change?
