### PR TITLE
Bump libdatadog to 2.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "bitmaps",
@@ -453,7 +453,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-ffi"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon-ffi"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "ddcommon",
@@ -579,7 +579,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "anyhow",
  "datadog-ipc",
@@ -610,7 +610,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry-ffi"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "datadog-ipc",
  "ddcommon-ffi",

--- a/ddcommon-ffi/Cargo.toml
+++ b/ddcommon-ffi/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ddcommon-ffi"
-version = "2.1.0"
+version = "2.2.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/ddcommon/Cargo.toml
+++ b/ddcommon/Cargo.toml
@@ -5,7 +5,7 @@
 edition = "2021"
 license = "Apache-2.0"
 name = "ddcommon"
-version = "2.1.0"
+version = "2.2.0"
 
 [lib]
 crate-type = ["lib"]

--- a/ddtelemetry-ffi/Cargo.toml
+++ b/ddtelemetry-ffi/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ddtelemetry-ffi"
-version = "2.1.0"
+version = "2.2.0"
 edition = "2021"
 
 [lib]

--- a/ddtelemetry/Cargo.toml
+++ b/ddtelemetry/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 license = "Apache 2.0"
 name = "ddtelemetry"
-version = "2.1.0"
+version = "2.2.0"
 
 [features]
 default = []

--- a/profiling-ffi/Cargo.toml
+++ b/profiling-ffi/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "datadog-profiling-ffi"
-version = "2.1.0"
+version = "2.2.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "datadog-profiling"
-version = "2.1.0"
+version = "2.2.0"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
# What does this PR do?

Bump libdatadog profiling package version to 2.2.0

# Motivation

Ship new features and bug fixes to profiles/tracers

