### PR TITLE
Add PR automatic labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,24 @@
+profiling:
+- profiling/**/*
+- profiling-ffi/**/*
+
+common:
+- ddcommon/**/*
+- ddcommon-ffi/**/*
+
+ci-build:
+- .github/**/*
+- .gitlab-ci.yml
+- windows/**/*
+- build-*
+
+mini-agent:
+- trace-mini-agent/**/*
+- serverless/**/*
+- trace-normalization/**/*
+- trace-obfuscaiton/**/*
+- trace-utils/**/*
+
+telemetry:
+- ddtelemetry/**/*
+- ddtelemetry-ffi/**/*

--- a/.github/workflows/pr-auto-labeler.yml
+++ b/.github/workflows/pr-auto-labeler.yml
@@ -1,0 +1,15 @@
+name: "Pull Request Labeler"
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v4
+      with:
+        sync-labels: "true"


### PR DESCRIPTION
# What does this PR do?

Automatically add label to PR in order to get the scope of the PR when listing all the PR.

# Motivation

This can be used later to improve release note (ex.: for profiling related release, only get PRs involved with `profiling`, `common`... labels)

