### PR TITLE
Mini Agent: use lzma upx compression when building for release

### DIFF
--- a/.github/workflows/publish-serverless-agent.yml
+++ b/.github/workflows/publish-serverless-agent.yml
@@ -1,8 +1,10 @@
 name: Build and Release Serverless Agent
 on:
   push:
-    tags:
-      - 'sls-**'
+    branches:
+      - david.lee/mini-agent-build-workflow-lzma
+    # tags:
+    #   - 'sls-**'
 
 jobs:
   build:
@@ -43,14 +45,19 @@ jobs:
           for file in target/release/binaries/*/*
           do
             chmod +x "$file"
-            upx "$file" --ultra-brute
+            upx "$file" --lzma
           done
       - name: Zip binaries
         run: zip -r datadog-serverless-agent.zip *
         working-directory: target/release/binaries
-      - name: Release
-        uses: softprops/action-gh-release@v1
+      - name: Upload artifacts for testing
+        uses: actions/upload-artifact@v3
         with:
-          draft: true
-          generate_release_notes: true
-          files: target/release/binaries/datadog-serverless-agent.zip
+          name: test
+          path: target/release/binaries/datadog-serverless-agent.zip
+      # - name: Release
+      #   uses: softprops/action-gh-release@v1
+      #   with:
+      #     draft: true
+      #     generate_release_notes: true
+      #     files: target/release/binaries/datadog-serverless-agent.zip

--- a/.github/workflows/publish-serverless-agent.yml
+++ b/.github/workflows/publish-serverless-agent.yml
@@ -1,10 +1,8 @@
 name: Build and Release Serverless Agent
 on:
   push:
-    branches:
-      - david.lee/mini-agent-build-workflow-lzma
-    # tags:
-    #   - 'sls-**'
+    tags:
+      - 'sls-**'
 
 jobs:
   build:
@@ -50,14 +48,9 @@ jobs:
       - name: Zip binaries
         run: zip -r datadog-serverless-agent.zip *
         working-directory: target/release/binaries
-      - name: Upload artifacts for testing
-        uses: actions/upload-artifact@v3
+      - name: Release
+        uses: softprops/action-gh-release@v1
         with:
-          name: test
-          path: target/release/binaries/datadog-serverless-agent.zip
-      # - name: Release
-      #   uses: softprops/action-gh-release@v1
-      #   with:
-      #     draft: true
-      #     generate_release_notes: true
-      #     files: target/release/binaries/datadog-serverless-agent.zip
+          draft: true
+          generate_release_notes: true
+          files: target/release/binaries/datadog-serverless-agent.zip


### PR DESCRIPTION
# What does this PR do?

Compressing with `upx "$filename" --ultra-brute` in a ubuntu-latest github workflow broke the executable and made it un-runnable. Using `--lzma` worked correctly however

Using lzma compression decreases binary size by 10KB.

# How to test the change?

Tested the workflow manually, verified the mini agent binary executes properly. Tested the --lzma compressed binary in Google Cloud Functions and found a negligible performance difference over 20 cold start invocations.
