### PR TITLE
Report downstream gitlab pipeline failures to github

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,7 +17,7 @@ trigger_internal_build:
 
 # Following jobs are required otherwise gitsync will not report downstream pipeline failure to github
 
-# This job is used to determine is downstream pipeline has succeeded
+# This job is used to determine if downstream pipeline has succeeded
 report_failure:
   tags: ["arch:amd64"]
   when: on_failure

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,3 +14,26 @@ trigger_internal_build:
     project: DataDog/apm-reliability/libddprof-build
     strategy: depend
     branch: $DOWNSTREAM_BRANCH
+
+# Following jobs are required otherwise gitsync will not report downstream pipeline failure to github
+
+# This job is used to determine is downstream pipeline has succeeded
+report_failure:
+  tags: ["arch:amd64"]
+  when: on_failure
+  needs: [trigger_internal_build]
+  # allow_failure: true prevents the job from showing up in github statuses (because it's filtered by gitsync)
+  allow_failure: true
+  script:
+    - echo "STATUS=1" >> .env
+  artifacts:
+    reports:
+      dotenv: .env
+
+# Final job that will show in github statuses
+report_gitlab_CI_status:
+  tags: ["arch:amd64"]
+  when: always
+  stage: .post
+  script:
+    - exit ${STATUS}


### PR DESCRIPTION
# What does this PR do?

It seems that since there are no "real" jobs in gitlab pipeline, only a trigger for a downstream pipeline, gitsync does not push any status check to github (status checks are associated to "real" jobs). The workaround it to create an actual job whose status depends on status of downstream pipeline.
