### PR TITLE
Fixing all the outstanding issues with the sidecar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,6 +591,7 @@ dependencies = [
  "io-lifetimes",
  "lazy_static",
  "libc",
+ "manual_future",
  "nix",
  "pin-project",
  "rand",
@@ -1144,6 +1145,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a8cbbb2831780bc3b9c15a41f5b49222ef756b6730a95f3decfdd15903eb5a3"
 dependencies = [
  "twox-hash",
+]
+
+[[package]]
+name = "manual_future"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "943968aefb9b0fdf36cccc03f6cd9d6698b23574ab49eccc185ae6c5cb6ad43e"
+dependencies = [
+ "futures",
 ]
 
 [[package]]

--- a/LICENSE-3rdparty.yml
+++ b/LICENSE-3rdparty.yml
@@ -4374,6 +4374,33 @@ third_party_libraries:
   licenses:
   - license: MIT
     text: NOT FOUND
+- package_name: manual_future
+  package_version: 0.1.1
+  license: MIT
+  licenses:
+  - license: MIT
+    text: |
+      MIT License
+
+      Copyright (c) 2019 Dominic Marcuse
+
+      Permission is hereby granted, free of charge, to any person obtaining a copy
+      of this software and associated documentation files (the "Software"), to deal
+      in the Software without restriction, including without limitation the rights
+      to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+      copies of the Software, and to permit persons to whom the Software is
+      furnished to do so, subject to the following conditions:
+
+      The above copyright notice and this permission notice shall be included in all
+      copies or substantial portions of the Software.
+
+      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+      IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+      FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+      AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+      LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+      OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+      SOFTWARE.
 - package_name: memchr
   package_version: 2.5.0
   license: Unlicense/MIT

--- a/ddtelemetry/Cargo.toml
+++ b/ddtelemetry/Cargo.toml
@@ -12,6 +12,7 @@ tracing = ["tracing/std", "tracing-subscriber"]
 anyhow = { version = "1.0" }
 ddcommon = { path = "../ddcommon" }
 futures = { version = "0.3", default-features = false }
+manual_future = "0.1.1"
 http = "0.2"
 hyper = { version = "0.14", features = ["client"], default-features = false }
 lazy_static = "1.4"

--- a/ddtelemetry/src/config.rs
+++ b/ddtelemetry/src/config.rs
@@ -194,7 +194,8 @@ impl Config {
             self.endpoint = Some(Endpoint {
                 url: url_with_telemetry_path(url)?,
                 api_key,
-            })
+            });
+            self.mock_client_file = None;
         }
         Ok(())
     }

--- a/ddtelemetry/src/ipc/interface.rs
+++ b/ddtelemetry/src/ipc/interface.rs
@@ -278,8 +278,7 @@ impl TelemetryServer {
             },
             Transport::try_from(AsyncChannel::from(socket)).unwrap(),
         );
-
-        server.execute(self.serve()).await
+        datadog_ipc::sequential::execute_sequential(server.requests(), self.serve(), 100).await
     }
 
     fn get_session(&self, session_id: &String) -> SessionInfo {

--- a/ddtelemetry/src/ipc/interface.rs
+++ b/ddtelemetry/src/ipc/interface.rs
@@ -482,7 +482,10 @@ impl TelemetryInterface for TelemetryServer {
             cfg.set_url(&agent_url).ok();
         });
 
-        Box::pin(async move { session.shutdown_running_instances().await })
+        Box::pin(async move {
+            session.shutdown_running_instances().await;
+            no_response().await
+        })
     }
 }
 
@@ -555,17 +558,10 @@ pub mod blocking {
         session_id: String,
         agent_url: String,
     ) -> io::Result<()> {
-        let res = transport.call(TelemetryInterfaceRequest::SetSessionAgentUrl {
+        transport.send(TelemetryInterfaceRequest::SetSessionAgentUrl {
             session_id,
             agent_url,
-        })?;
-        match res {
-            TelemetryInterfaceResponse::SetSessionAgentUrl(_) => Ok(()),
-            _ => Err(io::Error::new(
-                io::ErrorKind::Other,
-                "wrong response type when setting session agent url",
-            )),
-        }
+        })
     }
 
     pub fn ping(transport: &mut TelemetryTransport) -> io::Result<Duration> {

--- a/ddtelemetry/src/ipc/interface.rs
+++ b/ddtelemetry/src/ipc/interface.rs
@@ -368,10 +368,11 @@ impl TelemetryServer {
     }
 }
 
-type NoResponse = Pending<()>;
+type NoResponse = Ready<()>;
 
 fn no_response() -> NoResponse {
-    future::pending()
+    Context::current().discard_response = true;
+    future::ready(())
 }
 
 impl TelemetryInterface for TelemetryServer {

--- a/ddtelemetry/src/ipc/sidecar/config.rs
+++ b/ddtelemetry/src/ipc/sidecar/config.rs
@@ -4,6 +4,7 @@
 use std::{collections::HashMap, path::PathBuf, time::Duration};
 
 use ddcommon::parse_uri;
+use spawn_worker::LibDependency;
 
 const ENV_SIDECAR_IPC_MODE: &str = "_DD_DEBUG_SIDECAR_IPC_MODE";
 const SIDECAR_IPC_MODE_SHARED: &str = "shared";
@@ -50,7 +51,7 @@ pub struct Config {
     pub ipc_mode: IpcMode,
     pub log_method: LogMethod,
     pub idle_linger_time: Duration,
-    pub library_dependencies: Vec<PathBuf>,
+    pub library_dependencies: Vec<LibDependency>,
     pub child_env: HashMap<std::ffi::OsString, std::ffi::OsString>,
 }
 

--- a/ipc/src/lib.rs
+++ b/ipc/src/lib.rs
@@ -1,13 +1,14 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
-#[cfg(unix)]
-pub mod handles;
-pub mod platform;
-
-#[cfg(unix)]
-pub mod transport;
 
 #[cfg(unix)]
 pub mod example_interface;
+#[cfg(unix)]
+pub mod handles;
+#[cfg(unix)]
+pub mod transport;
+
+pub mod platform;
+pub mod sequential;
 
 pub use tarpc;

--- a/ipc/src/sequential.rs
+++ b/ipc/src/sequential.rs
@@ -1,0 +1,88 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::{ready, Future, Stream};
+use tarpc::{
+    self,
+    server::{Channel, InFlightRequest, Requests, Serve},
+};
+
+/// Replaces tarpc::server::Channel::execute which spawns one task per message with an executor
+/// that spawns a single worker and queues requests for this task.
+///
+/// If the queue is full, the requests is dropped and will be cancelled by tarpc.
+pub fn execute_sequential<C, S>(
+    reqs: Requests<C>,
+    serve: S,
+    max_requests: usize,
+) -> SequentialExecutor<C, S>
+where
+    C: Channel,
+    S: Serve<C::Req, Resp = C::Resp> + Send + 'static,
+    C::Req: Send + 'static,
+    C::Resp: Send + 'static,
+    S::Fut: Send,
+{
+    let (tx, mut rx) =
+        tokio::sync::mpsc::channel::<(S, InFlightRequest<C::Req, C::Resp>)>(max_requests);
+
+    tokio::spawn(async move {
+        loop {
+            let (serve, req) = match rx.recv().await {
+                None => return,
+                Some(s) => s,
+            };
+            req.execute(serve).await;
+        }
+    });
+    SequentialExecutor {
+        inner: reqs,
+        serve,
+        tx,
+    }
+}
+
+#[pin_project::pin_project]
+pub struct SequentialExecutor<C, S>
+where
+    C: Channel + 'static,
+{
+    #[pin]
+    inner: Requests<C>,
+    serve: S,
+    tx: tokio::sync::mpsc::Sender<(S, InFlightRequest<C::Req, C::Resp>)>,
+}
+
+impl<C, S> Future for SequentialExecutor<C, S>
+where
+    C: Channel + 'static,
+    C::Req: Send + 'static,
+    C::Resp: Send + 'static,
+    S: Serve<C::Req, Resp = C::Resp> + Send + 'static + Clone,
+    S::Fut: Send,
+{
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        while let Some(response_handler) = ready!(self.as_mut().project().inner.poll_next(cx)) {
+            match response_handler {
+                Ok(resp) => {
+                    let server = self.serve.clone();
+                    if let Err(err) = self.as_ref().tx.try_send((server, resp)) {
+                        // TODO: should we log something in case we drop the request on the floor?
+                    }
+                }
+                Err(e) => {
+                    // TODO: should we log something in case we drop the request on the floor?
+                    break;
+                }
+            }
+        }
+        Poll::Ready(())
+    }
+}

--- a/spawn_worker/src/trampoline.c
+++ b/spawn_worker/src/trampoline.c
@@ -8,6 +8,8 @@
 #ifndef _WIN32
 #include <dlfcn.h>
 #include <unistd.h>
+#else
+#define unlink _unlink
 #endif
 
 int main(int argc, char *argv[]) {

--- a/spawn_worker/src/unix/spawn.rs
+++ b/spawn_worker/src/unix/spawn.rs
@@ -489,6 +489,8 @@ impl SpawnWorker {
 
         if self.daemonize {
             if let Fork::Parent(_) = do_fork()? {
+                // silence lsan and such things
+                unsafe { libc::close(2); }
                 std::process::exit(0);
             }
         }


### PR DESCRIPTION
* This branch includes Pauls changes (#151, #152)
* Fix for Pauls PR about the sequential executor: Returning a future which instantly resolves instead of Future::Pending
* Fix for Pauls PR to exclude the memfd from being closed
* Close all the file descriptors in the intermediary forked process too (musl has an atexit handler which wreaks havoc *see below)
* Changed set_session_agent_url to not send a response (some tests were blocking in read(), waiting for the sidecar to reply)
* Temp files are controlled by the process spawning logic and can be removed by the spawned process.
* equeue_actions now can properly handle further updates after the initial flush, like a Lifecycle(Stop) event. Before that went mostly through thanks to the race condition that a stop immediately followed the flush event and then got enqueued before the flush dequeued it... (Also: why is there nothing like a completable future natively in std or tokio?)

With musl, when you read from a file via fread, it'll read up to the next kibibyte. I.e. musl reads 1024 bytes, and stores the current read position offset to the file descriptor position in its FILE struct.
Then, when you exit() a program, musl will update the file descriptions to seek to the actual position.
Now, in PHP CLI scripts, we open the script file and advance past a shebang line. That happens before ddtrace is loaded. When ddtrace is loaded and it forks, the new intermediary (i.e. fork 1 in the double fork) process will also see the FILE struct. It then exits. Helpful musl sees the file descriptor and ... does a seek() to the actual position. When the original process (race conditions ftw) then reads the file, it'll read from 1024 bytes too early (a negative position), leading to a segfault (outside of the mmap()'ped reagion).
