### PR TITLE
Update proto files

### DIFF
--- a/.github/workflows/verify-proto-files.yml
+++ b/.github/workflows/verify-proto-files.yml
@@ -12,9 +12,8 @@ jobs:
         working-directory: trace-protobuf/src/pb
         run: |
           GO_AGENT_PROTO=$(curl -s "https://raw.githubusercontent.com/DataDog/datadog-agent/master/pkg/trace/pb/agent_payload.proto")
-          GO_AGENT_PROTO_FIXED=$(echo "$GO_AGENT_PROTO" | sed -e '1,2d')
 
-          echo "$GO_AGENT_PROTO_FIXED" | diff agent_payload.proto -
+          echo "$GO_AGENT_PROTO" | diff agent_payload.proto -
       - name: diff stats.proto
         working-directory: trace-protobuf/src/pb
         run: |

--- a/trace-protobuf/src/pb.rs
+++ b/trace-protobuf/src/pb.rs
@@ -10,50 +10,63 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Span {
     /// service is the name of the service with which this span is associated.
+    /// @gotags: json:"service" msg:"service"
     #[prost(string, tag = "1")]
     #[serde(default)]
     pub service: ::prost::alloc::string::String,
     /// name is the operation name of this span.
+    /// @gotags: json:"name" msg:"name"
     #[prost(string, tag = "2")]
     pub name: ::prost::alloc::string::String,
     /// resource is the resource name of this span, also sometimes called the endpoint (for web spans).
+    /// @gotags: json:"resource" msg:"resource"
     #[prost(string, tag = "3")]
     pub resource: ::prost::alloc::string::String,
     /// traceID is the ID of the trace to which this span belongs.
+    /// @gotags: json:"trace_id" msg:"trace_id"
     #[prost(uint64, tag = "4")]
     pub trace_id: u64,
     /// spanID is the ID of this span.
+    /// @gotags: json:"span_id" msg:"span_id"
     #[prost(uint64, tag = "5")]
     pub span_id: u64,
     /// parentID is the ID of this span's parent, or zero if this span has no parent.
+    /// @gotags: json:"parent_id" msg:"parent_id"
     #[prost(uint64, tag = "6")]
     #[serde(default)]
     pub parent_id: u64,
     /// start is the number of nanoseconds between the Unix epoch and the beginning of this span.
+    /// @gotags: json:"start" msg:"start"
     #[prost(int64, tag = "7")]
     pub start: i64,
     /// duration is the time length of this span in nanoseconds.
+    /// @gotags: json:"duration" msg:"duration"
     #[prost(int64, tag = "8")]
     pub duration: i64,
     /// error is 1 if there is an error associated with this span, or 0 if there is not.
+    /// @gotags: json:"error" msg:"error"
     #[prost(int32, tag = "9")]
     #[serde(default)]
     pub error: i32,
     /// meta is a mapping from tag name to tag value for string-valued tags.
+    /// @gotags: json:"meta" msg:"meta"
     #[prost(map = "string, string", tag = "10")]
     pub meta: ::std::collections::HashMap<
         ::prost::alloc::string::String,
         ::prost::alloc::string::String,
     >,
     /// metrics is a mapping from tag name to tag value for numeric-valued tags.
+    /// @gotags: json:"metrics" msg:"metrics"
     #[prost(map = "string, double", tag = "11")]
     #[serde(default)]
     pub metrics: ::std::collections::HashMap<::prost::alloc::string::String, f64>,
     /// type is the type of the service with which this span is associated.  Example values: web, db, lambda.
+    /// @gotags: json:"type" msg:"type"
     #[prost(string, tag = "12")]
     #[serde(default)]
     pub r#type: ::prost::alloc::string::String,
     /// meta_struct is a registry of structured "other" data used by, e.g., AppSec.
+    /// @gotags: json:"meta_struct,omitempty" msg:"meta_struct"
     #[prost(map = "string, bytes", tag = "13")]
     #[serde(default)]
     pub meta_struct: ::std::collections::HashMap<
@@ -66,21 +79,26 @@ pub struct Span {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TraceChunk {
     /// priority specifies sampling priority of the trace.
+    /// @gotags: json:"priority" msg:"priority"
     #[prost(int32, tag = "1")]
     pub priority: i32,
     /// origin specifies origin product ("lambda", "rum", etc.) of the trace.
+    /// @gotags: json:"origin" msg:"origin"
     #[prost(string, tag = "2")]
     pub origin: ::prost::alloc::string::String,
     /// spans specifies list of containing spans.
+    /// @gotags: json:"spans" msg:"spans"
     #[prost(message, repeated, tag = "3")]
     pub spans: ::prost::alloc::vec::Vec<Span>,
     /// tags specifies tags common in all `spans`.
+    /// @gotags: json:"tags" msg:"tags"
     #[prost(map = "string, string", tag = "4")]
     pub tags: ::std::collections::HashMap<
         ::prost::alloc::string::String,
         ::prost::alloc::string::String,
     >,
     /// droppedTrace specifies whether the trace was dropped by samplers or not.
+    /// @gotags: json:"dropped_trace" msg:"dropped_trace"
     #[prost(bool, tag = "5")]
     pub dropped_trace: bool,
 }
@@ -89,36 +107,46 @@ pub struct TraceChunk {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TracerPayload {
     /// containerID specifies the ID of the container where the tracer is running on.
+    /// @gotags: json:"container_id" msg:"container_id"
     #[prost(string, tag = "1")]
     pub container_id: ::prost::alloc::string::String,
     /// languageName specifies language of the tracer.
+    /// @gotags: json:"language_name" msg:"language_name"
     #[prost(string, tag = "2")]
     pub language_name: ::prost::alloc::string::String,
     /// languageVersion specifies language version of the tracer.
+    /// @gotags: json:"language_version" msg:"language_version"
     #[prost(string, tag = "3")]
     pub language_version: ::prost::alloc::string::String,
     /// tracerVersion specifies version of the tracer.
+    /// @gotags: json:"tracer_version" msg:"tracer_version"
     #[prost(string, tag = "4")]
     pub tracer_version: ::prost::alloc::string::String,
     /// runtimeID specifies V4 UUID representation of a tracer session.
+    /// @gotags: json:"runtime_id" msg:"runtime_id"
     #[prost(string, tag = "5")]
     pub runtime_id: ::prost::alloc::string::String,
     /// chunks specifies list of containing trace chunks.
+    /// @gotags: json:"chunks" msg:"chunks"
     #[prost(message, repeated, tag = "6")]
     pub chunks: ::prost::alloc::vec::Vec<TraceChunk>,
     /// tags specifies tags common in all `chunks`.
+    /// @gotags: json:"tags" msg:"tags"
     #[prost(map = "string, string", tag = "7")]
     pub tags: ::std::collections::HashMap<
         ::prost::alloc::string::String,
         ::prost::alloc::string::String,
     >,
     /// env specifies `env` tag that set with the tracer.
+    /// @gotags: json:"env" msg:"env"
     #[prost(string, tag = "8")]
     pub env: ::prost::alloc::string::String,
     /// hostname specifies hostname of where the tracer is running.
+    /// @gotags: json:"hostname" msg:"hostname"
     #[prost(string, tag = "9")]
     pub hostname: ::prost::alloc::string::String,
     /// version specifies `version` tag that set with the tracer.
+    /// @gotags: json:"app_version" msg:"app_version"
     #[prost(string, tag = "10")]
     pub app_version: ::prost::alloc::string::String,
 }

--- a/trace-protobuf/src/pb/agent_payload.proto
+++ b/trace-protobuf/src/pb/agent_payload.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 
 package pb;
+option go_package = "github.com/DataDog/datadog-agent/pkg/trace/pb";
 
 import "tracer_payload.proto";
 

--- a/trace-protobuf/src/pb/agent_payload.proto
+++ b/trace-protobuf/src/pb/agent_payload.proto
@@ -1,3 +1,5 @@
+// protoc -I. -I$GOPATH/src --gogofaster_out=. span.proto tracer_payload.proto agent_payload.proto
+
 syntax = "proto3";
 
 package pb;

--- a/trace-protobuf/src/pb/span.proto
+++ b/trace-protobuf/src/pb/span.proto
@@ -1,34 +1,46 @@
 syntax = "proto3";
 
 package pb;
-
-import "gogo.proto";
+option go_package="github.com/DataDog/datadog-agent/pkg/trace/pb";
 
 message Span {
     // service is the name of the service with which this span is associated.
-    string service = 1 [(gogoproto.jsontag) = "service", (gogoproto.moretags) = "msg:\"service\""];
+    // @gotags: json:"service" msg:"service"
+    string service = 1;
     // name is the operation name of this span.
-    string name = 2 [(gogoproto.jsontag) = "name", (gogoproto.moretags) = "msg:\"name\""];
+    // @gotags: json:"name" msg:"name"
+    string name = 2;
     // resource is the resource name of this span, also sometimes called the endpoint (for web spans).
-    string resource = 3 [(gogoproto.jsontag) = "resource", (gogoproto.moretags) = "msg:\"resource\""];
+    // @gotags: json:"resource" msg:"resource"
+    string resource = 3;
     // traceID is the ID of the trace to which this span belongs.
-    uint64 traceID = 4 [(gogoproto.jsontag) = "trace_id", (gogoproto.moretags) = "msg:\"trace_id\""];
+    // @gotags: json:"trace_id" msg:"trace_id"
+    uint64 traceID = 4;
     // spanID is the ID of this span.
-    uint64 spanID = 5 [(gogoproto.jsontag) = "span_id", (gogoproto.moretags) = "msg:\"span_id\""];
+    // @gotags: json:"span_id" msg:"span_id"
+    uint64 spanID = 5;
     // parentID is the ID of this span's parent, or zero if this span has no parent.
-    uint64 parentID = 6 [(gogoproto.jsontag) = "parent_id", (gogoproto.moretags) = "msg:\"parent_id\""];
+    // @gotags: json:"parent_id" msg:"parent_id"
+    uint64 parentID = 6;
     // start is the number of nanoseconds between the Unix epoch and the beginning of this span.
-    int64 start = 7 [(gogoproto.jsontag) = "start", (gogoproto.moretags) = "msg:\"start\""];
+    // @gotags: json:"start" msg:"start"
+    int64 start = 7;
     // duration is the time length of this span in nanoseconds.
-    int64 duration = 8 [(gogoproto.jsontag) = "duration", (gogoproto.moretags) = "msg:\"duration\""];
+    // @gotags: json:"duration" msg:"duration"
+    int64 duration = 8;
     // error is 1 if there is an error associated with this span, or 0 if there is not.
-    int32 error = 9 [(gogoproto.jsontag) = "error", (gogoproto.moretags) = "msg:\"error\""];
+    // @gotags: json:"error" msg:"error"
+    int32 error = 9;
     // meta is a mapping from tag name to tag value for string-valued tags.
-    map<string, string> meta = 10 [(gogoproto.jsontag) = "meta", (gogoproto.moretags) = "msg:\"meta\""];
+    // @gotags: json:"meta" msg:"meta"
+    map<string, string> meta = 10;
     // metrics is a mapping from tag name to tag value for numeric-valued tags.
-    map<string, double> metrics = 11 [(gogoproto.jsontag) = "metrics", (gogoproto.moretags) = "msg:\"metrics\""];
+    // @gotags: json:"metrics" msg:"metrics"
+    map<string, double> metrics = 11;
     // type is the type of the service with which this span is associated.  Example values: web, db, lambda.
-    string type = 12 [(gogoproto.jsontag) = "type", (gogoproto.moretags) = "msg:\"type\""];
+    // @gotags: json:"type" msg:"type"
+    string type = 12;
     // meta_struct is a registry of structured "other" data used by, e.g., AppSec.
-    map<string, bytes> meta_struct = 13 [(gogoproto.jsontag) = "meta_struct,omitempty", (gogoproto.moretags) = "msg:\"meta_struct\""];
+    // @gotags: json:"meta_struct,omitempty" msg:"meta_struct"
+    map<string, bytes> meta_struct = 13;
 }

--- a/trace-protobuf/src/pb/tracer_payload.proto
+++ b/trace-protobuf/src/pb/tracer_payload.proto
@@ -1,44 +1,58 @@
 syntax = "proto3";
 
 package pb;
-
-import "gogo.proto";
+option go_package="github.com/DataDog/datadog-agent/pkg/trace/pb";
 import "span.proto";
 
 // TraceChunk represents a list of spans with the same trace ID. In other words, a chunk of a trace.
 message TraceChunk {
 	// priority specifies sampling priority of the trace.
-	int32 priority = 1 [(gogoproto.jsontag) = "priority", (gogoproto.moretags) = "msg:\"priority\""];
+	// @gotags: json:"priority" msg:"priority"
+	int32 priority = 1;
 	// origin specifies origin product ("lambda", "rum", etc.) of the trace.
-	string origin = 2 [(gogoproto.jsontag) = "origin", (gogoproto.moretags) = "msg:\"origin\""];
+	// @gotags: json:"origin" msg:"origin"
+	string origin = 2;
 	// spans specifies list of containing spans.
-	repeated Span spans = 3 [(gogoproto.jsontag) = "spans", (gogoproto.moretags) = "msg:\"spans\""];
+	// @gotags: json:"spans" msg:"spans"
+	repeated Span spans = 3;
 	// tags specifies tags common in all `spans`.
-	map<string, string> tags = 4 [(gogoproto.jsontag) = "tags", (gogoproto.moretags) = "msg:\"tags\""];
+	// @gotags: json:"tags" msg:"tags"
+	map<string, string> tags = 4;
 	// droppedTrace specifies whether the trace was dropped by samplers or not.
-	bool droppedTrace = 5 [(gogoproto.jsontag) = "dropped_trace", (gogoproto.moretags) = "msg:\"dropped_trace\""];
+	// @gotags: json:"dropped_trace" msg:"dropped_trace"
+	bool droppedTrace = 5;
 }
 
 // TracerPayload represents a payload the trace agent receives from tracers.
 message TracerPayload {
 	// containerID specifies the ID of the container where the tracer is running on.
-	string containerID = 1 [(gogoproto.jsontag) = "container_id", (gogoproto.moretags) = "msg:\"container_id\""];
+	// @gotags: json:"container_id" msg:"container_id"
+	string containerID = 1;
 	// languageName specifies language of the tracer.
-	string languageName = 2 [(gogoproto.jsontag) = "language_name", (gogoproto.moretags) = "msg:\"language_name\""];
+	// @gotags: json:"language_name" msg:"language_name"
+	string languageName = 2;
 	// languageVersion specifies language version of the tracer.
-	string languageVersion = 3 [(gogoproto.jsontag) = "language_version", (gogoproto.moretags) = "msg:\"language_version\""];
+	// @gotags: json:"language_version" msg:"language_version"
+	string languageVersion = 3;
 	// tracerVersion specifies version of the tracer.
-	string tracerVersion = 4 [(gogoproto.jsontag) = "tracer_version", (gogoproto.moretags) = "msg:\"tracer_version\""];
+	// @gotags: json:"tracer_version" msg:"tracer_version"
+	string tracerVersion = 4;
 	// runtimeID specifies V4 UUID representation of a tracer session.
-	string runtimeID = 5 [(gogoproto.jsontag) = "runtime_id", (gogoproto.moretags) = "msg:\"runtime_id\""];
+	// @gotags: json:"runtime_id" msg:"runtime_id"
+	string runtimeID = 5;
 	// chunks specifies list of containing trace chunks.
-	repeated TraceChunk chunks = 6 [(gogoproto.jsontag) = "chunks", (gogoproto.moretags) = "msg:\"chunks\""];
+	// @gotags: json:"chunks" msg:"chunks"
+	repeated TraceChunk chunks = 6;
 	// tags specifies tags common in all `chunks`.
-	map<string, string> tags = 7 [(gogoproto.jsontag) = "tags", (gogoproto.moretags) = "msg:\"tags\""];
+	// @gotags: json:"tags" msg:"tags"
+	map<string, string> tags = 7;
 	// env specifies `env` tag that set with the tracer.
-	string env = 8 [(gogoproto.jsontag) = "env", (gogoproto.moretags) = "msg:\"env\""];
+	// @gotags: json:"env" msg:"env"
+	string env = 8;
 	// hostname specifies hostname of where the tracer is running.
-	string hostname = 9 [(gogoproto.jsontag) = "hostname", (gogoproto.moretags) = "msg:\"hostname\""];
+	// @gotags: json:"hostname" msg:"hostname"
+	string hostname = 9;
 	// version specifies `version` tag that set with the tracer.
-	string appVersion = 10 [(gogoproto.jsontag) = "app_version", (gogoproto.moretags) = "msg:\"app_version\""];
+	// @gotags: json:"app_version" msg:"app_version"
+	string appVersion = 10;
 }


### PR DESCRIPTION
# What does this PR do?

Agent proto files and those found in trace-protobuf are out of sync. This PR updates the protobuf files & remove an unnecessary line from the verify proto CI

autogenerated rust structs (from proto files) are unchanged, verified by running:
`cargo build --features generate-protobuf` in `trace-protobuf`

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
