### PR TITLE
[Draft] Expose container_id API

### DIFF
--- a/ddcommon-ffi/src/container_id.rs
+++ b/ddcommon-ffi/src/container_id.rs
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+
+use std::ffi::CString;
+use ddcommon::container_id::get_container_id;
+
+use std::os::raw::{c_char, c_int};
+
+#[repr(C)]
+pub struct FfiOptionString {
+    pub data: *const c_char,
+    pub is_some: c_int,
+}
+
+#[no_mangle]
+pub extern "C" fn get_container_id_ffi(pid: c_int) -> FfiOptionString {
+    let pid = if pid >= 0 { Some(pid as u32) } else { None };
+    if let Some(container_id) = get_container_id(pid) {
+        let container_id_cstr = CString::new(container_id).unwrap();
+        FfiOptionString {
+            data: container_id_cstr.into_raw(),
+            is_some: 1,
+        }
+    } else {
+        FfiOptionString {
+            data: std::ptr::null(),
+            is_some: 0,
+        }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn free_container_id_ffi(data: *mut c_char) {
+    if !data.is_null() {
+        unsafe {
+            drop(CString::from_raw(data));
+        }
+    }
+}

--- a/ddcommon-ffi/src/container_id.rs
+++ b/ddcommon-ffi/src/container_id.rs
@@ -1,8 +1,8 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
 
-use std::ffi::CString;
 use ddcommon::container_id::get_container_id;
+use std::ffi::CString;
 
 use std::os::raw::{c_char, c_int};
 

--- a/ddcommon-ffi/src/lib.rs
+++ b/ddcommon-ffi/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod error;
 
+pub mod container_id;
 pub mod option;
 pub mod slice;
 pub mod tags;

--- a/ddcommon/src/container_id.rs
+++ b/ddcommon/src/container_id.rs
@@ -9,8 +9,6 @@ use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::Path;
 use std::path::PathBuf;
-use std::collections::HashMap;
-use std::sync::Mutex;
 
 /* Extract container id from /proc/self/group
 
@@ -111,7 +109,6 @@ fn get_cgroup_path(pid: Option<u32>) -> PathBuf {
 
 pub fn get_self_container_id() -> Option<&'static str> {
     // cache container id in a static to avoid recomputing it at each call
-
     lazy_static! {
         static ref CONTAINER_ID: Option<String> =
             extract_container_id(get_cgroup_path(None).as_path()).ok();
@@ -119,30 +116,13 @@ pub fn get_self_container_id() -> Option<&'static str> {
     CONTAINER_ID.as_deref()
 }
 
-// todo: giving a handle to the user would better
-lazy_static! {
-    static ref CGROUP_PATH_CACHE: Mutex<HashMap<Option<u32>, PathBuf>> = Mutex::new(HashMap::new());
-    static ref CONTAINER_ID_CACHE: Mutex<HashMap<PathBuf, String>> = Mutex::new(HashMap::new());
-}
-
 pub fn get_container_id(pid: Option<u32>) -> Option<String> {
-    let mut cgroup_path_cache = CGROUP_PATH_CACHE.lock().unwrap();
-
     // lookup cgroup path (for this pid)
-    let cgroup_path = cgroup_path_cache
-        .entry(pid)
-        .or_insert_with(|| get_cgroup_path(pid));
-
-    let mut container_id_cache = CONTAINER_ID_CACHE.lock().unwrap();
-    if let Some(container_id) = container_id_cache.get(cgroup_path) {
-        return Some(container_id.clone());
-    }
+    let cgroup_path = get_cgroup_path(pid);
 
     if let Ok(container_id) = extract_container_id(&cgroup_path) {
-        container_id_cache.insert(cgroup_path.clone(), container_id.clone());
         return Some(container_id);
     }
-
     None
 }
 

--- a/ddcommon/src/lib.rs
+++ b/ddcommon/src/lib.rs
@@ -85,7 +85,7 @@ impl Endpoint {
             builder = builder.header(header::DATADOG_API_KEY, HeaderValue::from_str(api_key)?);
         }
 
-        if let Some(container_id) = container_id::get_container_id() {
+        if let Some(container_id) = container_id::get_self_container_id() {
             builder = builder.header(header::DATADOG_CONTAINER_ID, container_id);
         }
 

--- a/ddtelemetry/src/lib.rs
+++ b/ddtelemetry/src/lib.rs
@@ -18,7 +18,7 @@ pub mod worker;
 pub fn build_host() -> data::Host {
     data::Host {
         hostname: info::os::real_hostname().unwrap_or_else(|_| String::from("unknown_hostname")),
-        container_id: container_id::get_container_id().map(|f| f.to_string()),
+        container_id: container_id::get_self_container_id().map(|f| f.to_string()),
         os: Some(String::from(info::os::os_name())),
         os_version: info::os::os_version().ok(),
         kernel_name: None,


### PR DESCRIPTION
# What does this PR do?

Expose the container ID API

# Motivation

In native, we need to get this information for different PIDs.
This will allow us to add information by sample on the container ID.

# Additional Notes

WIP I still have to adjust this to the libdatadog types.

# How to test the change?

I'm adding integrated tests to the native profiler with different container IDs.
