### PR TITLE
Mini Agent: Support env var set custom trace & trace stats intake urls

### DIFF
--- a/trace-mini-agent/src/config.rs
+++ b/trace-mini-agent/src/config.rs
@@ -39,10 +39,17 @@ impl Config {
 
         let dd_site = env::var("DD_SITE").unwrap_or_else(|_| "datadoghq.com".to_string());
 
-        let trace_intake_url = env::var("DD_TRACE_INTAKE_URL")
-            .unwrap_or_else(|_| construct_trace_intake_url(&dd_site, TRACE_INTAKE_ROUTE));
-        let trace_stats_intake_url = env::var("DD_TRACE_STATS_INTAKE_URL")
-            .unwrap_or_else(|_| construct_trace_intake_url(&dd_site, TRACE_STATS_INTAKE_ROUTE));
+        // construct the trace & trace stats intake urls based on DD_SITE env var (to flush traces & trace stats to)
+        let mut trace_intake_url = format!("https://trace.agent.{dd_site}{TRACE_INTAKE_ROUTE}");
+        let mut trace_stats_intake_url =
+            format!("https://trace.agent.{dd_site}{TRACE_STATS_INTAKE_ROUTE}");
+
+        // DD_APM_DD_URL env var will primarily be used for integration tests
+        // overrides the entire trace/trace stats intake url prefix
+        if let Ok(endpoint_prefix) = env::var("DD_APM_DD_URL") {
+            trace_intake_url = format!("{endpoint_prefix}{TRACE_INTAKE_ROUTE}");
+            trace_stats_intake_url = format!("{endpoint_prefix}{TRACE_STATS_INTAKE_ROUTE}");
+        };
 
         Ok(Config {
             api_key,
@@ -56,10 +63,6 @@ impl Config {
             trace_stats_intake_url,
         })
     }
-}
-
-fn construct_trace_intake_url(prefix: &str, route: &str) -> String {
-    format!("https://trace.agent.{prefix}{route}")
 }
 
 #[cfg(test)]
@@ -147,27 +150,16 @@ mod tests {
     #[serial]
     fn test_set_custom_trace_and_trace_stats_intake_url() {
         env::set_var("DD_API_KEY", "_not_a_real_key_");
-        env::set_var(
-            "DD_TRACE_INTAKE_URL",
-            "notdatadoghq.com/not/api/v0.2/traces",
-        );
-        env::set_var(
-            "DD_TRACE_STATS_INTAKE_URL",
-            "notdatadoghq.com/not/api/v0.2/stats",
-        );
+        env::set_var("DD_APM_DD_URL", "notdatadoghq.com");
         let config_res = config::Config::new();
         assert!(config_res.is_ok());
         let config = config_res.unwrap();
-        assert_eq!(
-            config.trace_intake_url,
-            "notdatadoghq.com/not/api/v0.2/traces"
-        );
+        assert_eq!(config.trace_intake_url, "notdatadoghq.com/api/v0.2/traces");
         assert_eq!(
             config.trace_stats_intake_url,
-            "notdatadoghq.com/not/api/v0.2/stats"
+            "notdatadoghq.com/api/v0.2/stats"
         );
         env::remove_var("DD_API_KEY");
-        env::remove_var("DD_TRACE_INTAKE_URL");
-        env::remove_var("DD_TRACE_STATS_INTAKE_URL");
+        env::remove_var("DD_APM_DD_URL");
     }
 }

--- a/trace-mini-agent/src/config.rs
+++ b/trace-mini-agent/src/config.rs
@@ -160,7 +160,7 @@ mod tests {
         let config = config_res.unwrap();
         assert_eq!(
             config.trace_intake_url,
-            "notdatadoghq.com/not/api/v0.2/trace"
+            "notdatadoghq.com/not/api/v0.2/traces"
         );
         assert_eq!(
             config.trace_stats_intake_url,

--- a/trace-mini-agent/src/config.rs
+++ b/trace-mini-agent/src/config.rs
@@ -150,14 +150,17 @@ mod tests {
     #[serial]
     fn test_set_custom_trace_and_trace_stats_intake_url() {
         env::set_var("DD_API_KEY", "_not_a_real_key_");
-        env::set_var("DD_APM_DD_URL", "notdatadoghq.com");
+        env::set_var("DD_APM_DD_URL", "http://127.0.0.1:3333");
         let config_res = config::Config::new();
         assert!(config_res.is_ok());
         let config = config_res.unwrap();
-        assert_eq!(config.trace_intake_url, "notdatadoghq.com/api/v0.2/traces");
+        assert_eq!(
+            config.trace_intake_url,
+            "http://127.0.0.1:3333/api/v0.2/traces"
+        );
         assert_eq!(
             config.trace_stats_intake_url,
-            "notdatadoghq.com/api/v0.2/stats"
+            "http://127.0.0.1:3333/api/v0.2/stats"
         );
         env::remove_var("DD_API_KEY");
         env::remove_var("DD_APM_DD_URL");


### PR DESCRIPTION
# What does this PR do?

Let the trace + trace stats intake url prefix be configurable by the `DD_APM_DD_URL` environment variable. To be used for integration testing.

Setting `DD_APM_DD_URL=http://127.0.0.1:3333` will result in the following two endpoints being used:
```
http://127.0.0.1:3333/api/v0.2/traces
http://127.0.0.1:3333/api/v0.2/stats
```

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
