### PR TITLE
Fix sidecar_mockgen when symbols are fully dynamic in source binary

### DIFF
--- a/spawn_worker/build.rs
+++ b/spawn_worker/build.rs
@@ -15,6 +15,10 @@ fn main() {
 
     if !cfg!(target_os = "windows") {
         builder.link_dynamically("dl");
+        if cfg!(target_os = "linux") {
+            builder.flag("-Wl,--no-as-needed");
+        }
+        builder.link_dynamically("m"); // rust code generally requires libm. Just link against it.
     }
 
     builder.try_compile_executable("trampoline.bin").unwrap();

--- a/tools/sidecar_mockgen/src/lib.rs
+++ b/tools/sidecar_mockgen/src/lib.rs
@@ -43,10 +43,10 @@ pub fn generate_mock_symbols(binary: &Path, objects: &[&Path]) -> Result<String,
     }
 
     let mut generated = String::new();
-    for sym in so_file.symbols() {
+    for sym in so_file.symbols().chain(so_file.dynamic_symbols()) {
         if sym.is_definition() {
             if let Ok(name) = sym.name() {
-                if missing_symbols.contains(name) {
+                if missing_symbols.remove(name) {
                     _ = match sym.kind() {
                         SymbolKind::Text => writeln!(generated, "void {}() {{}}", name),
                         // Ignore symbols of size 0, like _GLOBAL_OFFSET_TABLE_ on alpine


### PR DESCRIPTION
# What does this PR do?

And force libm to be linked in trampoline, given that it's going to be used to link against rust code, which needs libm.

# Motivation

Allowing more targets to build the sidecar... Tried to compile it outside of our docker images with compilers in the wild...