### PR TITLE
Put Connector::default() into lazy_static! to avoid repeated overhead of root cert fetching

### DIFF
--- a/ddcommon/src/connector/mod.rs
+++ b/ddcommon/src/connector/mod.rs
@@ -5,6 +5,7 @@ use futures::future::BoxFuture;
 use futures::{future, FutureExt};
 use hyper::client::HttpConnector;
 
+use lazy_static::lazy_static;
 use rustls::ClientConfig;
 use std::future::Future;
 use std::pin::Pin;
@@ -27,9 +28,13 @@ pub enum Connector {
     Https(hyper_rustls::HttpsConnector<hyper::client::HttpConnector>),
 }
 
+lazy_static! {
+    static ref DEFAULT_CONNECTOR: Connector = Connector::new();
+}
+
 impl Default for Connector {
     fn default() -> Self {
-        Self::new()
+        DEFAULT_CONNECTOR.clone()
     }
 }
 

--- a/ddtelemetry/src/worker/http_client.rs
+++ b/ddtelemetry/src/worker/http_client.rs
@@ -50,7 +50,7 @@ pub fn from_config(c: &Config) -> Box<dyn HttpClient + Sync + Send> {
         Box::new(HyperClient {
             inner: hyper::Client::builder()
                 .pool_idle_timeout(std::time::Duration::from_secs(30))
-                .build(ddcommon::connector::Connector::new()),
+                .build(ddcommon::connector::Connector::default()),
         })
     }
 }

--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -271,7 +271,7 @@ impl Exporter {
         // Set idle to 0, which prevents the pipe being broken every 2nd request
         let client = hyper::Client::builder()
             .pool_max_idle_per_host(0)
-            .build(connector::Connector::new());
+            .build(connector::Connector::default());
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()?;


### PR DESCRIPTION
With many different telemetry workers (due to different services in sidecar), overhead can be significant on startup.