### PR TITLE
Minor: Add help message on CI failure

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,4 +36,5 @@ report_gitlab_CI_status:
   when: always
   stage: .post
   script:
+    - echo "TIP: If you see this failing, it's because something else in the GitLab pipeline failed. Follow the link to the pipeline and check for other things that failed prior to this step."
     - exit ${STATUS}


### PR DESCRIPTION
**What does this PR do?**:

Add a tiny message pointing people in the right direction if something fails in GitLab CI.

**Motivation**:

I got confused by this, so might as well improve it so that I'm the last person to be confused :)

**Additional Notes**:

N/A

**How to test the change?**:

Validate that this message shows up when going to the "report_gitlab_CI_status" job in CI.