### PR TITLE
Fix CI in main branch by running cargo fmt

### DIFF
--- a/ipc/tarpc/tarpc/examples/custom_transport.rs
+++ b/ipc/tarpc/tarpc/examples/custom_transport.rs
@@ -20,29 +20,29 @@
 //
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-//     let bind_addr = "/tmp/tarpc_on_unix_example.sock";
-//
-//     let _ = std::fs::remove_file(bind_addr);
-//
-//     let listener = UnixListener::bind(bind_addr).unwrap();
-//     let codec_builder = LengthDelimitedCodec::builder();
-//     tokio::spawn(async move {
-//         loop {
-//             let (conn, _addr) = listener.accept().await.unwrap();
-//             let framed = codec_builder.new_framed(conn);
-//             let transport = transport::new(framed, Bincode::default());
-//
-//             let fut = BaseChannel::with_defaults(transport).execute(Service.serve());
-//             tokio::spawn(fut);
-//         }
-//     });
-//
-//     let conn = UnixStream::connect(bind_addr).await?;
-//     let transport = transport::new(codec_builder.new_framed(conn), Bincode::default());
-//     PingServiceClient::new(Default::default(), transport)
-//         .spawn()
-//         .ping(tarpc::context::current())
-//         .await?;
-//
+    //     let bind_addr = "/tmp/tarpc_on_unix_example.sock";
+    //
+    //     let _ = std::fs::remove_file(bind_addr);
+    //
+    //     let listener = UnixListener::bind(bind_addr).unwrap();
+    //     let codec_builder = LengthDelimitedCodec::builder();
+    //     tokio::spawn(async move {
+    //         loop {
+    //             let (conn, _addr) = listener.accept().await.unwrap();
+    //             let framed = codec_builder.new_framed(conn);
+    //             let transport = transport::new(framed, Bincode::default());
+    //
+    //             let fut = BaseChannel::with_defaults(transport).execute(Service.serve());
+    //             tokio::spawn(fut);
+    //         }
+    //     });
+    //
+    //     let conn = UnixStream::connect(bind_addr).await?;
+    //     let transport = transport::new(codec_builder.new_framed(conn), Bincode::default());
+    //     PingServiceClient::new(Default::default(), transport)
+    //         .spawn()
+    //         .ping(tarpc::context::current())
+    //         .await?;
+    //
     Ok(())
 }

--- a/ipc/tarpc/tarpc/src/context.rs
+++ b/ipc/tarpc/tarpc/src/context.rs
@@ -136,7 +136,7 @@ impl Context {
             trace_context: trace::Context::try_from(&span)
                 .unwrap_or_else(|_| trace::Context::default()),
             discard_response: false,
-            deadline: Deadline::default().0
+            deadline: Deadline::default().0,
         }
     }
 

--- a/ipc/tarpc/tarpc/src/server/testing.rs
+++ b/ipc/tarpc/tarpc/src/server/testing.rs
@@ -8,7 +8,7 @@ use crate::{
     cancellations::{cancellations, CanceledRequests, RequestCancellation},
     context,
     server::{Channel, Config, RequestResponse, ResponseGuard, TrackedRequest},
-    Request
+    Request,
 };
 use futures::{task::*, Sink, Stream};
 use pin_project::pin_project;
@@ -45,7 +45,10 @@ impl<In, Resp> Sink<RequestResponse<Resp>> for FakeChannel<In, RequestResponse<R
         self.project().sink.poll_ready(cx).map_err(|e| match e {})
     }
 
-    fn start_send(mut self: Pin<&mut Self>, response: RequestResponse<Resp>) -> Result<(), Self::Error> {
+    fn start_send(
+        mut self: Pin<&mut Self>,
+        response: RequestResponse<Resp>,
+    ) -> Result<(), Self::Error> {
         if let RequestResponse::Response(ref response) = response {
             self.as_mut()
                 .project()
@@ -114,7 +117,8 @@ impl<Req, Resp> FakeChannel<io::Result<TrackedRequest<Req>>, RequestResponse<Res
 }
 
 impl FakeChannel<(), ()> {
-    pub fn default<Req, Resp>() -> FakeChannel<io::Result<TrackedRequest<Req>>, RequestResponse<Resp>> {
+    pub fn default<Req, Resp>(
+    ) -> FakeChannel<io::Result<TrackedRequest<Req>>, RequestResponse<Resp>> {
         let (request_cancellation, canceled_requests) = cancellations();
         FakeChannel {
             stream: Default::default(),


### PR DESCRIPTION
**What does this PR do?**:

This PR uses `rustup run nightly cargo fmt --all` to reformat the code in the main branch and hopefully fix up the failed CI jobs which are complaining about formatting.

For reference:
* https://gitlab.ddbuild.io/DataDog/apm-reliability/libddprof-build/-/jobs/288056193
* https://gitlab.ddbuild.io/DataDog/apm-reliability/libddprof-build/-/jobs/288056194

**Motivation**:

Bring `main` back to green.

**Additional Notes**:

Having blocking steps in CI for running the formatter seems a bit too heavy-handed...

**How to test the change?**:

Validate that CI is back to green.