### PR TITLE
Fix bug in yaml syntax introduced in #182

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,5 +36,5 @@ report_gitlab_CI_status:
   when: always
   stage: .post
   script:
-    - echo "TIP: If you see this failing, it's because something else in the GitLab pipeline failed. Follow the link to the pipeline and check for other things that failed prior to this step."
+    - "echo TIP: If you see this failing, something else in the GitLab pipeline failed. Follow the link to the pipeline and check for other things that failed prior to this step."
     - exit ${STATUS}


### PR DESCRIPTION
**What does this PR do?**:

Fix a bug in YAML syntax introduced in #182.

**Motivation**:

Fix broken CI step.

**Additional Notes**:

HOW CAN YAML BE MORE ANNOYING THAN JSON.

**How to test the change?**:

Validate that GitLab CI pipeline step runs.