### PR TITLE
profiling: fix sample types error message

### DIFF
--- a/profiling/src/profile/mod.rs
+++ b/profiling/src/profile/mod.rs
@@ -462,8 +462,8 @@ impl Profile {
         anyhow::ensure!(
             sample.values.len() == self.sample_types.len(),
             "expected {} sample types, but sample had {} sample types",
-            sample.values.len(),
             self.sample_types.len(),
+            sample.values.len(),
         );
 
         let values = sample.values.clone();


### PR DESCRIPTION
# What does this PR do?

This PR fixes the error message which can be misleading when investigating issues.

# Motivation

If you create a profile with 2 samples types and add a sample with 3 sample types, you will get this error message:

```
expected 3 sample types, but sample had 2 sample types
```
But, it's not correct, we should have got:
```
expected 2 sample types, but sample had 3 sample types
```

# Additional Notes

N/A

# How to test the change?

N/A
