### PR TITLE
Bump libdatadog to 3.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling"
-version = "2.2.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "bitmaps",
@@ -486,7 +486,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-ffi"
-version = "2.2.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -640,7 +640,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon"
-version = "2.2.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon-ffi"
-version = "2.2.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "ddcommon",
@@ -672,7 +672,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry"
-version = "2.2.0"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "ddcommon",
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry-ffi"
-version = "2.2.0"
+version = "3.0.0"
 dependencies = [
  "ddcommon-ffi",
  "ddtelemetry",

--- a/ddcommon-ffi/Cargo.toml
+++ b/ddcommon-ffi/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ddcommon-ffi"
-version = "2.2.0"
+version = "3.0.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/ddcommon/Cargo.toml
+++ b/ddcommon/Cargo.toml
@@ -5,7 +5,7 @@
 edition = "2021"
 license = "Apache-2.0"
 name = "ddcommon"
-version = "2.2.0"
+version = "3.0.0"
 
 [lib]
 crate-type = ["lib"]

--- a/ddtelemetry-ffi/Cargo.toml
+++ b/ddtelemetry-ffi/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "ddtelemetry-ffi"
-version = "2.2.0"
+version = "3.0.0"
 edition = "2021"
 
 [lib]

--- a/ddtelemetry/Cargo.toml
+++ b/ddtelemetry/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2021"
 license = "Apache 2.0"
 name = "ddtelemetry"
-version = "2.2.0"
+version = "3.0.0"
 
 [features]
 default = []

--- a/profiling-ffi/Cargo.toml
+++ b/profiling-ffi/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "datadog-profiling-ffi"
-version = "2.2.0"
+version = "3.0.0"
 edition = "2021"
 license = "Apache-2.0"
 

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "datadog-profiling"
-version = "2.2.0"
+version = "3.0.0"
 edition = "2021"
 license = "Apache-2.0"
 


### PR DESCRIPTION
**What does this PR do?**:

Bump libdatadog version to 3.0.0 in preparation for release.

**Motivation**:

Release next version.

**Additional Notes**:

As we discussed via slack/in the previous weekly meeting, since #181 contains a very small backwards-incompatible change to `ddog_prof_Exporter_Request_build`, then since we're trying to strictly adhere to semver, I'm bumping the major version of the library.

Nevertheless, upgrading from 2.2.0 to 3.0.0 is really trivial.

**How to test the change?**:

Validate that CI is still green? Only the version really changes :)