### PR TITLE
Package libdatadog v3.0.0 for Ruby

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -10,7 +10,28 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        ruby: [2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, head]
+        ruby: [2.1, 2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, head]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+        working-directory: ruby/
+    - run: cd ruby && bundle exec rake
+  # Workaround for broken issue
+  # ```
+  # ERROR:  While executing gem ... (RuntimeError)
+  # Marshal.load reentered at marshal_load
+  # ```
+  # suggested in https://github.com/ruby/setup-ruby/issues/496 (use ubuntu 20.04 instead of a later version)
+  test-legacy-workaround:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-20.04]
+        ruby: [2.2]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -11,7 +11,7 @@ require "rubygems/package"
 
 RSpec::Core::RakeTask.new(:spec)
 
-LIB_VERSION_TO_PACKAGE = "2.0.0"
+LIB_VERSION_TO_PACKAGE = "3.0.0"
 unless LIB_VERSION_TO_PACKAGE.start_with?(Libdatadog::LIB_VERSION)
   raise "`LIB_VERSION_TO_PACKAGE` setting in <Rakefile> (#{LIB_VERSION_TO_PACKAGE}) does not match " \
     "`LIB_VERSION` setting in <lib/libdatadog/version.rb> (#{Libdatadog::LIB_VERSION})"
@@ -20,22 +20,22 @@ end
 LIB_GITHUB_RELEASES = [
   {
     file: "libdatadog-aarch64-alpine-linux-musl.tar.gz",
-    sha256: "ceca9edb50cc6918a85d73f3dbc71a8dc00858e297b95c9115691535e757f4c0",
+    sha256: "d9774bd28600fdc7c931146637d6410884d67a5e443486f1d2bfa320c4f00cb0",
     ruby_platform: "aarch64-linux-musl"
   },
   {
     file: "libdatadog-aarch64-unknown-linux-gnu.tar.gz",
-    sha256: "e3c4f6cab36e449faee4e15ac7fd3c41dfff16b3c11e3f83a9a4d8d2c898e528",
+    sha256: "71b89626f585ebf385482fb9d000c71f91721b395df8d352ce04a825c1f1776a",
     ruby_platform: "aarch64-linux"
   },
   {
     file: "libdatadog-x86_64-alpine-linux-musl.tar.gz",
-    sha256: "88818c03e1fb9a7212959b8d4d6cff06eaacdae48ad96e708784ffe051a10ea8",
+    sha256: "3fba3b542cbdd44bfb9fde09c5a65aabb34a92e56904dc6c6f3f53a0beb8ccef",
     ruby_platform: "x86_64-linux-musl"
   },
   {
     file: "libdatadog-x86_64-unknown-linux-gnu.tar.gz",
-    sha256: "faca4ac2af0a9ecc150e9dbf6a21336afa43bcbb75a33765818bc3e0c0c9e00a",
+    sha256: "39418275058a5ba96d6284bb6add0e9fbf6a59d7de0755d10184a0223f21c3ed",
     ruby_platform: "x86_64-linux"
   }
 ]

--- a/ruby/docker-compose.yml
+++ b/ruby/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     platform: linux/x86_64
     stdin_open: true
     tty: true
-    command: bash -c 'cd /libdatadog/ruby && bundle install && bundle exec rake push_to_rubygems'
+    command: bash -c 'git config --global --add safe.directory /libdatadog && cd /libdatadog/ruby && bundle install && bundle exec rake push_to_rubygems'
     volumes:
       - ..:/libdatadog
       - bundle-3.1:/usr/local/bundle

--- a/ruby/lib/libdatadog/version.rb
+++ b/ruby/lib/libdatadog/version.rb
@@ -2,7 +2,7 @@
 
 module Libdatadog
   # Current libdatadog version
-  LIB_VERSION = "2.0.0"
+  LIB_VERSION = "3.0.0"
 
   GEM_MAJOR_VERSION = "1"
   GEM_MINOR_VERSION = "0"


### PR DESCRIPTION
**What does this PR do?**:

This PR includes the changes documented in the "Releasing a new version to rubygems.org" part of the README: <https://github.com/datadog/libdatadog/tree/main/ruby#releasing-a-new-version-to-rubygemsorg>

It also includes:
* A CI workaround for the Ruby 2.2 github action (this Ruby release is getting quite old so testing it is increasingly difficult)
* A tweak to make modern versions of git happy when running the release script

**Motivation**:

Enable Ruby to use libdatadog v3.0.0.

**Additional Notes**:

Ruby actually skipped libdatadog v2.1 and v2.2 because their changes either didn't impact Ruby, or added features that Ruby didn't need yet.

**How to test the change?**:

I've tested this release locally against the changes in https://github.com/datadog/dd-trace-rb/pull/2927 .

As a reminder, new libdatadog releases don't get automatically picked up by Ruby, so the PR that bumps the Ruby profiler will also test this release against all supported Ruby versions.
