### PR TITLE
Minor: Remove Ruby workaround for upstream issue

### DIFF
--- a/ruby/gems.rb
+++ b/ruby/gems.rb
@@ -8,7 +8,6 @@ gemspec
 gem "rake", ">= 12.0", "< 14"
 gem "rspec", "~> 3.10"
 gem "standard", "~> 1.7", ">= 1.7.2" unless RUBY_VERSION < "2.6"
-gem "standard-performance", "< 1.1.1" unless RUBY_VERSION < "2.6"
 gem "http", "~> 5.0" unless RUBY_VERSION < "2.5"
 gem "pry"
 gem "pry-byebug" unless RUBY_VERSION > "3.1"


### PR DESCRIPTION
**What does this PR do?**:

In our Ruby packaging, we use the `standard` gem, which provides a code auto-formatter. This gem pulls in `standard-performance` as one of its dependencies.

Recently, version 1.1.1 of `standard-performance` was released, and this update was picked up and was breaking in CI.

I reported this issue upstream on
https://github.com/standardrb/standard-performance/issues/11 ; as well as forcing an earlier version to be used.

Now, 1.1.2 has been released and thus we can remove our workaround that was avoiding the problematic version.

**Motivation**:

Keep using the latest version of `standard` and its dependencies.

**Additional Notes**:

N/A

**How to test the change?**:

Validate that CI is still green!