### PR TITLE
style: fix clippy::default-constructed-unit-structs

### DIFF
--- a/ddcommon-ffi/src/vec.rs
+++ b/ddcommon-ffi/src/vec.rs
@@ -51,7 +51,7 @@ impl<T> From<alloc::vec::Vec<T>> for Vec<T> {
             ptr: v.as_mut_ptr(),
             len: v.len(),
             capacity: v.capacity(),
-            _marker: PhantomData::default(),
+            _marker: PhantomData,
         }
     }
 }


### PR DESCRIPTION
# What does this PR do?

Rust 1.71 was released, which means our `cargo +stable clippy ...` commands are now on a new version. Looks like this time there's just a single failing lint, `clippy::default-constructed-unit-structs`.

# Motivation

Ivo told me the main branch CI was broken.

# Additional Notes

Nope.

# How to test the change?

Existing tests are adquate.
