### PR TITLE
Mini Agent: Integrate tag replacement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -574,6 +574,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "datadog-trace-normalization",
+ "datadog-trace-obfuscation",
  "datadog-trace-protobuf",
  "datadog-trace-utils",
  "duplicate",
@@ -606,6 +607,8 @@ dependencies = [
  "datadog-trace-protobuf",
  "duplicate",
  "regex",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/trace-mini-agent/Cargo.toml
+++ b/trace-mini-agent/Cargo.toml
@@ -14,6 +14,7 @@ serde_json = "1.0"
 datadog-trace-protobuf = { path = "../trace-protobuf" }
 datadog-trace-utils = { path = "../trace-utils" }
 datadog-trace-normalization = { path = "../trace-normalization" }
+datadog-trace-obfuscation = { path = "../trace-obfuscation" }
 
 [dev-dependencies]
 rmp-serde = "1.1.1"

--- a/trace-mini-agent/src/config.rs
+++ b/trace-mini-agent/src/config.rs
@@ -1,14 +1,16 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
 
+use log::error;
 use std::env;
 
+use datadog_trace_obfuscation::replacer::{ReplaceRule, self};
 use datadog_trace_utils::trace_utils;
 
 const TRACE_INTAKE_ROUTE: &str = "/api/v0.2/traces";
 const TRACE_STATS_INTAKE_ROUTE: &str = "/api/v0.2/stats";
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Config {
     pub api_key: String,
     pub function_name: Option<String>,
@@ -24,6 +26,7 @@ pub struct Config {
     pub trace_intake_url: String,
     pub trace_stats_intake_url: String,
     pub dd_site: String,
+    pub tag_replace_rules: Option<Vec<ReplaceRule>>,
 }
 
 impl Config {
@@ -65,6 +68,21 @@ impl Config {
             trace_stats_intake_url = format!("{endpoint_prefix}{TRACE_STATS_INTAKE_ROUTE}");
         };
 
+        let tag_replace_rules: Option<Vec<ReplaceRule>> = match env::var("DD_APM_REPLACE_TAGS") {
+            Ok(replace_rules_str) => {
+                match replacer::parse_rules_from_string(&replace_rules_str) {
+                    Ok(res) => Some(res),
+                    Err(e) => {
+                        error!("Failed to parse DD_APM_REPLACE_TAGS: {}", e);
+                        None
+                    }
+                }
+            },
+            Err(_) => {
+                None
+            }
+        };
+
         Ok(Config {
             api_key,
             function_name,
@@ -77,6 +95,7 @@ impl Config {
             dd_site,
             trace_intake_url,
             trace_stats_intake_url,
+            tag_replace_rules
         })
     }
 }

--- a/trace-mini-agent/src/config.rs
+++ b/trace-mini-agent/src/config.rs
@@ -4,7 +4,7 @@
 use log::error;
 use std::env;
 
-use datadog_trace_obfuscation::replacer::{ReplaceRule, self};
+use datadog_trace_obfuscation::replacer::{self, ReplaceRule};
 use datadog_trace_utils::trace_utils;
 
 const TRACE_INTAKE_ROUTE: &str = "/api/v0.2/traces";
@@ -69,18 +69,14 @@ impl Config {
         };
 
         let tag_replace_rules: Option<Vec<ReplaceRule>> = match env::var("DD_APM_REPLACE_TAGS") {
-            Ok(replace_rules_str) => {
-                match replacer::parse_rules_from_string(&replace_rules_str) {
-                    Ok(res) => Some(res),
-                    Err(e) => {
-                        error!("Failed to parse DD_APM_REPLACE_TAGS: {}", e);
-                        None
-                    }
+            Ok(replace_rules_str) => match replacer::parse_rules_from_string(&replace_rules_str) {
+                Ok(res) => Some(res),
+                Err(e) => {
+                    error!("Failed to parse DD_APM_REPLACE_TAGS: {}", e);
+                    None
                 }
             },
-            Err(_) => {
-                None
-            }
+            Err(_) => None,
         };
 
         Ok(Config {
@@ -95,7 +91,7 @@ impl Config {
             dd_site,
             trace_intake_url,
             trace_stats_intake_url,
-            tag_replace_rules
+            tag_replace_rules,
         })
     }
 }

--- a/trace-mini-agent/src/config.rs
+++ b/trace-mini-agent/src/config.rs
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
 
-use log::error;
+use log::{debug, error};
 use std::env;
 
 use datadog_trace_obfuscation::replacer::{self, ReplaceRule};
@@ -70,9 +70,12 @@ impl Config {
 
         let tag_replace_rules: Option<Vec<ReplaceRule>> = match env::var("DD_APM_REPLACE_TAGS") {
             Ok(replace_rules_str) => match replacer::parse_rules_from_string(&replace_rules_str) {
-                Ok(res) => Some(res),
+                Ok(res) => {
+                    debug!("Successfully parsed DD_APM_REPLACE_TAGS: {res:?}");
+                    Some(res)
+                }
                 Err(e) => {
-                    error!("Failed to parse DD_APM_REPLACE_TAGS: {}", e);
+                    error!("Failed to parse DD_APM_REPLACE_TAGS: {e}");
                     None
                 }
             },

--- a/trace-mini-agent/src/trace_processor.rs
+++ b/trace-mini-agent/src/trace_processor.rs
@@ -4,6 +4,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use datadog_trace_obfuscation::replacer;
 use hyper::{http, Body, Request, Response, StatusCode};
 use log::{error, info};
 use tokio::sync::mpsc::Sender;
@@ -120,6 +121,10 @@ impl TraceProcessor for ServerlessTraceProcessor {
                 config.function_name.clone(),
                 &config.env_type,
             );
+
+            if let Some(rules) = &config.tag_replace_rules {
+                replacer::replace_trace_tags(&mut chunk.spans, &rules)
+            }
 
             trace_chunks.push(chunk);
 
@@ -258,6 +263,7 @@ mod tests {
             dd_site: "datadoghq.com".to_string(),
             env_type: trace_utils::EnvironmentType::CloudFunction,
             os: "linux".to_string(),
+            tag_replace_rules: None
         }
     }
 

--- a/trace-mini-agent/src/trace_processor.rs
+++ b/trace-mini-agent/src/trace_processor.rs
@@ -123,7 +123,7 @@ impl TraceProcessor for ServerlessTraceProcessor {
             );
 
             if let Some(rules) = &config.tag_replace_rules {
-                replacer::replace_trace_tags(&mut chunk.spans, &rules)
+                replacer::replace_trace_tags(&mut chunk.spans, rules)
             }
 
             trace_chunks.push(chunk);
@@ -263,7 +263,7 @@ mod tests {
             dd_site: "datadoghq.com".to_string(),
             env_type: trace_utils::EnvironmentType::CloudFunction,
             os: "linux".to_string(),
-            tag_replace_rules: None
+            tag_replace_rules: None,
         }
     }
 

--- a/trace-obfuscation/Cargo.toml
+++ b/trace-obfuscation/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0"
 regex = "1"
+serde = { version = "1.0.145", features = ["derive"] }
+serde_json = "1.0"
 datadog-trace-protobuf = { path = "../trace-protobuf" }
 
 [dev-dependencies]

--- a/trace-obfuscation/benches/replace_trace_tags_bench.rs
+++ b/trace-obfuscation/benches/replace_trace_tags_bench.rs
@@ -10,14 +10,13 @@ use datadog_trace_obfuscation::replacer;
 use datadog_trace_protobuf::pb;
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let rules: &[replacer::ReplaceRule] = &replacer::parse_rules_from_string(&[
-        ["http.url", "(token/)([^/]*)", "${1}?"],
-        ["http.url", "guid", "[REDACTED]"],
-        ["*", "(token/)([^/]*)", "${1}?"],
-        ["*", "this", "that"],
-        ["custom.tag", "(/foo/bar/).*", "${1}extra"],
-        ["resource.name", "prod", "stage"],
-    ])
+    let rules: &[replacer::ReplaceRule] = &replacer::parse_rules_from_string(r#"[
+        {"name": "*", "pattern": "(token/)([^/]*)", "repl": "${1}?"},
+        {"name": "*", "pattern": "this", "repl": "that"},
+        {"name": "http.url", "pattern": "guid", "repl": "[REDACTED]"},
+        {"name": "custom.tag", "pattern": "(/foo/bar/).*", "repl": "${1}extra"},
+        {"name": "resource.name", "pattern": "prod", "repl": "stage"}
+    ]"#)
     .unwrap();
 
     let span_1 = pb::Span {

--- a/trace-obfuscation/benches/replace_trace_tags_bench.rs
+++ b/trace-obfuscation/benches/replace_trace_tags_bench.rs
@@ -10,13 +10,15 @@ use datadog_trace_obfuscation::replacer;
 use datadog_trace_protobuf::pb;
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let rules: &[replacer::ReplaceRule] = &replacer::parse_rules_from_string(r#"[
+    let rules: &[replacer::ReplaceRule] = &replacer::parse_rules_from_string(
+        r#"[
         {"name": "*", "pattern": "(token/)([^/]*)", "repl": "${1}?"},
         {"name": "*", "pattern": "this", "repl": "that"},
         {"name": "http.url", "pattern": "guid", "repl": "[REDACTED]"},
         {"name": "custom.tag", "pattern": "(/foo/bar/).*", "repl": "${1}extra"},
         {"name": "resource.name", "pattern": "prod", "repl": "stage"}
-    ]"#)
+    ]"#,
+    )
     .unwrap();
 
     let span_1 = pb::Span {

--- a/trace-obfuscation/src/replacer.rs
+++ b/trace-obfuscation/src/replacer.rs
@@ -7,7 +7,7 @@ use datadog_trace_protobuf::pb;
 use regex::Regex;
 use serde::Deserialize;
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize)]
 struct RawReplaceRule {
     name: String,
     pattern: String,

--- a/trace-obfuscation/src/replacer.rs
+++ b/trace-obfuscation/src/replacer.rs
@@ -58,9 +58,8 @@ pub fn replace_trace_tags(trace: &mut [pb::Span], rules: &[ReplaceRule]) {
 /// * returns a vec of ReplaceRules
 pub fn parse_rules_from_string(
     // rules: &'a [[&'a str; 3]],
-    rules: &str
+    rules: &str,
 ) -> anyhow::Result<Vec<ReplaceRule>> {
-
     let raw_rules = serde_json::from_str::<Vec<RawReplaceRule>>(rules)?;
 
     println!("raw rules: {:?}", raw_rules);

--- a/trace-obfuscation/src/replacer.rs
+++ b/trace-obfuscation/src/replacer.rs
@@ -56,7 +56,7 @@ pub fn replace_trace_tags(trace: &mut [pb::Span], rules: &[ReplaceRule]) {
 /// parse_rules_from_string takes an array of rules, represented as an array of length 3 arrays
 /// holding the tag name, regex pattern, and replacement string as strings.
 /// * returns a vec of ReplaceRules
-pub fn parse_rules_from_string<'a>(
+pub fn parse_rules_from_string(
     // rules: &'a [[&'a str; 3]],
     rules: &str
 ) -> anyhow::Result<Vec<ReplaceRule>> {

--- a/trace-obfuscation/src/replacer.rs
+++ b/trace-obfuscation/src/replacer.rs
@@ -62,8 +62,6 @@ pub fn parse_rules_from_string(
 ) -> anyhow::Result<Vec<ReplaceRule>> {
     let raw_rules = serde_json::from_str::<Vec<RawReplaceRule>>(rules)?;
 
-    println!("raw rules: {:?}", raw_rules);
-
     let mut vec: Vec<ReplaceRule> = Vec::with_capacity(rules.len());
 
     // for [name, pattern, repl] in rules {
@@ -171,8 +169,6 @@ mod tests {
     #[test]
     fn test_name() {
         let parsed_rules = replacer::parse_rules_from_string(rules);
-
-        println!("parsed rules: {:?}", parsed_rules);
 
         let root_span = new_test_span_with_tags(input);
         let child_span = new_test_span_with_tags(input);

--- a/trace-obfuscation/src/replacer.rs
+++ b/trace-obfuscation/src/replacer.rs
@@ -5,38 +5,46 @@
 
 use datadog_trace_protobuf::pb;
 use regex::Regex;
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug)]
+struct RawReplaceRule {
+    name: String,
+    pattern: String,
+    repl: String,
+}
 
 #[derive(Debug)]
-pub struct ReplaceRule<'a> {
+pub struct ReplaceRule {
     // name specifies the name of the tag that the replace rule addresses. However,
     // some exceptions apply such as:
     // * "resource.name" will target the resource
     // * "*" will target all tags and the resource
-    name: &'a str,
+    name: String,
 
     // re holds the regex pattern for matching.
     re: regex::Regex,
 
     // repl specifies the replacement string to be used when Pattern matches.
-    repl: &'a str,
+    repl: String,
 }
 
 /// replace_trace_tags replaces the tag values of all spans within a trace with a given set of rules.
 pub fn replace_trace_tags(trace: &mut [pb::Span], rules: &[ReplaceRule]) {
     for rule in rules {
         for span in trace.iter_mut() {
-            match rule.name {
+            match rule.name.as_ref() {
                 "*" => {
                     for (_, val) in span.meta.iter_mut() {
-                        *val = rule.re.replace_all(val, rule.repl).to_string();
+                        *val = rule.re.replace_all(val, &rule.repl).to_string();
                     }
                 }
                 "resource.name" => {
-                    span.resource = rule.re.replace_all(&span.resource, rule.repl).to_string();
+                    span.resource = rule.re.replace_all(&span.resource, &rule.repl).to_string();
                 }
                 _ => {
-                    if let Some(val) = span.meta.get_mut(rule.name) {
-                        let replaced_tag = rule.re.replace_all(val, rule.repl).to_string();
+                    if let Some(val) = span.meta.get_mut(&rule.name) {
+                        let replaced_tag = rule.re.replace_all(val, &rule.repl).to_string();
                         *val = replaced_tag;
                     }
                 }
@@ -49,21 +57,28 @@ pub fn replace_trace_tags(trace: &mut [pb::Span], rules: &[ReplaceRule]) {
 /// holding the tag name, regex pattern, and replacement string as strings.
 /// * returns a vec of ReplaceRules
 pub fn parse_rules_from_string<'a>(
-    rules: &'a [[&'a str; 3]],
-) -> anyhow::Result<Vec<ReplaceRule<'a>>> {
+    // rules: &'a [[&'a str; 3]],
+    rules: &str
+) -> anyhow::Result<Vec<ReplaceRule>> {
+
+    let raw_rules = serde_json::from_str::<Vec<RawReplaceRule>>(rules)?;
+
+    println!("raw rules: {:?}", raw_rules);
+
     let mut vec: Vec<ReplaceRule> = Vec::with_capacity(rules.len());
 
-    for [name, pattern, repl] in rules {
-        let compiled_regex = match Regex::new(pattern) {
+    // for [name, pattern, repl] in rules {
+    for raw_rule in raw_rules {
+        let compiled_regex = match Regex::new(&raw_rule.pattern) {
             Ok(res) => res,
             Err(err) => {
                 anyhow::bail!("Obfuscator Error: Error while parsing rule: {}", err)
             }
         };
         vec.push(ReplaceRule {
-            name,
+            name: raw_rule.name,
             re: compiled_regex,
-            repl,
+            repl: raw_rule.repl,
         });
     }
     Ok(vec)
@@ -109,11 +124,11 @@ mod tests {
     #[duplicate_item(
         [
         test_name   [test_replace_tags]
-        rules       [&[
-                        ["http.url", "(token/)([^/]*)", "${1}?"],
-                        ["http.url", "guid", "[REDACTED]"],
-                        ["custom.tag", "(/foo/bar/).*", "${1}extra"],
-                    ]]
+        rules       [r#"[
+                        {"name": "http.url", "pattern": "(token/)([^/]*)", "repl": "${1}?"},
+                        {"name": "http.url", "pattern": "guid", "repl": "[REDACTED]"},
+                        {"name": "custom.tag", "pattern": "(/foo/bar/).*", "repl": "${1}extra"}
+                    ]"#]
         input       [
                         HashMap::from([
                             ("http.url", "some/guid/token/abcdef/abc"),
@@ -129,13 +144,13 @@ mod tests {
         ]
         [
         test_name   [test_replace_tags_with_exceptions]
-        rules       [&[
-                        ["*", "(token/)([^/]*)", "${1}?"],
-                        ["*", "this", "that"],
-                        ["http.url", "guid", "[REDACTED]"],
-                        ["custom.tag", "(/foo/bar/).*", "${1}extra"],
-                        ["resource.name", "prod", "stage"],
-                    ]]
+        rules       [r#"[
+                        {"name": "*", "pattern": "(token/)([^/]*)", "repl": "${1}?"},
+                        {"name": "*", "pattern": "this", "repl": "that"},
+                        {"name": "http.url", "pattern": "guid", "repl": "[REDACTED]"},
+                        {"name": "custom.tag", "pattern": "(/foo/bar/).*", "repl": "${1}extra"},
+                        {"name": "resource.name", "pattern": "prod", "repl": "stage"}
+                    ]"#]
         input       [
                         HashMap::from([
                             ("resource.name", "this is prod"),
@@ -157,6 +172,9 @@ mod tests {
     #[test]
     fn test_name() {
         let parsed_rules = replacer::parse_rules_from_string(rules);
+
+        println!("parsed rules: {:?}", parsed_rules);
+
         let root_span = new_test_span_with_tags(input);
         let child_span = new_test_span_with_tags(input);
         let mut trace = [root_span, child_span];
@@ -179,7 +197,7 @@ mod tests {
 
     #[test]
     fn test_parse_rules_invalid_regex() {
-        let result = replacer::parse_rules_from_string(&[["http.url", ")", "${1}?"]]);
+        let result = replacer::parse_rules_from_string(r#"[{"http.url", ")", "${1}?"}]"#);
         assert!(result.is_err());
     }
 }


### PR DESCRIPTION
# What does this PR do?

Integrate the trace-obfuscation trace tag replacement into the mini agent.

Reads the `DD_APM_REPLACE_TAGS` env var for a list of JSON formatted replace rules, following [these docs](https://docs.datadoghq.com/tracing/configure_data_security/?tab=environmentvariable#scrub-sensitive-data-from-your-spans).

# Motivation

mini agent functionality

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
