### PR TITLE
Bump Rust version to 1.69

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         # Ignore nightly for now, it fails too often
-        rust_version: ["1.64.0", "stable"]
+        rust_version: ["1.69.0", "stable"]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 on: [push]
 env: 
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.64.0
+  RUST_VERSION: 1.69.0
 
 jobs:
   test:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@ variables:
   # These are gitlab variables so that it's easier to do a manual deploy
   # If these are set witih value and description, then it gives you UI elements
   DOWNSTREAM_BRANCH:
-    value: "dsn/Rust-169"
+    value: "main"
     description: "downstream jobs are triggered on this branch"
 
 trigger_internal_build:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@ variables:
   # These are gitlab variables so that it's easier to do a manual deploy
   # If these are set witih value and description, then it gives you UI elements
   DOWNSTREAM_BRANCH:
-    value: "main"
+    value: "dsn/Rust-169"
     description: "downstream jobs are triggered on this branch"
 
 trigger_internal_build:


### PR DESCRIPTION
# What does this PR do?

Uses the latest Rust version in Alpine.

# Motivation

Keeps up to date with the Rust version in Alpine

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

`cargo test` + CI