### PR TITLE
Fix outdated comment

### DIFF
--- a/profiling/src/profile/pprof.rs
+++ b/profiling/src/profile/pprof.rs
@@ -71,7 +71,6 @@ pub struct ValueType {
     pub unit: i64, // Index into string table
 }
 
-/// Currently, libdatadog only allows string values in labels.
 #[derive(Clone, Eq, PartialEq, Hash, ::prost::Message)]
 pub struct Label {
     #[prost(int64, tag = "1")]


### PR DESCRIPTION
# What does this PR do?

Removes an outdated comment.  The code is commented to state that we only use the "string" format for labels, but we actually use both (and even enforce the use of numeric labels in some cases https://github.com/DataDog/libdatadog/blob/20b50a9a8ed7f6a5427c25c88f6d9bd8270e2ccf/profiling/src/profile/mod.rs#L563 )
# Motivation

Comments should reflect reality

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

This only removes a comment, no semantic change to code