### PR TITLE
Aggregate profiling sample observations by timestamp, using a HashMap

### DIFF
--- a/profiling/src/profile/mod.rs
+++ b/profiling/src/profile/mod.rs
@@ -908,7 +908,7 @@ impl TryFrom<&Profile> for pprof::Profile {
 
         Ok(pprof::Profile {
             sample_types: profile.sample_types.clone(),
-            samples: samples, // DSN
+            samples, // DSN
             mappings: profile
                 .mappings
                 .iter()

--- a/profiling/src/profile/mod.rs
+++ b/profiling/src/profile/mod.rs
@@ -558,8 +558,7 @@ impl Profile {
     }
 
     /// Validates labels and converts them to the internal representation.
-    /// Also tracks the index of the label with key "local root span id".
-    ///     /// Validates labels and converts them to the internal representation.
+    /// Extracts out the timestamp label, if it exists.
     /// Also tracks the index of the label with key "local root span id".
     fn extract_sample_labels(
         &mut self,
@@ -908,7 +907,7 @@ impl TryFrom<&Profile> for pprof::Profile {
 
         Ok(pprof::Profile {
             sample_types: profile.sample_types.clone(),
-            samples, // DSN
+            samples,
             mappings: profile
                 .mappings
                 .iter()

--- a/profiling/src/profile/mod.rs
+++ b/profiling/src/profile/mod.rs
@@ -125,7 +125,7 @@ impl UpscalingRule {
 
 pub struct Profile {
     sample_types: Vec<ValueType>,
-    samples: FxIndexMap<Sample, std::collections::HashMap<Option<Timestamp>, Vec<i64>>>,
+    samples: FxIndexMap<Sample, HashMap<Option<Timestamp>, Vec<i64>>>,
     mappings: FxIndexSet<Mapping>,
     locations: FxIndexSet<Location>,
     functions: FxIndexSet<Function>,


### PR DESCRIPTION
# What does this PR do?

This PR refactors the profiling `Sample` structure, moving the `timestamp` from a label to a first class value in the data-structure.  This leads to a significant memory use reduction when the timeline feature is enabled.

# Motivation

The internal format used to store profile samples deduplicates based on stack trace and labels.  In the current format, timestamps are stored as labels, which means that this deduplication cannot happen when timestamps are enabled, significantly increasing memory usage.  By considering the timestamp part of the observations on the sample, and not a label, we allow the deduplication to work and save memory.

# Additional Notes

This saves space on the internal representation, but we still pay the cost of generating the duplicate structures when expanding out the pprof.

# How to test the change?
Following the instructions here https://datadoghq.atlassian.net/wiki/spaces/PROF/pages/2660237526/Ruby+Profiling+Notes I ran the ruby timeline test both with and without the change enabled. 

Before
```
╰─➤  TIMELINE=true bundle exec ruby ruby_overhead_experiment.rb
config: {:threads=>16, :depth=>50, :seconds=>60, :timeline_enabled=>true}
Before serialization, process rss usage is 96608k
After serialization, process rss usage is 131440k
Size of uncompressed serialized pprof: 9014k
After shrinking, process rss usage is 131440k
```

After
```
╰─➤  TIMELINE=true bundle exec ruby ruby_overhead_experiment.rb
config: {:threads=>16, :depth=>50, :seconds=>60, :timeline_enabled=>true}
Before serialization, process rss usage is 75552k
After serialization, process rss usage is 137856k
Size of uncompressed serialized pprof: 9014k
After shrinking, process rss usage is 137856k
```