### PR TITLE
Aggregate profiling sample observations by timestamp, using a vector

### DIFF
--- a/profiling/src/profile/mod.rs
+++ b/profiling/src/profile/mod.rs
@@ -908,7 +908,7 @@ impl TryFrom<&Profile> for pprof::Profile {
 
         Ok(pprof::Profile {
             sample_types: profile.sample_types.clone(),
-            samples: samples, // DSN
+            samples, // DSN
             mappings: profile
                 .mappings
                 .iter()

--- a/profiling/src/profile/mod.rs
+++ b/profiling/src/profile/mod.rs
@@ -558,8 +558,7 @@ impl Profile {
     }
 
     /// Validates labels and converts them to the internal representation.
-    /// Also tracks the index of the label with key "local root span id".
-    ///     /// Validates labels and converts them to the internal representation.
+    /// Extracts out the timestamp label, if it exists.
     /// Also tracks the index of the label with key "local root span id".
     fn extract_sample_labels(
         &mut self,
@@ -908,7 +907,7 @@ impl TryFrom<&Profile> for pprof::Profile {
 
         Ok(pprof::Profile {
             sample_types: profile.sample_types.clone(),
-            samples, // DSN
+            samples,
             mappings: profile
                 .mappings
                 .iter()

--- a/profiling/src/profile/mod.rs
+++ b/profiling/src/profile/mod.rs
@@ -125,7 +125,7 @@ impl UpscalingRule {
 
 pub struct Profile {
     sample_types: Vec<ValueType>,
-    samples: FxIndexMap<Sample, std::collections::HashMap<Option<Timestamp>, Vec<i64>>>,
+    samples: FxIndexMap<Sample, HashMap<Option<Timestamp>, Vec<i64>>>,
     mappings: FxIndexSet<Mapping>,
     locations: FxIndexSet<Location>,
     functions: FxIndexSet<Function>,


### PR DESCRIPTION
# What does this PR do?

This PR refactors the profiling `Sample` structure, moving the `timestamp` from a label to a first class value in the data-structure.  This leads to a significant memory use reduction when the timeline feature is enabled.  This is a competing PR with #202, using a different data-structure. 

# Motivation

The internal format used to store profile samples deduplicates based on stack trace and labels.  In the current format, timestamps are stored as labels, which means that this deduplication cannot happen when timestamps are enabled, significantly increasing memory usage.  By considering the timestamp part of the observations on the sample, and not a label, we allow the deduplication to work and save memory.

# Additional Notes

This saves space on the internal representation, but we still pay the cost of generating the duplicate structures when expanding out the pprof.

# How to test the change?
Following the instructions here https://datadoghq.atlassian.net/wiki/spaces/PROF/pages/2660237526/Ruby+Profiling+Notes I ran the ruby timeline test both with and without the change enabled. 

With this change, timestamps on
```
config: {:threads=>16, :depth=>50, :seconds=>60, :timeline_enabled=>true}
Before serialization, process rss usage is 71472k
After serialization, process rss usage is 113040k
Size of uncompressed serialized pprof: 9014k
After shrinking, process rss usage is 113056k
        2.94 real         2.47 user         0.19 sys
config: {:threads=>16, :depth=>50, :seconds=>60, :timeline_enabled=>true}
Before serialization, process rss usage is 71600k
After serialization, process rss usage is 113808k
Size of uncompressed serialized pprof: 9014k
After shrinking, process rss usage is 113824k
        2.75 real         2.47 user         0.19 sys
config: {:threads=>16, :depth=>50, :seconds=>60, :timeline_enabled=>true}
Before serialization, process rss usage is 71600k
After serialization, process rss usage is 113888k
Size of uncompressed serialized pprof: 9014k
After shrinking, process rss usage is 113904k
        2.75 real         2.48 user         0.19 sys
```

With the `HashMap`, timestamps on
```
config: {:threads=>16, :depth=>50, :seconds=>60, :timeline_enabled=>true}
Before serialization, process rss usage is 73488k
After serialization, process rss usage is 128656k
Size of uncompressed serialized pprof: 9014k
After shrinking, process rss usage is 127648k
        2.92 real         2.49 user         0.19 sys
config: {:threads=>16, :depth=>50, :seconds=>60, :timeline_enabled=>true}
Before serialization, process rss usage is 72688k
After serialization, process rss usage is 115792k
Size of uncompressed serialized pprof: 9014k
After shrinking, process rss usage is 114992k
        2.78 real         2.50 user         0.19 sys
config: {:threads=>16, :depth=>50, :seconds=>60, :timeline_enabled=>true}
Before serialization, process rss usage is 72128k
After serialization, process rss usage is 114320k
Size of uncompressed serialized pprof: 9014k
After shrinking, process rss usage is 114320k
        2.73 real         2.46 user         0.19 sys
```

With this change, no timestamps:
```
config: {:threads=>16, :depth=>50, :seconds=>60, :timeline_enabled=>false}
Before serialization, process rss usage is 65632k
After serialization, process rss usage is 65776k
Size of uncompressed serialized pprof: 3k
After shrinking, process rss usage is 65792k
        2.83 real         2.42 user         0.18 sys
config: {:threads=>16, :depth=>50, :seconds=>60, :timeline_enabled=>false}
Before serialization, process rss usage is 62992k
After serialization, process rss usage is 63120k
Size of uncompressed serialized pprof: 3k
After shrinking, process rss usage is 63152k
        2.65 real         2.40 user         0.17 sys
config: {:threads=>16, :depth=>50, :seconds=>60, :timeline_enabled=>false}
Before serialization, process rss usage is 63088k
After serialization, process rss usage is 63216k
Size of uncompressed serialized pprof: 3k
After shrinking, process rss usage is 63232k
        2.65 real         2.39 user         0.17 sys
```

With the `HashMap`, timestamps off
```
config: {:threads=>16, :depth=>50, :seconds=>60, :timeline_enabled=>false}
Before serialization, process rss usage is 63600k
After serialization, process rss usage is 63696k
Size of uncompressed serialized pprof: 3k
After shrinking, process rss usage is 63712k
        2.93 real         2.42 user         0.18 sys
config: {:threads=>16, :depth=>50, :seconds=>60, :timeline_enabled=>false}
Before serialization, process rss usage is 62448k
After serialization, process rss usage is 62560k
Size of uncompressed serialized pprof: 3k
After shrinking, process rss usage is 62560k
        2.68 real         2.43 user         0.17 sys
config: {:threads=>16, :depth=>50, :seconds=>60, :timeline_enabled=>false}
Before serialization, process rss usage is 64000k
After serialization, process rss usage is 64096k
Size of uncompressed serialized pprof: 3k
After shrinking, process rss usage is 64096k
        2.67 real         2.41 user         0.17 sys
```