### PR TITLE
Use unique types for PProfIds

### DIFF
--- a/profiling/src/profile/mod.rs
+++ b/profiling/src/profile/mod.rs
@@ -190,34 +190,6 @@ impl From<&StringId> for i64 {
     }
 }
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-#[repr(transparent)]
-pub struct PProfId(usize);
-
-impl From<&PProfId> for u64 {
-    fn from(id: &PProfId) -> Self {
-        id.0 as u64
-    }
-}
-
-impl From<PProfId> for u64 {
-    fn from(id: PProfId) -> Self {
-        id.0.try_into().unwrap_or(0)
-    }
-}
-
-impl From<&PProfId> for i64 {
-    fn from(value: &PProfId) -> Self {
-        value.0.try_into().unwrap_or(0)
-    }
-}
-
-impl From<PProfId> for i64 {
-    fn from(value: PProfId) -> Self {
-        value.0.try_into().unwrap_or(0)
-    }
-}
-
 #[derive(Eq, PartialEq, Hash)]
 struct Mapping {
     /// Address at which the binary (or DLL) is loaded into memory.

--- a/profiling/src/profile/mod.rs
+++ b/profiling/src/profile/mod.rs
@@ -173,7 +173,7 @@ impl StringId {
     }
 
     #[inline]
-    pub fn is_zero(&self) -> bool {
+    pub const fn is_zero(&self) -> bool {
         self.0 == 0
     }
 }

--- a/profiling/src/profile/mod.rs
+++ b/profiling/src/profile/mod.rs
@@ -37,7 +37,8 @@ impl FunctionId {
         // PProf reserves location 0.
         // Both this, and the serialization of the table, add 1 to avoid the 0 element
         let index = index.checked_add(1).expect("FunctionId to fit into a u32");
-        let index = NonZeroU32::new(index).unwrap();
+        // Safety: the `checked_add(1).expect(...)` guards this from ever being zero.
+        let index = unsafe { NonZeroU32::new_unchecked(index) };
         Self(index)
     }
 }
@@ -69,7 +70,8 @@ impl MappingId {
         // PProf reserves location 0.
         // Both this, and the serialization of the table, add 1 to avoid the 0 element
         let index = index.checked_add(1).expect("MappingId to fit into a u32");
-        let index = NonZeroU32::new(index).unwrap();
+        // Safety: the `checked_add(1).expect(...)` guards this from ever being zero.
+        let index = unsafe { NonZeroU32::new_unchecked(index) };
         Self(index)
     }
 }
@@ -101,7 +103,8 @@ impl SampleId {
         // PProf reserves location 0.
         // Both this, and the serialization of the table, add 1 to avoid the 0 element
         let index = index.checked_add(1).expect("SampleId to fit into a u32");
-        let index = NonZeroU32::new(index).unwrap();
+        // Safety: the `checked_add(1).expect(...)` guards this from ever being zero.
+        let index = unsafe { NonZeroU32::new_unchecked(index) };
         Self(index)
     }
 }
@@ -137,7 +140,8 @@ impl LocationId {
         // PProf reserves location 0.
         // Both this, and the serialization of the table, add 1 to avoid the 0 element
         let index = index.checked_add(1).expect("LocationId to fit into a u32");
-        let index = NonZeroU32::new(index).unwrap();
+        // Safety: the `checked_add(1).expect(...)` guards this from ever being zero.
+        let index = unsafe { NonZeroU32::new_unchecked(index) };
         Self(index)
     }
 }


### PR DESCRIPTION
# What does this PR do?

Increases type safety by using a first class type for various `PProfId` types, including `LocationId`, `MappingId` and `FunctionId`. Also does a bit of refactoring on the existing unique types as per PR comments.

# Motivation

Currently, Locations are identified by an `PProfId` value, which represents an index into a interning table.  This is error prone, since there are many PProfIds, generated by many different tables.  If we use the wrong one, we can get a panic, or nonsense values. If we store the index in a transparent type, the type system both documents and enforces the correct use of indicies.

As a side benefit, reduced the size of the index from `usize` to `u32`, saving 4 bytes per index.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
