### PR TITLE
Refactor profiler to make a cleaner seperation with pprof

### DIFF
--- a/profiling/src/profile/internal/function.rs
+++ b/profiling/src/profile/internal/function.rs
@@ -1,0 +1,72 @@
+pub use super::super::pprof;
+pub use super::super::StringId;
+use std::fmt::Debug;
+use std::num::NonZeroU32;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
+pub struct Function {
+    pub name: StringId,
+    pub system_name: StringId,
+    pub filename: StringId,
+    pub start_line: u32,
+}
+
+impl Function {
+    pub fn new<T>(name: StringId, system_name: StringId, filename: StringId, start_line: T) -> Self
+    where
+        T: TryInto<u32>,
+        T::Error: Debug,
+    {
+        let start_line: u32 = start_line
+            .try_into()
+            .expect("file line number to fit into a u32");
+        Self {
+            name,
+            system_name,
+            filename,
+            start_line,
+        }
+    }
+    pub fn to_pprof(&self, id: u64) -> pprof::Function {
+        pprof::Function {
+            id,
+            name: self.name.into(),
+            system_name: self.system_name.into(),
+            filename: self.filename.into(),
+            start_line: self.start_line.into(),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct FunctionId(NonZeroU32);
+
+impl FunctionId {
+    pub fn new<T>(v: T) -> Self
+    where
+        T: TryInto<u32>,
+        T::Error: Debug,
+    {
+        let index: u32 = v.try_into().expect("FunctionId to fit into a u32");
+
+        // PProf reserves location 0.
+        // Both this, and the serialization of the table, add 1 to avoid the 0 element
+        let index = index.checked_add(1).expect("FunctionId to fit into a u32");
+        // Safety: the `checked_add(1).expect(...)` guards this from ever being zero.
+        let index = unsafe { NonZeroU32::new_unchecked(index) };
+        Self(index)
+    }
+}
+
+impl From<FunctionId> for u64 {
+    fn from(s: FunctionId) -> Self {
+        Self::from(&s)
+    }
+}
+
+impl From<&FunctionId> for u64 {
+    fn from(s: &FunctionId) -> Self {
+        s.0.get().into()
+    }
+}

--- a/profiling/src/profile/internal/function.rs
+++ b/profiling/src/profile/internal/function.rs
@@ -1,3 +1,6 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+
 pub use super::super::pprof;
 pub use super::super::StringId;
 use std::fmt::Debug;

--- a/profiling/src/profile/internal/label.rs
+++ b/profiling/src/profile/internal/label.rs
@@ -1,0 +1,75 @@
+pub use super::super::pprof;
+pub use super::super::StringId;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
+pub enum LabelValue {
+    Str(StringId),
+    Num {
+        num: i64,
+        num_unit: Option<StringId>,
+    },
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
+pub struct Label {
+    key: StringId,
+    value: LabelValue,
+}
+
+impl Label {
+    pub fn has_num_value(&self) -> bool {
+        matches!(self.value, LabelValue::Num { .. })
+    }
+
+    pub fn has_string_value(&self) -> bool {
+        matches!(self.value, LabelValue::Str(_))
+    }
+
+    pub fn get_key(&self) -> StringId {
+        self.key
+    }
+
+    pub fn get_value(&self) -> &LabelValue {
+        &self.value
+    }
+
+    pub fn num(key: StringId, num: i64, num_unit: Option<StringId>) -> Self {
+        Self {
+            key,
+            value: LabelValue::Num { num, num_unit },
+        }
+    }
+
+    pub fn str(key: StringId, v: StringId) -> Self {
+        Self {
+            key,
+            value: LabelValue::Str(v),
+        }
+    }
+}
+
+impl From<Label> for pprof::Label {
+    fn from(l: Label) -> Self {
+        Self::from(&l)
+    }
+}
+
+impl From<&Label> for pprof::Label {
+    fn from(l: &Label) -> pprof::Label {
+        let key = l.key.into();
+        match l.value {
+            LabelValue::Str(str) => Self {
+                key,
+                str: str.into(),
+                num: 0,
+                num_unit: 0,
+            },
+            LabelValue::Num { num, num_unit } => Self {
+                key,
+                str: 0,
+                num,
+                num_unit: num_unit.map(i64::from).unwrap_or(0),
+            },
+        }
+    }
+}

--- a/profiling/src/profile/internal/label.rs
+++ b/profiling/src/profile/internal/label.rs
@@ -1,3 +1,6 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+
 pub use super::super::pprof;
 pub use super::super::StringId;
 

--- a/profiling/src/profile/internal/line.rs
+++ b/profiling/src/profile/internal/line.rs
@@ -1,3 +1,6 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+
 use crate::profile::pprof;
 use crate::profile::FunctionId;
 use std::fmt::Debug;

--- a/profiling/src/profile/internal/line.rs
+++ b/profiling/src/profile/internal/line.rs
@@ -1,0 +1,37 @@
+use crate::profile::pprof;
+use crate::profile::FunctionId;
+use std::fmt::Debug;
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
+pub struct Line {
+    /// The id of the corresponding Function for this line.
+    pub function_id: FunctionId,
+    /// Line number in source code.
+    pub line: u32,
+}
+
+impl Line {
+    pub fn new<T>(function_id: FunctionId, line: T) -> Self
+    where
+        T: TryInto<u32>,
+        T::Error: Debug,
+    {
+        let line: u32 = line.try_into().expect("line number to fit into a u32");
+        Self { function_id, line }
+    }
+}
+
+impl From<Line> for pprof::Line {
+    fn from(t: Line) -> Self {
+        Self::from(&t)
+    }
+}
+
+impl From<&Line> for pprof::Line {
+    fn from(t: &Line) -> Self {
+        Self {
+            function_id: t.function_id.into(),
+            line: t.line.into(),
+        }
+    }
+}

--- a/profiling/src/profile/internal/location.rs
+++ b/profiling/src/profile/internal/location.rs
@@ -1,3 +1,6 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+
 pub use super::super::pprof;
 use super::Line;
 use crate::profile::MappingId;

--- a/profiling/src/profile/internal/location.rs
+++ b/profiling/src/profile/internal/location.rs
@@ -1,0 +1,58 @@
+pub use super::super::pprof;
+use super::Line;
+use crate::profile::MappingId;
+use std::fmt::Debug;
+use std::num::NonZeroU32;
+
+#[derive(Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
+pub struct Location {
+    pub mapping_id: MappingId,
+    pub address: u64,
+    pub lines: Vec<Line>,
+    pub is_folded: bool,
+}
+
+impl Location {
+    pub fn to_pprof(&self, id: u64) -> pprof::Location {
+        pprof::Location {
+            id,
+            mapping_id: self.mapping_id.into(),
+            address: self.address,
+            lines: self.lines.iter().map(pprof::Line::from).collect(),
+            is_folded: self.is_folded,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct LocationId(NonZeroU32);
+
+impl LocationId {
+    pub fn new<T>(v: T) -> Self
+    where
+        T: TryInto<u32>,
+        T::Error: Debug,
+    {
+        let index: u32 = v.try_into().expect("LocationId to fit into a u32");
+
+        // PProf reserves location 0.
+        // Both this, and the serialization of the table, add 1 to avoid the 0 element
+        let index = index.checked_add(1).expect("LocationId to fit into a u32");
+        // Safety: the `checked_add(1).expect(...)` guards this from ever being zero.
+        let index = unsafe { NonZeroU32::new_unchecked(index) };
+        Self(index)
+    }
+}
+
+impl From<LocationId> for u64 {
+    fn from(s: LocationId) -> Self {
+        Self::from(&s)
+    }
+}
+
+impl From<&LocationId> for u64 {
+    fn from(s: &LocationId) -> Self {
+        s.0.get().into()
+    }
+}

--- a/profiling/src/profile/internal/mod.rs
+++ b/profiling/src/profile/internal/mod.rs
@@ -1,3 +1,5 @@
-pub mod value_type;
+mod label;
+mod value_type;
 
+pub use label::{Label, LabelValue};
 pub use value_type::ValueType;

--- a/profiling/src/profile/internal/mod.rs
+++ b/profiling/src/profile/internal/mod.rs
@@ -1,5 +1,9 @@
 mod label;
+mod line;
+mod location;
 mod value_type;
 
 pub use label::{Label, LabelValue};
+pub use line::Line;
+pub use location::{Location, LocationId};
 pub use value_type::ValueType;

--- a/profiling/src/profile/internal/mod.rs
+++ b/profiling/src/profile/internal/mod.rs
@@ -1,0 +1,3 @@
+pub mod value_type;
+
+pub use value_type::ValueType;

--- a/profiling/src/profile/internal/mod.rs
+++ b/profiling/src/profile/internal/mod.rs
@@ -1,8 +1,10 @@
+mod function;
 mod label;
 mod line;
 mod location;
 mod value_type;
 
+pub use function::{Function, FunctionId};
 pub use label::{Label, LabelValue};
 pub use line::Line;
 pub use location::{Location, LocationId};

--- a/profiling/src/profile/internal/mod.rs
+++ b/profiling/src/profile/internal/mod.rs
@@ -1,3 +1,6 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+
 mod function;
 mod label;
 mod line;

--- a/profiling/src/profile/internal/value_type.rs
+++ b/profiling/src/profile/internal/value_type.rs
@@ -14,7 +14,7 @@ impl From<ValueType> for pprof::ValueType {
 
 impl From<&ValueType> for pprof::ValueType {
     fn from(vt: &ValueType) -> Self {
-        pprof::ValueType {
+        Self {
             r#type: vt.r#type.into(),
             unit: vt.unit.into(),
         }

--- a/profiling/src/profile/internal/value_type.rs
+++ b/profiling/src/profile/internal/value_type.rs
@@ -1,0 +1,22 @@
+pub use super::super::pprof;
+pub use super::super::StringId;
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct ValueType {
+    pub r#type: StringId,
+    pub unit: StringId,
+}
+
+impl From<ValueType> for pprof::ValueType {
+    fn from(vt: ValueType) -> Self {
+        Self::from(&vt)
+    }
+}
+
+impl From<&ValueType> for pprof::ValueType {
+    fn from(vt: &ValueType) -> Self {
+        pprof::ValueType {
+            r#type: vt.r#type.into(),
+            unit: vt.unit.into(),
+        }
+    }
+}

--- a/profiling/src/profile/pprof.rs
+++ b/profiling/src/profile/pprof.rs
@@ -165,7 +165,7 @@ pub struct Function {
     #[prost(int64, tag = "4")]
     pub filename: i64, // Index into string table
     #[prost(int64, tag = "5")]
-    pub start_line: i64, // Index into string table
+    pub start_line: i64, // Line number in source file.
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# What does this PR do?

Refactors the profiler to make a cleaner seperation between the profiler internal representation and pprof

# Motivation

The profiler has three layers: API, internal representation, and pprof.  The internal representation is currently entangled with the pprof types, which is undesirable:

* It ties the IR into (potentially memory inefficient) pprof structures, with larger indicies than needed.
* It limits memory safety: many indicies are `i64` rather than typesafe transparent types
* It makes the code less modular and harder to understand.

This PR addresses these issues by creating a cleaner IR without the references to pprof types.

# Additional Notes

* The new structures were factored out into their own file structure, away from the 2.5KLOC file.  More work on this in the future would be great, but is a topic for a future PR.
* 32 bits ought to be enough for everyone, right?  Are there any structures where `u32` is too small to be a reasonable index value?
* the `upscale` values function currently takes `pprof::Label`s.  This might be a good target for a future refactor.

# How to test the change?

Describe here in detail how the change can be validated.
