### PR TITLE
Feature(profiling-replayer): Implement memory tracking

### DIFF
--- a/profiling-replayer/Cargo.toml
+++ b/profiling-replayer/Cargo.toml
@@ -11,3 +11,4 @@ anyhow = "1.0"
 clap = { version = "4.3.21", features = ["cargo", "color", "derive"] }
 datadog-profiling = { path = "../profiling"}
 prost = "0.11"
+sysinfo = {version = "0.29.8", default-features = false}


### PR DESCRIPTION
# What does this PR do?

Adds memory tracking to the profiling-replayer, via a `-m` or `--mem` flag.

# Motivation

The first step towards optimizing memory is knowing how much we're actually using.

# Additional Notes

At least on mac, the reported memory usage seems quite noisy. For two consecuative runs:

```
Memory usage (kB)
Before adding samples:  102678
After adding samples:   104792  Delta: 2113
After serializing:      119209  Delta: 14417
...
Memory usage (kB)
Before adding samples:  101974
After adding samples:   105332  Delta: 3358
After serializing:      118603  Delta: 13271
```

# How to test the change?

run the profiler as before, but also pass the `-m` flag.