### PR TITLE
[draft] profiler: Don't store the unnecessary length field for Sample Observations

### DIFF
--- a/profiling/src/profile/internal/mod.rs
+++ b/profiling/src/profile/internal/mod.rs
@@ -1,0 +1,5 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+
+mod observation;
+pub use observation::*;

--- a/profiling/src/profile/internal/observation.rs
+++ b/profiling/src/profile/internal/observation.rs
@@ -1,24 +1,52 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
 
+use std::cell::RefCell;
+
+thread_local! {
+    static LENGTH: RefCell<Option<usize>> = RefCell::new( None);
+}
+
 #[repr(transparent)]
 pub struct Observation {
-    data: Box<[i64]>,
+    data: *mut i64,
 }
 
 impl From<Vec<i64>> for Observation {
-    fn from(v: Vec<i64>) -> Self {
-        let data = v.into_boxed_slice();
-        Self { data }
+    fn from(mut v: Vec<i64>) -> Self {
+        println!("from {:?} {:?}", v, Self::len());
+        if let Some(len) = Self::len() {
+            assert_eq!(len, v.len(), "Sample observation was the wrong length");
+        } else {
+            LENGTH.with(|len| *len.borrow_mut() = Some(v.len()));
+        }
+        let b = v.into_boxed_slice();
+        let p = Box::into_raw(b);
+
+        Self { data: p as *mut i64}
     }
 }
 
 impl Observation {
+    pub fn len() -> Option<usize> {
+        LENGTH.with(|len| *len.borrow())
+    }
+
     pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, i64> {
-        self.data.iter_mut()
+        self.as_mut_ref().iter_mut()
     }
 
     pub fn as_ref(&self) -> &[i64] {
-        &self.data
+        unsafe {
+            let len: usize = Self::len().expect("LENGTH to exist by the time we use it");
+            std::slice::from_raw_parts(self.data, len)
+        }
+    }
+
+    pub fn as_mut_ref(&mut self) -> &mut [i64] {
+        unsafe {
+            let len: usize = Self::len().expect("LENGTH to exist by the time we use it");
+            std::slice::from_raw_parts_mut(self.data, len)
+        }
     }
 }

--- a/profiling/src/profile/internal/observation.rs
+++ b/profiling/src/profile/internal/observation.rs
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+
+#[repr(transparent)]
+pub struct Observation {
+    data: Box<[i64]>,
+}
+
+impl From<Vec<i64>> for Observation {
+    fn from(v: Vec<i64>) -> Self {
+        let data = v.into_boxed_slice();
+        Self { data }
+    }
+}
+
+impl Observation {
+    pub fn iter_mut(&mut self) -> core::slice::IterMut<'_, i64> {
+        self.data.iter_mut()
+    }
+
+    pub fn as_ref(&self) -> &[i64] {
+        &self.data
+    }
+}

--- a/profiling/src/profile/internal/observation.rs
+++ b/profiling/src/profile/internal/observation.rs
@@ -16,7 +16,6 @@ pub struct Observation {
 
 impl From<Vec<i64>> for Observation {
     fn from(v: Vec<i64>) -> Self {
-        println!("from {:?} {:?}", v, Self::len());
         if let Some(len) = Self::len() {
             assert_eq!(len, v.len(), "Sample observation was the wrong length");
         } else {

--- a/profiling/src/profile/mod.rs
+++ b/profiling/src/profile/mod.rs
@@ -2,9 +2,11 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
 
 pub mod api;
+pub mod internal;
 pub mod pprof;
 pub mod profiled_endpoints;
 use core::fmt;
+use internal::Observation;
 use std::borrow::{Borrow, Cow};
 use std::convert::TryInto;
 use std::fmt::Debug;
@@ -257,28 +259,6 @@ impl UpscalingRule {
             }
             UpscalingInfo::Proportional { scale } => scale,
         }
-    }
-}
-
-#[repr(transparent)]
-pub struct Observation {
-    data: Box<[i64]>,
-}
-
-impl From<Vec<i64>> for Observation {
-    fn from(v: Vec<i64>) -> Self {
-        let data = v.into_boxed_slice();
-        Self { data }
-    }
-}
-
-impl Observation {
-    fn iter_mut(&mut self) -> core::slice::IterMut<'_, i64> {
-        self.data.iter_mut()
-    }
-
-    fn as_ref(&self) -> &[i64] {
-        &self.data
     }
 }
 

--- a/profiling/src/profile/mod.rs
+++ b/profiling/src/profile/mod.rs
@@ -1111,8 +1111,10 @@ mod api_test {
                 ..Default::default()
             },
         ];
-
+        println!("{:?}", Observation::len());
         let mut profile = Profile::builder().sample_types(sample_types).build();
+        println!("{:?}", Observation::len());
+
         let sample_id = profile
             .add(api::Sample {
                 locations,
@@ -1120,6 +1122,7 @@ mod api_test {
                 labels: vec![],
             })
             .expect("add to succeed");
+        println!("{:?}", Observation::len());
 
         assert_eq!(sample_id, SampleId::new(0));
     }
@@ -1240,6 +1243,7 @@ mod api_test {
 
     #[test]
     fn reset() {
+        println!("{:?}", Observation::len());
         let mut profile = provide_distinct_locations();
         /* This set of asserts is to make sure it's a non-empty profile that we
          * are working with so that we can test that reset works.
@@ -1253,7 +1257,9 @@ mod api_test {
         assert!(profile.endpoints.mappings.is_empty());
         assert!(profile.endpoints.stats.is_empty());
 
+        println!("{:?}", Observation::len());
         let prev = profile.reset(None).expect("reset to succeed");
+        println!("{:?}", Observation::len());
 
         // These should all be empty now
         assert!(profile.functions.is_empty());


### PR DESCRIPTION
# What does this PR do?

Replaces the 24 byte `Vec<i64>` used by each sample with an 8 byte pointer.

# Motivation

Each sample has a vec of observations, which has both a capacity and a length member, both of which are 8 bytes.  This is wasteful, because all observations for a Profile are of the same length.  Instead, we only actually need a single pointer, and can store the length off to the side.

# Additional Notes

This has `unsafe` code and could use an extra careful review

The current implementation has a issue when multiple profiles are created, with different Sample Observation types. This happens for e.g. in our unit tests.  I'm trying to see if there is a clean solution.
# How to test the change?

Describe here in detail how the change can be validated.
