### PR TITLE
Add sidecar metrics into their own namespace, fix seq id

### DIFF
--- a/ddtelemetry/examples/tm-worker-test.rs
+++ b/ddtelemetry/examples/tm-worker-test.rs
@@ -40,7 +40,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         Vec::new(),
         data::metrics::MetricType::Count,
         false,
-        data::metrics::MetricNamespace::Trace,
+        data::metrics::MetricNamespace::Tracers,
     );
     handle.send_start().unwrap();
 

--- a/ddtelemetry/src/data/metrics.rs
+++ b/ddtelemetry/src/data/metrics.rs
@@ -18,9 +18,10 @@ pub struct Serie {
 #[derive(Serialize, Debug, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum MetricNamespace {
-    Trace,
-    Profiling,
+    Tracers,
+    Profilers,
     Appsec,
+    Sidecar,
 }
 
 #[derive(Serialize, Debug, Clone, Copy)]

--- a/ddtelemetry/src/metrics.rs
+++ b/ddtelemetry/src/metrics.rs
@@ -234,14 +234,14 @@ mod test {
             Vec::new(),
             MetricType::Gauge,
             false,
-            MetricNamespace::Trace,
+            MetricNamespace::Tracers,
         );
         let context_key_2 = contexts.register_metric_context(
             "metric2".into(),
             Vec::new(),
             MetricType::Gauge,
             false,
-            MetricNamespace::Trace,
+            MetricNamespace::Tracers,
         );
         let extra_tags = vec![Tag::from_value("service:foobar").unwrap()];
 

--- a/ddtelemetry/src/worker/mod.rs
+++ b/ddtelemetry/src/worker/mod.rs
@@ -783,7 +783,7 @@ impl TelemetryWorkerBuilder {
             },
             config,
             mailbox,
-            seq_id: AtomicU64::new(0),
+            seq_id: AtomicU64::new(1),
             runtime_id: self
                 .runtime_id
                 .unwrap_or_else(|| uuid::Uuid::new_v4().to_string()),

--- a/ipc/src/platform/unix/mem_handle.rs
+++ b/ipc/src/platform/unix/mem_handle.rs
@@ -195,23 +195,23 @@ impl NamedShmHandle {
                 | Mode::S_IWOTH,
         )?;
         ftruncate(fd, size as off_t)?;
-        Self::new(fd, path, size)
+        Self::new(fd, Some(path), size)
     }
 
     pub fn open(path: CString) -> io::Result<NamedShmHandle> {
         let fd = shm_open(path.as_bytes(), OFlag::O_RDWR, Mode::empty())?;
         let file: File = unsafe { OwnedFd::from_raw_fd(fd) }.into();
         let size = file.metadata()?.size() as usize;
-        Self::new(file.into_raw_fd(), path, size)
+        Self::new(file.into_raw_fd(), None, size)
     }
 
-    fn new(fd: RawFd, path: CString, size: usize) -> io::Result<NamedShmHandle> {
+    fn new(fd: RawFd, path: Option<CString>, size: usize) -> io::Result<NamedShmHandle> {
         Ok(NamedShmHandle {
             inner: ShmHandle {
                 handle: unsafe { PlatformHandle::from_raw_fd(fd) },
                 size,
             },
-            path: Some(ShmPath { name: path }),
+            path: path.map(|path| ShmPath { name: path }),
         })
     }
 }

--- a/sidecar/src/unix.rs
+++ b/sidecar/src/unix.rs
@@ -100,18 +100,18 @@ fn self_telemetry(server: SidecarServer, mut shutdown_receiver: Receiver<()>) ->
                         worker: &worker,
                         server: &server,
                         submitted_payloads: worker.register_metric_context(
-                            "sidecar.submitted_payloads".to_string(),
+                            "server.submitted_payloads".to_string(),
                             vec![],
                             MetricType::Count,
                             true,
-                            MetricNamespace::Trace,
+                            MetricNamespace::Sidecar,
                         ),
                         active_sessions: worker.register_metric_context(
-                            "sidecar.active_sessions".to_string(),
+                            "server.active_sessions".to_string(),
                             vec![],
                             MetricType::Gauge,
                             true,
-                            MetricNamespace::Trace,
+                            MetricNamespace::Sidecar,
                         ),
                     };
 


### PR DESCRIPTION
Also fixes that opened (as opposed to created) named shm handles are always unlinked. Oops.