### PR TITLE
refactor: Move profiler internal types to the internal module

### DIFF
--- a/profiling/src/profile/internal/endpoints.rs
+++ b/profiling/src/profile/internal/endpoints.rs
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+use super::StringId;
+use crate::profile::profiled_endpoints::ProfiledEndpointsStats;
+use crate::profile::FxIndexMap;
+
+pub struct Endpoints {
+    pub mappings: FxIndexMap<u64, StringId>,
+    pub local_root_span_id_label: StringId,
+    pub endpoint_label: StringId,
+    pub stats: ProfiledEndpointsStats,
+}
+
+impl Endpoints {
+    pub fn new() -> Self {
+        Self {
+            mappings: Default::default(),
+            local_root_span_id_label: Default::default(),
+            endpoint_label: Default::default(),
+            stats: Default::default(),
+        }
+    }
+}
+
+impl Default for Endpoints {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/profiling/src/profile/internal/endpoints.rs
+++ b/profiling/src/profile/internal/endpoints.rs
@@ -5,9 +5,9 @@ use crate::profile::profiled_endpoints::ProfiledEndpointsStats;
 use crate::profile::FxIndexMap;
 
 pub struct Endpoints {
-    pub mappings: FxIndexMap<u64, StringId>,
-    pub local_root_span_id_label: StringId,
     pub endpoint_label: StringId,
+    pub local_root_span_id_label: StringId,
+    pub mappings: FxIndexMap<u64, StringId>,
     pub stats: ProfiledEndpointsStats,
 }
 

--- a/profiling/src/profile/internal/mod.rs
+++ b/profiling/src/profile/internal/mod.rs
@@ -1,6 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
 
+mod endpoints;
 mod function;
 mod label;
 mod location;
@@ -11,6 +12,7 @@ mod string;
 mod upscaling;
 mod value_type;
 
+pub use endpoints::*;
 pub use function::*;
 pub use label::*;
 pub use location::*;

--- a/profiling/src/profile/internal/mod.rs
+++ b/profiling/src/profile/internal/mod.rs
@@ -5,16 +5,20 @@ mod function;
 mod label;
 mod location;
 mod mapping;
+mod sample;
 mod stack_trace;
 mod string;
+mod upscaling;
 mod value_type;
 
 pub use function::*;
 pub use label::*;
 pub use location::*;
 pub use mapping::*;
+pub use sample::*;
 pub use stack_trace::*;
 pub use string::*;
+pub use upscaling::*;
 pub use value_type::*;
 
 use super::pprof;

--- a/profiling/src/profile/internal/sample.rs
+++ b/profiling/src/profile/internal/sample.rs
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+
+use super::{Label, StackTraceId};
+use std::hash::Hash;
+#[derive(Eq, PartialEq, Hash)]
+pub struct Sample {
+    pub stacktrace: StackTraceId,
+
+    /// label includes additional context for this sample. It can include
+    /// things like a thread id, allocation size, etc
+    pub labels: Vec<Label>,
+
+    /// Offset into `labels` for the label with key == "local root span id".
+    pub local_root_span_id_label_offset: Option<usize>,
+}

--- a/profiling/src/profile/internal/sample.rs
+++ b/profiling/src/profile/internal/sample.rs
@@ -5,12 +5,12 @@ use super::{Label, StackTraceId};
 use std::hash::Hash;
 #[derive(Eq, PartialEq, Hash)]
 pub struct Sample {
-    pub stacktrace: StackTraceId,
-
     /// label includes additional context for this sample. It can include
     /// things like a thread id, allocation size, etc
     pub labels: Vec<Label>,
 
     /// Offset into `labels` for the label with key == "local root span id".
     pub local_root_span_id_label_offset: Option<usize>,
+
+    pub stacktrace: StackTraceId,
 }

--- a/profiling/src/profile/internal/upscaling.rs
+++ b/profiling/src/profile/internal/upscaling.rs
@@ -1,0 +1,133 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+
+use super::StringId;
+use crate::profile::api::UpscalingInfo;
+use crate::profile::FxIndexMap;
+pub struct UpscalingRule {
+    pub values_offset: Vec<usize>,
+    pub upscaling_info: UpscalingInfo,
+}
+
+impl UpscalingRule {
+    pub fn compute_scale(&self, values: &[i64]) -> f64 {
+        match self.upscaling_info {
+            UpscalingInfo::Poisson {
+                sum_value_offset,
+                count_value_offset,
+                sampling_distance,
+            } => {
+                // This should not happen, but if it happens,
+                // do not upscale
+                if values[sum_value_offset] == 0 || values[count_value_offset] == 0 {
+                    return 1_f64;
+                }
+
+                let avg = values[sum_value_offset] as f64 / values[count_value_offset] as f64;
+                1_f64 / (1_f64 - (-avg / sampling_distance as f64).exp())
+            }
+            UpscalingInfo::Proportional { scale } => scale,
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct UpscalingRules {
+    rules: FxIndexMap<(StringId, StringId), Vec<UpscalingRule>>,
+    // this is just an optimization in the case where we check collisions (when adding
+    // a by-value rule) against by-label rules
+    // 32 should be enough for the size of the bitmap
+    offset_modified_by_bylabel_rule: bitmaps::Bitmap<32>,
+}
+
+impl UpscalingRules {
+    pub fn add(&mut self, label_name_id: StringId, label_value_id: StringId, rule: UpscalingRule) {
+        // fill the bitmap for by-label rules
+        if !label_name_id.is_zero() || !label_value_id.is_zero() {
+            rule.values_offset.iter().for_each(|offset| {
+                self.offset_modified_by_bylabel_rule.set(*offset, true);
+            })
+        }
+        match self.rules.get_index_of(&(label_name_id, label_value_id)) {
+            None => {
+                let rules = vec![rule];
+                self.rules.insert((label_name_id, label_value_id), rules);
+            }
+            Some(index) => {
+                let (_, rules) = self
+                    .rules
+                    .get_index_mut(index)
+                    .expect("Already existing rules");
+                rules.push(rule);
+            }
+        }
+    }
+
+    pub fn get(&self, k: &(StringId, StringId)) -> Option<&Vec<UpscalingRule>> {
+        self.rules.get(k)
+    }
+
+    pub fn check_collisions(
+        &self,
+        values_offset: &[usize],
+        label_name: (&str, StringId),
+        label_value: (&str, StringId),
+        upscaling_info: &UpscalingInfo,
+    ) -> anyhow::Result<()> {
+        // Check for duplicates
+        fn is_overlapping(v1: &[usize], v2: &[usize]) -> bool {
+            v1.iter().any(|x| v2.contains(x))
+        }
+
+        fn vec_to_string(v: &[usize]) -> String {
+            format!("{:?}", v)
+        }
+
+        let colliding_rule = match self.rules.get(&(label_name.1, label_value.1)) {
+            Some(rules) => rules
+                .iter()
+                .find(|rule| is_overlapping(&rule.values_offset, values_offset)),
+            None => None,
+        };
+
+        anyhow::ensure!(
+            colliding_rule.is_none(),
+            "There are dupicated by-label rules for the same label name: {} and label value: {} with at least one value offset in common.\n\
+            Existing values offset(s) {}, new rule values offset(s) {}.\n\
+            Existing upscaling info: {}, new rule upscaling info: {}",
+            vec_to_string(&colliding_rule.unwrap().values_offset), vec_to_string(values_offset),
+            label_name.0, label_value.0,
+            upscaling_info, colliding_rule.unwrap().upscaling_info
+        );
+
+        // if we are adding a by-value rule, we need to check against
+        // all by-label rules for collisions
+        if label_name.1.is_zero() && label_value.1.is_zero() {
+            let collision_offset = values_offset
+                .iter()
+                .find(|offset| self.offset_modified_by_bylabel_rule.get(**offset));
+
+            anyhow::ensure!(
+                collision_offset.is_none(),
+                "The by-value rule is collinding with at least one by-label rule at offset {}\n\
+                by-value rule values offset(s) {}",
+                collision_offset.unwrap(),
+                vec_to_string(values_offset)
+            )
+        } else if let Some(rules) = self.rules.get(&(StringId::ZERO, StringId::ZERO)) {
+            let collide_with_byvalue_rule = rules
+                .iter()
+                .find(|rule| is_overlapping(&rule.values_offset, values_offset));
+            anyhow::ensure!(collide_with_byvalue_rule.is_none(),
+                "The by-label rule (label name {}, label value {}) is colliding with a by-value rule on values offsets\n\
+                Existing values offset(s) {}, new rule values offset(s) {}",
+                label_name.0, label_value.0, vec_to_string(&collide_with_byvalue_rule.unwrap().values_offset),
+                vec_to_string(values_offset))
+        }
+        Ok(())
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+}

--- a/profiling/src/profile/internal/upscaling.rs
+++ b/profiling/src/profile/internal/upscaling.rs
@@ -7,8 +7,8 @@ use crate::profile::pprof;
 use crate::profile::FxIndexMap;
 
 pub struct UpscalingRule {
-    values_offset: Vec<usize>,
     upscaling_info: UpscalingInfo,
+    values_offset: Vec<usize>,
 }
 
 impl UpscalingRule {

--- a/profiling/src/profile/internal/upscaling.rs
+++ b/profiling/src/profile/internal/upscaling.rs
@@ -72,10 +72,6 @@ impl UpscalingRules {
         }
     }
 
-    pub fn get(&self, k: &(StringId, StringId)) -> Option<&Vec<UpscalingRule>> {
-        self.rules.get(k)
-    }
-
     pub fn check_collisions(
         &self,
         values_offset: &[usize],
@@ -136,6 +132,14 @@ impl UpscalingRules {
         Ok(())
     }
 
+    pub fn get(&self, k: &(StringId, StringId)) -> Option<&Vec<UpscalingRule>> {
+        self.rules.get(k)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+
     // TODO: Consider whether to use the internal Label here instead
     pub fn upscale_values(
         &self,
@@ -184,9 +188,5 @@ impl UpscalingRules {
         }
 
         Ok(new_values)
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.rules.is_empty()
     }
 }

--- a/profiling/src/profile/mod.rs
+++ b/profiling/src/profile/mod.rs
@@ -41,13 +41,6 @@ pub struct Profile {
     upscaling_rules: UpscalingRules,
 }
 
-pub struct Endpoints {
-    mappings: FxIndexMap<u64, StringId>,
-    local_root_span_id_label: StringId,
-    endpoint_label: StringId,
-    stats: ProfiledEndpointsStats,
-}
-
 #[derive(Default)]
 pub struct ProfileBuilder<'a> {
     period: Option<api::Period<'a>>,
@@ -133,23 +126,6 @@ pub struct EncodedProfile {
     pub end: SystemTime,
     pub buffer: Vec<u8>,
     pub endpoints_stats: ProfiledEndpointsStats,
-}
-
-impl Endpoints {
-    pub fn new() -> Self {
-        Self {
-            mappings: Default::default(),
-            local_root_span_id_label: Default::default(),
-            endpoint_label: Default::default(),
-            stats: Default::default(),
-        }
-    }
-}
-
-impl Default for Endpoints {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 // For testing and debugging purposes

--- a/profiling/src/profile/mod.rs
+++ b/profiling/src/profile/mod.rs
@@ -9,7 +9,7 @@ pub mod profiled_endpoints;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::convert::TryInto;
-use std::hash::{BuildHasherDefault, Hash};
+use std::hash::BuildHasherDefault;
 use std::num::NonZeroI64;
 use std::time::{Duration, SystemTime};
 
@@ -24,45 +24,6 @@ pub type FxIndexSet<K> = indexmap::IndexSet<K, BuildHasherDefault<rustc_hash::Fx
 
 pub type Timestamp = NonZeroI64;
 pub type TimestampedObservation = (Timestamp, Box<[i64]>);
-
-#[derive(Eq, PartialEq, Hash)]
-struct Sample {
-    pub stacktrace: StackTraceId,
-
-    /// label includes additional context for this sample. It can include
-    /// things like a thread id, allocation size, etc
-    pub labels: Vec<Label>,
-
-    /// Offset into `labels` for the label with key == "local root span id".
-    local_root_span_id_label_offset: Option<usize>,
-}
-
-pub struct UpscalingRule {
-    values_offset: Vec<usize>,
-    upscaling_info: UpscalingInfo,
-}
-
-impl UpscalingRule {
-    pub fn compute_scale(&self, values: &[i64]) -> f64 {
-        match self.upscaling_info {
-            UpscalingInfo::Poisson {
-                sum_value_offset,
-                count_value_offset,
-                sampling_distance,
-            } => {
-                // This should not happen, but if it happens,
-                // do not upscale
-                if values[sum_value_offset] == 0 || values[count_value_offset] == 0 {
-                    return 1_f64;
-                }
-
-                let avg = values[sum_value_offset] as f64 / values[count_value_offset] as f64;
-                1_f64 / (1_f64 - (-avg / sampling_distance as f64).exp())
-            }
-            UpscalingInfo::Proportional { scale } => scale,
-        }
-    }
-}
 
 pub struct Profile {
     aggregated_samples: HashMap<Sample, Box<[i64]>>,
@@ -85,107 +46,6 @@ pub struct Endpoints {
     local_root_span_id_label: StringId,
     endpoint_label: StringId,
     stats: ProfiledEndpointsStats,
-}
-
-#[derive(Default)]
-pub struct UpscalingRules {
-    rules: FxIndexMap<(StringId, StringId), Vec<UpscalingRule>>,
-    // this is just an optimization in the case where we check collisions (when adding
-    // a by-value rule) against by-label rules
-    // 32 should be enough for the size of the bitmap
-    offset_modified_by_bylabel_rule: bitmaps::Bitmap<32>,
-}
-
-impl UpscalingRules {
-    pub fn add(&mut self, label_name_id: StringId, label_value_id: StringId, rule: UpscalingRule) {
-        // fill the bitmap for by-label rules
-        if !label_name_id.is_zero() || !label_value_id.is_zero() {
-            rule.values_offset.iter().for_each(|offset| {
-                self.offset_modified_by_bylabel_rule.set(*offset, true);
-            })
-        }
-        match self.rules.get_index_of(&(label_name_id, label_value_id)) {
-            None => {
-                let rules = vec![rule];
-                self.rules.insert((label_name_id, label_value_id), rules);
-            }
-            Some(index) => {
-                let (_, rules) = self
-                    .rules
-                    .get_index_mut(index)
-                    .expect("Already existing rules");
-                rules.push(rule);
-            }
-        }
-    }
-
-    pub fn get(&self, k: &(StringId, StringId)) -> Option<&Vec<UpscalingRule>> {
-        self.rules.get(k)
-    }
-
-    fn check_collisions(
-        &self,
-        values_offset: &[usize],
-        label_name: (&str, StringId),
-        label_value: (&str, StringId),
-        upscaling_info: &UpscalingInfo,
-    ) -> anyhow::Result<()> {
-        // Check for duplicates
-        fn is_overlapping(v1: &[usize], v2: &[usize]) -> bool {
-            v1.iter().any(|x| v2.contains(x))
-        }
-
-        fn vec_to_string(v: &[usize]) -> String {
-            format!("{:?}", v)
-        }
-
-        let colliding_rule = match self.rules.get(&(label_name.1, label_value.1)) {
-            Some(rules) => rules
-                .iter()
-                .find(|rule| is_overlapping(&rule.values_offset, values_offset)),
-            None => None,
-        };
-
-        anyhow::ensure!(
-            colliding_rule.is_none(),
-            "There are dupicated by-label rules for the same label name: {} and label value: {} with at least one value offset in common.\n\
-            Existing values offset(s) {}, new rule values offset(s) {}.\n\
-            Existing upscaling info: {}, new rule upscaling info: {}",
-            vec_to_string(&colliding_rule.unwrap().values_offset), vec_to_string(values_offset),
-            label_name.0, label_value.0,
-            upscaling_info, colliding_rule.unwrap().upscaling_info
-        );
-
-        // if we are adding a by-value rule, we need to check against
-        // all by-label rules for collisions
-        if label_name.1.is_zero() && label_value.1.is_zero() {
-            let collision_offset = values_offset
-                .iter()
-                .find(|offset| self.offset_modified_by_bylabel_rule.get(**offset));
-
-            anyhow::ensure!(
-                collision_offset.is_none(),
-                "The by-value rule is collinding with at least one by-label rule at offset {}\n\
-                by-value rule values offset(s) {}",
-                collision_offset.unwrap(),
-                vec_to_string(values_offset)
-            )
-        } else if let Some(rules) = self.rules.get(&(StringId::ZERO, StringId::ZERO)) {
-            let collide_with_byvalue_rule = rules
-                .iter()
-                .find(|rule| is_overlapping(&rule.values_offset, values_offset));
-            anyhow::ensure!(collide_with_byvalue_rule.is_none(),
-                "The by-label rule (label name {}, label value {}) is colliding with a by-value rule on values offsets\n\
-                Existing values offset(s) {}, new rule values offset(s) {}",
-                label_name.0, label_value.0, vec_to_string(&collide_with_byvalue_rule.unwrap().values_offset),
-                vec_to_string(values_offset))
-        }
-        Ok(())
-    }
-
-    fn is_empty(&self) -> bool {
-        self.rules.is_empty()
-    }
 }
 
 #[derive(Default)]
@@ -703,6 +563,7 @@ impl Profile {
     }
 
     // TODO: Consider whether to use the internal Label here instead
+    // TODO move this to upscaling rules
     fn upscale_values(&self, values: &[i64], labels: &[pprof::Label]) -> anyhow::Result<Vec<i64>> {
         let mut new_values = values.to_vec();
 


### PR DESCRIPTION
# What does this PR do?

Moves internal datastructures out of the `profile/mod.rs` file into `profile/internal/<structure_name>.rs`.

# Motivation

This work was partially completed in #214, but some types were missed.  Collecting them too.
# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
