### PR TITLE
Refactor common unit test create_test_span function into trace-utils

### DIFF
--- a/trace-mini-agent/src/trace_processor.rs
+++ b/trace-mini-agent/src/trace_processor.rs
@@ -4,11 +4,11 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use datadog_trace_obfuscation::replacer;
 use hyper::{http, Body, Request, Response, StatusCode};
 use log::info;
 use tokio::sync::mpsc::Sender;
 
+use datadog_trace_obfuscation::replacer;
 use datadog_trace_utils::trace_utils;
 use datadog_trace_utils::trace_utils::SendData;
 
@@ -163,7 +163,7 @@ mod tests {
 
         let start = get_current_timestamp_nanos();
 
-        let json_span = create_test_json_span(111, 222, 333, start);
+        let json_span = create_test_json_span(11, 222, 333, start);
 
         let bytes = rmp_serde::to_vec(&vec![vec![json_span]]).unwrap();
         let request = Request::builder()
@@ -196,11 +196,11 @@ mod tests {
             language_name: "nodejs".to_string(),
             language_version: "v19.7.0".to_string(),
             tracer_version: "4.0.0".to_string(),
-            runtime_id: "afjksdljfkllksdj-28934889".to_string(),
+            runtime_id: "test-runtime-id-value".to_string(),
             chunks: vec![pb::TraceChunk {
                 priority: i8::MIN as i32,
                 origin: "".to_string(),
-                spans: vec![create_test_span(111, 222, 333, start, true)],
+                spans: vec![create_test_span(11, 222, 333, start, true)],
                 tags: HashMap::new(),
                 dropped_trace: false,
             }],
@@ -262,7 +262,7 @@ mod tests {
             language_name: "nodejs".to_string(),
             language_version: "v19.7.0".to_string(),
             tracer_version: "4.0.0".to_string(),
-            runtime_id: "afjksdljfkllksdj-28934889".to_string(),
+            runtime_id: "test-runtime-id-value".to_string(),
             chunks: vec![pb::TraceChunk {
                 priority: i8::MIN as i32,
                 origin: "".to_string(),

--- a/trace-mini-agent/src/trace_processor.rs
+++ b/trace-mini-agent/src/trace_processor.rs
@@ -4,11 +4,11 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use datadog_trace_obfuscation::replacer;
 use hyper::{http, Body, Request, Response, StatusCode};
 use log::info;
 use tokio::sync::mpsc::Sender;
 
-use datadog_trace_obfuscation::replacer;
 use datadog_trace_utils::trace_utils;
 use datadog_trace_utils::trace_utils::SendData;
 
@@ -107,7 +107,6 @@ impl TraceProcessor for ServerlessTraceProcessor {
 #[cfg(test)]
 mod tests {
     use hyper::Request;
-    use serde_json::json;
     use std::{
         collections::HashMap,
         sync::Arc,
@@ -120,69 +119,11 @@ mod tests {
         trace_processor::{self, TraceProcessor},
     };
     use datadog_trace_protobuf::pb;
-    use datadog_trace_utils::trace_utils;
+    use datadog_trace_utils::{
+        trace_test_utils::{create_test_json_span, create_test_span},
+        trace_utils,
+    };
     use ddcommon::Endpoint;
-
-    fn create_test_span(start: i64, span_id: u64, parent_id: u64, is_top_level: bool) -> pb::Span {
-        let mut span = pb::Span {
-            trace_id: 111,
-            span_id,
-            service: "test-service".to_string(),
-            name: "test_name".to_string(),
-            resource: "test-resource".to_string(),
-            parent_id,
-            start,
-            duration: 5,
-            error: 0,
-            meta: HashMap::from([
-                ("service".to_string(), "test-service".to_string()),
-                ("env".to_string(), "test-env".to_string()),
-                (
-                    "runtime-id".to_string(),
-                    "afjksdljfkllksdj-28934889".to_string(),
-                ),
-            ]),
-            metrics: HashMap::new(),
-            r#type: "".to_string(),
-            meta_struct: HashMap::new(),
-        };
-        if is_top_level {
-            span.metrics.insert("_top_level".to_string(), 1.0);
-            span.meta
-                .insert("_dd.origin".to_string(), "cloudfunction".to_string());
-            span.meta
-                .insert("origin".to_string(), "cloudfunction".to_string());
-            span.meta.insert(
-                "functionname".to_string(),
-                "dummy_function_name".to_string(),
-            );
-            span.r#type = "serverless".to_string();
-        }
-        span
-    }
-
-    fn create_test_json_span(start: i64, span_id: u64, parent_id: u64) -> serde_json::Value {
-        json!(
-            {
-                "trace_id": 111,
-                "span_id": span_id,
-                "service": "test-service",
-                "name": "test_name",
-                "resource": "test-resource",
-                "parent_id": parent_id,
-                "start": start,
-                "duration": 5,
-                "error": 0,
-                "meta": {
-                    "service": "test-service",
-                    "env": "test-env",
-                    "runtime-id": "afjksdljfkllksdj-28934889",
-                },
-                "metrics": {},
-                "meta_struct": {},
-            }
-        )
-    }
 
     fn get_current_timestamp_nanos() -> i64 {
         SystemTime::now()
@@ -222,7 +163,7 @@ mod tests {
 
         let start = get_current_timestamp_nanos();
 
-        let json_span = create_test_json_span(start, 222, 0);
+        let json_span = create_test_json_span(111, 222, 333, start);
 
         let bytes = rmp_serde::to_vec(&vec![vec![json_span]]).unwrap();
         let request = Request::builder()
@@ -259,7 +200,7 @@ mod tests {
             chunks: vec![pb::TraceChunk {
                 priority: i8::MIN as i32,
                 origin: "".to_string(),
-                spans: vec![create_test_span(start, 222, 0, true)],
+                spans: vec![create_test_span(111, 222, 333, start, true)],
                 tags: HashMap::new(),
                 dropped_trace: false,
             }],
@@ -285,9 +226,9 @@ mod tests {
         let start = get_current_timestamp_nanos();
 
         let json_trace = vec![
-            create_test_json_span(start, 333, 222),
-            create_test_json_span(start, 222, 0),
-            create_test_json_span(start, 444, 333),
+            create_test_json_span(11, 333, 222, start),
+            create_test_json_span(11, 222, 0, start),
+            create_test_json_span(11, 444, 333, start),
         ];
 
         let bytes = rmp_serde::to_vec(&vec![json_trace]).unwrap();
@@ -326,9 +267,9 @@ mod tests {
                 priority: i8::MIN as i32,
                 origin: "".to_string(),
                 spans: vec![
-                    create_test_span(start, 333, 222, false),
-                    create_test_span(start, 222, 0, true),
-                    create_test_span(start, 444, 333, false),
+                    create_test_span(11, 333, 222, start, false),
+                    create_test_span(11, 222, 0, start, true),
+                    create_test_span(11, 444, 333, start, false),
                 ],
                 tags: HashMap::new(),
                 dropped_trace: false,
@@ -338,7 +279,6 @@ mod tests {
             hostname: "".to_string(),
             app_version: "".to_string(),
         };
-
         assert_eq!(
             expected_tracer_payload,
             tracer_payload.unwrap().get_payloads()[0]

--- a/trace-utils/src/lib.rs
+++ b/trace-utils/src/lib.rs
@@ -3,4 +3,5 @@
 
 pub mod config_utils;
 pub mod stats_utils;
+pub mod trace_test_utils;
 pub mod trace_utils;

--- a/trace-utils/src/trace_test_utils.rs
+++ b/trace-utils/src/trace_test_utils.rs
@@ -1,0 +1,79 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+
+use std::collections::HashMap;
+
+use datadog_trace_protobuf::pb;
+use serde_json::json;
+
+pub fn create_test_span(
+    trace_id: u64,
+    span_id: u64,
+    parent_id: u64,
+    start: i64,
+    is_top_level: bool,
+) -> pb::Span {
+    let mut span = pb::Span {
+        trace_id,
+        span_id,
+        service: "test-service".to_string(),
+        name: "test_name".to_string(),
+        resource: "test-resource".to_string(),
+        parent_id,
+        start,
+        duration: 5,
+        error: 0,
+        meta: HashMap::from([
+            ("service".to_string(), "test-service".to_string()),
+            ("env".to_string(), "test-env".to_string()),
+            (
+                "runtime-id".to_string(),
+                "afjksdljfkllksdj-28934889".to_string(),
+            ),
+        ]),
+        metrics: HashMap::new(),
+        r#type: "".to_string(),
+        meta_struct: HashMap::new(),
+    };
+    if is_top_level {
+        span.metrics.insert("_top_level".to_string(), 1.0);
+        span.meta
+            .insert("_dd.origin".to_string(), "cloudfunction".to_string());
+        span.meta
+            .insert("origin".to_string(), "cloudfunction".to_string());
+        span.meta.insert(
+            "functionname".to_string(),
+            "dummy_function_name".to_string(),
+        );
+        span.r#type = "serverless".to_string();
+    }
+    span
+}
+
+pub fn create_test_json_span(
+    trace_id: u64,
+    span_id: u64,
+    parent_id: u64,
+    start: i64,
+) -> serde_json::Value {
+    json!(
+        {
+            "trace_id": trace_id,
+            "span_id": span_id,
+            "service": "test-service",
+            "name": "test_name",
+            "resource": "test-resource",
+            "parent_id": parent_id,
+            "start": start,
+            "duration": 5,
+            "error": 0,
+            "meta": {
+                "service": "test-service",
+                "env": "test-env",
+                "runtime-id": "afjksdljfkllksdj-28934889",
+            },
+            "metrics": {},
+            "meta_struct": {},
+        }
+    )
+}

--- a/trace-utils/src/trace_test_utils.rs
+++ b/trace-utils/src/trace_test_utils.rs
@@ -28,7 +28,7 @@ pub fn create_test_span(
             ("env".to_string(), "test-env".to_string()),
             (
                 "runtime-id".to_string(),
-                "afjksdljfkllksdj-28934889".to_string(),
+                "test-runtime-id-value".to_string(),
             ),
         ]),
         metrics: HashMap::new(),
@@ -70,7 +70,7 @@ pub fn create_test_json_span(
             "meta": {
                 "service": "test-service",
                 "env": "test-env",
-                "runtime-id": "afjksdljfkllksdj-28934889",
+                "runtime-id": "test-runtime-id-value",
             },
             "metrics": {},
             "meta_struct": {},

--- a/trace-utils/src/trace_utils.rs
+++ b/trace-utils/src/trace_utils.rs
@@ -651,7 +651,7 @@ mod tests {
             HashMap::from([
                 (
                     "runtime-id".to_string(),
-                    "afjksdljfkllksdj-28934889".to_string()
+                    "test-runtime-id-value".to_string()
                 ),
                 ("_dd.origin".to_string(), "azurefunction".to_string()),
                 ("origin".to_string(), "azurefunction".to_string()),
@@ -676,7 +676,7 @@ mod tests {
             HashMap::from([
                 (
                     "runtime-id".to_string(),
-                    "afjksdljfkllksdj-28934889".to_string()
+                    "test-runtime-id-value".to_string()
                 ),
                 ("_dd.origin".to_string(), "cloudfunction".to_string()),
                 ("origin".to_string(), "cloudfunction".to_string()),

--- a/trace-utils/src/trace_utils.rs
+++ b/trace-utils/src/trace_utils.rs
@@ -537,7 +537,7 @@ mod tests {
     use std::collections::HashMap;
 
     use super::{get_root_span_index, set_serverless_root_span_tags};
-    use crate::trace_utils;
+    use crate::{trace_test_utils::create_test_span, trace_utils};
     use datadog_trace_protobuf::pb;
 
     #[tokio::test]
@@ -612,30 +612,12 @@ mod tests {
         }
     }
 
-    fn create_test_span(trace_id: u64, span_id: u64, parent_id: u64) -> pb::Span {
-        pb::Span {
-            trace_id,
-            span_id,
-            service: "service".to_string(),
-            name: "name".to_string(),
-            resource: "".to_string(),
-            parent_id,
-            start: 0,
-            duration: 5,
-            error: 0,
-            meta: HashMap::new(),
-            metrics: HashMap::new(),
-            r#type: "".to_string(),
-            meta_struct: HashMap::new(),
-        }
-    }
-
     #[test]
     fn test_get_root_span_index_from_complete_trace() {
         let trace = vec![
-            create_test_span(1234, 12341, 0),
-            create_test_span(1234, 12342, 12341),
-            create_test_span(1234, 12343, 12342),
+            create_test_span(1234, 12341, 0, 1, false),
+            create_test_span(1234, 12342, 12341, 1, false),
+            create_test_span(1234, 12343, 12342, 1, false),
         ];
 
         let root_span_index = get_root_span_index(&trace);
@@ -646,9 +628,9 @@ mod tests {
     #[test]
     fn test_get_root_span_index_from_partial_trace() {
         let trace = vec![
-            create_test_span(1234, 12342, 12341),
-            create_test_span(1234, 12341, 12340), // this is the root span, it's parent is not in the trace
-            create_test_span(1234, 12343, 12342),
+            create_test_span(1234, 12342, 12341, 1, false),
+            create_test_span(1234, 12341, 12340, 1, false), // this is the root span, it's parent is not in the trace
+            create_test_span(1234, 12343, 12342, 1, false),
         ];
 
         let root_span_index = get_root_span_index(&trace);
@@ -658,7 +640,7 @@ mod tests {
 
     #[test]
     fn test_set_serverless_root_span_tags_azure_function() {
-        let mut span = create_test_span(1234, 12342, 12341);
+        let mut span = create_test_span(1234, 12342, 12341, 1, false);
         set_serverless_root_span_tags(
             &mut span,
             Some("test_function".to_string()),
@@ -667,9 +649,15 @@ mod tests {
         assert_eq!(
             span.meta,
             HashMap::from([
+                (
+                    "runtime-id".to_string(),
+                    "afjksdljfkllksdj-28934889".to_string()
+                ),
                 ("_dd.origin".to_string(), "azurefunction".to_string()),
                 ("origin".to_string(), "azurefunction".to_string()),
-                ("functionname".to_string(), "test_function".to_string())
+                ("functionname".to_string(), "test_function".to_string()),
+                ("env".to_string(), "test-env".to_string()),
+                ("service".to_string(), "test-service".to_string())
             ]),
         );
         assert_eq!(span.r#type, "serverless".to_string())
@@ -677,7 +665,7 @@ mod tests {
 
     #[test]
     fn test_set_serverless_root_span_tags_cloud_function() {
-        let mut span = create_test_span(1234, 12342, 12341);
+        let mut span = create_test_span(1234, 12342, 12341, 1, false);
         set_serverless_root_span_tags(
             &mut span,
             Some("test_function".to_string()),
@@ -686,9 +674,15 @@ mod tests {
         assert_eq!(
             span.meta,
             HashMap::from([
+                (
+                    "runtime-id".to_string(),
+                    "afjksdljfkllksdj-28934889".to_string()
+                ),
                 ("_dd.origin".to_string(), "cloudfunction".to_string()),
                 ("origin".to_string(), "cloudfunction".to_string()),
-                ("functionname".to_string(), "test_function".to_string())
+                ("functionname".to_string(), "test_function".to_string()),
+                ("env".to_string(), "test-env".to_string()),
+                ("service".to_string(), "test-service".to_string())
             ]),
         );
         assert_eq!(span.r#type, "serverless".to_string())


### PR DESCRIPTION
# What does this PR do?

Refactor common `create_test_span function` into `trace-utils`

# Motivation

cleanliness

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

This PR only touches unit tests. Unit tests are 🟢 
