### PR TITLE
cicd rfc

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,3 +13,7 @@ Anything else we should know when reviewing?
 # How to test the change?
 
 Describe here in detail how the change can be validated.
+
+## For Reviewers
+- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
+- [ ] This PR doesn't touch any of that.


### PR DESCRIPTION
Brings libdatadog into adherence with our policy for public repos.  This is especially important here because libdatadog artifacts are consumed as published from this repo.