### PR TITLE
perf(profiling): tune initial buffer sizes

### DIFF
--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -238,8 +238,14 @@ impl ProfileExporter {
         );
 
         for file in files {
-            // We tend to have good compression ratios
-            let buffer = Vec::with_capacity((file.bytes.len() / 10).next_power_of_two());
+            // We tend to have good compression ratios for the pprof files,
+            // especially with timeline enabled. Not all files compress this
+            // well, but these are just initial Vec sizes, not a hard-bound.
+            // Using 1/10 gives us a better start than starting at zero, while
+            // not reserving too much for things that compress really well, and
+            // power-of-two capacities are almost always the best performing.
+            let capacity = (file.bytes.len() / 10).next_power_of_two();
+            let buffer = Vec::with_capacity(capacity);
             let mut encoder = FrameEncoder::new(buffer);
             encoder.write_all(file.bytes)?;
             let encoded = encoder.finish()?;

--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -238,7 +238,9 @@ impl ProfileExporter {
         );
 
         for file in files {
-            let mut encoder = FrameEncoder::new(Vec::new());
+            // We tend to have good compression ratios
+            let buffer = Vec::with_capacity((file.bytes.len() / 10).next_power_of_two());
+            let mut encoder = FrameEncoder::new(buffer);
             encoder.write_all(file.bytes)?;
             let encoded = encoder.finish()?;
             /* The Datadog RFC examples strip off the file extension, but the exact behavior isn't

--- a/profiling/src/profile/mod.rs
+++ b/profiling/src/profile/mod.rs
@@ -482,7 +482,7 @@ impl Profile {
             .as_nanos()
             .min(i64::MAX as u128) as i64;
 
-        let mut buffer: Vec<u8> = Vec::new();
+        let mut buffer: Vec<u8> = Vec::with_capacity(32 * 1024);
         profile.encode(&mut buffer)?;
 
         Ok(EncodedProfile {

--- a/profiling/src/profile/mod.rs
+++ b/profiling/src/profile/mod.rs
@@ -482,7 +482,18 @@ impl Profile {
             .as_nanos()
             .min(i64::MAX as u128) as i64;
 
-        let mut buffer: Vec<u8> = Vec::with_capacity(32 * 1024);
+        // On 2023-08-23, we analyzed the uploaded tarball size per language.
+        // These tarballs include 1 or more profiles, but for most languages
+        // using libdatadog (all?) there is only 1 profile, so this is a good
+        // proxy for the compressed, final size of the profiles.
+        // We found that for all languages using libdatadog, the average
+        // tarball was at least 18 KiB. Since these archives are compressed,
+        // and because profiles compress well, especially ones with timeline
+        // enabled (over 9x for some analyzed timeline profiles), this initial
+        // size of 32KiB should definitely out-perform starting at zero for
+        // time consumed, allocator pressure, and allocator fragmentation.
+        const INITIAL_PPROF_BUFFER_SIZE: usize = 32 * 1024;
+        let mut buffer: Vec<u8> = Vec::with_capacity(INITIAL_PPROF_BUFFER_SIZE);
         profile.encode(&mut buffer)?;
 
         Ok(EncodedProfile {


### PR DESCRIPTION
# What does this PR do?

This tunes the initial buffer sizes for encoding the profiles into the serialized pprof format, and also when compressing  files for upload.

# Motivation

The goal is to reduce allocator fragmentation, pressure, and generally return more memory to the system. In a separate PR, Ivo recorded some RSS numbers before/after serialization, and noticed in that PR how it freed up dozens of KiB of memory. The thing is, that change only allocated ~1KiB of string data into a separate arena allocator. The entire difference is therefore about the memory allocation patterns, and not their sizes.

That PR is a bit more complex, and Ivo wasn't sure about shipping it. This PR is very simple, and has a similar effect by simplifying allocations in a different area.

# Additional Notes

None.

# How to test the change?

Just test as normal, but notice that your system RSS when compared to before should return more memory after serialization than it did before.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
