### PR TITLE
fix: warnings on new Rust 1.72.0 toolchain

### DIFF
--- a/ddcommon-ffi/src/slice.rs
+++ b/ddcommon-ffi/src/slice.rs
@@ -164,7 +164,7 @@ impl<'a, T> Default for Slice<'a, T> {
 impl<'a, T: 'a> From<&'a [T]> for Slice<'a, T> {
     fn from(s: &'a [T]) -> Self {
         // SAFETY: Rust slices meet all the invariants required for Slice::new.
-        unsafe { Slice::new(s.as_ptr() as *const T, s.len()) }
+        unsafe { Slice::new(s.as_ptr(), s.len()) }
     }
 }
 

--- a/ddcommon-ffi/src/vec.rs
+++ b/ddcommon-ffi/src/vec.rs
@@ -23,7 +23,7 @@ pub struct Vec<T: Sized> {
 
 impl<T: PartialEq> PartialEq for Vec<T> {
     fn eq(&self, other: &Self) -> bool {
-        self.len() == other.len() && self.into_iter().zip(other.into_iter()).all(|(s, o)| s == o)
+        self.len() == other.len() && self.iter().zip(other.iter()).all(|(s, o)| s == o)
     }
 }
 

--- a/ddcommon/src/cstr.rs
+++ b/ddcommon/src/cstr.rs
@@ -54,18 +54,18 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_invalid_cstr_with_extra_null_character() {
-        cstr!("/dev/null\0\0");
+        _ = cstr!("/dev/null\0\0");
     }
 
     #[test]
     #[should_panic]
     fn test_invalid_cstr_u8_without_terminatid_nul() {
-        cstr_u8!(b"/dev/null");
+        _ = cstr_u8!(b"/dev/null");
     }
 
     #[test]
     #[should_panic]
     fn test_invalid_cstr_with_nul_character() {
-        cstr!("/dev/\0null");
+        _ = cstr!("/dev/\0null");
     }
 }

--- a/ddtelemetry/src/metrics.rs
+++ b/ddtelemetry/src/metrics.rs
@@ -76,7 +76,7 @@ impl MetricBuckets {
         for (key, bucket) in self.buckets.drain() {
             self.series
                 .entry(key)
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push((timestamp, bucket.value()))
         }
     }

--- a/ipc/src/platform/unix/mod.rs
+++ b/ipc/src/platform/unix/mod.rs
@@ -126,7 +126,7 @@ mod tests {
         let mut handles = meta.drain_to_send();
         let second_batch = meta.drain_to_send();
 
-        handles.extend(second_batch.into_iter());
+        handles.extend(second_batch);
         assert_eq!(MAX_FDS * 2, handles.len());
         assert_eq!(0, meta.drain_to_send().len());
 

--- a/ipc/tarpc/tarpc/src/client.rs
+++ b/ipc/tarpc/tarpc/src/client.rs
@@ -242,7 +242,6 @@ where
 {
     let (to_dispatch, pending_requests) = mpsc::channel(config.pending_request_buffer);
     let (cancellation, canceled_requests) = cancellations();
-    let canceled_requests = canceled_requests;
 
     NewClient {
         client: Channel {
@@ -514,7 +513,6 @@ where
         // poll_next_request only returns Ready if there is room to buffer another request.
         // Therefore, we can call write_request without fear of erroring due to a full
         // buffer.
-        let request_id = request_id;
         let request = ClientMessage::Request(Request {
             id: request_id,
             message: request,

--- a/profiling/src/profile/mod.rs
+++ b/profiling/src/profile/mod.rs
@@ -959,22 +959,22 @@ mod api_test {
          */
         let mut profile = provide_distinct_locations();
 
-        let period = Some((
+        let period = (
             10_000_000,
             ValueType {
                 r#type: profile.intern("wall-time"),
                 unit: profile.intern("nanoseconds"),
             },
-        ));
-        profile.period = period;
+        );
+        profile.period = Some(period);
 
         let prev = profile.reset(None).expect("reset to succeed");
-        assert_eq!(period, prev.period);
+        assert_eq!(Some(period), prev.period);
 
         // Resolve the string values to check that they match (their string
         // table offsets may not match).
         let (value, period_type) = profile.period.expect("profile to have a period");
-        assert_eq!(value, period.unwrap().0);
+        assert_eq!(value, period.0);
         assert_eq!(profile.get_string(period_type.r#type), "wall-time");
         assert_eq!(profile.get_string(period_type.unit), "nanoseconds");
     }

--- a/sidecar/src/interface.rs
+++ b/sidecar/src/interface.rs
@@ -715,18 +715,14 @@ impl SidecarServer {
         // TODO: log errors
         let instance_option =
             if let Ok((handle, worker_join)) = builder.spawn_with_config(config.clone()).await {
-                tracing::info!("spawning worker {config:?}");
+                info!("spawning worker {config:?}");
 
                 let instance = AppInstance {
                     telemetry: handle,
                     telemetry_worker_shutdown: worker_join.map(Result::ok).boxed().shared(),
                 };
 
-                instance
-                    .telemetry
-                    .send_msgs(inital_actions.into_iter())
-                    .await
-                    .ok();
+                instance.telemetry.send_msgs(inital_actions).await.ok();
 
                 instance
                     .telemetry

--- a/trace-obfuscation/benches/credit_cards_bench.rs
+++ b/trace-obfuscation/benches/credit_cards_bench.rs
@@ -8,7 +8,7 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use datadog_trace_obfuscation::credit_cards::is_card_number;
 
 fn is_card_number_bench(c: &mut Criterion) {
-    let ccs = vec![
+    let ccs = [
         "378282246310005",
         "  378282246310005",
         "  3782-8224-6310-005 ",
@@ -27,7 +27,7 @@ fn is_card_number_bench(c: &mut Criterion) {
 }
 
 fn is_card_number_no_luhn_bench(c: &mut Criterion) {
-    let ccs = vec![
+    let ccs = [
         "378282246310005",
         "  378282246310005",
         "  3782-8224-6310-005 ",


### PR DESCRIPTION
# What does this PR do?

This fixes clippy lints that showed up on the recently released 1.72.0 toolchain.

# Motivation

CI was failing in another PR due to the new Rust release.

# Additional Notes

Nope.

# How to test the change?

Everything should work literally the same.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
