### PR TITLE
fix(profiling): TrimmedObservation should be Send

### DIFF
--- a/profiling/src/profile/internal/observation/trimmed_observation.rs
+++ b/profiling/src/profile/internal/observation/trimmed_observation.rs
@@ -37,6 +37,12 @@ pub(super) struct TrimmedObservation {
     data: *mut i64,
 }
 
+/// # Safety
+/// Since [TrimmedObservation] is essentially Box<[i64]> that's been shrunk
+/// down in size with no other semantic changes, and that type is [Send], then
+/// so is [TrimmedObservation].
+unsafe impl Send for TrimmedObservation {}
+
 impl TrimmedObservation {
     /// Safety: the ObservationLength must have come from the same profile as the Observation
     pub unsafe fn as_mut_slice(&mut self, len: ObservationLength) -> &mut [i64] {


### PR DESCRIPTION
# What does this PR do?

This implements `Send` for `TrimmedObservation` in profiling.

# Motivation

This broke the PHP profiler, which I found when trying to measure the latest round of changes.

# Additional Notes

I believe it's safe, but if you could think about my justification and see if it's bad, I would appreciate it.

# How to test the change?

Try to store or use a Profile in a context which requires `Send`, and notice it was broken, and now it's not. In the PHP profiler's case, it tried to send a profile through a crossbeam channel.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
