### PR TITLE
Profiler: Take timestamp as an explicit argument, rather than hiding in the label

### DIFF
--- a/examples/ffi/exporter.cpp
+++ b/examples/ffi/exporter.cpp
@@ -64,7 +64,7 @@ int main(int argc, char *argv[]) {
       .values = {&value, 1},
       .labels = {&label, 1},
   };
-  auto add_result = ddog_prof_Profile_add(profile.get(), sample);
+  auto add_result = ddog_prof_Profile_add(profile.get(), sample, 0);
   if (add_result.tag != DDOG_PROF_PROFILE_RESULT_OK) {
     print_error("Failed to add sample to profile: ", add_result.err);
     ddog_Error_drop(&add_result.err);

--- a/examples/ffi/profiles.c
+++ b/examples/ffi/profiles.c
@@ -40,7 +40,7 @@ int main(void) {
   for (int i = 0; i < 10000000; i++) {
     label.num = i;
 
-    ddog_prof_Profile_Result add_result = ddog_prof_Profile_add(&profile, sample);
+    ddog_prof_Profile_Result add_result = ddog_prof_Profile_add(&profile, sample, 0);
     if (add_result.tag != DDOG_PROF_PROFILE_RESULT_OK) {
       ddog_CharSlice message = ddog_Error_message(&add_result.err);
       fprintf(stderr, "%*s", (int)message.len, message.ptr);

--- a/profiling-ffi/src/profiles.rs
+++ b/profiling-ffi/src/profiles.rs
@@ -766,7 +766,7 @@ mod test {
                 labels: Slice::default(),
             };
 
-            let result = Result::from(ddog_prof_Profile_add(&mut profile, sample));
+            let result = Result::from(ddog_prof_Profile_add(&mut profile, sample, None));
             result.unwrap_err();
             ddog_prof_Profile_drop(&mut profile);
         }
@@ -809,7 +809,7 @@ mod test {
                 labels: Slice::from(&labels),
             };
 
-            Result::from(ddog_prof_Profile_add(&mut profile, sample)).unwrap();
+            Result::from(ddog_prof_Profile_add(&mut profile, sample, None)).unwrap();
             assert_eq!(
                 profile
                     .inner
@@ -819,7 +819,7 @@ mod test {
                 1
             );
 
-            Result::from(ddog_prof_Profile_add(&mut profile, sample)).unwrap();
+            Result::from(ddog_prof_Profile_add(&mut profile, sample, None)).unwrap();
             assert_eq!(
                 profile
                     .inner
@@ -884,7 +884,7 @@ mod test {
             labels: Slice::from(labels.as_slice()),
         };
 
-        Result::from(ddog_prof_Profile_add(&mut profile, main_sample)).unwrap();
+        Result::from(ddog_prof_Profile_add(&mut profile, main_sample, None)).unwrap();
         assert_eq!(
             profile
                 .inner
@@ -894,7 +894,7 @@ mod test {
             1
         );
 
-        Result::from(ddog_prof_Profile_add(&mut profile, test_sample)).unwrap();
+        Result::from(ddog_prof_Profile_add(&mut profile, test_sample, None)).unwrap();
         assert_eq!(
             profile
                 .inner

--- a/profiling-replayer/src/main.rs
+++ b/profiling-replayer/src/main.rs
@@ -162,7 +162,7 @@ fn main() -> anyhow::Result<()> {
         let mut depths: Vec<usize> = replayer
             .samples
             .iter()
-            .map(|sample| sample.locations.len())
+            .map(|(_, sample)| sample.locations.len())
             .collect();
 
         depths.sort();
@@ -183,8 +183,8 @@ fn main() -> anyhow::Result<()> {
     }
 
     let before = Instant::now();
-    for sample in samples {
-        outprof.add(sample)?;
+    for (timestamp, sample) in samples {
+        outprof.add(sample, timestamp)?;
     }
     let duration = before.elapsed();
 

--- a/profiling/examples/profiles.rs
+++ b/profiling/examples/profiles.rs
@@ -60,7 +60,7 @@ fn main() {
         .period(Some(period))
         .build();
 
-    match profile.add(sample) {
+    match profile.add(sample, None) {
         Ok(_) => {}
         Err(_) => exit(1),
     }

--- a/profiling/src/profile/mod.rs
+++ b/profiling/src/profile/mod.rs
@@ -234,14 +234,6 @@ impl Profile {
         })
     }
 
-    pub fn add_no_timestamp(&mut self, sample: api::Sample) -> anyhow::Result<()> {
-        assert_eq!(
-            sample.labels.iter().find(|l| l.key == "end_timestamp_ns"),
-            None
-        );
-        self.add(sample, None)
-    }
-
     pub fn add(&mut self, sample: api::Sample, timestamp: Option<Timestamp>) -> anyhow::Result<()> {
         anyhow::ensure!(
             sample.values.len() == self.sample_types.len(),
@@ -754,12 +746,12 @@ mod api_test {
         assert_eq!(profile.only_for_testing_num_aggregated_samples(), 0);
 
         profile
-            .add_no_timestamp(main_sample)
+            .add(main_sample, None)
             .expect("profile to not be full");
         assert_eq!(profile.only_for_testing_num_aggregated_samples(), 1);
 
         profile
-            .add_no_timestamp(test_sample)
+            .add(test_sample, None)
             .expect("profile to not be full");
         assert_eq!(profile.only_for_testing_num_aggregated_samples(), 2);
 
@@ -959,7 +951,7 @@ mod api_test {
             labels: vec![id_label],
         };
 
-        assert!(profile.add_no_timestamp(sample).is_err());
+        assert!(profile.add(sample, None).is_err());
     }
 
     #[test]
@@ -1010,9 +1002,9 @@ mod api_test {
             labels: vec![id2_label, other_label],
         };
 
-        profile.add_no_timestamp(sample1).expect("add to success");
+        profile.add(sample1, None).expect("add to success");
 
-        profile.add_no_timestamp(sample2).expect("add to success");
+        profile.add(sample2, None).expect("add to success");
 
         profile.add_endpoint(10, Cow::from("my endpoint"));
 
@@ -1166,7 +1158,7 @@ mod api_test {
             labels,
         };
 
-        profile.add_no_timestamp(sample).unwrap_err();
+        profile.add(sample, None).unwrap_err();
     }
 
     #[test]
@@ -1197,7 +1189,7 @@ mod api_test {
             labels: vec![id_label],
         };
 
-        profile.add_no_timestamp(sample1).expect("add to success");
+        profile.add(sample1, None).expect("add to success");
 
         let serialized_profile = pprof::Profile::try_from(&profile).unwrap();
 
@@ -1246,7 +1238,7 @@ mod api_test {
             labels: vec![],
         };
 
-        profile.add_no_timestamp(sample1).expect("add to success");
+        profile.add(sample1, None).expect("add to success");
 
         let upscaling_info = UpscalingInfo::Proportional { scale: 2.0 };
         let values_offset = vec![0];
@@ -1274,7 +1266,7 @@ mod api_test {
             labels: vec![],
         };
 
-        profile.add_no_timestamp(sample1).expect("add to success");
+        profile.add(sample1, None).expect("add to success");
 
         let upscaling_info = UpscalingInfo::Proportional { scale: 2.7 };
         let values_offset = vec![0];
@@ -1302,7 +1294,7 @@ mod api_test {
             labels: vec![],
         };
 
-        profile.add_no_timestamp(sample1).expect("add to success");
+        profile.add(sample1, None).expect("add to success");
 
         let upscaling_info = UpscalingInfo::Poisson {
             sum_value_offset: 1,
@@ -1334,7 +1326,7 @@ mod api_test {
             labels: vec![],
         };
 
-        profile.add_no_timestamp(sample1).expect("add to success");
+        profile.add(sample1, None).expect("add to success");
 
         let upscaling_info = UpscalingInfo::Poisson {
             sum_value_offset: 1,
@@ -1366,7 +1358,7 @@ mod api_test {
             labels: vec![],
         };
 
-        profile.add_no_timestamp(sample1).expect("add to success");
+        profile.add(sample1, None).expect("add to success");
 
         // invalid sampling_distance vaue
         let upscaling_info = UpscalingInfo::Poisson {
@@ -1436,8 +1428,8 @@ mod api_test {
             labels: vec![],
         };
 
-        profile.add_no_timestamp(sample1).expect("add to success");
-        profile.add_no_timestamp(sample2).expect("add to success");
+        profile.add(sample1, None).expect("add to success");
+        profile.add(sample2, None).expect("add to success");
 
         // upscale the first value and the last one
         let values_offset: Vec<usize> = vec![0, 2];
@@ -1492,8 +1484,8 @@ mod api_test {
             labels: vec![],
         };
 
-        profile.add_no_timestamp(sample1).expect("add to success");
-        profile.add_no_timestamp(sample2).expect("add to success");
+        profile.add(sample1, None).expect("add to success");
+        profile.add(sample2, None).expect("add to success");
 
         let mut values_offset: Vec<usize> = vec![0];
 
@@ -1537,7 +1529,7 @@ mod api_test {
             labels: vec![id_label],
         };
 
-        profile.add_no_timestamp(sample1).expect("add to success");
+        profile.add(sample1, None).expect("add to success");
 
         let values_offset: Vec<usize> = vec![0];
 
@@ -1593,7 +1585,7 @@ mod api_test {
             labels: vec![id_label],
         };
 
-        profile.add_no_timestamp(sample1).expect("add to success");
+        profile.add(sample1, None).expect("add to success");
 
         let upscaling_info = UpscalingInfo::Proportional { scale: 2.0 };
         let values_offset: Vec<usize> = vec![0];
@@ -1650,8 +1642,8 @@ mod api_test {
             labels: vec![],
         };
 
-        profile.add_no_timestamp(sample1).expect("add to success");
-        profile.add_no_timestamp(sample2).expect("add to success");
+        profile.add(sample1, None).expect("add to success");
+        profile.add(sample2, None).expect("add to success");
 
         let upscaling_info = UpscalingInfo::Proportional { scale: 2.0 };
         let values_offset: Vec<usize> = vec![0];
@@ -1721,8 +1713,8 @@ mod api_test {
             labels: vec![id_no_match_label, id_label2],
         };
 
-        profile.add_no_timestamp(sample1).expect("add to success");
-        profile.add_no_timestamp(sample2).expect("add to success");
+        profile.add(sample1, None).expect("add to success");
+        profile.add(sample2, None).expect("add to success");
 
         // add rule for the first sample on the 1st value
         let upscaling_info = UpscalingInfo::Proportional { scale: 2.0 };
@@ -1774,7 +1766,7 @@ mod api_test {
             labels: vec![id_label],
         };
 
-        profile.add_no_timestamp(sample1).expect("add to success");
+        profile.add(sample1, None).expect("add to success");
 
         // upscale samples and wall-time values
         let values_offset: Vec<usize> = vec![0, 1];
@@ -1810,7 +1802,7 @@ mod api_test {
             labels: vec![id_label],
         };
 
-        profile.add_no_timestamp(sample1).expect("add to success");
+        profile.add(sample1, None).expect("add to success");
 
         let upscaling_info = UpscalingInfo::Proportional { scale: 2.0 };
         let mut value_offsets: Vec<usize> = vec![0];
@@ -2082,7 +2074,7 @@ mod api_test {
             labels: vec![id_label],
         };
 
-        profile.add_no_timestamp(sample1).expect("add to success");
+        profile.add(sample1, None).expect("add to success");
 
         let mut value_offsets: Vec<usize> = vec![0, 1];
         // Add by-label rule first
@@ -2150,8 +2142,8 @@ mod api_test {
             labels: vec![id2_label],
         };
 
-        profile.add_no_timestamp(sample1).expect("add to success");
-        profile.add_no_timestamp(sample2).expect("add to success");
+        profile.add(sample1, None).expect("add to success");
+        profile.add(sample2, None).expect("add to success");
 
         profile.add_endpoint(10, Cow::from("endpoint 10"));
         profile.add_endpoint(large_span_id, Cow::from("large endpoint"));


### PR DESCRIPTION
# What does this PR do?

Changes the API for the profiler to take the timestamp explicitly

# Motivation

Currently, the client does the work of building a label with the timestamp, and adding it to the Labels on the sample.
libdatadog then finds that label, extracts the information, and removes it from the vector.  Making it a function argument is cleaner and clearer.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
