### PR TITLE
Reduce memory consumption by consuming the profile as we serialize it

### DIFF
--- a/examples/ffi/exporter.cpp
+++ b/examples/ffi/exporter.cpp
@@ -86,7 +86,7 @@ int main(int argc, char *argv[]) {
   }
 
   ddog_prof_Profile_SerializeResult serialize_result =
-      ddog_prof_Profile_serialize(profile.get(), nullptr, nullptr);
+      ddog_prof_Profile_serialize(profile.get(), nullptr, nullptr, nullptr);
   if (serialize_result.tag == DDOG_PROF_PROFILE_SERIALIZE_RESULT_ERR) {
     print_error("Failed to serialize profile: ", serialize_result.err);
     ddog_Error_drop(&serialize_result.err);

--- a/profiling-ffi/src/profiles.rs
+++ b/profiling-ffi/src/profiles.rs
@@ -658,6 +658,7 @@ impl From<profile::EncodedProfile> for EncodedProfile {
 }
 
 /// Serialize the aggregated profile.
+/// Drains the data, and then resets the profile for future use.
 ///
 /// Don't forget to clean up the ok with `ddog_prof_EncodedProfile_drop` or
 /// the error variant with `ddog_Error_drop` when you are done with them.
@@ -671,6 +672,7 @@ impl From<profile::EncodedProfile> for EncodedProfile {
 ///                      under anomalous conditions this may fail as system clocks can be adjusted,
 ///                      or the programmer accidentally passed an earlier time. The duration of
 ///                      the serialized profile will be set to zero for these cases.
+/// * `start_time` - Optional start time for the next profile.
 ///
 /// # Safety
 /// The `profile` must point to a valid profile object.
@@ -682,6 +684,7 @@ pub unsafe extern "C" fn ddog_prof_Profile_serialize(
     profile: *mut Profile,
     end_time: Option<&Timespec>,
     duration_nanos: Option<&i64>,
+    start_time: Option<&Timespec>,
 ) -> SerializeResult {
     let profile = match profile_ptr_to_inner(profile) {
         Ok(ok) => ok,
@@ -691,13 +694,22 @@ pub unsafe extern "C" fn ddog_prof_Profile_serialize(
             ))
         }
     };
+    let old_profile = match profile.reset(start_time.map(SystemTime::from)) {
+        Ok(ok) => ok,
+        Err(err) => {
+            return SerializeResult::Err(Error::from(
+                err.context("ddog_prof_Profile_serialize failed"),
+            ))
+        }
+    };
+
     let end_time = end_time.map(SystemTime::from);
     let duration = match duration_nanos {
         None => None,
         Some(x) if *x < 0 => None,
         Some(x) => Some(Duration::from_nanos((*x) as u64)),
     };
-    match profile.serialize(end_time, duration) {
+    match old_profile.serialize(end_time, duration) {
         Ok(ok) => SerializeResult::Ok(ok.into()),
         Err(err) => SerializeResult::Err(err.into()),
     }

--- a/profiling/src/collections/identifiable/mod.rs
+++ b/profiling/src/collections/identifiable/mod.rs
@@ -75,9 +75,9 @@ impl<T: Item> Dedup<T> for FxIndexSet<T> {
     }
 }
 
-pub fn to_pprof_vec<T: PprofItem>(collection: &FxIndexSet<T>) -> Vec<T::PprofMessage> {
+pub fn to_pprof_vec<T: PprofItem>(collection: FxIndexSet<T>) -> Vec<T::PprofMessage> {
     collection
-        .iter()
+        .into_iter()
         .enumerate()
         .map(|(index, item)| item.to_pprof(<T as Item>::Id::from_offset(index)))
         .collect()

--- a/profiling/src/collections/identifiable/mod.rs
+++ b/profiling/src/collections/identifiable/mod.rs
@@ -75,7 +75,7 @@ impl<T: Item> Dedup<T> for FxIndexSet<T> {
     }
 }
 
-pub fn to_pprof_vec<T: PprofItem>(collection: FxIndexSet<T>) -> Vec<T::PprofMessage> {
+pub fn into_pprof_vec<T: PprofItem>(collection: FxIndexSet<T>) -> Vec<T::PprofMessage> {
     collection
         .into_iter()
         .enumerate()

--- a/profiling/src/profile/internal/observation/observations.rs
+++ b/profiling/src/profile/internal/observation/observations.rs
@@ -83,6 +83,35 @@ impl Observations {
     }
 }
 
+pub struct ObservationsIntoIter {
+    it: Box<dyn Iterator<Item = <ObservationsIntoIter as IntoIterator>::Item>>,
+}
+
+impl Iterator for ObservationsIntoIter {
+    type Item = (Sample, Option<Timestamp>, Vec<i64>);
+    fn next(&mut self) -> Option<Self::Item> {
+        self.it.next()
+    }
+}
+
+impl IntoIterator for Observations {
+    type Item = (Sample, Option<Timestamp>, Vec<i64>);
+    type IntoIter = ObservationsIntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let it = self.inner.into_iter().flat_map(|mut observations| {
+            let td = std::mem::take(&mut observations.timestamped_data);
+            let ad = std::mem::take(&mut observations.aggregated_data);
+            let td_it = td.into_iter().map(|(s, t, o)| (s, Some(t), o));
+            let ad_it = ad.into_iter().map(|(s, o)| (s, None, o));
+            td_it
+                .chain(ad_it)
+                .map(move |(s, t, o)| (s, t, unsafe { o.into_vec(observations.obs_len) }))
+        });
+        ObservationsIntoIter { it: Box::new(it) }
+    }
+}
+
 impl Drop for NonEmptyObservations {
     fn drop(&mut self) {
         let o = self.obs_len;
@@ -294,4 +323,49 @@ mod test {
         // This should panic
         o.add(s1, None, vec![4, 5]);
     }
+
+    #[test]
+    fn into_iter_test() {
+        let mut o = Observations::default();
+        // These are only for test purposes. The only thing that matters is that
+        // they differ
+        let s1 = Sample {
+            labels: LabelSetId::from_offset(1),
+            stacktrace: StackTraceId::from_offset(1),
+        };
+        let s2 = Sample {
+            labels: LabelSetId::from_offset(2),
+            stacktrace: StackTraceId::from_offset(2),
+        };
+        let s3 = Sample {
+            labels: LabelSetId::from_offset(3),
+            stacktrace: StackTraceId::from_offset(3),
+        };
+        let t1 = Some(Timestamp::new(1).unwrap());
+
+        o.add(s1, None, vec![1, 2, 3]);
+        o.add(s1, None, vec![4, 5, 6]);
+        o.add(s2, None, vec![7, 8, 9]);
+        o.add(s3, t1, vec![1, 1, 2]);
+
+        let mut count = 0;
+        o.into_iter().for_each(|(k, ts, v)| {
+            count += 1;
+            if k == s1 {
+                assert!(ts.is_none());
+                assert_eq!(v, vec![5, 7, 9]);
+            } else if k == s2 {
+                assert!(ts.is_none());
+                assert_eq!(v, vec![7, 8, 9]);
+            } else if k == s3 {
+                assert_eq!(ts, t1);
+                assert_eq!(v, vec![1, 1, 2]);
+            } else {
+                panic!("Unexpected key");
+            }
+        });
+        // Two of the samples were aggregated, so three total samples at the end
+        assert_eq!(count, 3);
+    }
+
 }

--- a/profiling/src/profile/internal/observation/observations.rs
+++ b/profiling/src/profile/internal/observation/observations.rs
@@ -367,5 +367,4 @@ mod test {
         // Two of the samples were aggregated, so three total samples at the end
         assert_eq!(count, 3);
     }
-
 }

--- a/profiling/src/profile/internal/observation/trimmed_observation.rs
+++ b/profiling/src/profile/internal/observation/trimmed_observation.rs
@@ -96,6 +96,18 @@ impl TrimmedObservation {
             Box::from_raw(s)
         }
     }
+
+    /// Safety: the ObservationLength must have come from the same profile as the Observation
+    pub(super) unsafe fn into_vec(mut self, len: ObservationLength) -> Vec<i64> {
+        unsafe {
+            // We built this from a vec.  Put it back together again.
+            Vec::from_raw_parts(
+                mem::replace(&mut self.data, std::ptr::null_mut()),
+                len.0,
+                len.0,
+            )
+        }
+    }
 }
 
 impl Drop for TrimmedObservation {
@@ -168,6 +180,18 @@ mod test {
         unsafe {
             assert_eq!(t.as_slice(o), &vec![1, 2]);
             let b = t.into_boxed_slice(o);
+            assert_eq!(*b, vec![1, 2]);
+        }
+    }
+
+    #[test]
+    fn into_vec_test() {
+        let v = vec![1, 2];
+        let o = ObservationLength::new(2);
+        let t = TrimmedObservation::new(v, o);
+        unsafe {
+            assert_eq!(t.as_slice(o), &vec![1, 2]);
+            let b = t.into_vec(o);
             assert_eq!(*b, vec![1, 2]);
         }
     }

--- a/profiling/src/profile/internal/upscaling.rs
+++ b/profiling/src/profile/internal/upscaling.rs
@@ -143,12 +143,10 @@ impl UpscalingRules {
     // TODO: Consider whether to use the internal Label here instead
     pub fn upscale_values(
         &self,
-        values: &[i64],
+        values: &mut [i64],
         labels: &[pprof::Label],
         sample_types: &Vec<ValueType>,
-    ) -> anyhow::Result<Vec<i64>> {
-        let mut new_values = values.to_vec();
-
+    ) -> anyhow::Result<()> {
         if !self.is_empty() {
             let mut values_to_update: Vec<usize> = vec![0; sample_types.len()];
 
@@ -181,12 +179,12 @@ impl UpscalingRules {
                 rules.iter().for_each(|rule| {
                     let scale = rule.compute_scale(values);
                     rule.values_offset.iter().for_each(|offset| {
-                        new_values[*offset] = (new_values[*offset] as f64 * scale).round() as i64
+                        values[*offset] = (values[*offset] as f64 * scale).round() as i64
                     })
                 })
             });
         }
 
-        Ok(new_values)
+        Ok(())
     }
 }

--- a/profiling/src/profile/mod.rs
+++ b/profiling/src/profile/mod.rs
@@ -400,13 +400,13 @@ impl Profile {
     ///                may also accidentally pass an earlier time. The duration will be set to zero
     ///                these cases.
     pub fn serialize(
-        self,
+        mut self,
         end_time: Option<SystemTime>,
         duration: Option<Duration>,
     ) -> anyhow::Result<EncodedProfile> {
         let end = end_time.unwrap_or_else(SystemTime::now);
         let start = self.start_time;
-        let endpoints_stats = self.endpoints.stats.clone();
+        let endpoints_stats = std::mem::take(&mut self.endpoints.stats);
 
         let mut profile: pprof::Profile = self.try_into()?;
 
@@ -576,9 +576,9 @@ impl TryFrom<Profile> for pprof::Profile {
                 .map(pprof::ValueType::from)
                 .collect(),
             samples,
-            mappings: to_pprof_vec(profile.mappings),
-            locations: to_pprof_vec(profile.locations),
-            functions: to_pprof_vec(profile.functions),
+            mappings: into_pprof_vec(profile.mappings),
+            locations: into_pprof_vec(profile.locations),
+            functions: into_pprof_vec(profile.functions),
             string_table: profile.strings.into_iter().collect(),
             time_nanos: profile
                 .start_time


### PR DESCRIPTION
# What does this PR do?

Takes the `Profile` by ownership instead of borrow while serializing, allowing a more memory-efficient translation

# Motivation

Currently, we clone all values as we build the serializer.  Instead, we can take them by owned value, and save a lot of clones (and hence customer memory use)

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
