### PR TITLE
Use Cargo workspace properties and document MSRV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-normalization"
-version = "2.1.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "datadog-trace-protobuf",
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-obfuscation"
-version = "2.1.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-protobuf"
-version = "2.1.0"
+version = "4.0.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-utils"
-version = "2.1.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "datadog-trace-normalization",
@@ -2881,7 +2881,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "0.1.0"
+version = "4.0.0"
 dependencies = [
  "lazy_static",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ members = [
 # https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2
 resolver = "2"
 
+# These are used by many packages, but not all. For instance, the sidecar and
+# serverless packages wanted to maintain their own version numbers. Some of
+# their depenencies also remain under their own versioning.
 [workspace.package]
 rust-version = "1.69"
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,12 @@ members = [
 # https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2
 resolver = "2"
 
+[workspace.package]
+rust-version = "1.69"
+edition = "2021"
+version = "4.0.0"
+license = "Apache-2.0"
+
 [profile.dev]
 debug = 2 # full debug info
 

--- a/README.md
+++ b/README.md
@@ -29,4 +29,4 @@ bash build-profiling-ffi.sh /opt/libdatadog
 
 #### Build Dependencies
 
-Rust 1.60 or newer with cargo. Some platforms may need protoc; others have it shipped in prost-build.
+Rust 1.69 or newer with cargo. Some platforms may need protoc; others have it shipped in prost-build.

--- a/ddcommon-ffi/Cargo.toml
+++ b/ddcommon-ffi/Cargo.toml
@@ -3,9 +3,10 @@
 
 [package]
 name = "ddcommon-ffi"
-version = "4.0.0"
-edition = "2021"
-license = "Apache-2.0"
+edition.workspace = true
+version.workspace = true
+rust-version.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/ddcommon/Cargo.toml
+++ b/ddcommon/Cargo.toml
@@ -2,10 +2,11 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
 
 [package]
-edition = "2021"
-license = "Apache-2.0"
 name = "ddcommon"
-version = "4.0.0"
+edition.workspace = true
+version.workspace = true
+rust-version.workspace = true
+license.workspace = true
 
 [lib]
 crate-type = ["lib"]

--- a/ddtelemetry-ffi/Cargo.toml
+++ b/ddtelemetry-ffi/Cargo.toml
@@ -3,8 +3,10 @@
 
 [package]
 name = "ddtelemetry-ffi"
-version = "4.0.0"
-edition = "2021"
+edition.workspace = true
+version.workspace = true
+rust-version.workspace = true
+license.workspace = true
 
 [lib]
 crate-type = ["lib", "staticlib", "cdylib"]

--- a/ddtelemetry/Cargo.toml
+++ b/ddtelemetry/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
-edition = "2021"
-license = "Apache 2.0"
 name = "ddtelemetry"
-version = "4.0.0"
+edition.workspace = true
+version.workspace = true
+rust-version.workspace = true
+license.workspace = true
 
 [features]
 default = []

--- a/profiling-ffi/Cargo.toml
+++ b/profiling-ffi/Cargo.toml
@@ -3,9 +3,10 @@
 
 [package]
 name = "datadog-profiling-ffi"
-version = "4.0.0"
-edition = "2021"
-license = "Apache-2.0"
+edition.workspace = true
+version.workspace = true
+rust-version.workspace = true
+license.workspace = true
 
 [lib]
 # LTO is ignored if "lib" is added as crate type

--- a/profiling-replayer/Cargo.toml
+++ b/profiling-replayer/Cargo.toml
@@ -2,9 +2,10 @@
 name = "datadog-profiling-replayer"
 authors = ["Levi Morrison <levi.morrison@datadoghq.com>"]
 description = "Takes a pprof file and 'replays' it using libdatadog commands."
-version = "4.0.0"
-edition = "2021"
-license = "Apache-2.0"
+edition.workspace = true
+version.workspace = true
+rust-version.workspace = true
+license.workspace = true
 
 [dependencies]
 anyhow = "1.0"

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -3,9 +3,10 @@
 
 [package]
 name = "datadog-profiling"
-version = "4.0.0"
-edition = "2021"
-license = "Apache-2.0"
+edition.workspace = true
+version.workspace = true
+rust-version.workspace = true
+license.workspace = true
 
 [lib]
 crate-type = ["lib"]

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -3,8 +3,10 @@
 
 [package]
 name = "tools"
-version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+version.workspace = true
+rust-version.workspace = true
+license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/trace-normalization/Cargo.toml
+++ b/trace-normalization/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "datadog-trace-normalization"
-version = "2.1.0"
 authors = ["David Lee <david.lee@datadoghq.com>"]
-edition = "2021"
+edition.workspace = true
+version.workspace = true
+rust-version.workspace = true
+license.workspace = true
 
 [dependencies]
 anyhow = "1.0"

--- a/trace-obfuscation/Cargo.toml
+++ b/trace-obfuscation/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "datadog-trace-obfuscation"
-version = "2.1.0"
 authors = ["David Lee <david.lee@datadoghq.com>"]
-edition = "2021"
+edition.workspace = true
+version.workspace = true
+rust-version.workspace = true
+license.workspace = true
 
 [dependencies]
 anyhow = "1.0"

--- a/trace-protobuf/Cargo.toml
+++ b/trace-protobuf/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "datadog-trace-protobuf"
-version = "2.1.0"
 authors = ["David Lee <david.lee@datadoghq.com>"]
-edition = "2021"
+edition.workspace = true
+version.workspace = true
+rust-version.workspace = true
+license.workspace = true
 
 [dependencies]
 prost = "0.11.6"

--- a/trace-utils/Cargo.toml
+++ b/trace-utils/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "datadog-trace-utils"
-version = "2.1.0"
 authors = ["David Lee <david.lee@datadoghq.com>"]
-edition = "2021"
+edition.workspace = true
+version.workspace = true
+rust-version.workspace = true
+license.workspace = true
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
# What does this PR do?

This adds `workspace.package` to the root `Cargo.toml`:

```rs
rust-version = "1.69"
edition = "2021"
version = "4.0.0"
license = "Apache-2.0"
```

# Motivation

This allows changing things in fewer places. I hope to make changing the minimum supported rust version (MSRV), edition, and libdatadog version easier.

# Additional Notes

Not every crate inherits these new properties. The serverless and sidecar crates, and some of their dependencies, have remained under their own versioning and control.

# How to test the change?

Regular tests should apply. This shouldn't change any behavior.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
