### PR TITLE
refactor!(profiling-ffi): ddog_prof_Profile_new can fail

### DIFF
--- a/ddcommon-ffi/src/vec.rs
+++ b/ddcommon-ffi/src/vec.rs
@@ -21,6 +21,10 @@ pub struct Vec<T: Sized> {
     _marker: PhantomData<T>,
 }
 
+unsafe impl<T: Send> Send for Vec<T> {}
+
+unsafe impl<T: Sync> Sync for Vec<T> {}
+
 impl<T: PartialEq> PartialEq for Vec<T> {
     fn eq(&self, other: &Self) -> bool {
         self.len() == other.len() && self.iter().zip(other.iter()).all(|(s, o)| s == o)

--- a/examples/ffi/profiles.c
+++ b/examples/ffi/profiles.c
@@ -6,6 +6,7 @@
 #include <datadog/common.h>
 #include <datadog/profiling.h>
 #include <stdio.h>
+#include <stdlib.h>
 
 int main(void) {
   const ddog_prof_ValueType wall_time = {
@@ -15,7 +16,14 @@ int main(void) {
   const ddog_prof_Slice_ValueType sample_types = {&wall_time, 1};
   const ddog_prof_Period period = {wall_time, 60};
 
-  ddog_prof_Profile profile = ddog_prof_Profile_new(sample_types, &period, NULL);
+  ddog_prof_Profile_NewResult new_result = ddog_prof_Profile_new(sample_types, &period, NULL);
+  if (new_result.tag != DDOG_PROF_PROFILE_NEW_RESULT_OK) {
+    ddog_CharSlice message = ddog_Error_message(&new_result.err);
+    fprintf(stderr, "%*s", (int)message.len, message.ptr);
+    exit(EXIT_FAILURE);
+  }
+
+  ddog_prof_Profile *profile = &new_result.ok;
 
   ddog_prof_Location root_location = {
       // yes, a zero-initialized mapping is valid
@@ -40,7 +48,7 @@ int main(void) {
   for (int i = 0; i < 10000000; i++) {
     label.num = i;
 
-    ddog_prof_Profile_Result add_result = ddog_prof_Profile_add(&profile, sample, 0);
+    ddog_prof_Profile_Result add_result = ddog_prof_Profile_add(profile, sample, 0);
     if (add_result.tag != DDOG_PROF_PROFILE_RESULT_OK) {
       ddog_CharSlice message = ddog_Error_message(&add_result.err);
       fprintf(stderr, "%*s", (int)message.len, message.ptr);
@@ -51,13 +59,13 @@ int main(void) {
   //   printf("Press any key to reset and drop...");
   //   getchar();
 
-  ddog_prof_Profile_Result reset_result = ddog_prof_Profile_reset(&profile, NULL);
+  ddog_prof_Profile_Result reset_result = ddog_prof_Profile_reset(profile, NULL);
   if (reset_result.tag != DDOG_PROF_PROFILE_RESULT_OK) {
     ddog_CharSlice message = ddog_Error_message(&reset_result.err);
     fprintf(stderr, "%*s", (int)message.len, message.ptr);
     ddog_Error_drop(&reset_result.err);
   }
-  ddog_prof_Profile_drop(&profile);
+  ddog_prof_Profile_drop(profile);
 
   printf("Press any key to exit...");
   getchar();

--- a/profiling-ffi/cbindgen.toml
+++ b/profiling-ffi/cbindgen.toml
@@ -34,8 +34,9 @@ renaming_overrides_prefixing = true
 
 "ExporterNewResult" = "ddog_prof_Exporter_NewResult"
 "File" = "ddog_prof_Exporter_File"
-"ProfileResult" = "ddog_prof_Profile_Result"
 "ProfileExporter" = "ddog_prof_Exporter"
+"ProfileNewResult" = "ddog_prof_Profile_NewResult"
+"ProfileResult" = "ddog_prof_Profile_Result"
 "Request" = "ddog_prof_Exporter_Request"
 "RequestBuildResult" = "ddog_prof_Exporter_Request_BuildResult"
 "SendResult" = "ddog_prof_Exporter_SendResult"


### PR DESCRIPTION
# What does this PR do?

`ddog_prof_Profile_new` now returns a `ddog_prof_Profile_NewResult` instead of a `ddog_prof_Profile`.

# Motivation

Currently, this routine doesn't fail. In the future, it's expected to be possible to fail, so we want to get clients to be prepared for it since we're also shipping breaking changes in v5.0.0 already.

# Additional Notes

None.

# How to test the change?

Adapt to the above change and test as usual otherwise. Note that currently it cannot fail, but do not rely on that. Add proper error handling.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
