### PR TITLE
Integrate Sql Obfuscator (sql obfuscation 3/3)

### DIFF
--- a/trace-obfuscation/src/obfuscate.rs
+++ b/trace-obfuscation/src/obfuscate.rs
@@ -36,7 +36,7 @@ pub fn obfuscate_span(span: &mut pb::Span, config: &ObfuscationConfig) {
             if span.resource.is_empty() {
                 return;
             }
-            let sql_obfuscation_result = obfuscate_sql_string(&span.resource, false);
+            let sql_obfuscation_result = obfuscate_sql_string(&span.resource, config);
             if let Some(err) = sql_obfuscation_result.error {
                 debug!(
                     "Error parsing SQL query: {}. Resource: {}",
@@ -122,6 +122,8 @@ mod tests {
             http_remove_query_string: false,
             http_remove_path_digits: false,
             obfuscate_memcached: false,
+            sql_replace_digits: false,
+            sql_literal_escapes: false,
         };
         obfuscate_span(&mut span, &obf_config);
         assert_eq!(span.resource, "SELECT username from users where id = ?");

--- a/trace-obfuscation/src/obfuscate.rs
+++ b/trace-obfuscation/src/obfuscate.rs
@@ -33,7 +33,7 @@ pub fn obfuscate_span(span: &mut pb::Span, config: &ObfuscationConfig) {
             }
         }
         "sql" | "cassandra" => {
-            if span.resource.is_empty() {
+            if span.resource.is_empty() || !config.obfuscate_sql {
                 return;
             }
             let sql_obfuscation_result = obfuscate_sql_string(&span.resource, config);
@@ -78,6 +78,7 @@ mod tests {
             http_remove_query_string: true,
             http_remove_path_digits: true,
             obfuscate_memcached: false,
+            obfuscate_sql: false,
             sql_replace_digits: false,
             sql_literal_escapes: false,
         };
@@ -103,6 +104,7 @@ mod tests {
             http_remove_query_string: false,
             http_remove_path_digits: false,
             obfuscate_memcached: false,
+            obfuscate_sql: false,
             sql_replace_digits: false,
             sql_literal_escapes: false,
         };
@@ -122,6 +124,7 @@ mod tests {
             http_remove_query_string: false,
             http_remove_path_digits: false,
             obfuscate_memcached: false,
+            obfuscate_sql: true,
             sql_replace_digits: false,
             sql_literal_escapes: false,
         };

--- a/trace-obfuscation/src/obfuscation_config.rs
+++ b/trace-obfuscation/src/obfuscation_config.rs
@@ -14,6 +14,7 @@ pub struct ObfuscationConfig {
     pub http_remove_query_string: bool,
     pub http_remove_path_digits: bool,
     pub obfuscate_memcached: bool,
+    pub obfuscate_sql: bool,
     pub sql_replace_digits: bool,
     pub sql_literal_escapes: bool,
 }
@@ -41,11 +42,15 @@ impl ObfuscationConfig {
         let obfuscate_memcached =
             parse_env::bool("DD_APM_OBFUSCATION_MEMCACHED_ENABLED").unwrap_or(false);
 
+        let obfuscate_sql =
+            parse_env::bool("DD_APM_OBFUSCATION_SQL_ENABLED").unwrap_or(true);
+
         Ok(ObfuscationConfig {
             tag_replace_rules,
             http_remove_query_string,
             http_remove_path_digits,
             obfuscate_memcached,
+            obfuscate_sql,
             sql_replace_digits: false,
             sql_literal_escapes: false,
         })

--- a/trace-obfuscation/src/obfuscation_config.rs
+++ b/trace-obfuscation/src/obfuscation_config.rs
@@ -42,8 +42,7 @@ impl ObfuscationConfig {
         let obfuscate_memcached =
             parse_env::bool("DD_APM_OBFUSCATION_MEMCACHED_ENABLED").unwrap_or(false);
 
-        let obfuscate_sql =
-            parse_env::bool("DD_APM_OBFUSCATION_SQL_ENABLED").unwrap_or(true);
+        let obfuscate_sql = parse_env::bool("DD_APM_OBFUSCATION_SQL_ENABLED").unwrap_or(true);
 
         Ok(ObfuscationConfig {
             tag_replace_rules,

--- a/trace-obfuscation/src/sql.rs
+++ b/trace-obfuscation/src/sql.rs
@@ -1305,6 +1305,7 @@ LIMIT 1
             http_remove_query_string: false,
             http_remove_path_digits: false,
             obfuscate_memcached: false,
+            obfuscate_sql: true,
             sql_replace_digits: replace_digits,
             sql_literal_escapes: false,
         };


### PR DESCRIPTION
# What does this PR do?

integrates the sql obfuscator into trace span obfuscation. PR 3/3 for sql trace obfuscation

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Future work includes:
- store `literal_escapes` config val in a modifiable mutex, so the obfuscator can switch default behavior if it detects backslashes are being treated as characters, rather then escapes
- add postgres & sql server specific logic & unit tests
- add the ability to replace digits only in specific tables
-  

# How to test the change?

Describe here in detail how the change can be validated.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
