### PR TITLE
Json Obfuscator

### DIFF
--- a/trace-obfuscation/src/json.rs
+++ b/trace-obfuscation/src/json.rs
@@ -108,7 +108,7 @@ mod tests {
                   "post_tags": [ "?" ],
                   "index": "?"
                 }
-              }).to_string()];
+              })];
         ]
         [
             test_name       [test_obfuscate_json_3]

--- a/trace-obfuscation/src/json.rs
+++ b/trace-obfuscation/src/json.rs
@@ -9,7 +9,7 @@ use serde_json::{json, Value};
 
 use crate::{obfuscation_config::ObfuscationConfig, sql::obfuscate_sql_string};
 
-pub fn obfuscate_json(
+pub fn obfuscate_json_string(
     config: &ObfuscationConfig,
     json_str: &str,
     keep_values: Vec<String>,
@@ -79,7 +79,7 @@ mod tests {
 
     use crate::obfuscation_config::ObfuscationConfig;
 
-    use super::obfuscate_json;
+    use super::obfuscate_json_string;
 
     fn parse_test_args(argv: Vec<&str>) -> Vec<String> {
         argv.iter().map(|&s| s.to_string()).collect::<Vec<String>>()
@@ -501,7 +501,7 @@ mod tests {
             sql_replace_digits: false,
             sql_literal_escapes: false,
         };
-        let result = obfuscate_json(
+        let result = obfuscate_json_string(
             &config,
             input.to_string().as_str(),
             parse_test_args(keep_values),
@@ -992,7 +992,7 @@ mod tests {
             sql_replace_digits: false,
             sql_literal_escapes: false,
         };
-        let result = obfuscate_json(
+        let result = obfuscate_json_string(
             &config,
             input.to_string().as_str(),
             parse_test_args(keep_values),

--- a/trace-obfuscation/src/json.rs
+++ b/trace-obfuscation/src/json.rs
@@ -65,28 +65,20 @@ mod tests {
 
     use super::obfuscate_json;
 
-    macro_rules! vec_of_strings {
-        ( $( $x:expr ),* ) => {
-            {
-                let mut temp_vec = Vec::new();
-                $(
-                    temp_vec.push($x.to_string());
-                )*
-                temp_vec
-            }
-        };
+    fn parse_test_args(argv: Vec<&str>) -> Vec<String> {
+        argv.iter().map(|&s| s.to_string()).collect::<Vec<String>>()
     }
 
     #[duplicate_item(
         [
             test_name       [test_obfuscate_json_1]
-            keep_values     [vec_of_strings![]]
+            keep_values     [vec![]]
             input           [json!( { "query": { "multi_match" : { "query" : "guide", "fields" : ["_all", { "key": "value", "other": ["1", "2", {"k": "v"}] }, "2"] } } } )]
             expected        [json!( { "query": { "multi_match": { "query": "?", "fields" : ["?", { "key": "?", "other": ["?", "?", {"k": "?"}] }, "?"] } } } )];
         ]
         [
             test_name       [test_obfuscate_json_2]
-            keep_values     [vec_of_strings![]]
+            keep_values     [vec![]]
             input           [json!({
                 "highlight": {
                   "pre_tags": [ "<em>" ],
@@ -104,31 +96,31 @@ mod tests {
         ]
         [
             test_name       [test_obfuscate_json_3]
-            keep_values     [vec_of_strings!["other"]]
+            keep_values     [vec!["other"]]
             input           [json!( { "query": { "multi_match" : { "query" : "guide", "fields" : ["_all", { "key": "value", "other": ["1", "2", {"k": "v"}] }, "2"] } } } )]
             expected        [json!( { "query": { "multi_match": { "query": "?", "fields" : ["?", { "key": "?", "other": ["1", "2", {"k": "v"}] }, "?"] } } } )];
         ]
         [
             test_name       [test_obfuscate_json_4]
-            keep_values     [vec_of_strings!["fields"]]
+            keep_values     [vec!["fields"]]
             input           [json!( {"fields" : ["_all", { "key": "value", "other": ["1", "2", {"k": "v"}] }, "2"]} )]
             expected        [json!( {"fields" : ["_all", { "key": "value", "other": ["1", "2", {"k": "v"}] }, "2"]} )];
         ]
         [
             test_name       [test_obfuscate_json_5]
-            keep_values     [vec_of_strings!["k"]]
+            keep_values     [vec!["k"]]
             input           [json!( {"fields" : ["_all", { "key": "value", "other": ["1", "2", {"k": "v"}] }, "2"]} )]
             expected        [json!( {"fields" : ["?", { "key": "?", "other": ["?", "?", {"k": "v"}] }, "?"]} )];
         ]
         [
             test_name       [test_obfuscate_json_6]
-            keep_values     [vec_of_strings!["C"]]
+            keep_values     [vec!["C"]]
             input           [json!( {"fields" : [{"A": 1, "B": {"C": 3}}, "2"]} )]
             expected        [json!( {"fields" : [{"A": "?", "B": {"C": 3}}, "?"]} )];
         ]
         [
             test_name       [test_obfuscate_json_7]
-            keep_values     [vec_of_strings![]]
+            keep_values     [vec![]]
             input           [json!( {
                 "query": {
                    "match" : {
@@ -162,7 +154,7 @@ mod tests {
         ]
         [
             test_name       [test_obfuscate_json_8]
-            keep_values     [vec_of_strings!["_source"]]
+            keep_values     [vec!["_source"]]
             input           [json!( {
                 "query": {
                    "match" : {
@@ -196,7 +188,7 @@ mod tests {
         ]
         [
             test_name       [test_obfuscate_json_9]
-            keep_values     [vec_of_strings!["query"]]
+            keep_values     [vec!["query"]]
             input           [json!( {
                 "query": {
                    "match" : {
@@ -230,7 +222,7 @@ mod tests {
         ]
         [
             test_name       [test_obfuscate_json_10]
-            keep_values     [vec_of_strings!["match"]]
+            keep_values     [vec!["match"]]
             input           [json!( {
                 "query": {
                    "match" : {
@@ -264,7 +256,7 @@ mod tests {
         ]
         [
             test_name       [test_obfuscate_json_11]
-            keep_values     [vec_of_strings!["hits"]]
+            keep_values     [vec!["hits"]]
             input           [json!( {
                 "outer": {
                     "total": 2,
@@ -348,7 +340,7 @@ mod tests {
         ]
         [
             test_name       [test_obfuscate_json_12]
-            keep_values     [vec_of_strings!["_index", "title"]]
+            keep_values     [vec!["_index", "title"]]
             input           [json!( {
                 "hits": {
                     "total": 2,
@@ -432,7 +424,7 @@ mod tests {
         ]
         [
             test_name       [test_obfuscate_json_13]
-            keep_values     [vec_of_strings!["_source"]]
+            keep_values     [vec!["_source"]]
             input           [json!( {
                 "query": {
                   "bool": {
@@ -493,36 +485,36 @@ mod tests {
             sql_replace_digits: false,
             sql_literal_escapes: false,
         };
-        let result = obfuscate_json(&config, input.to_string().as_str(), keep_values, vec_of_strings![]);
+        let result = obfuscate_json(&config, input.to_string().as_str(), parse_test_args(keep_values), vec![]);
         assert_eq!(result, expected.to_string());
     }
 
     #[duplicate_item(
         [
             test_name       [test_obfuscate_json_sql_queries_1]
-            keep_values     [vec_of_strings!["hello"]]
-            sql_values      [vec_of_strings!["query"]]
+            keep_values     [vec!["hello"]]
+            sql_values      [vec!["query"]]
             input           [json!( {"query": "select * from table where id = 2", "hello": "world", "hi": "there"} )]
             expected        [json!( {"query": "select * from table where id = ?", "hello": "world", "hi": "?"} )];
         ]
         [
             test_name       [test_obfuscate_json_sql_queries_2]
-            keep_values     [vec_of_strings![]]
-            sql_values      [vec_of_strings!["object"]]
+            keep_values     [vec![]]
+            sql_values      [vec!["object"]]
             input           [json!( {"object": {"not a": "query"}} )]
             expected        [json!( {"object": {"not a": "?"}} )];
         ]
         [
             test_name       [test_obfuscate_json_sql_queries_3]
-            keep_values     [vec_of_strings![]]
-            sql_values      [vec_of_strings!["object"]]
+            keep_values     [vec![]]
+            sql_values      [vec!["object"]]
             input           [json!( {"object": ["not", "a", "query"]} )]
             expected        [json!( {"object": ["?", "?", "?"]} )];
         ]
         [
             test_name       [test_obfuscate_json_sql_queries_4]
-            keep_values     [vec_of_strings!["select_id", "using_filesort", "table_name", "access_type", "possible_keys", "key", "key_length", "used_key_parts", "used_columns", "ref", "update"]]
-            sql_values      [vec_of_strings!["attached_condition"]]
+            keep_values     [vec!["select_id", "using_filesort", "table_name", "access_type", "possible_keys", "key", "key_length", "used_key_parts", "used_columns", "ref", "update"]]
+            sql_values      [vec!["attached_condition"]]
             input           [json!( {
                 "query_block": {
                   "select_id": 1,
@@ -606,8 +598,8 @@ mod tests {
         ]
         [
             test_name       [test_obfuscate_json_sql_queries_5]
-            keep_values     [vec_of_strings!["Loops", "Actual Rows", "Actual Startup Time", "Actual Total Time", "Alias", "Async Capable", "Average Sort Space Used", "Cache Evictions", "Cache Hits", "Cache Misses", "Cache Overflows", "Calls", "Command", "Conflict Arbiter Indexes", "Conflict Resolution", "Conflicting Tuples", "Constraint Name", "CTE Name", "Custom Plan Provider", "Deforming", "Emission", "Exact Heap Blocks", "Execution Time", "Expressions", "Foreign Delete", "Foreign Insert", "Foreign Update", "Full-sort Groups", "Function Call", "Function Name", "Generation", "Group Count", "Grouping Sets", "Group Key", "HashAgg Batches", "Hash Batches", "Hash Buckets", "Heap Fetches", "I/O Read Time", "I/O Write Time", "Index Name", "Inlining", "Join Type", "Local Dirtied Blocks", "Local Hit Blocks", "Local Read Blocks", "Local Written Blocks", "Lossy Heap Blocks", "Node Type", "Optimization", "Original Hash Batches", "Original Hash Buckets", "Parallel Aware", "Parent Relationship", "Partial Mode", "Peak Memory Usage", "Peak Sort Space Used", "Planned Partitions", "Planning Time", "Pre-sorted Groups", "Presorted Key", "Query Identifier", "Plan Rows", "Plan Width", "Relation Name", "Rows Removed by Conflict Filter", "Rows Removed by Filter", "Rows Removed by Index Recheck", "Rows Removed by Join Filter", "Sampling Method", "Scan Direction", "Schema", "Settings", "Shared Dirtied Blocks", "Shared Hit Blocks", "Shared Read Blocks", "Shared Written Blocks", "Single Copy", "Sort Key", "Sort Method", "Sort Methods Used", "Sort Space", "Sort Space Type", "Sort Space Used", "Startup Cost", "Strategy", "Subplan Name", "Subplans Removed", "Target Tables", "Temp Read Blocks", "Temp Written Blocks", "Time", "Timing", "Total", "Trigger", "Trigger Name", "Triggers", "Tuples Inserted", "Tuplestore Name", "Total Cost", "WAL Bytes", "WAL FPI", "WAL Records", "Worker", "Worker Number", "Workers", "Workers Launched", "Workers Planned"]]
-            sql_values      [vec_of_strings!["Cache Key", "Conflict Filter", "Filter", "Hash Cond", "Index Cond", "Join Filter", "Merge Cond", "Output", "Recheck Cond", "Repeatable Seed", "Sampling Parameters", "TID Cond"]]
+            keep_values     [vec!["Loops", "Actual Rows", "Actual Startup Time", "Actual Total Time", "Alias", "Async Capable", "Average Sort Space Used", "Cache Evictions", "Cache Hits", "Cache Misses", "Cache Overflows", "Calls", "Command", "Conflict Arbiter Indexes", "Conflict Resolution", "Conflicting Tuples", "Constraint Name", "CTE Name", "Custom Plan Provider", "Deforming", "Emission", "Exact Heap Blocks", "Execution Time", "Expressions", "Foreign Delete", "Foreign Insert", "Foreign Update", "Full-sort Groups", "Function Call", "Function Name", "Generation", "Group Count", "Grouping Sets", "Group Key", "HashAgg Batches", "Hash Batches", "Hash Buckets", "Heap Fetches", "I/O Read Time", "I/O Write Time", "Index Name", "Inlining", "Join Type", "Local Dirtied Blocks", "Local Hit Blocks", "Local Read Blocks", "Local Written Blocks", "Lossy Heap Blocks", "Node Type", "Optimization", "Original Hash Batches", "Original Hash Buckets", "Parallel Aware", "Parent Relationship", "Partial Mode", "Peak Memory Usage", "Peak Sort Space Used", "Planned Partitions", "Planning Time", "Pre-sorted Groups", "Presorted Key", "Query Identifier", "Plan Rows", "Plan Width", "Relation Name", "Rows Removed by Conflict Filter", "Rows Removed by Filter", "Rows Removed by Index Recheck", "Rows Removed by Join Filter", "Sampling Method", "Scan Direction", "Schema", "Settings", "Shared Dirtied Blocks", "Shared Hit Blocks", "Shared Read Blocks", "Shared Written Blocks", "Single Copy", "Sort Key", "Sort Method", "Sort Methods Used", "Sort Space", "Sort Space Type", "Sort Space Used", "Startup Cost", "Strategy", "Subplan Name", "Subplans Removed", "Target Tables", "Temp Read Blocks", "Temp Written Blocks", "Time", "Timing", "Total", "Trigger", "Trigger Name", "Triggers", "Tuples Inserted", "Tuplestore Name", "Total Cost", "WAL Bytes", "WAL FPI", "WAL Records", "Worker", "Worker Number", "Workers", "Workers Launched", "Workers Planned"]]
+            sql_values      [vec!["Cache Key", "Conflict Filter", "Filter", "Hash Cond", "Index Cond", "Join Filter", "Merge Cond", "Output", "Recheck Cond", "Repeatable Seed", "Sampling Parameters", "TID Cond"]]
             input           [json!( {
                 "Plan": {
                   "Node Type": "Aggregate",
@@ -979,7 +971,7 @@ mod tests {
             sql_replace_digits: false,
             sql_literal_escapes: false,
         };
-        let result = obfuscate_json(&config, input.to_string().as_str(), keep_values, sql_values);
+        let result = obfuscate_json(&config, input.to_string().as_str(), parse_test_args(keep_values), parse_test_args(sql_values));
         assert_eq!(result, expected.to_string());
     }
 }

--- a/trace-obfuscation/src/json.rs
+++ b/trace-obfuscation/src/json.rs
@@ -27,22 +27,16 @@ pub fn obfuscate_json_string(
     let empty_vec = Vec::new();
 
     let json_keep_values = match obfuscation_type {
-        JSONObfuscationType::MongoDB => {
-            config.mongodb_keep_values.as_ref()
-        }
-        JSONObfuscationType::Elasticsearch => {
-            config.elasticsearch_keep_values.as_ref()
-        }
-    }.unwrap_or(&empty_vec);
+        JSONObfuscationType::MongoDB => config.mongodb_keep_values.as_ref(),
+        JSONObfuscationType::Elasticsearch => config.elasticsearch_keep_values.as_ref(),
+    }
+    .unwrap_or(&empty_vec);
 
     let json_sql_values = match obfuscation_type {
-        JSONObfuscationType::MongoDB => {
-            config.mongodb_obfuscate_sql_values.as_ref()
-        }
-        JSONObfuscationType::Elasticsearch => {
-            config.elasticsearch_obfuscate_sql_values.as_ref()
-        }
-    }.unwrap_or(&empty_vec);
+        JSONObfuscationType::MongoDB => config.mongodb_obfuscate_sql_values.as_ref(),
+        JSONObfuscationType::Elasticsearch => config.elasticsearch_obfuscate_sql_values.as_ref(),
+    }
+    .unwrap_or(&empty_vec);
 
     recurse_and_replace_json(
         config,
@@ -102,7 +96,7 @@ mod tests {
     use duplicate::duplicate_item;
     use serde_json::json;
 
-    use crate::{obfuscation_config::ObfuscationConfig, json::JSONObfuscationType};
+    use crate::{json::JSONObfuscationType, obfuscation_config::ObfuscationConfig};
 
     use super::obfuscate_json_string;
 

--- a/trace-obfuscation/src/json.rs
+++ b/trace-obfuscation/src/json.rs
@@ -1,0 +1,501 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present
+// Datadog, Inc.
+
+use std::collections::HashSet;
+
+use serde_json::{json, Value};
+
+pub fn obfuscate_json(json_str: &str, keep_values: Vec<String>) -> String {
+    let mut json_dict: Value = serde_json::from_str(json_str).unwrap_or_default();
+    if json_dict.is_null() {
+        return "?".to_string();
+    }
+    recurse_and_replace_json(&mut json_dict, &HashSet::from_iter(keep_values));
+
+    json_dict.to_string()
+}
+
+fn recurse_and_replace_json(value: &mut Value, keep_values: &HashSet<String>) {
+    match value {
+        Value::Object(map) => {
+            for (k, v) in map {
+                if !keep_values.contains(k) {
+                    if !v.is_array() && !v.is_object() {
+                        *v = json!("?");
+                    }
+                    recurse_and_replace_json(v, keep_values);
+                }
+            }
+        }
+        Value::Array(arr) => {
+            for (_, v) in arr.iter_mut().enumerate() {
+                if !v.is_array() && !v.is_object() {
+                    *v = json!("?");
+                }
+                recurse_and_replace_json(v, keep_values);
+            }
+        }
+        _ => (),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use duplicate::duplicate_item;
+    use serde_json::json;
+
+    use super::obfuscate_json;
+
+    #[duplicate_item(
+        [
+            test_name       [test_obfuscate_json_1]
+            keep_values     [vec!["other".to_string()]]
+            input           [json!({
+                "query": {
+                    "multi_match": {
+                        "query": "guide",
+                        "fields": [
+                            "_all",
+                            {
+                                "key": "value",
+                                "other": ["1", "2", {"k": "v"}]
+                            },
+                            "2"
+                            ],
+                    }
+                }
+            })]
+            expected        [json!({
+                "query": {
+                    "multi_match": {
+                        "query": "?",
+                        "fields": [
+                            "?",
+                            {
+                                "key": "?",
+                                "other": ["1", "2", {"k": "v"}]
+                            },
+                            "?"
+                            ],
+                    }
+                }
+            }).to_string()];
+        ]
+        [
+            test_name       [test_obfuscate_json_2]
+            keep_values     [vec![]]
+            input           [json!({
+                "highlight": {
+                    "pre_tags": [ "<em>" ],
+                    "post_tags": [ "</em>" ],
+                    "index": 1
+                }
+            })]
+            expected        [json!({
+                "highlight": {
+                    "pre_tags": [ "?" ],
+                    "post_tags": [ "?" ],
+                    "index": "?"
+                }
+            }).to_string()];
+        ]
+        [
+            test_name       [test_obfuscate_json_3]
+            keep_values     [vec!["other".to_string()]]
+            input           [json!({ "query": { "multi_match" : { "query" : "guide", "fields" : ["_all", { "key": "value", "other": ["1", "2", {"k": "v"}] }, "2"] } } } )]
+            expected        [json!({ "query": { "multi_match": { "query": "?", "fields" : ["?", { "key": "?", "other": ["1", "2", {"k": "v"}] }, "?"] } } }).to_string()];
+        ]
+        [
+            test_name       [test_obfuscate_json_4]
+            keep_values     [vec!["fields".to_string()]]
+            input           [json!({"fields" : ["_all", { "key": "value", "other": ["1", "2", {"k": "v"}] }, "2"]})]
+            expected        [json!({"fields" : ["_all", { "key": "value", "other": ["1", "2", {"k": "v"}] }, "2"]}).to_string()];
+        ]
+        [
+            test_name       [test_obfuscate_json_5]
+            keep_values     [vec!["k".to_string()]]
+            input           [json!({"fields" : ["_all", { "key": "value", "other": ["1", "2", {"k": "v"}] }, "2"]})]
+            expected        [json!({"fields" : ["?", { "key": "?", "other": ["?", "?", {"k": "v"}] }, "?"]}).to_string()];
+        ]
+        [
+            test_name       [test_obfuscate_json_6]
+            keep_values     [vec!["C".to_string()]]
+            input           [json!({"fields" : [{"A": 1, "B": {"C": 3}}, "2"]})]
+            expected        [json!({"fields" : [{"A": "?", "B": {"C": 3}}, "?"]}).to_string()];
+        ]
+        [
+            test_name       [test_obfuscate_json_7]
+            keep_values     [vec![]]
+            input           [json!({
+                "query": {
+                   "match" : {
+                      "title" : "in action"
+                   }
+                },
+                "size": 2,
+                "from": 0,
+                "_source": [ "title", "summary", "publish_date" ],
+                "highlight": {
+                   "fields" : {
+                      "title" : {}
+                   }
+                }
+            })]
+            expected        [json!({
+                "query": {
+                   "match" : {
+                      "title" : "?"
+                   }
+                },
+                "size": "?",
+                "from": "?",
+                "_source": [ "?", "?", "?" ],
+                "highlight": {
+                   "fields" : {
+                      "title" : {}
+                   }
+                }
+            }).to_string()];
+        ]
+        [
+            test_name       [test_obfuscate_json_8]
+            keep_values     [vec!["_source".to_string()]]
+            input           [json!({
+                "query": {
+                   "match" : {
+                      "title" : "in action"
+                   }
+                },
+                "size": 2,
+                "from": 0,
+                "_source": [ "title", "summary", "publish_date" ],
+                "highlight": {
+                   "fields" : {
+                      "title" : {}
+                   }
+                }
+            })]
+            expected        [json!({
+                "query": {
+                   "match" : {
+                      "title" : "?"
+                   }
+                },
+                "size": "?",
+                "from": "?",
+                "_source": [ "title", "summary", "publish_date" ],
+                "highlight": {
+                   "fields" : {
+                      "title" : {}
+                   }
+                }
+            }).to_string()];
+        ]
+        [
+            test_name       [test_obfuscate_json_9]
+            keep_values     [vec!["query".to_string()]]
+            input           [json!({
+                "query": {
+                   "match" : {
+                      "title" : "in action"
+                   }
+                },
+                "size": 2,
+                "from": 0,
+                "_source": [ "title", "summary", "publish_date" ],
+                "highlight": {
+                   "fields" : {
+                      "title" : {}
+                   }
+                }
+            })]
+            expected        [json!({
+                "query": {
+                   "match" : {
+                      "title" : "in action"
+                   }
+                },
+                "size": "?",
+                "from": "?",
+                "_source": [ "?", "?", "?" ],
+                "highlight": {
+                   "fields" : {
+                      "title" : {}
+                   }
+                }
+            }).to_string()];
+        ]
+        [
+            test_name       [test_obfuscate_json_10]
+            keep_values     [vec!["match".to_string()]]
+            input           [json!({
+                "query": {
+                   "match" : {
+                      "title" : "in action"
+                   }
+                },
+                "size": 2,
+                "from": 0,
+                "_source": [ "title", "summary", "publish_date" ],
+                "highlight": {
+                   "fields" : {
+                      "title" : {}
+                   }
+                }
+            })]
+            expected        [json!({
+                "query": {
+                   "match" : {
+                      "title" : "in action"
+                   }
+                },
+                "size": "?",
+                "from": "?",
+                "_source": [ "?", "?", "?" ],
+                "highlight": {
+                   "fields" : {
+                      "title" : {}
+                   }
+                }
+            }).to_string()];
+        ]
+        [
+            test_name       [test_obfuscate_json_11]
+            keep_values     [vec!["hits".to_string()]]
+            input           [json!({
+                "outer": {
+                    "total": 2,
+                    "max_score": 0.9105287,
+                    "hits": [
+                     {
+                       "_index": "bookdb_index",
+                       "_type": "book",
+                       "_id": "3",
+                       "_score": 0.9105287,
+                       "_source": {
+                        "summary": "build scalable search applications using Elasticsearch without having to do complex low-level programming or understand advanced data science algorithms",
+                        "title": "Elasticsearch in Action",
+                        "publish_date": "2015-12-03"
+                       },
+                       "highlight": {
+                        "title": [
+                          "Elasticsearch Action"
+                        ]
+                       }
+                     },
+                     {
+                       "_index": "bookdb_index",
+                       "_type": "book",
+                       "_id": "4",
+                       "_score": 0.9105287,
+                       "_source": {
+                        "summary": "Comprehensive guide to implementing a scalable search engine using Apache Solr",
+                        "title": "Solr in Action",
+                        "publish_date": "2014-04-05"
+                       },
+                       "highlight": {
+                        "title": [
+                          "Solr in Action"
+                        ]
+                       }
+                     }
+                    ]
+                }
+            })]
+            expected        [json!({
+                "outer": {
+                    "total": "?",
+                    "max_score": "?",
+                    "hits": [
+                     {
+                       "_index": "bookdb_index",
+                       "_type": "book",
+                       "_id": "3",
+                       "_score": 0.9105287,
+                       "_source": {
+                        "summary": "build scalable search applications using Elasticsearch without having to do complex low-level programming or understand advanced data science algorithms",
+                        "title": "Elasticsearch in Action",
+                        "publish_date": "2015-12-03"
+                       },
+                       "highlight": {
+                        "title": [
+                          "Elasticsearch Action"
+                        ]
+                       }
+                     },
+                     {
+                       "_index": "bookdb_index",
+                       "_type": "book",
+                       "_id": "4",
+                       "_score": 0.9105287,
+                       "_source": {
+                        "summary": "Comprehensive guide to implementing a scalable search engine using Apache Solr",
+                        "title": "Solr in Action",
+                        "publish_date": "2014-04-05"
+                       },
+                       "highlight": {
+                        "title": [
+                          "Solr in Action"
+                        ]
+                       }
+                     }
+                    ]
+                }
+            }).to_string()];
+        ]
+        [
+            test_name       [test_obfuscate_json_12]
+            keep_values     [vec!["_index".to_string(), "title".to_string()]]
+            input           [json!({
+                "hits": {
+                    "total": 2,
+                    "max_score": 0.9105287,
+                    "hits": [
+                     {
+                       "_index": "bookdb_index",
+                       "_type": "book",
+                       "_id": "3",
+                       "_score": 0.9105287,
+                       "_source": {
+                        "summary": "build scalable search applications using Elasticsearch without having to do complex low-level programming or understand advanced data science algorithms",
+                        "title": "Elasticsearch in Action",
+                        "publish_date": "2015-12-03"
+                       },
+                       "highlight": {
+                        "title": [
+                          "Elasticsearch Action"
+                        ]
+                       }
+                     },
+                     {
+                       "_index": "bookdb_index",
+                       "_type": "book",
+                       "_id": "4",
+                       "_score": 0.9105287,
+                       "_source": {
+                        "summary": "Comprehensive guide to implementing a scalable search engine using Apache Solr",
+                        "title": "Solr in Action",
+                        "publish_date": "2014-04-05"
+                       },
+                       "highlight": {
+                        "title": [
+                          "Solr Action"
+                        ]
+                       }
+                     }
+                    ]
+                }
+            })]
+            expected        [json!({
+                "hits": {
+                    "total": "?",
+                    "max_score": "?",
+                    "hits": [
+                     {
+                       "_index": "bookdb_index",
+                       "_type": "?",
+                       "_id": "?",
+                       "_score": "?",
+                       "_source": {
+                        "summary": "?",
+                        "title": "Elasticsearch in Action",
+                        "publish_date": "?"
+                       },
+                       "highlight": {
+                        "title": [
+                          "Elasticsearch Action"
+                        ]
+                       }
+                     },
+                     {
+                       "_index": "bookdb_index",
+                       "_type": "?",
+                       "_id": "?",
+                       "_score": "?",
+                       "_source": {
+                        "summary": "?",
+                        "title": "Solr in Action",
+                        "publish_date": "?"
+                       },
+                       "highlight": {
+                        "title": [
+                          "Solr Action"
+                        ]
+                       }
+                     }
+                    ]
+                }
+            }).to_string()];
+        ]
+        [
+            test_name       [test_obfuscate_json_13]
+            keep_values     [vec!["_source".to_string()]]
+            input           [json!({
+                "query": {
+                  "bool": {
+                    "must": [ { "match": { "title": "smith" } } ],
+                    "must_not": [ { "match_phrase": { "title": "granny smith" } } ],
+                    "filter": [ { "exists": { "field": "title" } } ]
+                  }
+                },
+                "aggs": {
+                  "my_agg": { "terms": { "field": "user", "size": 10 } }
+                },
+                "highlight": {
+                  "pre_tags": [ "<em>" ], "post_tags": [ "</em>" ],
+                  "fields": {
+                    "body": { "number_of_fragments": 1, "fragment_size": 20 },
+                    "title": {}
+                  }
+                },
+                "size": 20,
+                "from": 100,
+                "_source": [ "title", "id" ],
+                "sort": [ { "_id": { "order": "desc" } } ]
+              })]
+            expected        [json!({
+                "query": {
+                  "bool": {
+                    "must": [ { "match": { "title": "?" } } ],
+                    "must_not": [ { "match_phrase": { "title": "?" } } ],
+                    "filter": [ { "exists": { "field": "?" } } ]
+                  }
+                },
+                "aggs": {
+                  "my_agg": { "terms": { "field": "?", "size": "?" } }
+                },
+                "highlight": {
+                  "pre_tags": [ "?" ], "post_tags": [ "?" ],
+                  "fields": {
+                    "body": { "number_of_fragments": "?", "fragment_size": "?" },
+                    "title": {}
+                  }
+                },
+                "size": "?",
+                "from": "?",
+                "_source": [ "title", "id" ],
+                "sort": [ { "_id": { "order": "?" } }
+                ]
+              }).to_string()];
+        ]
+        [
+            test_name       [test_obfuscate_json_14]
+            keep_values     [vec!["C".to_string()]]
+            input           ["not valid json"]
+            expected        ["?".to_string()];
+        ]
+        [
+            test_name       [test_obfuscate_json_15]
+            keep_values     [vec!["C".to_string()]]
+            input           [json!({"fields" : [{"A": 1, "B": {"C": 3}}, "2"]})]
+            expected        [json!({"fields" : [{"A": "?", "B": {"C": 3}}, "?"]}).to_string()];
+        ]
+    )]
+    #[test]
+    fn test_name() {
+        let result = obfuscate_json(input.to_string().as_str(), keep_values);
+        assert_eq!(result, expected);
+    }
+}

--- a/trace-obfuscation/src/lib.rs
+++ b/trace-obfuscation/src/lib.rs
@@ -4,6 +4,7 @@
 // Datadog, Inc.
 
 #![deny(clippy::all)]
+#![recursion_limit = "512"]
 
 pub mod credit_cards;
 pub mod http;

--- a/trace-obfuscation/src/lib.rs
+++ b/trace-obfuscation/src/lib.rs
@@ -8,6 +8,7 @@
 pub mod credit_cards;
 pub mod http;
 pub mod memcached;
+pub mod json;
 pub mod obfuscate;
 pub mod obfuscation_config;
 pub mod replacer;

--- a/trace-obfuscation/src/lib.rs
+++ b/trace-obfuscation/src/lib.rs
@@ -8,8 +8,8 @@
 
 pub mod credit_cards;
 pub mod http;
-pub mod memcached;
 pub mod json;
+pub mod memcached;
 pub mod obfuscate;
 pub mod obfuscation_config;
 pub mod replacer;

--- a/trace-obfuscation/src/obfuscation_config.rs
+++ b/trace-obfuscation/src/obfuscation_config.rs
@@ -41,7 +41,7 @@ impl ObfuscationConfig {
             },
             Err(_) => None,
         };
-        
+
         // HTTP
         let http_remove_query_string =
             parse_env::bool("DD_APM_OBFUSCATION_HTTP_REMOVE_QUERY_STRING").unwrap_or(false);
@@ -54,19 +54,26 @@ impl ObfuscationConfig {
         let obfuscate_sql = parse_env::bool("DD_APM_OBFUSCATION_SQL_ENABLED").unwrap_or(true);
 
         // Elastic Search
-        let obfuscate_elasticsearch = parse_env::bool("DD_APM_OBFUSCATION_ELASTICSEARCH_ENABLED").unwrap_or(false);
-        let elasticsearch_keep_values_raw = parse_env::str_not_empty("DD_APM_OBFUSCATION_ELASTICSEARCH_KEEP_VALUES");
+        let obfuscate_elasticsearch =
+            parse_env::bool("DD_APM_OBFUSCATION_ELASTICSEARCH_ENABLED").unwrap_or(false);
+        let elasticsearch_keep_values_raw =
+            parse_env::str_not_empty("DD_APM_OBFUSCATION_ELASTICSEARCH_KEEP_VALUES");
         let elasticsearch_keep_values = parse_arr_from_string(elasticsearch_keep_values_raw);
-       
-        let elasticsearch_obfuscate_sql_values_raw = parse_env::str_not_empty("DD_APM_OBFUSCATION_ELASTICSEARCH_OBFUSCATE_SQL_VALUES");
-        let elasticsearch_obfuscate_sql_values = parse_arr_from_string(elasticsearch_obfuscate_sql_values_raw);
+
+        let elasticsearch_obfuscate_sql_values_raw =
+            parse_env::str_not_empty("DD_APM_OBFUSCATION_ELASTICSEARCH_OBFUSCATE_SQL_VALUES");
+        let elasticsearch_obfuscate_sql_values =
+            parse_arr_from_string(elasticsearch_obfuscate_sql_values_raw);
 
         // MongoDB
-        let obfuscate_mongodb = parse_env::bool("DD_APM_OBFUSCATION_MONGODB_ENABLED").unwrap_or(false);
-        let mongodb_keep_values_raw = parse_env::str_not_empty("DD_APM_OBFUSCATION_MONGODB_KEEP_VALUES");
+        let obfuscate_mongodb =
+            parse_env::bool("DD_APM_OBFUSCATION_MONGODB_ENABLED").unwrap_or(false);
+        let mongodb_keep_values_raw =
+            parse_env::str_not_empty("DD_APM_OBFUSCATION_MONGODB_KEEP_VALUES");
         let mongodb_keep_values = parse_arr_from_string(mongodb_keep_values_raw);
-        
-        let mongodb_obfuscate_sql_values_raw = parse_env::str_not_empty("DD_APM_OBFUSCATION_MONGODB_OBFUSCATE_SQL_VALUES");
+
+        let mongodb_obfuscate_sql_values_raw =
+            parse_env::str_not_empty("DD_APM_OBFUSCATION_MONGODB_OBFUSCATE_SQL_VALUES");
         let mongodb_obfuscate_sql_values = parse_arr_from_string(mongodb_obfuscate_sql_values_raw);
 
         Ok(ObfuscationConfig {
@@ -118,9 +125,9 @@ fn parse_arr_from_string(str: Option<String>) -> Option<Vec<String>> {
     }
     let res: Vec<&str> = s.split_ascii_whitespace().collect();
     if res.is_empty() {
-        return None
+        return None;
     }
-    return Some(res.iter().map(|s| s.to_string()).collect())
+    return Some(res.iter().map(|s| s.to_string()).collect());
 }
 
 #[cfg(test)]

--- a/trace-obfuscation/src/obfuscation_config.rs
+++ b/trace-obfuscation/src/obfuscation_config.rs
@@ -17,10 +17,17 @@ pub struct ObfuscationConfig {
     pub obfuscate_sql: bool,
     pub sql_replace_digits: bool,
     pub sql_literal_escapes: bool,
+    pub obfuscate_elasticsearch: bool,
+    pub elasticsearch_keep_values: Option<Vec<String>>,
+    pub elasticsearch_obfuscate_sql_values: Option<Vec<String>>,
+    pub obfuscate_mongodb: bool,
+    pub mongodb_keep_values: Option<Vec<String>>,
+    pub mongodb_obfuscate_sql_values: Option<Vec<String>>,
 }
 
 impl ObfuscationConfig {
     pub fn new() -> Result<ObfuscationConfig, Box<dyn std::error::Error>> {
+        // Tag Replacement
         let tag_replace_rules: Option<Vec<ReplaceRule>> = match env::var("DD_APM_REPLACE_TAGS") {
             Ok(replace_rules_str) => match replacer::parse_rules_from_string(&replace_rules_str) {
                 Ok(res) => {
@@ -34,6 +41,8 @@ impl ObfuscationConfig {
             },
             Err(_) => None,
         };
+        
+        // HTTP
         let http_remove_query_string =
             parse_env::bool("DD_APM_OBFUSCATION_HTTP_REMOVE_QUERY_STRING").unwrap_or(false);
         let http_remove_path_digits =
@@ -44,6 +53,22 @@ impl ObfuscationConfig {
 
         let obfuscate_sql = parse_env::bool("DD_APM_OBFUSCATION_SQL_ENABLED").unwrap_or(true);
 
+        // Elastic Search
+        let obfuscate_elasticsearch = parse_env::bool("DD_APM_OBFUSCATION_ELASTICSEARCH_ENABLED").unwrap_or(false);
+        let elasticsearch_keep_values_raw = parse_env::str_not_empty("DD_APM_OBFUSCATION_ELASTICSEARCH_KEEP_VALUES");
+        let elasticsearch_keep_values = parse_arr_from_string(elasticsearch_keep_values_raw);
+       
+        let elasticsearch_obfuscate_sql_values_raw = parse_env::str_not_empty("DD_APM_OBFUSCATION_ELASTICSEARCH_OBFUSCATE_SQL_VALUES");
+        let elasticsearch_obfuscate_sql_values = parse_arr_from_string(elasticsearch_obfuscate_sql_values_raw);
+
+        // MongoDB
+        let obfuscate_mongodb = parse_env::bool("DD_APM_OBFUSCATION_MONGODB_ENABLED").unwrap_or(false);
+        let mongodb_keep_values_raw = parse_env::str_not_empty("DD_APM_OBFUSCATION_MONGODB_KEEP_VALUES");
+        let mongodb_keep_values = parse_arr_from_string(mongodb_keep_values_raw);
+        
+        let mongodb_obfuscate_sql_values_raw = parse_env::str_not_empty("DD_APM_OBFUSCATION_MONGODB_OBFUSCATE_SQL_VALUES");
+        let mongodb_obfuscate_sql_values = parse_arr_from_string(mongodb_obfuscate_sql_values_raw);
+
         Ok(ObfuscationConfig {
             tag_replace_rules,
             http_remove_query_string,
@@ -52,6 +77,79 @@ impl ObfuscationConfig {
             obfuscate_sql,
             sql_replace_digits: false,
             sql_literal_escapes: false,
+            obfuscate_elasticsearch,
+            elasticsearch_keep_values,
+            elasticsearch_obfuscate_sql_values,
+            obfuscate_mongodb,
+            mongodb_keep_values,
+            mongodb_obfuscate_sql_values,
         })
+    }
+
+    /// Returns a new obfuscation config with all values false, for testing.
+    pub fn new_test_config() -> ObfuscationConfig {
+        ObfuscationConfig {
+            tag_replace_rules: None,
+            http_remove_query_string: false,
+            http_remove_path_digits: false,
+            obfuscate_memcached: false,
+            obfuscate_sql: false,
+            sql_replace_digits: false,
+            sql_literal_escapes: false,
+            obfuscate_elasticsearch: false,
+            elasticsearch_keep_values: None,
+            elasticsearch_obfuscate_sql_values: None,
+            obfuscate_mongodb: false,
+            mongodb_keep_values: None,
+            mongodb_obfuscate_sql_values: None,
+        }
+    }
+}
+
+/// parses an Option<Vec<String>> from an Option<String>,
+/// where the input string is a comma separated list
+/// ex: "[a, b]"" or "a, b"
+fn parse_arr_from_string(str: Option<String>) -> Option<Vec<String>> {
+    str.as_ref()?;
+    let mut s: String = str.unwrap().replace(',', " ");
+    if s.starts_with('[') && s.ends_with(']') {
+        s.remove(0);
+        s.remove(s.len() - 1);
+    }
+    let res: Vec<&str> = s.split_ascii_whitespace().collect();
+    if res.is_empty() {
+        return None
+    }
+    return Some(res.iter().map(|s| s.to_string()).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use duplicate::duplicate_item;
+
+    use super::parse_arr_from_string;
+
+    #[duplicate_item(
+        test_name                           input                       expected;
+        [test_parse_arr_from_string_1]  [None]                      [None];
+        [test_parse_arr_from_string_2]  [Some("".to_string())]          [None];
+        [test_parse_arr_from_string_3]  [Some("[]".to_string())]        [None];
+        [test_parse_arr_from_string_4]  [Some("[a]".to_string())]       [Some(vec!["a".to_string()])];
+        [test_parse_arr_from_string_5]  [Some("a".to_string())]         [Some(vec!["a".to_string()])];
+        [test_parse_arr_from_string_6]  [Some("[a,b]".to_string())]     [Some(vec!["a".to_string(), "b".to_string()])];
+        [test_parse_arr_from_string_7]  [Some("[a, b]".to_string())]    [Some(vec!["a".to_string(), "b".to_string()])];
+        [test_parse_arr_from_string_8]  [Some("[a,  b]".to_string())]   [Some(vec!["a".to_string(), "b".to_string()])];
+        [test_parse_arr_from_string_9]  [Some("a,b".to_string())]       [Some(vec!["a".to_string(), "b".to_string()])];
+        [test_parse_arr_from_string_10] [Some("a,   b".to_string())]    [Some(vec!["a".to_string(), "b".to_string()])];
+        [test_parse_arr_from_string_11] [Some("[a,b".to_string())]      [Some(vec!["[a".to_string(), "b".to_string()])];
+        [test_parse_arr_from_string_12] [Some("a,b]".to_string())]      [Some(vec!["a".to_string(), "b]".to_string()])];
+        [test_parse_arr_from_string_13] [Some("a],[b".to_string())]     [Some(vec!["a]".to_string(), "[b".to_string()])];
+        [test_parse_arr_from_string_14] [Some("a,[],b".to_string())]    [Some(vec!["a".to_string(), "[]".to_string(), "b".to_string()])];
+        [test_parse_arr_from_string_15] [Some("[,]".to_string())]       [None];
+    )]
+    #[test]
+    fn test_name() {
+        let result = parse_arr_from_string(input);
+        assert_eq!(result, expected)
     }
 }

--- a/trace-obfuscation/src/sql.rs
+++ b/trace-obfuscation/src/sql.rs
@@ -1292,15 +1292,10 @@ LIMIT 1
     )]
     #[test]
     fn test_name() {
-        let obf_config = obfuscation_config::ObfuscationConfig {
-            tag_replace_rules: None,
-            http_remove_query_string: false,
-            http_remove_path_digits: false,
-            obfuscate_memcached: false,
-            obfuscate_sql: true,
-            sql_replace_digits: replace_digits,
-            sql_literal_escapes: false,
-        };
+        let mut obf_config = obfuscation_config::ObfuscationConfig::new_test_config();
+        obf_config.obfuscate_sql = true;
+        obf_config.sql_replace_digits = replace_digits;
+
         let result = obfuscate_sql_string(input, &obf_config);
         assert_eq!(result.obfuscated_string.unwrap(), expected);
     }


### PR DESCRIPTION
# What does this PR do?

Adds a JSON string obfuscator, to be used in mongodb/elasticsearch obfuscation.

**Important:**

The main difference between this impl and the go agent one is we are `serde_json` to completely load the json string, recursively traversing the JSON tree and replacing/obfuscating values. 

The go agent obfuscator is able to obfuscate partial JSON strings (ending in `...`), this obfuscator will fail to load and return `?` instead.

Because the json string is loaded with `serde_json`, obfuscation has the side affect of normalizing the json string.

Relies on the sql obfuscator

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

unit tests copied from go agent obfuscator

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
