### PR TITLE
Integrate json obfuscator

### DIFF
--- a/trace-obfuscation/src/obfuscate.rs
+++ b/trace-obfuscation/src/obfuscate.rs
@@ -178,7 +178,7 @@ mod tests {
         obfuscate_span(&mut span, &obf_config);
         assert_eq!(
             span.meta.get("elasticsearch.body").unwrap().to_string(),
-            json!( { "key": "?", "obj": { "arr": ["?", "?"]}} ).to_string()
+            r#"{"key":"?","obj":{"arr":["?","?"]}}"#,
         )
     }
 }


### PR DESCRIPTION
# What does this PR do?

Integrates the JSON obfuscator into the span obfuscator, for mongodb and elasticsearch spans.

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
