### PR TITLE
Mini Agent: Extract azure env vars + add tags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,6 +799,7 @@ dependencies = [
  "datadog-trace-normalization",
  "datadog-trace-protobuf",
  "ddcommon",
+ "duplicate",
  "flate2",
  "futures",
  "hyper",

--- a/trace-utils/Cargo.toml
+++ b/trace-utils/Cargo.toml
@@ -22,5 +22,6 @@ datadog-trace-protobuf = { path = "../trace-protobuf" }
 datadog-trace-normalization = { path = "../trace-normalization" }
 
 [dev-dependencies]
+duplicate = "0.4.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 serde_json = "1.0"

--- a/trace-utils/src/trace_utils.rs
+++ b/trace-utils/src/trace_utils.rs
@@ -499,10 +499,8 @@ fn process_azure_env_vars_and_set_tags(
 
     let resource_id = format!("/subscriptions/{subscription_id}/resourcegroups/{resource_group}/providers/microsoft.web/sites/{site_name}");
 
-    span.meta.insert(
-        "azurefunction.resource.id".to_string(),
-        resource_id,
-    );
+    span.meta
+        .insert("azurefunction.resource.id".to_string(), resource_id);
     span.meta.insert(
         "azurefunction.resource.group".to_string(),
         resource_group.to_string(),


### PR DESCRIPTION
# What does this PR do?

Adds logic into the mini agent to process azure env vars, and add the following tags:

- azurefunction.resource.id
- azurefunction.resource.group
- azurefunction.subscription.id
- azurefunction.site.name
- azurefunction.environment.os

The `azurefunction.resource.id` is constructed in the following format:
`/subscriptions/<subscription-id>/resourcegroups/<resource-group>/providers/microsoft.web/sites/<site-name>`

<img width="1349" alt="image" src="https://github.com/DataDog/libdatadog/assets/51187184/c90fa632-d17d-484d-9b62-3a0aa09126ea">


# Motivation

Azure trace tracking

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
