### PR TITLE
Refactor: reorganize functions in internal/profile to clarify the public api

### DIFF
--- a/profiling-ffi/src/profiles.rs
+++ b/profiling-ffi/src/profiles.rs
@@ -423,7 +423,7 @@ unsafe fn ddog_prof_profile_add_impl(
 ) -> anyhow::Result<()> {
     let profile = profile_ptr_to_inner(profile_ptr)?;
 
-    match sample.try_into().map(|s| profile.add(s, timestamp)) {
+    match sample.try_into().map(|s| profile.add_sample(s, timestamp)) {
         Ok(r) => match r {
             Ok(_) => Ok(()),
             Err(err) => Err(err),

--- a/profiling-replayer/src/main.rs
+++ b/profiling-replayer/src/main.rs
@@ -183,7 +183,7 @@ fn main() -> anyhow::Result<()> {
 
     let before = Instant::now();
     for (timestamp, sample) in samples {
-        outprof.add(sample, timestamp)?;
+        outprof.add_sample(sample, timestamp)?;
     }
     let duration = before.elapsed();
 

--- a/profiling/examples/profiles.rs
+++ b/profiling/examples/profiles.rs
@@ -59,7 +59,7 @@ fn main() {
     // Intentionally use the current time.
     let mut profile = Profile::new(SystemTime::now(), &sample_types, Some(period));
 
-    match profile.add(sample, None) {
+    match profile.add_sample(sample, None) {
         Ok(_) => {}
         Err(_) => exit(1),
     }


### PR DESCRIPTION
# What does this PR do?

The `internal::profile` module has both public API, and private helper functions.  Seperates them out to make it easier to see the public API when reading the code.

# Motivation

It's nice when code is easier to read.  Had been working on this file, and kept wishing it was organized like this, so just did it.

# Additional Notes

I renamed `add` to `add_sample` to follow the naming scheme of the rest of the file.

# How to test the change?

This is a refactor, covered by existing tests.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
