### PR TITLE
Fix version in sidecar ffi for dependencies and integrations

### DIFF
--- a/sidecar-ffi/src/unix.rs
+++ b/sidecar-ffi/src/unix.rs
@@ -285,9 +285,8 @@ pub unsafe extern "C" fn ddog_sidecar_telemetry_addDependency(
     dependency_name: ffi::CharSlice,
     dependency_version: ffi::CharSlice,
 ) -> MaybeError {
-    let version = dependency_version
-        .is_empty()
-        .then(|| dependency_version.to_utf8_lossy().into_owned());
+    let version =
+        (!dependency_version.is_empty()).then(|| dependency_version.to_utf8_lossy().into_owned());
 
     let dependency = TelemetryActions::AddDependecy(Dependency {
         name: dependency_name.to_utf8_lossy().into_owned(),
@@ -314,9 +313,8 @@ pub unsafe extern "C" fn ddog_sidecar_telemetry_addIntegration(
     integration_version: ffi::CharSlice,
     integration_enabled: bool,
 ) -> MaybeError {
-    let version = integration_version
-        .is_empty()
-        .then(|| integration_version.to_utf8_lossy().into_owned());
+    let version =
+        (!integration_version.is_empty()).then(|| integration_version.to_utf8_lossy().into_owned());
 
     let integration = TelemetryActions::AddIntegration(Integration {
         name: integration_name.to_utf8_lossy().into_owned(),


### PR DESCRIPTION
The versions were ... picked up if they were empty. Which sort of defeats the point.