### PR TITLE
Bump libdatadog version to 5.0.0 in preparation for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -595,7 +595,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "bitmaps",
@@ -626,7 +626,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-ffi"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -642,7 +642,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-replayer"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-normalization"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "datadog-trace-protobuf",
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-obfuscation"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -782,7 +782,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-protobuf"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-utils"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "datadog-trace-normalization",
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "futures",
@@ -838,7 +838,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon-ffi"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "ddcommon",
@@ -847,7 +847,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "anyhow",
  "ddcommon",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry-ffi"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "ddcommon",
  "ddcommon-ffi",
@@ -2925,7 +2925,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "lazy_static",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.69"
 edition = "2021"
-version = "4.0.0"
+version = "5.0.0"
 license = "Apache-2.0"
 
 [profile.dev]


### PR DESCRIPTION
**What does this PR do?**

This PR bumps the libdatadog version to 5.0.0. This PR looks a bit different from previous PRs to bump libdatadog version [(here's the 4.0.0 PR as an example)](https://github.com/DataDog/libdatadog/pull/236) because in [this PR](https://github.com/DataDog/libdatadog/pull/247) we've centralized the version on the single `Cargo.toml` file.

Furthermore, we're going from 4.0.0 to 5.0.0 because there were a number of backwards-incompatible changes to the profiling APIs.

**Motivation:**

Release libdatadog 5.0.0.

**Additional Notes:**

If I haven't missed anything, the backwards incompatible API changes were the following:

* The value of the `end_timestamp_ns` label is now provided as a regular argument to `ddog_prof_Profile_add`
* The libdatadog 5 serializer outputs compressed pprof files
* The exporter has a new API that takes two lists, a list of files to compress and a list of files to assume are compressed when exporting
* The libdatadog 5 serializer now resets profiles as part of serializing them
* The `ddog_prof_Profile_new` now returns a result structure

**How to test the change?**

I've tested the libdatadog 5 releases using the Ruby profiler, see https://github.com/DataDog/dd-trace-rb/pull/3169 for my draft PR.

**For Reviewers**
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
