### PR TITLE
Run Miri everywhere

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -3,7 +3,7 @@ on:
   push:
 
 jobs:
-  profiler-test:
+  run-miri:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -13,7 +13,6 @@ jobs:
         toolchain: nightly
         override: true
         components: miri
-    - run: cd ${GITHUB_WORKSPACE}/profiling && MIRIFLAGS="-Zmiri-disable-isolation" cargo miri test
-    - run: cd ${GITHUB_WORKSPACE}/profiling-ffi && MIRIFLAGS="-Zmiri-disable-isolation" cargo miri test
+    - run: MIRIFLAGS="-Zmiri-disable-isolation" cargo miri test
     # We need to disable isolation because 
     # "unsupported operation: `clock_gettime` with `REALTIME` clocks not available when isolation is enabled" 

--- a/ddcommon/src/connector/mod.rs
+++ b/ddcommon/src/connector/mod.rs
@@ -132,6 +132,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     /// Verify that the Connector type implements the correct bound Connect + Clone
     /// to be able to use the hyper::Client
     fn test_hyper_client_from_connector() {
@@ -139,6 +140,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     /// Verify that Connector will only allow non tls connections if root certificates
     /// are not found
     async fn test_missing_root_certificates_only_allow_http_connections() {

--- a/ddtelemetry-ffi/src/lib.rs
+++ b/ddtelemetry-ffi/src/lib.rs
@@ -118,6 +118,7 @@ mod test_c_ffi {
     use ddcommon::{parse_uri, Endpoint};
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_set_builder_str_param() {
         let mut builder = std::ptr::null_mut();
 
@@ -176,6 +177,7 @@ mod test_c_ffi {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_set_builder_enum_param() {
         let mut builder = std::ptr::null_mut();
 
@@ -226,6 +228,7 @@ mod test_c_ffi {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_worker_run() {
         unsafe {
             let mut builder = std::ptr::null_mut();

--- a/ddtelemetry/src/worker/http_client.rs
+++ b/ddtelemetry/src/worker/http_client.rs
@@ -105,6 +105,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn test_mock_client() {
         let output: Vec<u8> = Vec::new();
         let c = MockClient {

--- a/ipc/src/platform/unix/platform_handle.rs
+++ b/ipc/src/platform/unix/platform_handle.rs
@@ -185,6 +185,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_platform_handles_fd_handling() {
         let mut file = tempfile::tempfile().unwrap();
         assert_file_is_open_for_writing!(file);
@@ -205,6 +206,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_platform_handle_fd_borrowing() {
         let mut file = tempfile::tempfile().unwrap();
         assert_file_is_open_for_writing!(file);

--- a/ipc/tarpc/tarpc/src/client.rs
+++ b/ipc/tarpc/tarpc/src/client.rs
@@ -629,6 +629,7 @@ mod tests {
     use tracing::Span;
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn response_completes_request_future() {
         let (mut dispatch, mut _channel, mut server_channel) = set_up();
         let cx = &mut Context::from_waker(noop_waker_ref());
@@ -650,6 +651,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn dispatch_response_cancels_on_drop() {
         let (cancellation, mut canceled_requests) = cancellations();
         let (_, mut response) = oneshot::channel();
@@ -665,6 +667,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn dispatch_response_doesnt_cancel_after_complete() {
         let (cancellation, mut canceled_requests) = cancellations();
         let (tx, mut response) = oneshot::channel();
@@ -689,6 +692,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn stage_request() {
         let (mut dispatch, mut channel, _server_channel) = set_up();
         let cx = &mut Context::from_waker(noop_waker_ref());
@@ -707,6 +711,7 @@ mod tests {
 
     // Regression test for  https://github.com/google/tarpc/issues/220
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn stage_request_channel_dropped_doesnt_panic() {
         let (mut dispatch, mut channel, mut server_channel) = set_up();
         let cx = &mut Context::from_waker(noop_waker_ref());
@@ -729,6 +734,7 @@ mod tests {
 
     #[allow(unstable_name_collisions)]
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn stage_request_response_future_dropped_is_canceled_before_sending() {
         let (mut dispatch, mut channel, _server_channel) = set_up();
         let cx = &mut Context::from_waker(noop_waker_ref());
@@ -745,6 +751,7 @@ mod tests {
 
     #[allow(unstable_name_collisions)]
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn stage_request_response_future_dropped_is_canceled_after_sending() {
         let (mut dispatch, mut channel, _server_channel) = set_up();
         let cx = &mut Context::from_waker(noop_waker_ref());
@@ -766,6 +773,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn stage_request_response_closed_skipped() {
         let (mut dispatch, mut channel, _server_channel) = set_up();
         let cx = &mut Context::from_waker(noop_waker_ref());

--- a/ipc/tarpc/tarpc/src/lib.rs
+++ b/ipc/tarpc/tarpc/src/lib.rs
@@ -171,9 +171,9 @@
 //! #         future::ready(format!("Hello, {name}!"))
 //! #     }
 //! # }
-//! # #[cfg(not(feature = "tokio1"))]
+//! # #[cfg(any(not(feature = "tokio1"), miri))]
 //! # fn main() {}
-//! # #[cfg(feature = "tokio1")]
+//! # #[cfg(all(feature = "tokio1", not(miri)))]
 //! #[tokio::main]
 //! async fn main() -> anyhow::Result<()> {
 //!     let (client_transport, server_transport) = tarpc::transport::channel::unbounded();

--- a/ipc/tarpc/tarpc/src/server.rs
+++ b/ipc/tarpc/tarpc/src/server.rs
@@ -896,6 +896,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn base_channel_start_send_duplicate_request_returns_error() {
         let (mut channel, _tx) = test_channel::<(), ()>();
 
@@ -918,6 +919,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn base_channel_poll_next_aborts_multiple_requests() {
         let (mut channel, _tx) = test_channel::<(), ()>();
 
@@ -949,6 +951,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn base_channel_poll_next_aborts_canceled_request() {
         let (mut channel, mut tx) = test_channel::<(), ()>();
 
@@ -978,6 +981,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn base_channel_with_closed_transport_and_in_flight_request_returns_pending() {
         let (mut channel, tx) = test_channel::<(), ()>();
 
@@ -999,6 +1003,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn base_channel_with_closed_transport_and_no_in_flight_requests_returns_closed() {
         let (mut channel, tx) = test_channel::<(), ()>();
         drop(tx);
@@ -1009,6 +1014,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn base_channel_poll_next_yields_request() {
         let (mut channel, mut tx) = test_channel::<(), ()>();
         tx.send(fake_request(())).await.unwrap();
@@ -1020,6 +1026,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn base_channel_poll_next_aborts_request_and_yields_request() {
         let (mut channel, mut tx) = test_channel::<(), ()>();
 
@@ -1044,6 +1051,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn base_channel_start_send_removes_in_flight_request() {
         let (mut channel, _tx) = test_channel::<(), ()>();
 
@@ -1067,6 +1075,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn in_flight_request_drop_cancels_request() {
         let (mut requests, mut tx) = test_requests::<(), ()>();
         tx.send(fake_request(())).await.unwrap();
@@ -1087,6 +1096,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn in_flight_requests_successful_execute_doesnt_cancel_request() {
         let (mut requests, mut tx) = test_requests::<(), ()>();
         tx.send(fake_request(())).await.unwrap();
@@ -1105,6 +1115,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn requests_poll_next_response_returns_pending_when_buffer_full() {
         let (mut requests, _tx) = test_bounded_requests::<(), ()>(0);
 
@@ -1156,6 +1167,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn requests_pump_write_returns_pending_when_buffer_full() {
         let (mut requests, _tx) = test_bounded_requests::<(), ()>(0);
 
@@ -1211,6 +1223,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn requests_pump_read() {
         let (mut requests, mut tx) = test_requests::<(), ()>();
 

--- a/ipc/tarpc/tarpc/src/server/in_flight_requests.rs
+++ b/ipc/tarpc/tarpc/src/server/in_flight_requests.rs
@@ -137,6 +137,7 @@ mod tests {
     use futures_test::task::noop_context;
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn start_request_increases_len() {
         let mut in_flight_requests = InFlightRequests::default();
         assert_eq!(in_flight_requests.len(), 0);
@@ -147,6 +148,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn polling_expired_aborts() {
         let mut in_flight_requests = InFlightRequests::default();
         let abort_registration = in_flight_requests
@@ -169,6 +171,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn cancel_request_aborts() {
         let mut in_flight_requests = InFlightRequests::default();
         let abort_registration = in_flight_requests
@@ -185,6 +188,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn remove_request_doesnt_abort() {
         let mut in_flight_requests = InFlightRequests::default();
         assert!(in_flight_requests.deadlines.is_empty());

--- a/ipc/tarpc/tarpc/src/server/limits/requests_per_channel.rs
+++ b/ipc/tarpc/tarpc/src/server/limits/requests_per_channel.rs
@@ -192,6 +192,7 @@ mod tests {
     use tracing::Span;
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn throttler_in_flight_requests() {
         let throttler = MaxRequests {
             max_in_flight_requests: 0,
@@ -320,6 +321,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn throttler_start_send() {
         let throttler = MaxRequests {
             max_in_flight_requests: 0,

--- a/ipc/tarpc/tarpc/src/transport/channel.rs
+++ b/ipc/tarpc/tarpc/src/transport/channel.rs
@@ -170,6 +170,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn integration() -> anyhow::Result<()> {
         let _ = tracing_subscriber::fmt::try_init();
 

--- a/ipc/tarpc/tarpc/tests/service_functional.rs
+++ b/ipc/tarpc/tarpc/tests/service_functional.rs
@@ -36,6 +36,7 @@ impl Service for Server {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn sequential() -> anyhow::Result<()> {
     let _ = tracing_subscriber::fmt::try_init();
 
@@ -58,6 +59,7 @@ async fn sequential() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn dropped_channel_aborts_in_flight_requests() -> anyhow::Result<()> {
     #[tarpc_plugins::service]
     trait Loop {
@@ -108,6 +110,7 @@ async fn dropped_channel_aborts_in_flight_requests() -> anyhow::Result<()> {
 
 #[cfg(all(feature = "serde-transport", feature = "tcp"))]
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn serde_tcp() -> anyhow::Result<()> {
     use tarpc::serde_transport;
     use tokio_serde::formats::Json;
@@ -138,6 +141,7 @@ async fn serde_tcp() -> anyhow::Result<()> {
 
 #[cfg(all(feature = "serde-transport", feature = "unix", unix))]
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn serde_uds() -> anyhow::Result<()> {
     use tarpc::serde_transport;
     use tokio_serde::formats::Json;
@@ -168,6 +172,7 @@ async fn serde_uds() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn concurrent() -> anyhow::Result<()> {
     let _ = tracing_subscriber::fmt::try_init();
 
@@ -192,6 +197,7 @@ async fn concurrent() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn concurrent_join() -> anyhow::Result<()> {
     let _ = tracing_subscriber::fmt::try_init();
 
@@ -217,6 +223,7 @@ async fn concurrent_join() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn concurrent_join_all() -> anyhow::Result<()> {
     let _ = tracing_subscriber::fmt::try_init();
 
@@ -240,6 +247,7 @@ async fn concurrent_join_all() -> anyhow::Result<()> {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn counter() -> anyhow::Result<()> {
     #[tarpc::service]
     trait Counter {

--- a/ipc/tests/blocking_client.rs
+++ b/ipc/tests/blocking_client.rs
@@ -14,6 +14,7 @@ use datadog_ipc::example_interface::{
 };
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_blocking_client() {
     let (sock_a, sock_b) = StdUnixStream::pair().unwrap();
     // Setup async server

--- a/ipc/tests/flock.rs
+++ b/ipc/tests/flock.rs
@@ -30,6 +30,7 @@ pub extern "C" fn flock_test_entrypoint() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_file_locking_works_as_expected() {
     let d = tempdir().unwrap();
     let lock_path = d.path().join("file.lock");

--- a/sidecar-ffi/tests/sidecar.rs
+++ b/sidecar-ffi/tests/sidecar.rs
@@ -34,6 +34,7 @@ fn set_sidecar_per_process() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_ddog_ph_file_handling() {
     let fname = CString::new(std::env::temp_dir().join("test_file").to_str().unwrap()).unwrap();
     let mode = CString::new("a+").unwrap();

--- a/sidecar/src/setup/unix.rs
+++ b/sidecar/src/setup/unix.rs
@@ -190,6 +190,7 @@ mod tests {
     use super::Liaison;
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_shared_dir_can_connect_to_socket() -> anyhow::Result<()> {
         let tmpdir = tempdir().unwrap();
         let liaison = super::SharedDirLiaison::new(tmpdir.path());

--- a/sidecar/src/setup/unix.rs
+++ b/sidecar/src/setup/unix.rs
@@ -165,6 +165,7 @@ mod linux {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_abstract_socket_can_connect() {
         let l = AbstractUnixSocketLiaison::ipc_per_process();
         super::tests::basic_liaison_connection_test(&l).unwrap();

--- a/spawn_worker/tests/trampoline_unix.rs
+++ b/spawn_worker/tests/trampoline_unix.rs
@@ -18,6 +18,7 @@ fn rewind_and_read(file: &mut File) -> anyhow::Result<String> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_spawning_trampoline_worker() {
     let mut stdout = tempfile::tempfile().unwrap();
     let mut stderr = tempfile::tempfile().unwrap();

--- a/tests/spawn_from_lib/tests/spawn_unix.rs
+++ b/tests/spawn_from_lib/tests/spawn_unix.rs
@@ -21,6 +21,7 @@ fn rewind_and_read(file: &mut File) -> anyhow::Result<String> {
 /// to test the FdExec/Exec trampolining
 /// additionally run: RUSTFLAGS="-C prefer-dynamic" cargo test --package tests/spawn_from_lib
 #[test]
+#[cfg_attr(miri, ignore)]
 fn test_spawning_trampoline_worker() {
     let mut stdout = tempfile::tempfile().unwrap();
     let mut stderr = tempfile::tempfile().unwrap();

--- a/trace-mini-agent/src/env_verifier.rs
+++ b/trace-mini-agent/src/env_verifier.rs
@@ -299,6 +299,7 @@ mod tests {
     use super::{EnvVerifier, ServerlessEnvVerifier};
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn test_ensure_gcp_env_false_if_metadata_server_unreachable() {
         struct MockGoogleMetadataClient {}
         #[async_trait]
@@ -316,6 +317,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn test_ensure_gcp_env_false_if_no_server_in_response_headers() {
         struct MockGoogleMetadataClient {}
         #[async_trait]
@@ -336,6 +338,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn test_ensure_gcp_env_if_server_header_not_serverless() {
         struct MockGoogleMetadataClient {}
         #[async_trait]
@@ -357,6 +360,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn test_ensure_gcp_env_true_if_cloud_function_env() {
         struct MockGoogleMetadataClient {}
         #[async_trait]
@@ -395,6 +399,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn test_gcp_verify_environment_timeout_exceeded_gives_unknown_values() {
         let env_verifier = ServerlessEnvVerifier {};
         let res = env_verifier
@@ -428,6 +433,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn test_ensure_azure_env_windows_true() {
         struct MockAzureVerificationClient {}
         #[async_trait]
@@ -443,6 +449,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn test_ensure_azure_env_windows_false() {
         struct MockAzureVerificationClient {}
         #[async_trait]
@@ -465,6 +472,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn test_ensure_azure_env_linux_true() {
         struct MockAzureVerificationClient {}
         #[async_trait]
@@ -480,6 +488,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn test_ensure_azure_env_linux_false() {
         struct MockAzureVerificationClient {}
         #[async_trait]

--- a/trace-mini-agent/src/http_utils.rs
+++ b/trace-mini-agent/src/http_utils.rs
@@ -100,6 +100,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn test_request_content_length_missing() {
         let verify_result = verify_request_content_length(&HeaderMap::new(), 1, "Test Prefix");
         assert!(verify_result.is_some());
@@ -113,6 +114,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn test_request_content_length_cant_convert_to_str() {
         let verify_result = verify_request_content_length(
             &create_test_headers_with_content_length("❤❤❤❤❤❤❤"),
@@ -130,6 +132,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn test_request_content_length_cant_convert_to_usize() {
         let verify_result = verify_request_content_length(
             &create_test_headers_with_content_length("not_an_int"),
@@ -147,6 +150,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn test_request_content_length_too_long() {
         let verify_result = verify_request_content_length(
             &create_test_headers_with_content_length("100"),

--- a/trace-mini-agent/src/trace_processor.rs
+++ b/trace-mini-agent/src/trace_processor.rs
@@ -153,6 +153,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn test_process_trace() {
         let (tx, mut rx): (
             Sender<trace_utils::SendData>,
@@ -215,6 +216,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn test_process_trace_top_level_span_set() {
         let (tx, mut rx): (
             Sender<trace_utils::SendData>,

--- a/trace-utils/src/trace_utils.rs
+++ b/trace-utils/src/trace_utils.rs
@@ -541,6 +541,7 @@ mod tests {
     use datadog_trace_protobuf::pb;
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn test_get_traces_from_request_body() {
         let pairs = vec![
             (


### PR DESCRIPTION
# What does this PR do?

1. Runs Miri in CI on all of the library, not just profiling
2. Explicitly "ignores" the tests where Miri cannot currently run

# Motivation

Miri is great for catching bugs, and as much of the library as possible should take advantage of that.

# Additional Notes

1. Miri does not run on Tokio tests for now: https://github.com/tokio-rs/tokio/issues/3360
2. Miri cannot be directly disabled on doc-tests, so I had to use a slightly ugly patch there https://github.com/rust-lang/miri/issues/584#issuecomment-825798646
3. None of the issues I saw appeared to be bugs: they generally related to syscalls that Miri doesn't currently support.  We should investigate enabling these tests as Miri advances

# How to test the change?
Should just run in the CI

Describe here in detail how the change can be validated.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
