### PR TITLE
Sidecar: propagate environment to telemetry

### DIFF
--- a/sidecar-ffi/src/unix.rs
+++ b/sidecar-ffi/src/unix.rs
@@ -342,6 +342,7 @@ pub unsafe extern "C" fn ddog_sidecar_telemetry_flushServiceData(
     queue_id: &QueueId,
     runtime_meta: &RuntimeMeta,
     service_name: ffi::CharSlice,
+    env_name: ffi::CharSlice,
 ) -> MaybeError {
     try_c!(blocking::register_service_and_flush_queued_actions(
         transport,
@@ -349,6 +350,7 @@ pub unsafe extern "C" fn ddog_sidecar_telemetry_flushServiceData(
         queue_id,
         runtime_meta,
         service_name.to_utf8_lossy(),
+        env_name.to_utf8_lossy(),
     ));
 
     MaybeError::None

--- a/sidecar-ffi/tests/sidecar.rs
+++ b/sidecar-ffi/tests/sidecar.rs
@@ -118,7 +118,8 @@ fn test_ddog_sidecar_register_app() {
             &instance_id,
             &queue_id,
             &meta,
-            "service_name".into()
+            "service_name".into(),
+            "env_name".into()
         ));
         // reset session config - and cause shutdown of all existing instances
         ddog_sidecar_session_set_config(

--- a/sidecar/src/interface.rs
+++ b/sidecar/src/interface.rs
@@ -65,6 +65,7 @@ pub trait SidecarInterface {
         queue_id: QueueId,
         meta: RuntimeMeta,
         service_name: String,
+        env_name: String,
     );
     async fn set_session_config(session_id: String, config: SessionConfig);
     async fn shutdown_runtime(instance_id: InstanceId);
@@ -260,14 +261,14 @@ impl SessionInfo {
 
 #[allow(clippy::large_enum_variant)]
 enum AppOrQueue {
-    App(Shared<ManualFuture<String>>),
+    App(Shared<ManualFuture<(String, String)>>),
     Queue(EnqueuedTelemetryData),
 }
 
 #[allow(clippy::type_complexity)]
 #[derive(Clone, Default)]
 struct RuntimeInfo {
-    apps: Arc<Mutex<HashMap<String, Shared<ManualFuture<Option<AppInstance>>>>>>,
+    apps: Arc<Mutex<HashMap<(String, String), Shared<ManualFuture<Option<AppInstance>>>>>>,
     app_or_actions: Arc<Mutex<HashMap<QueueId, AppOrQueue>>>,
 }
 
@@ -276,17 +277,19 @@ impl RuntimeInfo {
     fn get_app(
         &self,
         service_name: &String,
+        env_name: &String,
     ) -> (
         Shared<ManualFuture<Option<AppInstance>>>,
         Option<ManualFutureCompleter<Option<AppInstance>>>,
     ) {
         let mut apps = self.apps.lock().unwrap();
-        if let Some(found) = apps.get(service_name) {
+        let key = (service_name.clone(), env_name.clone());
+        if let Some(found) = apps.get(&key) {
             (found.clone(), None)
         } else {
             let (future, completer) = ManualFuture::new();
             let shared = future.shared();
-            apps.insert(service_name.clone(), shared.clone());
+            apps.insert((service_name.clone(), env_name.clone()), shared.clone());
             (shared, Some(completer))
         }
     }
@@ -687,11 +690,12 @@ impl SidecarServer {
         instance_id: &InstanceId,
         runtime_meta: &RuntimeMeta,
         service_name: &String,
+        env_name: &String,
         inital_actions: Vec<TelemetryActions>,
     ) -> Option<AppInstance> {
         let rt_info = self.get_runtime(instance_id);
 
-        let (app_future, completer) = rt_info.get_app(service_name);
+        let (app_future, completer) = rt_info.get_app(service_name, env_name);
         if completer.is_none() {
             return app_future.await;
         }
@@ -703,7 +707,7 @@ impl SidecarServer {
             runtime_meta.tracer_version.clone(),
         );
         builder.runtime_id = Some(instance_id.runtime_id.clone());
-
+        builder.application.env = Some(env_name.clone());
         let session_info = self.get_session(&instance_id.session_id);
         let config = session_info
             .session_config
@@ -854,6 +858,7 @@ impl SidecarInterface for SidecarServer {
         queue_id: QueueId,
         runtime_meta: RuntimeMeta,
         service_name: String,
+        env_name: String,
     ) -> Self::RegisterServiceAndFlushQueuedActionsFut {
         // We need a channel to have enqueuing code await
         let (future, completer) = ManualFuture::new();
@@ -874,7 +879,7 @@ impl SidecarInterface for SidecarServer {
 
             tokio::spawn(async move {
                 if let Some(app) = self
-                    .get_app(&instance_id, &runtime_meta, &service_name, actions)
+                    .get_app(&instance_id, &runtime_meta, &service_name, &env_name, actions)
                     .await
                 {
                     let actions: Vec<_> = std::mem::take(&mut enqueued_data.actions);
@@ -891,7 +896,7 @@ impl SidecarInterface for SidecarServer {
 
                     app.telemetry.send_msgs(actions).await.ok();
                     // Ok, we dequeued all messages, now new enqueue_actions calls can handle it
-                    completer.complete(service_name).await;
+                    completer.complete((service_name, env_name)).await;
                 }
             });
         }
@@ -1056,6 +1061,7 @@ pub mod blocking {
         queue_id: &QueueId,
         runtime_metadata: &RuntimeMeta,
         service_name: Cow<str>,
+        env_name: Cow<str>,
     ) -> io::Result<()> {
         transport.send(
             SidecarInterfaceRequest::RegisterServiceAndFlushQueuedActions {
@@ -1063,6 +1069,7 @@ pub mod blocking {
                 queue_id: *queue_id,
                 meta: runtime_metadata.clone(),
                 service_name: service_name.into_owned(),
+                env_name: env_name.into_owned(),
             },
         )
     }

--- a/sidecar/src/interface.rs
+++ b/sidecar/src/interface.rs
@@ -689,8 +689,8 @@ impl SidecarServer {
         &self,
         instance_id: &InstanceId,
         runtime_meta: &RuntimeMeta,
-        service_name: &String,
-        env_name: &String,
+        service_name: &str,
+        env_name: &str,
         inital_actions: Vec<TelemetryActions>,
     ) -> Option<AppInstance> {
         let rt_info = self.get_runtime(instance_id);
@@ -701,13 +701,13 @@ impl SidecarServer {
         }
 
         let mut builder = TelemetryWorkerBuilder::new_fetch_host(
-            service_name.clone(),
+            service_name.to_owned(),
             runtime_meta.language_name.clone(),
             runtime_meta.language_version.clone(),
             runtime_meta.tracer_version.clone(),
         );
         builder.runtime_id = Some(instance_id.runtime_id.clone());
-        builder.application.env = Some(env_name.clone());
+        builder.application.env = Some(env_name.to_owned());
         let session_info = self.get_session(&instance_id.session_id);
         let config = session_info
             .session_config

--- a/sidecar/src/interface.rs
+++ b/sidecar/src/interface.rs
@@ -289,10 +289,7 @@ impl RuntimeInfo {
         } else {
             let (future, completer) = ManualFuture::new();
             let shared = future.shared();
-            apps.insert(
-                (service_name.to_owned(), env_name.to_owned()),
-                shared.clone(),
-            );
+            apps.insert(key, shared.clone());
             (shared, Some(completer))
         }
     }


### PR DESCRIPTION
# What does this PR do?

Telemetry data sent through the sidecar currently appears in the dashboard as a service without an environment, this PR fixes it by propagating the environment all the way from the PHP extension to the telemetry worker builder.

# Motivation

Fixing OSS vulnerability detection on ASM services.

# How to test the change?

This will be tested through https://github.com/DataDog/dd-trace-php/pull/2313

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
