### PR TITLE
Fix daemonization of sidecar closing stderr properly

### DIFF
--- a/sidecar/src/unix.rs
+++ b/sidecar/src/unix.rs
@@ -276,7 +276,7 @@ fn daemonize(listener: StdUnixListener, cfg: Config) -> io::Result<()> {
         }
         config::LogMethod::Disabled => {
             spawn_cfg.stdout(Stdio::Null);
-            spawn_cfg.stdout(Stdio::Null);
+            spawn_cfg.stderr(Stdio::Null);
         }
         _ => {}
     }


### PR DESCRIPTION
Fix https://github.com/DataDog/dd-trace-php/issues/2317: Disabled logging should close both stdout and stderr.