### PR TITLE
Fix clippy lint

### DIFF
--- a/ipc/tarpc/tarpc/examples/pubsub.rs
+++ b/ipc/tarpc/tarpc/examples/pubsub.rs
@@ -218,7 +218,7 @@ impl Publisher {
             for topic in topics {
                 subscriptions
                     .entry(topic)
-                    .or_insert_with(HashMap::new)
+                    .or_default()
                     .insert(subscriber_addr, subscriber.clone());
             }
         }


### PR DESCRIPTION
# What does this PR do?

Fix a small clippy lint

# Motivation

The tarpc code has been vendored because we forked it with minimal changes, and the fact that package managers didn't want us to depend on other github repositories to distribute libdatadog.

I wish we had a way to disable the clippy lint just for tarpc, without having to diverge further from upstream but [it looks like it's not possible](https://github.com/EmbarkStudios/rust-ecosystem/issues/22).

