### PR TITLE
[Profiling] Put LabelSetId into the sample labels to simplify deduplication on the backend

### DIFF
--- a/profiling/src/internal/profile.rs
+++ b/profiling/src/internal/profile.rs
@@ -586,7 +586,7 @@ mod api_test {
         check_label(profile, label, key, num, "", "");
     }
 
-    fn check_str_label(profile: &pprof::Profile, label: &pprof::Label, key: &str, str: &str) {
+    fn _check_str_label(profile: &pprof::Profile, label: &pprof::Label, key: &str, str: &str) {
         check_label(profile, label, key, 0, "", str);
     }
 
@@ -2108,19 +2108,17 @@ mod api_test {
 
         let local_root_span_id = locate_string("local root span id");
         let trace_endpoint = locate_string("trace endpoint");
+        let dd_following_labels_belong_to_set = locate_string("dd_following_labels_belong_to_set");
 
         // Set up the expected labels per sample
         let expected_labels = [
             [
                 pprof::Label {
-                    key: local_root_span_id,
+                    key: dd_following_labels_belong_to_set,
                     str: 0,
-                    num: large_num,
+                    num: 0,
                     num_unit: 0,
                 },
-                pprof::Label::str(trace_endpoint, locate_string("large endpoint")),
-            ],
-            [
                 pprof::Label {
                     key: local_root_span_id,
                     str: 0,
@@ -2128,6 +2126,21 @@ mod api_test {
                     num_unit: 0,
                 },
                 pprof::Label::str(trace_endpoint, locate_string("endpoint 10")),
+            ],
+            [
+                pprof::Label {
+                    key: dd_following_labels_belong_to_set,
+                    str: 0,
+                    num: 1,
+                    num_unit: 0,
+                },
+                pprof::Label {
+                    key: local_root_span_id,
+                    str: 0,
+                    num: large_num,
+                    num_unit: 0,
+                },
+                pprof::Label::str(trace_endpoint, locate_string("large endpoint")),
             ],
         ];
 


### PR DESCRIPTION
# What does this PR do?

Adds a new sample label "dd_following_labels_belong_to_set" whose value is the `LabelSetId` of the sample.

# Motivation

Timeline profiles create a huge number of samples with identical label sets, which require resources to process and deduplicate on the backend.  We've already done the work of deduplicating the labelsets, and have unique ids.  Dumping these into the label allows the backend to avoid having to even look at labels its seen before.

# Additional Notes

This change should not affect any other pprof based tools: they will simply ignore the unknown label.

This will slightly increase the size of the pprof file, since we're still sending the labelset for each sample. 

This change makes labels positional: all labels following the "dd_following_labels_belong_to_set" label must indeed belong to the set.  This restriction does not seem onerous, but YMMV.

# How to test the change?

* Updated existing tests to ensure the correct presence of this label.
* Performance: lets enable this for a test service, and see whether the backend can take advantage

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
