### PR TITLE
[Profiling] Put LabelSetId and StackTraceId into the sample labels to simplify deduplication on the backend

### DIFF
--- a/ipc/tarpc/tarpc/examples/pubsub.rs
+++ b/ipc/tarpc/tarpc/examples/pubsub.rs
@@ -218,7 +218,7 @@ impl Publisher {
             for topic in topics {
                 subscriptions
                     .entry(topic)
-                    .or_insert_with(HashMap::new)
+                    .or_default()
                     .insert(subscriber_addr, subscriber.clone());
             }
         }

--- a/profiling/src/internal/profile.rs
+++ b/profiling/src/internal/profile.rs
@@ -586,7 +586,7 @@ mod api_test {
         check_label(profile, label, key, num, "", "");
     }
 
-    fn check_str_label(profile: &pprof::Profile, label: &pprof::Label, key: &str, str: &str) {
+    fn _check_str_label(profile: &pprof::Profile, label: &pprof::Label, key: &str, str: &str) {
         check_label(profile, label, key, 0, "", str);
     }
 
@@ -2108,19 +2108,17 @@ mod api_test {
 
         let local_root_span_id = locate_string("local root span id");
         let trace_endpoint = locate_string("trace endpoint");
+        let dd_following_labels_belong_to_set = locate_string("dd_following_labels_belong_to_set");
 
         // Set up the expected labels per sample
         let expected_labels = [
             [
                 pprof::Label {
-                    key: local_root_span_id,
+                    key: dd_following_labels_belong_to_set,
                     str: 0,
-                    num: large_num,
+                    num: 0,
                     num_unit: 0,
                 },
-                pprof::Label::str(trace_endpoint, locate_string("large endpoint")),
-            ],
-            [
                 pprof::Label {
                     key: local_root_span_id,
                     str: 0,
@@ -2128,6 +2126,21 @@ mod api_test {
                     num_unit: 0,
                 },
                 pprof::Label::str(trace_endpoint, locate_string("endpoint 10")),
+            ],
+            [
+                pprof::Label {
+                    key: dd_following_labels_belong_to_set,
+                    str: 0,
+                    num: 1,
+                    num_unit: 0,
+                },
+                pprof::Label {
+                    key: local_root_span_id,
+                    str: 0,
+                    num: large_num,
+                    num_unit: 0,
+                },
+                pprof::Label::str(trace_endpoint, locate_string("large endpoint")),
             ],
         ];
 

--- a/profiling/src/internal/profile.rs
+++ b/profiling/src/internal/profile.rs
@@ -166,8 +166,8 @@ impl Profile {
         profile.endpoints.local_root_span_id_label = profile.intern("local root span id");
         profile.endpoints.endpoint_label = profile.intern("trace endpoint");
         profile.timestamp_key = profile.intern("end_timestamp_ns");
-        profile.label_set_start_key = profile.intern("dd_following_labels_belong_to_set");
-        profile.stack_id_key = profile.intern("dd_stack_id");
+        profile.label_set_start_key = profile.intern("datadog following labels belong to set");
+        profile.stack_id_key = profile.intern("datadog stack id");
 
         profile.sample_types = sample_types
             .iter()
@@ -578,11 +578,16 @@ mod api_test {
     use std::{borrow::Cow, collections::HashMap};
 
     fn check_label_prefix(profile: &pprof::Profile, label: &pprof::Label, num: i64) {
-        check_num_label(profile, label, "dd_following_labels_belong_to_set", num);
+        check_num_label(
+            profile,
+            label,
+            "datadog following labels belong to set",
+            num,
+        );
     }
 
     fn check_stacktrace_label(profile: &pprof::Profile, label: &pprof::Label, num: i64) {
-        check_num_label(profile, label, "dd_stack_id", num);
+        check_num_label(profile, label, "datadog stack id", num);
     }
 
     fn check_label(
@@ -2106,8 +2111,9 @@ mod api_test {
 
         let local_root_span_id = locate_string("local root span id");
         let trace_endpoint = locate_string("trace endpoint");
-        let dd_following_labels_belong_to_set = locate_string("dd_following_labels_belong_to_set");
-        let stack_id_key = locate_string("dd_stack_id");
+        let dd_following_labels_belong_to_set =
+            locate_string("datadog following labels belong to set");
+        let stack_id_key = locate_string("datadog stack id");
 
         // Set up the expected labels per sample
         let expected_labels = [
@@ -2252,10 +2258,10 @@ mod api_test {
         };
 
         let test_label_key = locate_string("test label");
-        let stack_id_key = locate_string("dd_stack_id");
+        let stack_id_key = locate_string("datadog stack id");
         let timestamp_key = locate_string("end_timestamp_ns");
         let dd_following_labels_belong_to_set_key =
-            locate_string("dd_following_labels_belong_to_set");
+            locate_string("datadog following labels belong to set");
 
         for sample in &serialized_profile.samples {
             match sample.values[0] {


### PR DESCRIPTION
# What does this PR do?

* Adds a new sample label "datadog stack id " whose value is the `StackTraceId` of the sample.
* Adds a new sample label "datadog following labels belong to set" whose value is the `LabelSetId` of the sample.

# Motivation

Timeline profiles create a huge number of samples with identical stack-traces and labels sets, which require resources to process and deduplicate on the backend.  We've already done the work of deduplicating the stack traces and label sets, and have unique ids per trace.  Dumping these into the label allows the backend to avoid having to even look at stacktraces and label sets its seen before.

# Additional Notes

This change should not affect any other pprof based tools: they will simply ignore the unknown label.

This will slightly increase the size of the pprof file, since we're still sending the stacktrace for each sample.  We could imagine a larger optimization where we only attach the actual stacktrace to the first sample, but this would break any other pprof based tools.

This is a rollup merge of #277 and #272 to allow them to be tested together

# How to test the change?

* Correctness: added a test
* Performance: lets enable this for a test service, and see whether the backend can take advantage

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
