### PR TITLE
Allow verify trace-protobuf to continue on error, try 2

### DIFF
--- a/.github/workflows/verify-proto-files.yml
+++ b/.github/workflows/verify-proto-files.yml
@@ -1,5 +1,7 @@
 name: 'Verify trace-protobuf'
-on: [push]
+on:
+  pull_request:
+    types: [ opened, synchronize, reopened ]
 
 jobs:
   verify-proto-files:
@@ -24,7 +26,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           outcome: ${{ steps.agent_payload_proto.outcome }}
-          test-id: agent_payload_proto
+          test-id: Verify trace-protobuf agent_payload_proto
       - name: diff tracer_payload.proto
         working-directory: trace-protobuf/src/pb
         continue-on-error: true
@@ -39,7 +41,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           outcome: ${{ steps.tracer_payload_proto.outcome }}
-          test-id: tracer_payload_proto
+          test-id: Verify trace-protobuf tracer_payload_proto
       - name: diff stats.proto
         working-directory: trace-protobuf/src/pb
         continue-on-error: true
@@ -54,7 +56,7 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           outcome: ${{ steps.stats_proto.outcome }}
-          test-id: stats_proto
+          test-id: Verify trace-protobuf stats_proto
       - name: diff span.proto
         working-directory: trace-protobuf/src/pb
         continue-on-error: true
@@ -69,4 +71,4 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           outcome: ${{ steps.span_proto.outcome }}
-          test-id: span_proto
+          test-id: Verify trace-protobuf span_proto


### PR DESCRIPTION
# What does this PR do?

In #275, I've attempted to add the `mainmatter/continue-on-error-comment` github action which replaces a CI error with a comment, so that it's less annoying when "Verify trace-protobuf" fails and we don't get a ugly red cross on every PR.

My first attempt didn't work! I missed that I needed to change the trigger for the verify action to be on pull requests, not on pushes.

This PR fixes that, and we should see the action comment show up as an example.

# Motivation

Fix #275.

# Additional Notes

N/A

# How to test the change?

See the comment that will show up!

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
