### PR TITLE
Fix codewoner ordering

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
+*                       @Datadog/libdatadog-core
 build-profiling-ffi.sh  @Datadog/libdatadog-profiling
 profiling*/             @Datadog/libdatadog-profiling
-ddtelemetry/            @Datadog/libdatadog-telemetry
+ddtelemetry*/           @Datadog/libdatadog-telemetry
 ruby/                   @Datadog/libdatadog-ruby
-*                       @Datadog/libdatadog-core
 Cargo.*                 @Datadog/libdatadog
 .gitignore              @Datadog/libdatadog
 .gitlab-ci.yaml         @Datadog/libdatadog


### PR DESCRIPTION
# What does this PR do?

In codewoners file, the last entry takes precedence so any entry before appearing before the wildcard is ignored, which is probably not the expected behaviour.

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
