### PR TITLE
Fix typo in ProfileExporter docs

### DIFF
--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -124,7 +124,7 @@ impl ProfileExporter {
     /// * `profiling_library_name` - Profiling library name, usually dd-trace-something, e.g. "dd-trace-rb". See
     ///   https://datadoghq.atlassian.net/wiki/spaces/PROF/pages/1538884229/Client#Header-values (Datadog internal link)
     ///   for a list of common values.
-    /// * `profliling_library_version` - Version used when publishing the profiling library to a package manager
+    /// * `profiling_library_version` - Version used when publishing the profiling library to a package manager
     /// * `family` - Profile family, e.g. "ruby"
     /// * `tags` - Tags to include with every profile reported by this exporter. It's also possible to include
     ///   profile-specific tags, see `additional_tags` on `build`.


### PR DESCRIPTION
# What does this PR do?

Just fixes a small typo in the docs.

# Motivation

Noticed it while trying to use the library.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

N/A

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
