### PR TITLE
feat(profiling-ffi): expose stack trace ids

### DIFF
--- a/profiling-ffi/cbindgen.toml
+++ b/profiling-ffi/cbindgen.toml
@@ -34,6 +34,7 @@ renaming_overrides_prefixing = true
 
 "ExporterNewResult" = "ddog_prof_Exporter_NewResult"
 "File" = "ddog_prof_Exporter_File"
+"ProfileAddStackTraceResult" = "ddog_prof_Profile_AddStackTraceResult"
 "ProfileExporter" = "ddog_prof_Exporter"
 "ProfileNewResult" = "ddog_prof_Profile_NewResult"
 "ProfileResult" = "ddog_prof_Profile_Result"

--- a/profiling/src/api.rs
+++ b/profiling/src/api.rs
@@ -5,6 +5,9 @@ use crate::pprof;
 use std::ops::{Add, Sub};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
+// Re-export certain internal items
+pub use crate::internal::{StackTraceId, Timestamp};
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct ValueType<'a> {
     pub r#type: &'a str,

--- a/profiling/src/internal/stack_trace.rs
+++ b/profiling/src/internal/stack_trace.rs
@@ -14,6 +14,8 @@ impl Item for StackTrace {
     type Id = StackTraceId;
 }
 
+/// An identifier for a stack trace. The representation detail is used
+/// internally by the FFI, so if you change it, change the FFI to match.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[repr(transparent)]
 pub struct StackTraceId(u32);


### PR DESCRIPTION
# What does this PR do?

Creates API surface for adding stack traces independently from their data.


# Motivation

This allows C FFI users to re-use the ids when they have some form of external caching already. Specifically designed for Ruby's PoC of heap profiling.

# Additional Notes

I haven't gotten to testing it yet, but it's mostly new plumbing for existing internal behavior so it might work already.

[PROF-8435](https://datadoghq.atlassian.net/browse/PROF-8435)

# How to test the change?

Use `ddog_prof_Profile_add_stack_trace` to create a stack id, and use `ddog_prof_Profile_add_observation` to associate values, labels, and optionally a timestamp with the stack id.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.


[PROF-8435]: https://datadoghq.atlassian.net/browse/PROF-8435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ