### PR TITLE
style: fix Rust 1.75 lints

### DIFF
--- a/ipc/src/example_interface.rs
+++ b/ipc/src/example_interface.rs
@@ -44,7 +44,7 @@ impl ExampleServer {
     pub async fn accept_connection(self, socket: UnixStream) {
         let server = tarpc::server::BaseChannel::new(
             tarpc::server::Config::default(),
-            Transport::try_from(AsyncChannel::from(socket)).unwrap(),
+            Transport::from(AsyncChannel::from(socket)),
         );
 
         server.execute(self.serve()).await

--- a/ipc/src/handles.rs
+++ b/ipc/src/handles.rs
@@ -152,4 +152,4 @@ mod transport_impls {
     }
 }
 
-pub use transport_impls::*;
+

--- a/ipc/src/handles.rs
+++ b/ipc/src/handles.rs
@@ -151,5 +151,3 @@ mod transport_impls {
         }
     }
 }
-
-

--- a/ipc/tarpc/tarpc/src/server/limits/requests_per_channel.rs
+++ b/ipc/tarpc/tarpc/src/server/limits/requests_per_channel.rs
@@ -256,7 +256,7 @@ mod tests {
         throttler.inner.push_req(1, 1);
         assert!(throttler.as_mut().poll_next(&mut testing::cx()).is_done());
         assert_eq!(throttler.inner.sink.len(), 1);
-        match throttler.inner.sink.get(0).unwrap() {
+        match throttler.inner.sink.front().unwrap() {
             RequestResponse::Response(resp) => {
                 assert_eq!(resp.request_id, 1);
                 assert!(resp.message.is_err());
@@ -346,7 +346,7 @@ mod tests {
             }))
             .unwrap();
         assert_eq!(throttler.inner.in_flight_requests.len(), 0);
-        match throttler.inner.sink.get(0).unwrap() {
+        match throttler.inner.sink.front().unwrap() {
             RequestResponse::Response(resp) => {
                 assert_eq!(
                     resp,

--- a/profiling/src/internal/profile.rs
+++ b/profiling/src/internal/profile.rs
@@ -735,9 +735,9 @@ mod api_test {
         }
         let samples = profile.sorted_samples();
 
-        let sample = samples.get(0).expect("index 0 to exist");
+        let sample = samples.first().expect("index 0 to exist");
         assert_eq!(sample.labels.len(), 1);
-        let label = sample.labels.get(0).expect("index 0 to exist");
+        let label = sample.labels.first().expect("index 0 to exist");
         let key = profile
             .string_table
             .get(label.key as usize)
@@ -757,7 +757,7 @@ mod api_test {
 
         let sample = samples.get(1).expect("index 1 to exist");
         assert_eq!(sample.labels.len(), 1);
-        let label = sample.labels.get(0).expect("index 0 to exist");
+        let label = sample.labels.first().expect("index 0 to exist");
         let key = profile
             .string_table
             .get(label.key as usize)
@@ -777,7 +777,7 @@ mod api_test {
 
         let sample = samples.get(2).expect("index 2 to exist");
         assert_eq!(sample.labels.len(), 2);
-        let label = sample.labels.get(0).expect("index 0 to exist");
+        let label = sample.labels.first().expect("index 0 to exist");
         let key = profile
             .string_table
             .get(label.key as usize)
@@ -965,12 +965,12 @@ mod api_test {
         assert_eq!(serialized_profile.samples.len(), 2);
         let samples = serialized_profile.sorted_samples();
 
-        let s1 = samples.get(0).expect("sample");
+        let s1 = samples.first().expect("sample");
 
         // The trace endpoint label should be added to the first sample
         assert_eq!(s1.labels.len(), 3);
 
-        let l1 = s1.labels.get(0).expect("label");
+        let l1 = s1.labels.first().expect("label");
 
         assert_eq!(
             serialized_profile
@@ -1147,7 +1147,7 @@ mod api_test {
         let serialized_profile = pprof::roundtrip_to_pprof(profile).unwrap();
 
         assert_eq!(serialized_profile.samples.len(), 1);
-        let first = serialized_profile.samples.get(0).expect("one sample");
+        let first = serialized_profile.samples.first().expect("one sample");
 
         assert_eq!(first.values[0], 1);
         assert_eq!(first.values[1], 10000);
@@ -1202,7 +1202,7 @@ mod api_test {
         let serialized_profile = pprof::roundtrip_to_pprof(profile).unwrap();
 
         assert_eq!(serialized_profile.samples.len(), 1);
-        let first = serialized_profile.samples.get(0).expect("one sample");
+        let first = serialized_profile.samples.first().expect("one sample");
 
         assert_eq!(first.values, vec![0, 10000, 42]);
     }
@@ -1230,7 +1230,7 @@ mod api_test {
         let serialized_profile = pprof::roundtrip_to_pprof(profile).unwrap();
 
         assert_eq!(serialized_profile.samples.len(), 1);
-        let first = serialized_profile.samples.get(0).expect("one sample");
+        let first = serialized_profile.samples.first().expect("one sample");
 
         assert_eq!(first.values, vec![3, 10000, 42]);
     }
@@ -1262,7 +1262,7 @@ mod api_test {
         let serialized_profile = pprof::roundtrip_to_pprof(profile).unwrap();
 
         assert_eq!(serialized_profile.samples.len(), 1);
-        let first = serialized_profile.samples.get(0).expect("one sample");
+        let first = serialized_profile.samples.first().expect("one sample");
 
         assert_eq!(first.values, vec![1, 298, 29]);
     }
@@ -1294,7 +1294,7 @@ mod api_test {
         let serialized_profile = pprof::roundtrip_to_pprof(profile).unwrap();
 
         assert_eq!(serialized_profile.samples.len(), 1);
-        let first = serialized_profile.samples.get(0).expect("one sample");
+        let first = serialized_profile.samples.first().expect("one sample");
 
         assert_eq!(first.values, vec![1, 16, 0]);
     }
@@ -1394,7 +1394,7 @@ mod api_test {
 
         let serialized_profile = pprof::roundtrip_to_pprof(profile).unwrap();
         let samples = serialized_profile.sorted_samples();
-        let first = samples.get(0).expect("first sample");
+        let first = samples.first().expect("first sample");
 
         assert_eq!(first.values, vec![2, 10000, 42]);
 
@@ -1459,7 +1459,7 @@ mod api_test {
 
         let serialized_profile = pprof::roundtrip_to_pprof(profile).unwrap();
         let samples = serialized_profile.sorted_samples();
-        let first = samples.get(0).expect("first sample");
+        let first = samples.first().expect("first sample");
 
         assert_eq!(first.values, vec![2, 10000, 105]);
 
@@ -1519,7 +1519,7 @@ mod api_test {
         let serialized_profile = pprof::roundtrip_to_pprof(profile).unwrap();
 
         assert_eq!(serialized_profile.samples.len(), 1);
-        let first = serialized_profile.samples.get(0).expect("one sample");
+        let first = serialized_profile.samples.first().expect("one sample");
 
         assert_eq!(first.values, vec![1, 10000, 42]);
     }
@@ -1554,7 +1554,7 @@ mod api_test {
         let serialized_profile = pprof::roundtrip_to_pprof(profile).unwrap();
 
         assert_eq!(serialized_profile.samples.len(), 1);
-        let first = serialized_profile.samples.get(0).expect("one sample");
+        let first = serialized_profile.samples.first().expect("one sample");
 
         assert_eq!(first.values, vec![2, 10000, 42]);
     }
@@ -1612,7 +1612,7 @@ mod api_test {
         let serialized_profile = pprof::roundtrip_to_pprof(profile).unwrap();
         let samples = serialized_profile.sorted_samples();
 
-        let first = samples.get(0).expect("one sample");
+        let first = samples.first().expect("one sample");
 
         assert_eq!(first.values, vec![2, 10000, 42]);
 
@@ -1696,7 +1696,7 @@ mod api_test {
 
         let serialized_profile = pprof::roundtrip_to_pprof(profile).unwrap();
         let samples = serialized_profile.sorted_samples();
-        let first = samples.get(0).expect("one sample");
+        let first = samples.first().expect("one sample");
 
         assert_eq!(first.values, vec![2, 10000, 42]);
 
@@ -1737,7 +1737,7 @@ mod api_test {
         let serialized_profile = pprof::roundtrip_to_pprof(profile).unwrap();
 
         assert_eq!(serialized_profile.samples.len(), 1);
-        let first = serialized_profile.samples.get(0).expect("one sample");
+        let first = serialized_profile.samples.first().expect("one sample");
 
         assert_eq!(first.values, vec![2, 20000, 42]);
     }
@@ -1779,7 +1779,7 @@ mod api_test {
         let serialized_profile = pprof::roundtrip_to_pprof(profile).unwrap();
 
         assert_eq!(serialized_profile.samples.len(), 1);
-        let first = serialized_profile.samples.get(0).expect("one sample");
+        let first = serialized_profile.samples.first().expect("one sample");
 
         assert_eq!(first.values, vec![2, 10000, 210]);
     }

--- a/profiling/src/pprof/mod.rs
+++ b/profiling/src/pprof/mod.rs
@@ -2,8 +2,11 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
 
 mod proto;
-pub mod sliced_proto;
-pub mod test_utils;
 
+pub mod sliced_proto;
 pub use proto::*;
+
+#[cfg(test)]
+pub mod test_utils;
+#[cfg(test)]
 pub use test_utils::*;

--- a/profiling/src/pprof/test_utils.rs
+++ b/profiling/src/pprof/test_utils.rs
@@ -1,7 +1,6 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
 
-#[cfg(test)]
 pub fn deserialize_compressed_pprof(encoded: &[u8]) -> anyhow::Result<super::Profile> {
     use prost::Message;
     use std::io::Read;
@@ -13,7 +12,6 @@ pub fn deserialize_compressed_pprof(encoded: &[u8]) -> anyhow::Result<super::Pro
     Ok(profile)
 }
 
-#[cfg(test)]
 pub fn roundtrip_to_pprof(profile: crate::internal::Profile) -> anyhow::Result<super::Profile> {
     let encoded = profile.serialize_into_compressed_pprof(None, None)?;
     deserialize_compressed_pprof(&encoded.buffer)

--- a/sidecar/src/interface.rs
+++ b/sidecar/src/interface.rs
@@ -575,7 +575,7 @@ impl SidecarServer {
             datadog_ipc::tarpc::server::Config {
                 pending_response_buffer: 10000,
             },
-            Transport::try_from(AsyncChannel::from(socket)).unwrap(),
+            Transport::from(AsyncChannel::from(socket)),
         );
 
         let mut executor = datadog_ipc::sequential::execute_sequential(

--- a/trace-normalization/src/normalizer.rs
+++ b/trace-normalization/src/normalizer.rs
@@ -118,7 +118,7 @@ pub(crate) fn is_valid_status_code(sc: &str) -> bool {
 /// * returns an error if there is a trace ID discrepancy between 2 spans
 /// * returns an error if at least one span cannot be normalized
 pub fn normalize_trace(trace: &mut [pb::Span]) -> anyhow::Result<()> {
-    let first_trace_id = match trace.get(0) {
+    let first_trace_id = match trace.first() {
         Some(first_span) => first_span.trace_id,
         None => anyhow::bail!("Normalize Trace Error: Trace is empty"),
     };


### PR DESCRIPTION
# What does this PR do?

This fixes a series of lints that now show up due to Rust 1.75's release.

# Motivation

I opened a PR for something else and notice the lints failed.

# Additional Notes

`cargo clippy --fix --lib` is pretty nice, but I still had to resolve two things by hand.

[PROF-8862](https://datadoghq.atlassian.net/browse/PROF-8286)

# How to test the change?

Everything should work the same. Locally, all tests still passed.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.

[PROF-8862]: https://datadoghq.atlassian.net/browse/PROF-8862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ