### PR TITLE
refactor: Slice and Vec

### DIFF
--- a/ddcommon-ffi/src/endpoint.rs
+++ b/ddcommon-ffi/src/endpoint.rs
@@ -10,7 +10,7 @@ use std::str::FromStr;
 #[no_mangle]
 #[must_use]
 pub extern "C" fn ddog_endpoint_from_url(url: crate::CharSlice) -> Option<Box<Endpoint>> {
-    parse_uri(unsafe { url.to_utf8_lossy() }.as_ref())
+    parse_uri(url.to_utf8_lossy().as_ref())
         .ok()
         .map(|url| Box::new(Endpoint { url, api_key: None }))
 }
@@ -23,7 +23,7 @@ pub extern "C" fn ddog_endpoint_from_api_key(api_key: crate::CharSlice) -> Box<E
     parts.authority = Some(Authority::from_static("datadoghq.com"));
     Box::new(Endpoint {
         url: hyper::Uri::from_parts(parts).unwrap(),
-        api_key: Some(unsafe { api_key.to_utf8_lossy().to_string().into() }),
+        api_key: Some(api_key.to_utf8_lossy().to_string().into()),
     })
 }
 
@@ -36,15 +36,13 @@ pub extern "C" fn ddog_endpoint_from_api_key_and_site(
     endpoint: &mut *mut Endpoint,
 ) -> Option<Box<Error>> {
     let mut parts = Parts::default();
-    parts.authority = Some(
-        match Authority::from_str(&unsafe { site.to_utf8_lossy() }) {
-            Ok(s) => s,
-            Err(e) => return Some(Box::new(Error::from(e.to_string()))),
-        },
-    );
+    parts.authority = Some(match Authority::from_str(&site.to_utf8_lossy()) {
+        Ok(s) => s,
+        Err(e) => return Some(Box::new(Error::from(e.to_string()))),
+    });
     *endpoint = Box::into_raw(Box::new(Endpoint {
         url: hyper::Uri::from_parts(parts).unwrap(),
-        api_key: Some(unsafe { api_key.to_utf8_lossy().to_string().into() }),
+        api_key: Some(api_key.to_utf8_lossy().to_string().into()),
     }));
     None
 }

--- a/ddcommon-ffi/src/slice.rs
+++ b/ddcommon-ffi/src/slice.rs
@@ -1,46 +1,52 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
 
+use core::slice;
 use std::borrow::Cow;
 use std::fmt::{Debug, Formatter};
 use std::marker::PhantomData;
 use std::os::raw::c_char;
 use std::str::Utf8Error;
 
-/// Remember, the data inside of each member is potentially coming from FFI,
-/// so every operation on it is unsafe!
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct Slice<'a, T: 'a> {
     /// Must be non-null and suitably aligned for the underlying type.
     ptr: *const T,
 
-    /// The number of elements (not bytes) that `.ptr` points to.
+    /// The number of elements (not bytes) that `.ptr` points to. Must be less
+    /// than or equal to [isize::MAX].
     len: usize,
-    marker: PhantomData<&'a [T]>,
+    _marker: PhantomData<&'a [T]>,
+}
+
+impl<'a, T: 'a> core::ops::Deref for Slice<'a, T> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
 }
 
 impl<'a, T: Debug> Debug for Slice<'a, T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        unsafe { f.debug_list().entries(self.as_slice().iter()).finish() }
+        self.as_slice().fmt(f)
     }
 }
 
 impl<'a, T: Eq> PartialEq<Self> for Slice<'a, T> {
     fn eq(&self, other: &Self) -> bool {
-        unsafe {
-            return self.as_slice() == other.as_slice();
-        }
+        **self == **other
     }
 }
 
 impl<'a, T: Eq> Eq for Slice<'a, T> {}
 
-// Use to represent strings -- should be valid UTF-8.
-pub type CharSlice<'a> = crate::Slice<'a, c_char>;
+/// Use to represent strings -- should be valid UTF-8.
+pub type CharSlice<'a> = Slice<'a, c_char>;
 
 /// Use to represent bytes -- does not need to be valid UTF-8.
-pub type ByteSlice<'a> = crate::Slice<'a, u8>;
+pub type ByteSlice<'a> = Slice<'a, u8>;
 
 /// This exists as an intrinsic, but it is private.
 pub fn is_aligned_and_not_null<T>(ptr: *const T) -> bool {
@@ -48,111 +54,66 @@ pub fn is_aligned_and_not_null<T>(ptr: *const T) -> bool {
 }
 
 pub trait AsBytes<'a> {
-    /// # Safety
-    /// Each implementor must document their safety requirements, but this is expected to be
-    /// unsafe as this is for FFI types.
-    unsafe fn as_bytes(&'a self) -> &'a [u8];
+    fn as_bytes(&'a self) -> &'a [u8];
 
-    /// # Safety
-    /// This function has the same safety requirements as `as_bytes`.
-    unsafe fn try_to_utf8(&'a self) -> Result<&'a str, Utf8Error> {
+    #[inline]
+    fn try_to_utf8(&'a self) -> Result<&'a str, Utf8Error> {
         std::str::from_utf8(self.as_bytes())
     }
 
-    /// # Safety
-    /// This function has the same safety requirements as `as_bytes`
-    unsafe fn to_utf8_lossy(&'a self) -> Cow<'a, str> {
+    #[inline]
+    fn to_utf8_lossy(&'a self) -> Cow<'a, str> {
         String::from_utf8_lossy(self.as_bytes())
     }
 }
 
 impl<'a> AsBytes<'a> for Slice<'a, u8> {
-    /// # Safety
-    /// Slice needs to satisfy most of the requirements of std::slice::from_raw_parts except the
-    /// aligned and non-null requirements, as this function will detect these conditions and
-    /// return an empty slice instead.
-    unsafe fn as_bytes(&'a self) -> &'a [u8] {
-        if is_aligned_and_not_null(self.ptr) {
-            std::slice::from_raw_parts(self.ptr, self.len)
-        } else {
-            &[]
-        }
+    fn as_bytes(&'a self) -> &'a [u8] {
+        self.as_slice()
     }
 }
 
 impl<'a> AsBytes<'a> for Slice<'a, i8> {
-    /// # Safety
-    /// Slice needs to satisfy most of the requirements of std::slice::from_raw_parts except the
-    /// aligned and non-null requirements, as this function will detect these conditions and
-    /// return an empty slice instead.
-    unsafe fn as_bytes(&'a self) -> &'a [u8] {
-        if is_aligned_and_not_null(self.ptr) {
-            std::slice::from_raw_parts(self.ptr as *const u8, self.len)
-        } else {
-            &[]
-        }
+    fn as_bytes(&'a self) -> &'a [u8] {
+        unsafe { slice::from_raw_parts(self.ptr.cast(), self.len) }
     }
 }
 
 impl<'a, T: 'a> Slice<'a, T> {
-    /// Creates a valid empty slice meaning that [Slice::len] is 0 and
-    /// [Slice::is_empty] is true.
+    /// Creates a valid empty slice (len=0, ptr is non-null).
     #[must_use]
     pub const fn empty() -> Self {
         Self {
             ptr: [].as_ptr(),
             len: 0,
-            marker: PhantomData,
+            _marker: PhantomData,
         }
     }
 
     /// # Safety
-    /// This function mostly has the same safety requirements as `std::str::from_raw_parts`, but
-    /// it can tolerate mis-aligned and null pointers.
-    pub unsafe fn new(ptr: *const T, len: usize) -> Self {
-        if is_aligned_and_not_null(ptr) {
-            Self {
-                ptr,
-                len,
-                ..Default::default()
-            }
-        } else {
-            Slice::empty()
+    /// Uphold the same safety requirements as [std::str::from_raw_parts].
+    pub const unsafe fn from_raw_parts(ptr: *const T, len: usize) -> Self {
+        Self {
+            ptr,
+            len,
+            _marker: PhantomData,
         }
     }
 
-    /// # Safety
-    /// This function mostly has the same safety requirements as `std::str::from_raw_parts`, but
-    /// it can tolerate mis-aligned and null pointers.
-    pub unsafe fn as_slice(&self) -> &'a [T] {
-        if is_aligned_and_not_null(self.ptr) {
-            std::slice::from_raw_parts(self.ptr, self.len)
-        } else {
-            &[]
+    pub const fn new(slice: &[T]) -> Self {
+        Self {
+            ptr: slice.as_ptr(),
+            len: slice.len(),
+            _marker: PhantomData,
         }
     }
 
-    /// # Safety
-    /// This function mostly has the same safety requirements as `std::str::from_raw_parts`, but
-    /// it can tolerate mis-aligned and null pointers.
-    pub unsafe fn into_slice(self) -> &'a [T] {
-        if is_aligned_and_not_null(self.ptr) {
-            std::slice::from_raw_parts(self.ptr, self.len)
-        } else {
-            &[]
-        }
+    pub const fn as_slice(&self) -> &'a [T] {
+        unsafe { slice::from_raw_parts(self.ptr, self.len) }
     }
 
-    pub fn len(&self) -> usize {
-        if is_aligned_and_not_null(self.ptr) {
-            self.len
-        } else {
-            0
-        }
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
+    pub const fn into_slice(self) -> &'a [T] {
+        unsafe { slice::from_raw_parts(self.ptr, self.len) }
     }
 }
 
@@ -164,21 +125,20 @@ impl<'a, T> Default for Slice<'a, T> {
 
 impl<'a, T: 'a> From<&'a [T]> for Slice<'a, T> {
     fn from(s: &'a [T]) -> Self {
-        // SAFETY: Rust slices meet all the invariants required for Slice::new.
-        unsafe { Slice::new(s.as_ptr(), s.len()) }
+        Slice::new(s)
     }
 }
 
 impl<'a, T> From<&'a Vec<T>> for Slice<'a, T> {
     fn from(value: &'a Vec<T>) -> Self {
-        Slice::from(value.as_slice())
+        Slice::new(value)
     }
 }
 
 impl<'a> From<&'a str> for Slice<'a, c_char> {
     fn from(s: &'a str) -> Self {
-        // SAFETY: Rust strings meet all the invariants required for Slice::new.
-        unsafe { Slice::new(s.as_ptr() as *const c_char, s.len()) }
+        // SAFETY: Rust strings meet all the invariants required.
+        unsafe { Slice::from_raw_parts(s.as_ptr().cast(), s.len()) }
     }
 }
 
@@ -193,7 +153,7 @@ mod test {
         let raw: &[u8] = b"_ZN9wikipedia7article6formatE";
         let slice = Slice::from(raw);
 
-        let converted: &[u8] = unsafe { slice.into_slice() };
+        let converted: &[u8] = slice.into_slice();
         assert_eq!(converted, raw);
     }
 
@@ -202,7 +162,7 @@ mod test {
         let raw: &[u8] = b"_ZN9wikipedia7article6formatE";
         let slice = Slice::from(raw);
 
-        let result = unsafe { slice.try_to_utf8() };
+        let result = slice.try_to_utf8();
         assert!(result.is_ok());
 
         let expected = "_ZN9wikipedia7article6formatE";
@@ -212,9 +172,9 @@ mod test {
     #[test]
     fn string_from_c_char() {
         let raw: &[u8] = b"_ZN9wikipedia7article6formatE";
-        let slice = unsafe { Slice::new(raw.as_ptr() as *const c_char, raw.len()) };
+        let slice = unsafe { Slice::from_raw_parts(raw.as_ptr() as *const c_char, raw.len()) };
 
-        let result = unsafe { slice.try_to_utf8() };
+        let result = slice.try_to_utf8();
         assert!(result.is_ok());
 
         let expected = "_ZN9wikipedia7article6formatE";
@@ -227,21 +187,13 @@ mod test {
     #[test]
     fn slice_from_foo() {
         let raw = Foo(42);
-        let ptr = &raw as *const Foo;
-        let slice = unsafe { Slice::new(ptr, 1) };
+        let ptr = &raw as *const _;
+        let slice = unsafe { Slice::from_raw_parts(ptr, 1) };
 
         let expected: &[Foo] = &[raw];
-        let actual: &[Foo] = unsafe { slice.as_slice() };
+        let actual: &[Foo] = slice.as_slice();
 
         assert_eq!(expected, actual)
-    }
-
-    #[test]
-    fn slice_from_null() {
-        let ptr: *const usize = std::ptr::null();
-        let expected: &[usize] = &[];
-        let actual: &[usize] = unsafe { Slice::new(ptr, 0).as_slice() };
-        assert_eq!(expected, actual);
     }
 
     #[test]
@@ -249,7 +201,7 @@ mod test {
         let slice: &[i32] = &[1, 2, 3];
         let slice = Slice::from(slice);
 
-        let mut iter = unsafe { slice.into_slice() }.iter();
+        let mut iter = slice.iter();
 
         assert_eq!(Some(&1), iter.next());
         assert_eq!(Some(&2), iter.next());

--- a/ddcommon-ffi/src/tags.rs
+++ b/ddcommon-ffi/src/tags.rs
@@ -108,7 +108,7 @@ mod tests {
                 ddog_Vec_Tag_push(&mut tags, CharSlice::from("sound"), CharSlice::from("woof"));
             assert!(matches!(result, PushTagResult::Ok));
             assert_eq!(1, tags.len());
-            assert_eq!("sound:woof", tags.get(0).unwrap().to_string());
+            assert_eq!("sound:woof", tags.first().unwrap().to_string());
         }
     }
 
@@ -119,7 +119,7 @@ mod tests {
         // SAFETY: CharSlices from Rust strings are safe.
         let result = unsafe { ddog_Vec_Tag_parse(CharSlice::from(dd_tags)) };
         assert_eq!(2, result.tags.len());
-        assert_eq!("env:staging:east", result.tags.get(0).unwrap().to_string());
+        assert_eq!("env:staging:east", result.tags.first().unwrap().to_string());
         assert_eq!("env_staging:east", result.tags.get(1).unwrap().to_string());
 
         // 'tags:' cannot end in a semi-colon, so expect an error.

--- a/ddcommon-ffi/src/vec.rs
+++ b/ddcommon-ffi/src/vec.rs
@@ -4,6 +4,7 @@
 extern crate alloc;
 
 use crate::slice::Slice;
+use core::ops::Deref;
 use std::io::Write;
 use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
@@ -27,7 +28,7 @@ unsafe impl<T: Sync> Sync for Vec<T> {}
 
 impl<T: PartialEq> PartialEq for Vec<T> {
     fn eq(&self, other: &Self) -> bool {
-        self.len() == other.len() && self.iter().zip(other.iter()).all(|(s, o)| s == o)
+        **self == **other
     }
 }
 
@@ -37,7 +38,7 @@ impl<T> Drop for Vec<T> {
     fn drop(&mut self) {
         let vec =
             unsafe { alloc::vec::Vec::from_raw_parts(self.ptr as *mut T, self.len, self.capacity) };
-        std::mem::drop(vec)
+        drop(vec)
     }
 }
 
@@ -73,7 +74,7 @@ impl<'a, T> IntoIterator for &'a Vec<T> {
     type IntoIter = core::slice::Iter<'a, T>;
 
     fn into_iter(self) -> Self::IntoIter {
-        unsafe { self.as_slice().into_slice() }.iter()
+        self.deref().iter()
     }
 }
 
@@ -93,35 +94,16 @@ impl<T> Vec<T> {
         self.replace(vec);
     }
 
-    pub fn len(&self) -> usize {
-        self.len
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.len > 0
-    }
-
     pub fn as_slice(&self) -> Slice<T> {
-        unsafe { Slice::new(self.ptr, self.len) }
+        unsafe { Slice::from_raw_parts(self.ptr, self.len) }
     }
+}
 
-    pub fn iter(&self) -> std::slice::Iter<T> {
-        unsafe { self.as_slice().into_slice() }.iter()
-    }
+impl<T> Deref for Vec<T> {
+    type Target = [T];
 
-    pub fn last(&self) -> Option<&T> {
-        if self.len == 0 {
-            return None;
-        }
-        unsafe { self.ptr.add(self.len - 1).as_ref() }
-    }
-
-    pub fn get(&self, index: usize) -> Option<&T> {
-        if index >= self.len {
-            None
-        } else {
-            unsafe { self.ptr.add(index).as_ref() }
-        }
+    fn deref(&self) -> &Self::Target {
+        self.as_slice().as_slice()
     }
 }
 
@@ -133,7 +115,7 @@ impl<T> Default for Vec<T> {
 
 #[cfg(test)]
 mod test {
-    use crate::vec::*;
+    use super::*;
 
     #[test]
     fn test_default() {
@@ -160,7 +142,7 @@ mod test {
         assert_eq!(ffi_vec.len(), 2);
         assert!(ffi_vec.capacity >= 2);
 
-        let slice = unsafe { ffi_vec.as_slice().as_slice() };
+        let slice = ffi_vec.deref();
         let [first, second]: [_; 2] = slice.try_into().expect("slice to have 2 items");
         assert_eq!(first, 1);
         assert_eq!(second, 2);

--- a/profiling-ffi/src/crashtracker.rs
+++ b/profiling-ffi/src/crashtracker.rs
@@ -31,14 +31,13 @@ impl<'a> TryFrom<CrashtrackerConfiguration<'a>>
     type Error = anyhow::Error;
     fn try_from(value: CrashtrackerConfiguration<'a>) -> anyhow::Result<Self> {
         fn option_from_char_slice(s: CharSlice) -> anyhow::Result<Option<String>> {
-            let s = unsafe { s.try_to_utf8()?.to_string() };
+            let s = s.try_to_utf8()?.to_string();
             Ok(s.is_empty().not().then_some(s))
         }
 
         let create_alt_stack = value.create_alt_stack;
         let endpoint = unsafe { Some(exporter::try_to_endpoint(value.endpoint)?) };
-        let path_to_receiver_binary =
-            unsafe { value.path_to_receiver_binary.try_to_utf8()?.to_string() };
+        let path_to_receiver_binary = value.path_to_receiver_binary.try_to_utf8()?.to_string();
         let resolve_frames = value.resolve_frames;
         let stderr_filename = option_from_char_slice(value.optional_stderr_filename)?;
         let stdout_filename = option_from_char_slice(value.optional_stdout_filename)?;
@@ -66,11 +65,9 @@ pub struct CrashtrackerMetadata<'a> {
 impl<'a> TryFrom<CrashtrackerMetadata<'a>> for datadog_crashtracker::CrashtrackerMetadata {
     type Error = anyhow::Error;
     fn try_from(value: CrashtrackerMetadata<'a>) -> anyhow::Result<Self> {
-        let profiling_library_name =
-            unsafe { value.profiling_library_name.try_to_utf8()?.to_string() };
-        let profiling_library_version =
-            unsafe { value.profiling_library_version.try_to_utf8()?.to_string() };
-        let family = unsafe { value.family.try_to_utf8()?.to_string() };
+        let profiling_library_name = value.profiling_library_name.try_to_utf8()?.to_string();
+        let profiling_library_version = value.profiling_library_version.try_to_utf8()?.to_string();
+        let family = value.family.try_to_utf8()?.to_string();
         let tags = value
             .tags
             .map(|tags| tags.iter().cloned().collect())

--- a/profiling-ffi/src/exporter.rs
+++ b/profiling-ffi/src/exporter.rs
@@ -156,9 +156,9 @@ fn ddog_prof_exporter_new_impl(
     tags: Option<&ddcommon_ffi::Vec<Tag>>,
     endpoint: Endpoint,
 ) -> anyhow::Result<ProfileExporter> {
-    let library_name = unsafe { profiling_library_name.to_utf8_lossy() }.into_owned();
-    let library_version = unsafe { profiling_library_version.to_utf8_lossy() }.into_owned();
-    let family = unsafe { family.to_utf8_lossy() }.into_owned();
+    let library_name = profiling_library_name.to_utf8_lossy().into_owned();
+    let library_version = profiling_library_version.to_utf8_lossy().into_owned();
+    let family = family.to_utf8_lossy().into_owned();
     let converted_endpoint = unsafe { try_to_endpoint(endpoint)? };
     let tags = tags.map(|tags| tags.iter().cloned().collect());
     ProfileExporter::new(

--- a/sidecar-ffi/src/unix.rs
+++ b/sidecar-ffi/src/unix.rs
@@ -137,7 +137,7 @@ pub extern "C" fn ddog_agent_remote_config_write(
     writer: &AgentRemoteConfigWriter<ShmHandle>,
     data: ffi::CharSlice,
 ) {
-    writer.write(unsafe { data.as_bytes() });
+    writer.write(data.as_bytes());
 }
 
 fn ddog_agent_remote_config_read_generic<'a, T>(
@@ -416,17 +416,15 @@ pub struct TracerHeaderTags<'a> {
 
 impl<'a> From<&'a TracerHeaderTags<'a>> for SerializedTracerHeaderTags {
     fn from(tags: &'a TracerHeaderTags<'a>) -> Self {
-        unsafe {
-            datadog_trace_utils::trace_utils::TracerHeaderTags {
-                lang: &tags.lang.to_utf8_lossy(),
-                lang_version: &tags.lang_version.to_utf8_lossy(),
-                lang_interpreter: &tags.lang_interpreter.to_utf8_lossy(),
-                lang_vendor: &tags.lang_vendor.to_utf8_lossy(),
-                tracer_version: &tags.tracer_version.to_utf8_lossy(),
-                container_id: &tags.container_id.to_utf8_lossy(),
-                client_computed_top_level: tags.client_computed_top_level,
-                client_computed_stats: tags.client_computed_stats,
-            }
+        datadog_trace_utils::trace_utils::TracerHeaderTags {
+            lang: &tags.lang.to_utf8_lossy(),
+            lang_version: &tags.lang_version.to_utf8_lossy(),
+            lang_interpreter: &tags.lang_interpreter.to_utf8_lossy(),
+            lang_vendor: &tags.lang_vendor.to_utf8_lossy(),
+            tracer_version: &tags.tracer_version.to_utf8_lossy(),
+            container_id: &tags.container_id.to_utf8_lossy(),
+            client_computed_top_level: tags.client_computed_top_level,
+            client_computed_stats: tags.client_computed_stats,
         }
         .into()
     }


### PR DESCRIPTION
# What does this PR do?

There are two main aspects to this:

 1. Implement `Deref<Target=[T]>` for `Slice` and `Vec`. This effectively allows callers to use all slice methods on both types. This culls some code while definitely being more expressive.
 2. Removes unsafe from most functions for these types. If you don't trust type coming from FFI, then check it at the boundary anyway. Once the types are correctly constructed, they aren't unsafe, and we don't need to infect everything.

# Motivation

I recently learned about the `Deref<Target=[T]>` trick and finally got around to applying it here.

# Additional Notes

I renamed `Slice::new` to `Slice::from_raw_parts` and added a `Slice::new` which is a `const fn`. I fixed all the code in the repository, but if you use it from outside, you may need to change.

# How to test the change?

Everything should work as before 👍🏻.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
