### PR TITLE
Update protobuf files for span links to avoid failure comments

### DIFF
--- a/trace-normalization/src/normalizer.rs
+++ b/trace-normalization/src/normalizer.rs
@@ -202,6 +202,7 @@ mod tests {
             parent_id: 1111,
             r#type: "http".to_string(),
             meta_struct: HashMap::new(),
+            span_links: vec![],
         }
     }
 

--- a/trace-obfuscation/benches/replace_trace_tags_bench.rs
+++ b/trace-obfuscation/benches/replace_trace_tags_bench.rs
@@ -46,6 +46,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         parent_id: 1111,
         r#type: "http".to_string(),
         meta_struct: HashMap::new(),
+        span_links: vec![],
     };
 
     let mut trace = [span_1];

--- a/trace-obfuscation/src/replacer.rs
+++ b/trace-obfuscation/src/replacer.rs
@@ -109,6 +109,7 @@ mod tests {
             parent_id: 1111,
             r#type: "http".to_string(),
             meta_struct: HashMap::new(),
+            span_links: vec![],
         };
         for (key, val) in tags {
             match key {

--- a/trace-protobuf/build.rs
+++ b/trace-protobuf/build.rs
@@ -47,6 +47,8 @@ fn generate_protobuf() {
     config.type_attribute("TracerPayload", "#[derive(Deserialize, Serialize)]");
     config.type_attribute("TraceChunk", "#[derive(Deserialize, Serialize)]");
 
+    config.type_attribute("SpanLink", "#[derive(Deserialize, Serialize)]");
+
     config.type_attribute("Span", "#[derive(Deserialize, Serialize)]");
     config.field_attribute(
         ".pb.Span",

--- a/trace-protobuf/src/pb.rs
+++ b/trace-protobuf/src/pb.rs
@@ -17,6 +17,44 @@ where
 #[derive(Deserialize, Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SpanLink {
+    /// @gotags: json:"trace_id" msg:"trace_id"
+    ///
+    /// Required.
+    #[prost(uint64, tag = "1")]
+    pub trace_id: u64,
+    /// @gotags: json:"trace_id_high" msg:"trace_id_high,omitempty"
+    ///
+    /// Optional. The high 64 bits of a referenced trace id.
+    #[prost(uint64, tag = "2")]
+    pub trace_id_high: u64,
+    /// @gotags: json:"span_id" msg:"span_id"
+    ///
+    /// Required.
+    #[prost(uint64, tag = "3")]
+    pub span_id: u64,
+    /// @gotags: msg:"attributes,omitempty"
+    ///
+    /// Optional. Simple mapping of keys to string values.
+    #[prost(map = "string, string", tag = "4")]
+    pub attributes: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
+    /// @gotags: msg:"tracestate,omitempty"
+    ///
+    /// Optional. W3C tracestate.
+    #[prost(string, tag = "5")]
+    pub tracestate: ::prost::alloc::string::String,
+    /// @gotags: msg:"flags,omitempty"
+    ///
+    /// Optional. W3C trace flags. If set, the high bit (bit 31) must be set.
+    #[prost(uint32, tag = "6")]
+    pub flags: u32,
+}
+#[derive(Deserialize, Serialize)]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Span {
     /// service is the name of the service with which this span is associated.
     /// @gotags: json:"service" msg:"service"
@@ -102,6 +140,12 @@ pub struct Span {
         ::prost::alloc::string::String,
         ::prost::alloc::vec::Vec<u8>,
     >,
+    /// span_links represents a collection of links, where each link defines a causal relationship between two spans.
+    /// @gotags: json:"span_links,omitempty" msg:"span_links,omitempty"
+    #[prost(message, repeated, tag = "14")]
+    #[serde(default)]
+    #[serde(deserialize_with = "deserialize_null_into_default")]
+    pub span_links: ::prost::alloc::vec::Vec<SpanLink>,
 }
 /// TraceChunk represents a list of spans with the same trace ID. In other words, a chunk of a trace.
 #[derive(Deserialize, Serialize)]

--- a/trace-protobuf/src/pb/span.proto
+++ b/trace-protobuf/src/pb/span.proto
@@ -4,6 +4,21 @@ package pb;
 
 option go_package="pkg/proto/pbgo/trace";
 
+message SpanLink {
+   // @gotags: json:"trace_id" msg:"trace_id"
+   uint64 traceID = 1;                         // Required.
+   // @gotags: json:"trace_id_high" msg:"trace_id_high,omitempty"
+   uint64 traceID_high = 2;                    // Optional. The high 64 bits of a referenced trace id. 
+   // @gotags: json:"span_id" msg:"span_id"
+   uint64 spanID = 3;                          // Required.
+   // @gotags: msg:"attributes,omitempty"
+   map<string, string> attributes = 4;         // Optional. Simple mapping of keys to string values.
+   // @gotags: msg:"tracestate,omitempty"
+   string tracestate = 5;                      // Optional. W3C tracestate.
+   // @gotags: msg:"flags,omitempty"
+   uint32 flags = 6;                           // Optional. W3C trace flags. If set, the high bit (bit 31) must be set.
+}
+
 message Span {
     // service is the name of the service with which this span is associated.
     // @gotags: json:"service" msg:"service"
@@ -44,4 +59,7 @@ message Span {
     // meta_struct is a registry of structured "other" data used by, e.g., AppSec.
     // @gotags: json:"meta_struct,omitempty" msg:"meta_struct,omitempty"
     map<string, bytes> meta_struct = 13;
+    // span_links represents a collection of links, where each link defines a causal relationship between two spans.
+    // @gotags: json:"span_links,omitempty" msg:"span_links,omitempty"
+    repeated SpanLink spanLinks = 14;
 }

--- a/trace-utils/src/trace_test_utils.rs
+++ b/trace-utils/src/trace_test_utils.rs
@@ -34,6 +34,7 @@ pub fn create_test_span(
         metrics: HashMap::new(),
         r#type: "".to_string(),
         meta_struct: HashMap::new(),
+        span_links: vec![],
     };
     if is_top_level {
         span.metrics.insert("_top_level".to_string(), 1.0);

--- a/trace-utils/src/trace_utils.rs
+++ b/trace-utils/src/trace_utils.rs
@@ -571,6 +571,7 @@ mod tests {
                     metrics: HashMap::new(),
                     meta_struct: HashMap::new(),
                     r#type: "".to_string(),
+                    span_links: vec![],
                 }]],
             ),
             (
@@ -597,6 +598,7 @@ mod tests {
                     metrics: HashMap::new(),
                     meta_struct: HashMap::new(),
                     r#type: "".to_string(),
+                    span_links: vec![],
                 }]],
             ),
         ];


### PR DESCRIPTION
# What does this PR do?

Updates the protobuf definition files and files using it to match the latest main in the Datadog Agent (again).

# Motivation

Annoying failure messages for every commit in every PR (again).
