### PR TITLE
style: fix clippy::ineffective-open-options

### DIFF
--- a/sidecar/src/log.rs
+++ b/sidecar/src/log.rs
@@ -29,7 +29,6 @@ fn create_logfile(path: &PathBuf) -> anyhow::Result<std::fs::File> {
     let log_file = std::fs::File::options()
         .create(true)
         .truncate(false)
-        .write(true)
         .append(true)
         .open(path)?;
     Ok(log_file)

--- a/sidecar/src/unix.rs
+++ b/sidecar/src/unix.rs
@@ -268,7 +268,6 @@ fn daemonize(listener: StdUnixListener, cfg: Config) -> io::Result<()> {
     match cfg.log_method {
         config::LogMethod::File(path) => {
             let file = File::options()
-                .write(true)
                 .append(true)
                 .truncate(false)
                 .create(true)


### PR DESCRIPTION
# What does this PR do?

Fixes new clippy lint.

# Motivation

Clippy started failing due to a new Rust release.

# Additional Notes

None.

# How to test the change?

Nothing changed as `append(true)` already implies `write(true)`.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
