### PR TITLE
fix: security alert for h2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1171,9 +1171,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",


### PR DESCRIPTION
# What does this PR do?

Updates `h2` security alert [security/dependabot/16](https://github.com/DataDog/libdatadog/security/dependabot/16).

# Motivation

I got notified on a `git push` this was there.

# Additional Notes

I don't think we use this functionality at all.

# How to test the change?

As I don't think we use this functionality, and this update is a security fix only, nothing should change at all.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
