### PR TITLE
[PROF-8944] Package libdatadog v6.0.0 for Ruby

### DIFF
--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -11,7 +11,7 @@ require "rubygems/package"
 
 RSpec::Core::RakeTask.new(:spec)
 
-LIB_VERSION_TO_PACKAGE = "5.0.0"
+LIB_VERSION_TO_PACKAGE = "6.0.0"
 unless LIB_VERSION_TO_PACKAGE.start_with?(Libdatadog::LIB_VERSION)
   raise "`LIB_VERSION_TO_PACKAGE` setting in <Rakefile> (#{LIB_VERSION_TO_PACKAGE}) does not match " \
     "`LIB_VERSION` setting in <lib/libdatadog/version.rb> (#{Libdatadog::LIB_VERSION})"
@@ -20,22 +20,22 @@ end
 LIB_GITHUB_RELEASES = [
   {
     file: "libdatadog-aarch64-alpine-linux-musl.tar.gz",
-    sha256: "f5fb14372b8d6018f4759eb81447dfec0d3393e8e4e44fe890c42045563b5de4",
+    sha256: "05d74d3fd7d6772df20f7ab883343e1e957141eebf3438699e9d11ba85645beb",
     ruby_platform: "aarch64-linux-musl"
   },
   {
     file: "libdatadog-aarch64-unknown-linux-gnu.tar.gz",
-    sha256: "2b3d1c5c3965ab4a9436aff4e101814eddaa59b59cb984ce6ebda45613aadbc3",
+    sha256: "06b4fef45c3ae9c4ea96122c0b9c87a265b7f32ba8684f6b799dbc1b7741d3cb",
     ruby_platform: "aarch64-linux"
   },
   {
     file: "libdatadog-x86_64-alpine-linux-musl.tar.gz",
-    sha256: "060482ff1c34940cf7fad1dc841693602e04e4fa54ac9e9f08cb688efcbab137",
+    sha256: "9bcf744862677a4bef0d826ac3cbe27d134fc3442ef5ac3a8d38e6783d83a659",
     ruby_platform: "x86_64-linux-musl"
   },
   {
     file: "libdatadog-x86_64-unknown-linux-gnu.tar.gz",
-    sha256: "11c09440271dd4374b8fca8f0faa66c43a5e057aae05902543beb1e6cb382e52",
+    sha256: "a0f0d71dd44e94039166ada166cb3917e262abc22a6f76784b8cc793b59da2c5",
     ruby_platform: "x86_64-linux"
   }
 ]

--- a/ruby/lib/libdatadog/version.rb
+++ b/ruby/lib/libdatadog/version.rb
@@ -2,7 +2,7 @@
 
 module Libdatadog
   # Current libdatadog version
-  LIB_VERSION = "5.0.0"
+  LIB_VERSION = "6.0.0"
 
   GEM_MAJOR_VERSION = "1"
   GEM_MINOR_VERSION = "0"


### PR DESCRIPTION
# What does this PR do?

This PR includes the changes documented in the "Releasing a new version to rubygems.org" part of the README:
https://github.com/datadog/libdatadog/tree/main/ruby#releasing-a-new-version-to-rubygemsorg

(It's also exactly the same as the [v5.0.0 release PR](https://github.com/DataDog/libdatadog/pull/267)).

# Motivation

Enable Ruby to use libdatadog v6.0.0.

# Additional Notes

N/A

# How to test the change?

I've tested this release locally against the changes in https://github.com/DataDog/dd-trace-rb/pull/3455 .

As a reminder, new libdatadog releases don't get automatically picked up by dd-trace-rb, so the PR that bumps the Ruby profiler will also test this release against all supported Ruby versions.

## For Reviewers

- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
