### PR TITLE
Minor CI fix - build telemetry ffi

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,8 +91,8 @@ jobs:
       - name: "Generate Telemetry FFI"
         shell: bash
         run: |
-           chmod +x build-profiling-ffi.sh
-           ./build-profiling-ffi.sh ${OUTPUT_FOLDER}/telemetry
+           chmod +x build-telemetry-ffi.sh
+           ./build-telemetry-ffi.sh ${OUTPUT_FOLDER}/telemetry
 
       - name: 'Publish libdatadog'
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
# What does this PR do?

Call the matching build telemetry step (instead of build-profiling-ffi)

# Motivation

N/A

# Additional Notes

NA

# How to test the change?

NA

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
