### PR TITLE
3rd party license check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -81,13 +81,25 @@ jobs:
       - name: "Generate new LICENSE-3rdparty.yml and check against the previous" 
         env: 
           CARGO_HOME: "/tmp/dd-cargo"
-        run: > 
+        run: |
+          # Run cargo bundle-licenses without directly checking against a previous snapshot
           cargo bundle-licenses \
             --format yaml \
-            --output /tmp/CI.yaml \
-            --previous LICENSE-3rdparty.yml \
-            --check-previous \
-          || diff /tmp/CI.yaml LICENSE-3rdparty.yml
+            --output /tmp/CI.yaml
+
+          # Normalize the paths in both files to ignore registry differences
+          sed -E 's/(registry\/src\/)[^\/]+/\1normalized_path/g' /tmp/CI.yaml > /tmp/CI_normalized.yaml
+          sed -E 's/(registry\/src\/)[^\/]+/\1normalized_path/g' LICENSE-3rdparty.yml > /tmp/LICENSE-3rdparty_normalized.yml
+
+          # Now perform the diff on the normalized files
+          if ! diff /tmp/CI_normalized.yaml /tmp/LICENSE-3rdparty_normalized.yml; then
+            echo "Differences detected."
+            exit 1
+          fi
+
+          echo "No differences found."
+
+
       - name: export the generated license file on failure
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
# What does this PR do?

The check on the 3rd party licenses was causing issues when the registry paths were different. This is a workaround where we ignore parts of the paths.

# Motivation

Fix 3rd party license check flakyness
Ignore differences due to path
```
registry/src/index.crates.io-6f17d22bba15001f/ring-0.16.20/LICENSE
```

# Additional Notes

NA

# How to test the change?

This is a CI change

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
