### PR TITLE
Update protobuf files for stats to avoid failure comments

### DIFF
--- a/trace-protobuf/src/pb.rs
+++ b/trace-protobuf/src/pb.rs
@@ -341,6 +341,14 @@ pub struct ClientStatsPayload {
     #[prost(string, repeated, tag = "12")]
     #[serde(default)]
     pub tags: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// The git commit SHA is obtained from a trace, where it may be set through a tracer <-> source code integration.
+    #[prost(string, tag = "13")]
+    #[serde(default)]
+    pub git_commit_sha: ::prost::alloc::string::String,
+    /// The image tag is obtained from a container's set of tags.
+    #[prost(string, tag = "14")]
+    #[serde(default)]
+    pub image_tag: ::prost::alloc::string::String,
 }
 /// ClientStatsBucket is a time bucket containing aggregated stats.
 #[derive(Deserialize, Serialize)]

--- a/trace-protobuf/src/pb/stats.proto
+++ b/trace-protobuf/src/pb/stats.proto
@@ -45,6 +45,10 @@ message ClientStatsPayload {
 	// Tags specifies a set of tags obtained from the orchestrator (where applicable) using the specified containerID.
 	// This field should be left empty by the client. It only applies to some specific environment.
 	repeated string tags = 12;
+	// The git commit SHA is obtained from a trace, where it may be set through a tracer <-> source code integration.
+	string git_commit_sha = 13;
+	// The image tag is obtained from a container's set of tags.
+	string image_tag = 14;
 }
 
 // ClientStatsBucket is a time bucket containing aggregated stats.


### PR DESCRIPTION
# What does this PR do?

Updates the protobuf definition files and files using it to match the latest main in the Datadog Agent.

# Motivation

Avoid failure comments for diffs in CI.

# Additional Notes



# How to test the change?



## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
