### PR TITLE
Validate protobuf file diffs on PRs against a fixed tag and add nightly

### DIFF
--- a/.github/workflows/diff-proto-files.sh
+++ b/.github/workflows/diff-proto-files.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+
+set -eux
+
+PROTO_FILE=""
+DATADOG_AGENT_TAG="main"
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --file)
+      PROTO_FILE=$2
+      shift && shift # past argument and value
+      ;;
+    --tag)
+      DATADOG_AGENT_TAG=$2
+      shift && shift # past argument and value
+      ;;
+    *)
+      echo "Unknown option $1"
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$PROTO_FILE" ]; then
+  echo "Missing --file argument"
+  exit 1
+fi
+
+GO_AGENT_PROTO=$(curl -s "https://raw.githubusercontent.com/DataDog/datadog-agent/$DATADOG_AGENT_TAG/pkg/proto/datadog/trace/$PROTO_FILE")
+FIX_IMPORT_PATH=$(echo "$GO_AGENT_PROTO" | sed -e 's/import "datadog\/trace\//import "/g')
+FIX_PACKAGE_NAME=$(echo "$FIX_IMPORT_PATH" | sed -e 's/datadog\.trace/pb/g')
+echo "$FIX_PACKAGE_NAME" | diff "$PROTO_FILE" -

--- a/.github/workflows/nightly-verify-proto-files.yml
+++ b/.github/workflows/nightly-verify-proto-files.yml
@@ -1,0 +1,59 @@
+name: 'Nightly verify trace-protobuf'
+
+on:
+  schedule:
+    - cron: '0 2 * * 1-5'
+
+env:
+  DATADOG_AGENT_TAG: "main"
+
+jobs:
+  nightly-verify-proto-files:
+    name: "Verify trace-protobuf .proto files are in sync with datadog-agent"        
+    runs-on: ubuntu-latest
+    environment: nightlies
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: diff agent_payload.proto
+        working-directory: trace-protobuf/src/pb
+        id: agent_payload_proto
+        if: always()
+        run: |
+          ../../../.github/workflows/diff-proto-files.sh --file agent_payload.proto --tag ${{ env.DATADOG_AGENT_TAG }}
+
+      - name: diff tracer_payload.proto
+        working-directory: trace-protobuf/src/pb
+        id: tracer_payload_proto
+        if: always()
+        run: |
+          ../../../.github/workflows/diff-proto-files.sh --file tracer_payload.proto --tag ${{ env.DATADOG_AGENT_TAG }}
+
+      - name: diff stats.proto
+        working-directory: trace-protobuf/src/pb
+        id: stats_proto
+        if: always()
+        run: |
+          ../../../.github/workflows/diff-proto-files.sh --file stats.proto --tag ${{ env.DATADOG_AGENT_TAG }}
+
+      - name: diff span.proto
+        working-directory: trace-protobuf/src/pb
+        id: span_proto
+        if: always()
+        run: |
+          ../../../.github/workflows/diff-proto-files.sh --file span.proto --tag ${{ env.DATADOG_AGENT_TAG }}
+
+      - name: report failure
+        id: slack
+        if: failure()
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "workflow_name": "${{ github.workflow }}",
+              "workflow_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.COMMON_COMPONENTS_FAILURE_NOTIFICATION_URL }}

--- a/.github/workflows/verify-proto-files.yml
+++ b/.github/workflows/verify-proto-files.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     types: [ opened, synchronize, reopened ]
 
+env:
+  DATADOG_AGENT_TAG: "7.52.0-rc.1"
+
 jobs:
   verify-proto-files:
     name: "Verify trace-protobuf .proto files are in sync with datadog-agent"
@@ -17,11 +20,8 @@ jobs:
         continue-on-error: true
         id: agent_payload_proto
         run: |
-          GO_AGENT_PROTO=$(curl -s "https://raw.githubusercontent.com/DataDog/datadog-agent/main/pkg/proto/datadog/trace/agent_payload.proto")
-          FIX_IMPORT_PATH=$(echo "$GO_AGENT_PROTO" | sed -e "s/datadog\/trace\/tracer_payload.proto/tracer_payload.proto/g")
-          FIX_PACKAGE_NAME=$(echo "$FIX_IMPORT_PATH" | sed -e "s/datadog.trace/pb/g")
+          ../../../.github/workflows/diff-proto-files.sh --file agent_payload.proto --tag ${{ env.DATADOG_AGENT_TAG }}
 
-          echo "$FIX_PACKAGE_NAME" | diff agent_payload.proto -
       - uses: mainmatter/continue-on-error-comment@b2606cc5ef2525ec21692999676a19f047e3e082 # v1.2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -32,11 +32,7 @@ jobs:
         continue-on-error: true
         id: tracer_payload_proto
         run: |
-          GO_AGENT_PROTO=$(curl -s "https://raw.githubusercontent.com/DataDog/datadog-agent/main/pkg/proto/datadog/trace/tracer_payload.proto")
-          FIX_IMPORT_PATH=$(echo "$GO_AGENT_PROTO" | sed -e "s/datadog\/trace\/span.proto/span.proto/g")
-          FIX_PACKAGE_NAME=$(echo "$FIX_IMPORT_PATH" | sed -e "s/datadog.trace/pb/g")
-
-          echo "$FIX_PACKAGE_NAME" | diff tracer_payload.proto -
+          ../../../.github/workflows/diff-proto-files.sh --file tracer_payload.proto --tag ${{ env.DATADOG_AGENT_TAG }}
       - uses: mainmatter/continue-on-error-comment@b2606cc5ef2525ec21692999676a19f047e3e082 # v1.2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -47,11 +43,7 @@ jobs:
         continue-on-error: true
         id: stats_proto
         run: |
-          GO_AGENT_PROTO=$(curl -s "https://raw.githubusercontent.com/DataDog/datadog-agent/main/pkg/proto/datadog/trace/stats.proto")
-          FIX_IMPORT_PATH=$(echo "$GO_AGENT_PROTO" | sed -e "s/github.com\/gogo\/protobuf\/gogoproto\/gogo.proto/gogo.proto/g")
-          FIX_PACKAGE_NAME=$(echo "$FIX_IMPORT_PATH" | sed -e "s/datadog.trace/pb/g")
-
-          echo "$FIX_PACKAGE_NAME" | diff stats.proto -
+          ../../../.github/workflows/diff-proto-files.sh --file stats.proto --tag ${{ env.DATADOG_AGENT_TAG }}
       - uses: mainmatter/continue-on-error-comment@b2606cc5ef2525ec21692999676a19f047e3e082 # v1.2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -62,11 +54,7 @@ jobs:
         continue-on-error: true
         id: span_proto
         run: |
-          GO_AGENT_PROTO=$(curl -s "https://raw.githubusercontent.com/DataDog/datadog-agent/main/pkg/proto/datadog/trace/span.proto")
-          FIX_IMPORT_PATH=$(echo "$GO_AGENT_PROTO" | sed -e "s/github.com\/gogo\/protobuf\/gogoproto\/gogo.proto/gogo.proto/g")
-          FIX_PACKAGE_NAME=$(echo "$FIX_IMPORT_PATH" | sed -e "s/datadog.trace/pb/g")
-
-          echo "$FIX_PACKAGE_NAME" | diff span.proto -
+          ../../../.github/workflows/diff-proto-files.sh --file span.proto --tag ${{ env.DATADOG_AGENT_TAG }}
       - uses: mainmatter/continue-on-error-comment@b2606cc5ef2525ec21692999676a19f047e3e082 # v1.2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# What does this PR do?

Changes the diff of tracing protobuf files against the Datadog agent to use a fixed tag, and adds a nightly job against `main` to catch changes.

# Motivation

This kept _failing_ and cluttering up PRs with unnecessary warnings. We still want to check that no bad differences are introduced, and keep track of upstream changes, hence the nightly job.

# Additional Notes

Nope.

# How to test the change?

Have been tested manually by triggering the actions.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
