### PR TITLE
Updated rustfmt rules

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
         uses: ./.github/actions/cache
       - name: Install latest nightly toolchain and rustfmt
         run: rustup update nightly && rustup default nightly && rustup component add rustfmt
-      - run: rm -rf ipc/tarpc && sed -i 's/tarpc.*//' ipc/Cargo.toml && cargo fmt --all -- --check
+      - run: cargo fmt --all -- --check
   clippy:
     name: "clippy #${{ matrix.rust_version }}"
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
-# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+# Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
 
 [workspace]
 members = [

--- a/bin_tests/Cargo.toml
+++ b/bin_tests/Cargo.toml
@@ -1,5 +1,5 @@
-# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+# Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
 
 [package]
 name = "bin_tests"

--- a/bin_tests/src/bin/crashtracker_bin_test.rs
+++ b/bin_tests/src/bin/crashtracker_bin_test.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 #[cfg(not(unix))]
 fn main() {}

--- a/bin_tests/src/bin/crashtracker_receiver.rs
+++ b/bin_tests/src/bin/crashtracker_receiver.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 #[cfg(not(unix))]
 fn main() {}

--- a/bin_tests/src/bin/test_the_tests.rs
+++ b/bin_tests/src/bin/test_the_tests.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 /// This is an empty binary used to test the machinery of building bins
 /// in cargo test works

--- a/bin_tests/src/lib.rs
+++ b/bin_tests/src/lib.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::{collections::HashMap, env, ops::DerefMut, path::PathBuf, process, sync::Mutex};
 

--- a/bin_tests/src/lib.rs
+++ b/bin_tests/src/lib.rs
@@ -63,7 +63,8 @@ fn inner_build_artifact(c: &ArtifactsBuild) -> anyhow::Result<PathBuf> {
     }
 
     /// This static variable contains the path in which cargo puts it's build artifacts
-    /// This relies on the assumption that the current binary is assumed to not have been moved from it's directory
+    /// This relies on the assumption that the current binary is assumed to not have been moved from
+    /// it's directory
     static ARTIFACT_DIR: OnceCell<PathBuf> = OnceCell::new();
     let artifact_dir = ARTIFACT_DIR.get_or_init(|| {
         let test_bin_location = PathBuf::from(env::args().next().unwrap());

--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 #![cfg(unix)]
 

--- a/bin_tests/tests/test_the_tests.rs
+++ b/bin_tests/tests/test_the_tests.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 #![cfg(unix)]
 

--- a/build-common/Cargo.toml
+++ b/build-common/Cargo.toml
@@ -1,5 +1,5 @@
-# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+# Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
 
 [package]
 name = "build_common"

--- a/build-common/src/cbindgen.rs
+++ b/build-common/src/cbindgen.rs
@@ -12,7 +12,8 @@ use std::{env, fs};
 /// Expects CARGO_MANIFEST_DIR to be set.
 /// If DESTDIR is set, it will be used as the base directory for the header file.
 ///         DESTDIR can be either relative or absolute.
-/// Either CARGO_TARGET_DIR is set, or `cargo locate-project --workspace` is used to find the base of the target directory.
+/// Either CARGO_TARGET_DIR is set, or `cargo locate-project --workspace` is used to find the base
+/// of the target directory.
 ///
 /// # Arguments
 ///
@@ -40,7 +41,8 @@ pub fn generate_and_configure_header(header_name: &str) {
                 .expect("Failed to extract project root path")
                 .replace('\"', "");
 
-            // Correctly find the parent of the Cargo.toml file's directory to approximate the workspace root
+            // Correctly find the parent of the Cargo.toml file's directory to approximate the
+            // workspace root
             PathBuf::from(project_root)
                 .parent()
                 .expect("Failed to find workspace root directory")
@@ -57,7 +59,8 @@ pub fn generate_and_configure_header(header_name: &str) {
 
     // Check if `deliverables_dir` is relative
     if deliverables_dir.is_relative() {
-        // Get the parent directory of `cargo_target_dir` to use as a base for the relative `deliverables_dir`
+        // Get the parent directory of `cargo_target_dir` to use as a base for the relative
+        // `deliverables_dir`
         let parent_dir = cargo_target_dir
             .parent()
             .expect("CARGO_TARGET_DIR does not have a parent directory, aborting build.");
@@ -74,9 +77,8 @@ pub fn generate_and_configure_header(header_name: &str) {
 ///
 /// * `crate_dir` - The directory of the crate to generate bindings for.
 /// * `header_name` - The name of the header file to generate.
-/// * `output_base_dir` - The base directory where the header file will be placed.
-///                       Should be an absolute path as build scripts are run from
-///                       the current crate's root.
+/// * `output_base_dir` - The base directory where the header file will be placed. Should be an
+///   absolute path as build scripts are run from the current crate's root.
 pub fn generate_header(crate_dir: PathBuf, header_name: &str, output_base_dir: PathBuf) {
     assert!(
         output_base_dir.is_absolute(),

--- a/build-common/src/cbindgen.rs
+++ b/build-common/src/cbindgen.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 use cbindgen::Config;
 use std::path::PathBuf;
 use std::process::Command;

--- a/build-common/src/lib.rs
+++ b/build-common/src/lib.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 #[cfg(not(feature = "cbindgen"))]
 pub fn generate_and_configure_header(_header_name: &str) {}

--- a/build-profiling-ffi.sh
+++ b/build-profiling-ffi.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
-# Unless explicitly stated otherwise all files in this repository are licensed
-# under the Apache License Version 2.0. This product includes software developed
-# at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+# Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
 
 get_abs_filename() {
   # $1 : relative filename

--- a/build-telemetry-ffi.sh
+++ b/build-telemetry-ffi.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
-# Unless explicitly stated otherwise all files in this repository are licensed
-# under the Apache License Version 2.0. This product includes software developed
-# at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+# Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
 
 set -eu
 

--- a/cmake/DatadogConfig.cmake.in
+++ b/cmake/DatadogConfig.cmake.in
@@ -1,6 +1,5 @@
-# Unless explicitly stated otherwise all files in this repository are licensed
-# under the Apache License Version 2.0. This product includes software developed
-# at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+# Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
 include(FindPackageHandleStandardArgs)
 
 if(DEFINED ENV{Datadog_ROOT})

--- a/crashtracker/libdatadog-crashtracking-receiver.c
+++ b/crashtracker/libdatadog-crashtracking-receiver.c
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2024-Present Datadog, Inc.
+// Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 #include <datadog/common.h>
 #include <datadog/profiling.h>

--- a/crashtracker/src/api.rs
+++ b/crashtracker/src/api.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 #![cfg(unix)]
 
 use crate::{

--- a/crashtracker/src/collectors.rs
+++ b/crashtracker/src/collectors.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Context;
 

--- a/crashtracker/src/constants.rs
+++ b/crashtracker/src/constants.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 pub const DD_CRASHTRACK_BEGIN_CONFIG: &str = "DD_CRASHTRACK_BEGIN_CONFIG";
 pub const DD_CRASHTRACK_BEGIN_COUNTERS: &str = "DD_CRASHTRACK_BEGIN_COUNTERS";

--- a/crashtracker/src/counters.rs
+++ b/crashtracker/src/counters.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use super::constants::*;
 use std::{

--- a/crashtracker/src/crash_handler.rs
+++ b/crashtracker/src/crash_handler.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 #![cfg(unix)]
 

--- a/crashtracker/src/crash_info.rs
+++ b/crashtracker/src/crash_info.rs
@@ -1,5 +1,6 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::stacktrace::StackFrame;
 use crate::CrashtrackerMetadata;
 use anyhow::Context;

--- a/crashtracker/src/lib.rs
+++ b/crashtracker/src/lib.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 //! This module implements a crashtracker based on catching UNIX signals and
 //! uploading the result to the backend.

--- a/crashtracker/src/lib.rs
+++ b/crashtracker/src/lib.rs
@@ -8,7 +8,7 @@
 //! 1. A signal handler, which catches a UNIX signal (SIGSEGV, SIGBUS, SIGABRT)
 //!    associated with a crash, and and collects information about the state of
 //!    the program at crash time.  The signal handler runs under a constrained
-//!    environment where many standard operations are illegal.  
+//!    environment where many standard operations are illegal.
 //!    https://man7.org/linux/man-pages/man7/signal-safety.7.html
 //!    In particular, memory allocation, and synchronization such as mutexes are
 //!    potentially UB.  The signal handler therefore does as little as possible
@@ -23,28 +23,26 @@
 //!    Once the receiver has completed, the crash-handler returns, allowing the
 //!    previous crash handler (if any) to execute, maintaining the customer
 //!    experience as much as possible.
-//! 2. The receiver process runs in the background, listening on `stdin`, which
-//!    is connected by a pipe to the parent process.  When a crash occurs, the
-//!    receiver gathers the information from the pipe, adds additional data
-//!    about the system state (e.g. /proc/cpuinfo and /proc/meminfo), formats it
-//!    into a crash report, uploads it to the backend, and then exits.
-//!    The receiver also exits if the pipe is closed without a crash report,
-//!    to avoid leaving a zombie process if the parent exits normally.
+//! 2. The receiver process runs in the background, listening on `stdin`, which is connected by a
+//!    pipe to the parent process.  When a crash occurs, the receiver gathers the information from
+//!    the pipe, adds additional data about the system state (e.g. /proc/cpuinfo and /proc/meminfo),
+//!    formats it into a crash report, uploads it to the backend, and then exits. The receiver also
+//!    exits if the pipe is closed without a crash report, to avoid leaving a zombie process if the
+//!    parent exits normally.
 //!
 //! Data collected:
 //! 1. The data collected by the crash-handler includes:
-//!    i. The signal type leading to the crash
-//!    ii. The stacktrace at time of crash (for the crashing thread).  Depending
-//!        on a flag, this can either be resolved, or raw addresses.
-//!        Resolving addresses provide more data, but sometimes crashes the
-//!        crash handler (ironic).
-//!    iii. System level info (e.g. /proc/self/maps).
-//!    iv. The result of counters describing the current state of the profiler.
+//!    1. The signal type leading to the crash
+//!    2. The stacktrace at time of crash (for the crashing thread). Depending on a flag, this can
+//!       either be resolved, or raw addresses. Resolving addresses provide more data, but sometimes
+//!       crashes the crash handler (ironic).
+//!    3. System level info (e.g. /proc/self/maps).
+//!    4. The result of counters describing the current state of the profiler.
 //! 2. Data augmented by the receiver includes:
-//!    i. Metadata provided by the caller (e.g. library & profiler versions).
-//!    ii. System info: OS version, /proc/cpuinfo /proc/meminfo, etc.
-//!    iii. A timestamp and GUID for tracking the crash report.
-//!    
+//!    1. Metadata provided by the caller (e.g. library & profiler versions).
+//!    2. System info: OS version, /proc/cpuinfo /proc/meminfo, etc.
+//!    3. A timestamp and GUID for tracking the crash report.
+//!
 //! Handling of forks
 //! Safety issues
 #![cfg(unix)]

--- a/crashtracker/src/receiver.rs
+++ b/crashtracker/src/receiver.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use self::stacktrace::StackFrame;
 use super::*;

--- a/crashtracker/src/receiver.rs
+++ b/crashtracker/src/receiver.rs
@@ -190,8 +190,7 @@ enum CrashReportStatus {
 
 /// Listens to `stream`, reading it line by line, until
 /// 1. A crash-report is received, in which case it is processed for upload
-/// 2. `stdin` closes without a crash report (i.e. if the parent terminated
-///    normally)
+/// 2. `stdin` closes without a crash report (i.e. if the parent terminated normally)
 /// In the case where the parent failed to transfer a full crash-report
 /// (for instance if it crashed while calculating the crash-report), we return
 /// a PartialCrashReport.

--- a/crashtracker/src/stacktrace.rs
+++ b/crashtracker/src/stacktrace.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2024-Present Datadog, Inc.
+// Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use blazesym::symbolize::{Input, Source, Sym, Symbolized, Symbolizer};
 use serde::{Deserialize, Serialize};

--- a/crashtracker/src/telemetry.rs
+++ b/crashtracker/src/telemetry.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
 use std::fmt::Write;

--- a/ddcommon-ffi/Cargo.toml
+++ b/ddcommon-ffi/Cargo.toml
@@ -1,5 +1,5 @@
-# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+# Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
 
 [package]
 name = "ddcommon-ffi"

--- a/ddcommon-ffi/build.rs
+++ b/ddcommon-ffi/build.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 extern crate build_common;
 
 use build_common::generate_and_configure_header;

--- a/ddcommon-ffi/cbindgen.toml
+++ b/ddcommon-ffi/cbindgen.toml
@@ -1,10 +1,11 @@
-# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+# Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
 
 language = "C"
 tab_width = 2
-header = """// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc."""
+header = """// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+"""
 include_guard = "DDOG_COMMON_H"
 style = "both"
 pragma_once = true

--- a/ddcommon-ffi/src/endpoint.rs
+++ b/ddcommon-ffi/src/endpoint.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::slice::AsBytes;
 use crate::Error;

--- a/ddcommon-ffi/src/endpoint.rs
+++ b/ddcommon-ffi/src/endpoint.rs
@@ -15,7 +15,8 @@ pub extern "C" fn ddog_endpoint_from_url(url: crate::CharSlice) -> Option<Box<En
         .map(|url| Box::new(Endpoint { url, api_key: None }))
 }
 
-// We'll just specify the base site here. If api key provided, different intakes need to use their own subdomains.
+// We'll just specify the base site here. If api key provided, different intakes need to use their
+// own subdomains.
 #[no_mangle]
 #[must_use]
 pub extern "C" fn ddog_endpoint_from_api_key(api_key: crate::CharSlice) -> Box<Endpoint> {
@@ -27,7 +28,8 @@ pub extern "C" fn ddog_endpoint_from_api_key(api_key: crate::CharSlice) -> Box<E
     })
 }
 
-// We'll just specify the base site here. If api key provided, different intakes need to use their own subdomains.
+// We'll just specify the base site here. If api key provided, different intakes need to use their
+// own subdomains.
 #[no_mangle]
 #[must_use]
 pub extern "C" fn ddog_endpoint_from_api_key_and_site(

--- a/ddcommon-ffi/src/error.rs
+++ b/ddcommon-ffi/src/error.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::slice::CharSlice;
 use crate::vec::Vec;

--- a/ddcommon-ffi/src/lib.rs
+++ b/ddcommon-ffi/src/lib.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 mod error;
 

--- a/ddcommon-ffi/src/option.rs
+++ b/ddcommon-ffi/src/option.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq)]

--- a/ddcommon-ffi/src/slice.rs
+++ b/ddcommon-ffi/src/slice.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use core::slice;
 use std::borrow::Cow;

--- a/ddcommon-ffi/src/tags.rs
+++ b/ddcommon-ffi/src/tags.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2022-Present Datadog, Inc.
+// Copyright 2022-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::slice::{AsBytes, CharSlice};
 use crate::Error;

--- a/ddcommon-ffi/src/vec.rs
+++ b/ddcommon-ffi/src/vec.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 extern crate alloc;
 

--- a/ddcommon/Cargo.toml
+++ b/ddcommon/Cargo.toml
@@ -1,5 +1,5 @@
-# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+# Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
 
 [package]
 name = "ddcommon"

--- a/ddcommon/src/azure_app_services.rs
+++ b/ddcommon/src/azure_app_services.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use lazy_static::lazy_static;
 use std::env;

--- a/ddcommon/src/config.rs
+++ b/ddcommon/src/config.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 pub mod parse_env {
     use http::Uri;

--- a/ddcommon/src/connector/conn_stream.rs
+++ b/ddcommon/src/connector/conn_stream.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::{
     pin::Pin,

--- a/ddcommon/src/connector/errors.rs
+++ b/ddcommon/src/connector/errors.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::error;
 use std::fmt;

--- a/ddcommon/src/connector/mod.rs
+++ b/ddcommon/src/connector/mod.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use futures::future::BoxFuture;
 use futures::{future, FutureExt};

--- a/ddcommon/src/connector/named_pipe.rs
+++ b/ddcommon/src/connector/named_pipe.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::path::{Path, PathBuf};
 

--- a/ddcommon/src/connector/uds.rs
+++ b/ddcommon/src/connector/uds.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::ffi::OsString;
 use std::os::unix::ffi::{OsStrExt, OsStringExt};

--- a/ddcommon/src/container_id.rs
+++ b/ddcommon/src/container_id.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use lazy_static::lazy_static;
 use regex::Regex;

--- a/ddcommon/src/cstr.rs
+++ b/ddcommon/src/cstr.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 #[doc(hidden)]
 pub const fn validate_cstr_contents(bytes: &[u8]) {

--- a/ddcommon/src/lib.rs
+++ b/ddcommon/src/lib.rs
@@ -80,10 +80,12 @@ where
 }
 
 // TODO: we should properly handle malformed urls
-// for windows and unix schemes:
-//    for compatibility reasons with existing implementation this parser stores the encoded path in authority section
-//    as there is no existing standard https://github.com/whatwg/url/issues/577 that covers this. We need to pick one hack or another
-// for file scheme implementation will simply backfill missing authority section
+// * For windows and unix schemes:
+//     * For compatibility reasons with existing implementation this parser stores the encoded path
+//       in authority section as there is no existing standard
+//       [see](https://github.com/whatwg/url/issues/577) that covers this. We need to pick one hack
+//       or another
+// * For file scheme implementation will simply backfill missing authority section
 pub fn parse_uri(uri: &str) -> anyhow::Result<hyper::Uri> {
     let scheme_pos = if let Some(scheme_pos) = uri.find("://") {
         scheme_pos

--- a/ddcommon/src/lib.rs
+++ b/ddcommon/src/lib.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::{borrow::Cow, ops::Deref, str::FromStr};
 

--- a/ddcommon/src/tag.rs
+++ b/ddcommon/src/tag.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::borrow::Cow;
 use std::fmt::{Debug, Display, Formatter};

--- a/ddtelemetry-ffi/Cargo.toml
+++ b/ddtelemetry-ffi/Cargo.toml
@@ -1,5 +1,5 @@
-# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+# Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
 
 [package]
 name = "ddtelemetry-ffi"

--- a/ddtelemetry-ffi/build.rs
+++ b/ddtelemetry-ffi/build.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 extern crate build_common;
 
 use build_common::generate_and_configure_header;

--- a/ddtelemetry-ffi/cbindgen.toml
+++ b/ddtelemetry-ffi/cbindgen.toml
@@ -1,10 +1,10 @@
-# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+# Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
 
 language = "C"
 tab_width = 2
-header = """// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+header = """// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 """
 include_guard = "DDOG_TELEMETRY_H"
 style = "both"

--- a/ddtelemetry-ffi/src/builder.rs
+++ b/ddtelemetry-ffi/src/builder.rs
@@ -1,5 +1,6 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
 use ddcommon::Endpoint;
 use ddcommon_ffi as ffi;
 use ddtelemetry::{

--- a/ddtelemetry-ffi/src/lib.rs
+++ b/ddtelemetry-ffi/src/lib.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use ddcommon_ffi as ffi;
 

--- a/ddtelemetry-ffi/src/worker_handle.rs
+++ b/ddtelemetry-ffi/src/worker_handle.rs
@@ -1,5 +1,6 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
 use ddcommon_ffi as ffi;
 use ddtelemetry::worker::TelemetryWorkerHandle;
 use ffi::slice::AsBytes;

--- a/ddtelemetry/examples/tm-ping.rs
+++ b/ddtelemetry/examples/tm-ping.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::{
     sync::atomic::{AtomicU64, Ordering},

--- a/ddtelemetry/examples/tm-worker-test.rs
+++ b/ddtelemetry/examples/tm-worker-test.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::{error::Error, time::Duration};
 

--- a/ddtelemetry/src/config.rs
+++ b/ddtelemetry/src/config.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use ddcommon::{config::parse_env, parse_uri, Endpoint};
 use std::{borrow::Cow, time::Duration};

--- a/ddtelemetry/src/data/common.rs
+++ b/ddtelemetry/src/data/common.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};
 

--- a/ddtelemetry/src/data/metrics.rs
+++ b/ddtelemetry/src/data/metrics.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use ddcommon::tag::Tag;
 use serde::{Deserialize, Serialize};

--- a/ddtelemetry/src/data/mod.rs
+++ b/ddtelemetry/src/data/mod.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 mod common;
 mod payloads;

--- a/ddtelemetry/src/data/payload.rs
+++ b/ddtelemetry/src/data/payload.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::data::*;
 use serde::Serialize;

--- a/ddtelemetry/src/data/payloads.rs
+++ b/ddtelemetry/src/data/payloads.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::data::metrics;
 

--- a/ddtelemetry/src/info.rs
+++ b/ddtelemetry/src/info.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 pub mod os {
     // TODO: this function will call API's (fargate, k8s, etc) in the future to get to real host API

--- a/ddtelemetry/src/lib.rs
+++ b/ddtelemetry/src/lib.rs
@@ -1,5 +1,6 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
 #![allow(clippy::mutex_atomic)]
 #![allow(clippy::nonminimal_bool)]
 

--- a/ddtelemetry/src/metrics.rs
+++ b/ddtelemetry/src/metrics.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::{
     collections::HashMap,

--- a/ddtelemetry/src/worker/builder.rs
+++ b/ddtelemetry/src/worker/builder.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::time::Duration;
 

--- a/ddtelemetry/src/worker/http_client.rs
+++ b/ddtelemetry/src/worker/http_client.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use ddcommon::HttpRequestBuilder;
 use http::uri::Parts;

--- a/ddtelemetry/src/worker/mod.rs
+++ b/ddtelemetry/src/worker/mod.rs
@@ -90,7 +90,6 @@ pub enum LifecycleAction {
 ///
 /// The identifier is a single 64 bit integer to save space an memory
 /// and to be able to generic on the way different languages handle
-///
 #[derive(Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct LogIdentifier {
     // Collisions? Never heard of them

--- a/ddtelemetry/src/worker/mod.rs
+++ b/ddtelemetry/src/worker/mod.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 mod builder;
 pub mod http_client;

--- a/ddtelemetry/src/worker/scheduler.rs
+++ b/ddtelemetry/src/worker/scheduler.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::time::{Duration, Instant};
 

--- a/ddtelemetry/src/worker/store.rs
+++ b/ddtelemetry/src/worker/store.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::{collections::VecDeque, hash::Hash};
 

--- a/ddtelemetry/src/worker/store.rs
+++ b/ddtelemetry/src/worker/store.rs
@@ -87,7 +87,8 @@ mod queuehasmpap {
         /// # Safety
         ///
         /// This function inserts a new item in the store unconditionnaly
-        /// If the item already exists, it's drop implementation will not be called, and memory might leak
+        /// If the item already exists, it's drop implementation will not be called, and memory
+        /// might leak
         ///
         /// The hash needs to be precomputed too
         fn insert_nocheck(&mut self, hash: u64, key: K, value: V) -> usize {

--- a/examples/ffi/profiles.c
+++ b/examples/ffi/profiles.c
@@ -1,7 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0. This product includes software
-// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
-// Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 #include <datadog/common.h>
 #include <datadog/profiling.h>

--- a/ipc/benches/ipc.rs
+++ b/ipc/benches/ipc.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 #[cfg(not(windows))]
 use criterion::{criterion_group, criterion_main, Criterion};

--- a/ipc/build.rs
+++ b/ipc/build.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 fn main() {
     // ensure symbols are properly exported for dlsym to be able to look them up

--- a/ipc/macros/src/lib.rs
+++ b/ipc/macros/src/lib.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use proc_macro::TokenStream;
 use quote::{format_ident, quote, ToTokens};

--- a/ipc/src/example_interface.rs
+++ b/ipc/src/example_interface.rs
@@ -63,7 +63,8 @@ impl ExampleInterface for ExampleServer {
 
     fn notify(self, _: Context) -> Self::NotifyFut {
         self.req_cnt.fetch_add(1, Ordering::AcqRel);
-        pending() // returning pending future, ensures the RPC system will not try to return a response to the client
+        pending() // returning pending future, ensures the RPC system will not try to return a
+                  // response to the client
     }
 
     type TimeNowFut = Ready<Duration>;

--- a/ipc/src/example_interface.rs
+++ b/ipc/src/example_interface.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 use std::{
     fs::File,
     sync::{

--- a/ipc/src/handles.rs
+++ b/ipc/src/handles.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::error::Error;
 

--- a/ipc/src/lib.rs
+++ b/ipc/src/lib.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 pub mod example_interface;
 pub mod handles;

--- a/ipc/src/platform/channel/metadata.rs
+++ b/ipc/src/platform/channel/metadata.rs
@@ -1,5 +1,6 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::handles::HandlesTransport;
 use crate::platform::metadata::ChannelMetadata;
 use crate::platform::PlatformHandle;

--- a/ipc/src/platform/channel/mod.rs
+++ b/ipc/src/platform/channel/mod.rs
@@ -1,3 +1,4 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
 mod metadata;

--- a/ipc/src/platform/mem_handle.rs
+++ b/ipc/src/platform/mem_handle.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::handles::{HandlesTransport, TransferHandles};
 use crate::platform::{mmap_handle, munmap_handle, OwnedFileHandle, PlatformHandle};

--- a/ipc/src/platform/message.rs
+++ b/ipc/src/platform/message.rs
@@ -1,5 +1,6 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::handles::{HandlesTransport, TransferHandles};
 use crate::platform::Message;
 

--- a/ipc/src/platform/mod.rs
+++ b/ipc/src/platform/mod.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 #[cfg(unix)]
 mod unix;

--- a/ipc/src/platform/platform_handle.rs
+++ b/ipc/src/platform/platform_handle.rs
@@ -32,7 +32,8 @@ pub struct PlatformHandle<T> {
             serialize_with = "serialize_rawhandle"
         )
     )]
-    pub(crate) fd: RawFileHandle, // Just an fd number to be used as reference e.g. when serializing, not for accessing actual fd
+    pub(crate) fd: RawFileHandle, /* Just an fd number to be used as reference e.g. when
+                                   * serializing, not for accessing actual fd */
     #[serde(skip)]
     pub(crate) inner: Option<Arc<OwnedFileHandle>>,
     pub(crate) phantom: PhantomData<T>,

--- a/ipc/src/platform/platform_handle.rs
+++ b/ipc/src/platform/platform_handle.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 #[cfg(windows)]
 //noinspection RsUnusedImport

--- a/ipc/src/platform/unix/channel.rs
+++ b/ipc/src/platform/unix/channel.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::handles::TransferHandles;
 use crate::platform::{Message, PlatformHandle};

--- a/ipc/src/platform/unix/channel/async_channel.rs
+++ b/ipc/src/platform/unix/channel/async_channel.rs
@@ -109,11 +109,11 @@ impl AsyncRead for AsyncChannel {
         let mut fds = [0; MAX_FDS];
 
         // Safety: this implementation is based on Tokio async read implementation,
-        // it is performing an UB operation by using uninitiallized memory - although in practice its somewhat defined
-        // there are still some unknowns WRT to future behaviors
-        // TODO: make sure this optimization is really needed - once BenchPlatform is connected to libdatadog
-        // benchmark unfilled_mut vs initialize_unfilled - and if the difference is negligible - then lets switch to
-        // implementation that doesn't use UB.
+        // it is performing an UB operation by using uninitiallized memory - although in practice
+        // its somewhat defined there are still some unknowns WRT to future behaviors
+        // TODO: make sure this optimization is really needed - once BenchPlatform is connected to
+        // libdatadog benchmark unfilled_mut vs initialize_unfilled - and if the difference
+        // is negligible - then lets switch to implementation that doesn't use UB.
         unsafe {
             let b = &mut *(buf.unfilled_mut() as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]);
             match project.inner.recv_with_fd(b, &mut fds) {

--- a/ipc/src/platform/unix/channel/async_channel.rs
+++ b/ipc/src/platform/unix/channel/async_channel.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use pin_project::pin_project;
 use sendfd::{RecvWithFd, SendWithFd};

--- a/ipc/src/platform/unix/channel/metadata.rs
+++ b/ipc/src/platform/unix/channel/metadata.rs
@@ -46,8 +46,9 @@ impl ChannelMetadata {
                 .into_iter()
                 .flat_map(|fd| self.fds_to_close.remove(&fd));
 
-            // if ACK came from the same PID, it means there is a duplicate PlatformHandle instance in the same
-            // process. Thus we should leak the handles allowing other PlatformHandle's to safely close
+            // if ACK came from the same PID, it means there is a duplicate PlatformHandle instance
+            // in the same process. Thus we should leak the handles allowing other
+            // PlatformHandle's to safely close
             if message.pid == self.pid {
                 for h in fds_to_close {
                     h.into_owned_handle()
@@ -55,7 +56,8 @@ impl ChannelMetadata {
                         .unwrap_or_default();
                 }
             } else {
-                // drain iterator closing all open file desriptors that were ACKed by the other party
+                // drain iterator closing all open file desriptors that were ACKed by the other
+                // party
                 fds_to_close.last();
             }
         }

--- a/ipc/src/platform/unix/channel/metadata.rs
+++ b/ipc/src/platform/unix/channel/metadata.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::{
     collections::{BTreeMap, VecDeque},

--- a/ipc/src/platform/unix/locks.rs
+++ b/ipc/src/platform/unix/locks.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::{
     io,

--- a/ipc/src/platform/unix/mem_handle.rs
+++ b/ipc/src/platform/unix/mem_handle.rs
@@ -1,5 +1,6 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::platform::{
     FileBackedHandle, MappedMem, MemoryHandle, NamedShmHandle, PlatformHandle, ShmHandle, ShmPath,
 };

--- a/ipc/src/platform/unix/message.rs
+++ b/ipc/src/platform/unix/message.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::os::unix::prelude::RawFd;
 

--- a/ipc/src/platform/unix/mod.rs
+++ b/ipc/src/platform/unix/mod.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 mod platform_handle;
 

--- a/ipc/src/platform/unix/platform_handle.rs
+++ b/ipc/src/platform/unix/platform_handle.rs
@@ -1,5 +1,6 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::platform::PlatformHandle;
 use io_lifetimes::{
     views::{SocketlikeView, SocketlikeViewType},

--- a/ipc/src/platform/unix/platform_handle.rs
+++ b/ipc/src/platform/unix/platform_handle.rs
@@ -16,7 +16,6 @@ impl<T> FromRawFd for PlatformHandle<T> {
     ///
     /// # Safety caller must ensure the RawFd is valid and open, and that the resulting PlatformHandle will
     /// # have exclusive ownership of the file descriptor
-    ///
     unsafe fn from_raw_fd(fd: RawFd) -> Self {
         let inner = Some(Arc::new(OwnedFd::from_raw_fd(fd)));
         Self {

--- a/ipc/src/platform/unix/sockets.rs
+++ b/ipc/src/platform/unix/sockets.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::{io, os::unix::net::UnixStream, path::Path};
 pub fn is_listening<P: AsRef<Path>>(path: P) -> io::Result<bool> {

--- a/ipc/src/platform/windows/channel.rs
+++ b/ipc/src/platform/windows/channel.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::handles::TransferHandles;
 use crate::platform::metadata::ProcessHandle;

--- a/ipc/src/platform/windows/channel/async_channel.rs
+++ b/ipc/src/platform/windows/channel/async_channel.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::platform::metadata::ProcessHandle;
 use crate::platform::Channel;

--- a/ipc/src/platform/windows/channel/metadata.rs
+++ b/ipc/src/platform/windows/channel/metadata.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter, Pointer};

--- a/ipc/src/platform/windows/mem_handle.rs
+++ b/ipc/src/platform/windows/mem_handle.rs
@@ -1,5 +1,6 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::platform::{
     FileBackedHandle, MappedMem, MemoryHandle, NamedShmHandle, PlatformHandle, ShmHandle, ShmPath,
 };

--- a/ipc/src/platform/windows/mem_handle.rs
+++ b/ipc/src/platform/windows/mem_handle.rs
@@ -73,7 +73,8 @@ fn alloc_shm(name: LPCSTR) -> io::Result<RawHandle> {
             INVALID_HANDLE_VALUE,
             null_mut(),
             // Windows does not allow for resizing file mappings (unlinke linux with ftruncate)
-            // Hence we resort to reserving space in the virtual mapping, which can be committed on demand
+            // Hence we resort to reserving space in the virtual mapping, which can be committed on
+            // demand
             PAGE_READWRITE | SEC_RESERVE,
             0,
             MAPPING_MAX_SIZE as DWORD,

--- a/ipc/src/platform/windows/message.rs
+++ b/ipc/src/platform/windows/message.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 #[derive(Deserialize, Serialize)]
 pub struct Message<Item> {
     pub item: Item,
-    // The handles are to be sent before via DuplicateHandle - post-transfer reassigns the correct handle
+    // The handles are to be sent before via DuplicateHandle - post-transfer reassigns the correct
+    // handle
     pub handles: HashMap<u64, u64>,
 }

--- a/ipc/src/platform/windows/message.rs
+++ b/ipc/src/platform/windows/message.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/ipc/src/platform/windows/mod.rs
+++ b/ipc/src/platform/windows/mod.rs
@@ -1,5 +1,6 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
 mod channel;
 pub use channel::*;
 

--- a/ipc/src/platform/windows/named_pipe.rs
+++ b/ipc/src/platform/windows/named_pipe.rs
@@ -1,5 +1,6 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
 use std::mem;
 use std::mem::MaybeUninit;
 use std::os::raw::c_void;

--- a/ipc/src/platform/windows/platform_handle.rs
+++ b/ipc/src/platform/windows/platform_handle.rs
@@ -12,7 +12,6 @@ impl<T> FromRawHandle for PlatformHandle<T> {
     ///
     /// # Safety caller must ensure the RawFd is valid and open, and that the resulting PlatformHandle will
     /// # have exclusive ownership of the file descriptor
-    ///
     unsafe fn from_raw_handle(handle: RawHandle) -> Self {
         let inner = Some(Arc::new(OwnedHandle::from_raw_handle(handle)));
         Self {

--- a/ipc/src/platform/windows/platform_handle.rs
+++ b/ipc/src/platform/windows/platform_handle.rs
@@ -1,5 +1,6 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::platform::platform_handle::PlatformHandle;
 use serde::{Deserialize, Deserializer, Serializer};
 use std::marker::PhantomData;

--- a/ipc/src/sequential.rs
+++ b/ipc/src/sequential.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::{
     pin::Pin,

--- a/ipc/src/transport/blocking.rs
+++ b/ipc/src/transport/blocking.rs
@@ -78,12 +78,14 @@ where
                         let dst = &mut *(dst as *mut _ as *mut [MaybeUninit<u8>]);
                         let mut buf_window = tokio::io::ReadBuf::uninit(dst);
                         // this implementation is based on Tokio async read implementation,
-                        // it is performing an UB operation by using uninitiallized memory - although in practice its somewhat defined
+                        // it is performing an UB operation by using uninitiallized memory -
+                        // although in practice its somewhat defined
                         // there are still some unknowns WRT to future behaviors
 
-                        // TODO: make sure this optimization is really needed - once BenchPlatform is connected to libdatadog
-                        // benchmark unfilled_mut vs initialize_unfilled - and if the difference is negligible - then lets switch to
-                        // implementation that doesn't use UB.
+                        // TODO: make sure this optimization is really needed - once BenchPlatform
+                        // is connected to libdatadog benchmark unfilled_mut
+                        // vs initialize_unfilled - and if the difference is negligible - then lets
+                        // switch to implementation that doesn't use UB.
                         let b = &mut *(buf_window.unfilled_mut() as *mut [MaybeUninit<u8>]
                             as *mut [u8]);
 
@@ -167,8 +169,9 @@ where
     }
 
     pub fn is_closed(&self) -> bool {
-        // The blocking transport is not supposed to be readable on the client side unless it's a response.
-        // So, outside of waiting for a response, it will never be readable unless the server side closed its socket.
+        // The blocking transport is not supposed to be readable on the client side unless it's a
+        // response. So, outside of waiting for a response, it will never be readable unless
+        // the server side closed its socket.
         self.transport.channel.probe_readable()
     }
 

--- a/ipc/src/transport/blocking.rs
+++ b/ipc/src/transport/blocking.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::{
     io::{self, Read, Write},

--- a/ipc/src/transport/mod.rs
+++ b/ipc/src/transport/mod.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 pub mod blocking;
 

--- a/ipc/tests/blocking_client.rs
+++ b/ipc/tests/blocking_client.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 #![cfg(unix)]
 use std::{
     io::Write,

--- a/ipc/tests/flock.rs
+++ b/ipc/tests/flock.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 #![cfg(unix)]
 
 use std::{

--- a/profiling-ffi/Cargo.toml
+++ b/profiling-ffi/Cargo.toml
@@ -1,5 +1,5 @@
-# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+# Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
 
 [package]
 name = "datadog-profiling-ffi"

--- a/profiling-ffi/build.rs
+++ b/profiling-ffi/build.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 extern crate build_common;
 
 use build_common::generate_and_configure_header;

--- a/profiling-ffi/cbindgen.toml
+++ b/profiling-ffi/cbindgen.toml
@@ -1,10 +1,11 @@
-# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+# Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
 
 language = "C"
 tab_width = 2
-header = """// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc."""
+header = """// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+"""
 include_guard = "DDOG_PROFILING_H"
 style = "both"
 pragma_once = true

--- a/profiling-ffi/datadog_profiling-static.pc.in
+++ b/profiling-ffi/datadog_profiling-static.pc.in
@@ -1,7 +1,5 @@
-# Unless explicitly stated otherwise all files in this repository are licensed
-# under the Apache License Version 2.0. This product includes software
-# developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
-# Datadog, Inc.
+# Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
 
 prefix=${pcfiledir}/../..
 exec_prefix=${prefix}

--- a/profiling-ffi/datadog_profiling.pc.in
+++ b/profiling-ffi/datadog_profiling.pc.in
@@ -1,7 +1,5 @@
-# Unless explicitly stated otherwise all files in this repository are licensed
-# under the Apache License Version 2.0. This product includes software
-# developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
-# Datadog, Inc.
+# Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
 
 prefix=${pcfiledir}/../..
 exec_prefix=${prefix}

--- a/profiling-ffi/datadog_profiling_with_rpath.pc.in
+++ b/profiling-ffi/datadog_profiling_with_rpath.pc.in
@@ -1,7 +1,5 @@
-# Unless explicitly stated otherwise all files in this repository are licensed
-# under the Apache License Version 2.0. This product includes software
-# developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
-# Datadog, Inc.
+# Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
 
 prefix=${pcfiledir}/../..
 exec_prefix=${prefix}

--- a/profiling-ffi/src/crashtracker.rs
+++ b/profiling-ffi/src/crashtracker.rs
@@ -1,5 +1,6 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
 #![cfg(unix)]
 
 use crate::exporter::{self, Endpoint};

--- a/profiling-ffi/src/exporter.rs
+++ b/profiling-ffi/src/exporter.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 #![allow(renamed_and_removed_lints)]
 #![allow(clippy::box_vec)]

--- a/profiling-ffi/src/exporter.rs
+++ b/profiling-ffi/src/exporter.rs
@@ -113,13 +113,16 @@ pub unsafe fn try_to_endpoint(endpoint: Endpoint) -> anyhow::Result<exporter::En
 
 /// Creates a new exporter to be used to report profiling data.
 /// # Arguments
-/// * `profiling_library_name` - Profiling library name, usually dd-trace-something, e.g. "dd-trace-rb". See
-///   https://datadoghq.atlassian.net/wiki/spaces/PROF/pages/1538884229/Client#Header-values (Datadog internal link)
+/// * `profiling_library_name` - Profiling library name, usually dd-trace-something, e.g.
+///   "dd-trace-rb". See
+///   https://datadoghq.atlassian.net/wiki/spaces/PROF/pages/1538884229/Client#Header-values
+///   (Datadog internal link)
 ///   for a list of common values.
-/// * `profliling_library_version` - Version used when publishing the profiling library to a package manager
+/// * `profliling_library_version` - Version used when publishing the profiling library to a package
+///   manager
 /// * `family` - Profile family, e.g. "ruby"
-/// * `tags` - Tags to include with every profile reported by this exporter. It's also possible to include
-///   profile-specific tags, see `additional_tags` on `profile_exporter_build`.
+/// * `tags` - Tags to include with every profile reported by this exporter. It's also possible to
+///   include profile-specific tags, see `additional_tags` on `profile_exporter_build`.
 /// * `endpoint` - Configuration for reporting data
 /// # Safety
 /// All pointers must refer to valid objects of the correct types.
@@ -210,8 +213,8 @@ impl From<RequestBuildResult> for Result<Box<Request>, String> {
 ///
 /// For details on the `optional_internal_metadata_json`, please reference the Datadog-internal
 /// "RFC: Attaching internal metadata to pprof profiles".
-/// If you use this parameter, please update the RFC with your use-case, so we can keep track of how this
-/// is getting used.
+/// If you use this parameter, please update the RFC with your use-case, so we can keep track of how
+/// this is getting used.
 ///
 /// For details on the `optional_info_json`, please reference the Datadog-internal
 /// "RFC: Pprof System Info Support".
@@ -322,9 +325,8 @@ unsafe fn rebox_request(request: Option<&mut Option<&mut Request>>) -> Option<Bo
 ///
 /// # Arguments
 /// * `exporter` - Borrows the exporter for sending the request.
-/// * `request` - Takes ownership of the request, replacing it with a null
-///               pointer. This is why it takes a double-pointer, rather than
-///               a single one.
+/// * `request` - Takes ownership of the request, replacing it with a null pointer. This is why it
+///   takes a double-pointer, rather than a single one.
 /// * `cancel` - Borrows the cancel, if any.
 ///
 /// # Safety
@@ -364,7 +366,8 @@ unsafe fn ddog_prof_exporter_send_impl(
     Ok(HttpStatus(response.status().as_u16()))
 }
 
-/// Can be passed as an argument to send and then be used to asynchronously cancel it from a different thread.
+/// Can be passed as an argument to send and then be used to asynchronously cancel it from a
+/// different thread.
 #[no_mangle]
 #[must_use]
 pub extern "C" fn ddog_CancellationToken_new() -> NonNull<CancellationToken> {
@@ -392,9 +395,9 @@ pub extern "C" fn ddog_CancellationToken_new() -> NonNull<CancellationToken> {
 ///     ddog_CancellationToken_drop(cancel_t2);
 /// ```
 ///
-/// Without clone, both t1 and t2 would need to synchronize to make sure neither was using the cancel
-/// before it could be dropped. With clone, there is no need for such synchronization, both threads
-/// have their own cancel and should drop that cancel after they are done with it.
+/// Without clone, both t1 and t2 would need to synchronize to make sure neither was using the
+/// cancel before it could be dropped. With clone, there is no need for such synchronization, both
+/// threads have their own cancel and should drop that cancel after they are done with it.
 ///
 /// # Safety
 /// If the `token` is non-null, it must point to a valid object.
@@ -470,9 +473,10 @@ mod test {
     fn parsed_event_json(request: RequestBuildResult) -> serde_json::Value {
         let request = Result::from(request).unwrap();
 
-        // Really hacky way of getting the event.json file contents, because I didn't want to implement a full multipart parser
-        // and didn't find a particularly good alternative.
-        // If you do figure out a better way, there's another copy of this code in the profiling tests, please update there too :)
+        // Really hacky way of getting the event.json file contents, because I didn't want to
+        // implement a full multipart parser and didn't find a particularly good
+        // alternative. If you do figure out a better way, there's another copy of this code
+        // in the profiling tests, please update there too :)
         let body = request.body();
         let body_bytes: String = String::from_utf8_lossy(
             &futures::executor::block_on(hyper::body::to_bytes(body)).unwrap(),
@@ -584,7 +588,8 @@ mod test {
         assert_eq!(parsed_event_json["tags_profiler"], json!(""));
         assert_eq!(parsed_event_json["version"], json!("4"));
 
-        // TODO: Assert on contents of attachments, as well as on the headers/configuration for the exporter
+        // TODO: Assert on contents of attachments, as well as on the headers/configuration for the
+        // exporter
     }
 
     #[test]

--- a/profiling-ffi/src/lib.rs
+++ b/profiling-ffi/src/lib.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::fmt::Debug;
 use std::time::SystemTime;

--- a/profiling-ffi/src/profiles.rs
+++ b/profiling-ffi/src/profiles.rs
@@ -330,7 +330,7 @@ impl<'a> TryFrom<Sample<'a>> for api::Sample<'a> {
 /// * `sample_types`
 /// * `period` - Optional period of the profile. Passing None/null translates to zero values.
 /// * `start_time` - Optional time the profile started at. Passing None/null will use the current
-///                  time.
+///   time.
 ///
 /// # Safety
 /// All slices must be have pointers that are suitably aligned for their type
@@ -510,9 +510,12 @@ pub unsafe extern "C" fn ddog_prof_Profile_add_endpoint_count(
 /// * `offset_values` - offset of the values
 /// * `label_name` - name of the label used to identify sample(s)
 /// * `label_value` - value of the label used to identify sample(s)
-/// * `sum_value_offset` - offset of the value used as a sum (compute the average with `count_value_offset`)
-/// * `count_value_offset` - offset of the value used as a count (compute the average with `sum_value_offset`)
-/// * `sampling_distance` - this is the threshold for this sampling window. This value must not be equal to 0
+/// * `sum_value_offset` - offset of the value used as a sum (compute the average with
+///   `count_value_offset`)
+/// * `count_value_offset` - offset of the value used as a count (compute the average with
+///   `sum_value_offset`)
+/// * `sampling_distance` - this is the threshold for this sampling window. This value must not be
+///   equal to 0
 ///
 /// # Safety
 /// This function must be called before serialize and must not be called after.
@@ -566,8 +569,10 @@ pub unsafe extern "C" fn ddog_prof_Profile_add_upscaling_rule_poisson(
 /// * `offset_values` - offset of the values
 /// * `label_name` - name of the label used to identify sample(s)
 /// * `label_value` - value of the label used to identify sample(s)
-/// * `total_sampled` - number of sampled event (found in the pprof). This value must not be equal to 0
-/// * `total_real` - number of events the profiler actually witnessed. This value must not be equal to 0
+/// * `total_sampled` - number of sampled event (found in the pprof). This value must not be equal
+///   to 0
+/// * `total_real` - number of events the profiler actually witnessed. This value must not be equal
+///   to 0
 ///
 /// # Safety
 /// This function must be called before serialize and must not be called after.
@@ -677,12 +682,12 @@ impl From<internal::EncodedProfile> for EncodedProfile {
 /// # Arguments
 /// * `profile` - a reference to the profile being serialized.
 /// * `end_time` - optional end time of the profile. If None/null is passed, the current time will
-///                be used.
+///   be used.
 /// * `duration_nanos` - Optional duration of the profile. Passing None or a negative duration will
-///                      mean the duration will based on the end time minus the start time, but
-///                      under anomalous conditions this may fail as system clocks can be adjusted,
-///                      or the programmer accidentally passed an earlier time. The duration of
-///                      the serialized profile will be set to zero for these cases.
+///   mean the duration will based on the end time minus the start time, but under anomalous
+///   conditions this may fail as system clocks can be adjusted, or the programmer accidentally
+///   passed an earlier time. The duration of the serialized profile will be set to zero for these
+///   cases.
 /// * `start_time` - Optional start time for the next profile.
 ///
 /// # Safety

--- a/profiling-ffi/src/profiles.rs
+++ b/profiling-ffi/src/profiles.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::Timespec;
 use datadog_profiling::api;

--- a/profiling-replayer/src/main.rs
+++ b/profiling-replayer/src/main.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 mod profile_index;
 mod replayer;

--- a/profiling-replayer/src/profile_index.rs
+++ b/profiling-replayer/src/profile_index.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
 use datadog_profiling::pprof::{Function, Location, Mapping, Profile};

--- a/profiling-replayer/src/replayer.rs
+++ b/profiling-replayer/src/replayer.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::profile_index::ProfileIndex;
 use datadog_profiling::api;

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -1,5 +1,5 @@
-# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+# Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
 
 [package]
 name = "datadog-profiling"

--- a/profiling/examples/profiles.rs
+++ b/profiling/examples/profiles.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use datadog_profiling::api;
 use datadog_profiling::internal::Profile;

--- a/profiling/src/api.rs
+++ b/profiling/src/api.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::pprof;
 use std::ops::{Add, Sub};

--- a/profiling/src/collections/identifiable/mod.rs
+++ b/profiling/src/collections/identifiable/mod.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 mod string_id;
 

--- a/profiling/src/collections/identifiable/string_id.rs
+++ b/profiling/src/collections/identifiable/string_id.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use super::*;
 

--- a/profiling/src/collections/mod.rs
+++ b/profiling/src/collections/mod.rs
@@ -1,4 +1,4 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 pub mod identifiable;

--- a/profiling/src/exporter/config.rs
+++ b/profiling/src/exporter/config.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 #[cfg(unix)]
 use ddcommon::connector::uds;

--- a/profiling/src/exporter/errors.rs
+++ b/profiling/src/exporter/errors.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::error;
 use std::fmt;

--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::borrow::Cow;
 use std::future;

--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -124,10 +124,11 @@ impl ProfileExporter {
     /// * `profiling_library_name` - Profiling library name, usually dd-trace-something, e.g. "dd-trace-rb". See
     ///   https://datadoghq.atlassian.net/wiki/spaces/PROF/pages/1538884229/Client#Header-values (Datadog internal link)
     ///   for a list of common values.
-    /// * `profiling_library_version` - Version used when publishing the profiling library to a package manager
+    /// * `profiling_library_version` - Version used when publishing the profiling library to a
+    ///   package manager
     /// * `family` - Profile family, e.g. "ruby"
-    /// * `tags` - Tags to include with every profile reported by this exporter. It's also possible to include
-    ///   profile-specific tags, see `additional_tags` on `build`.
+    /// * `tags` - Tags to include with every profile reported by this exporter. It's also possible
+    ///   to include profile-specific tags, see `additional_tags` on `build`.
     /// * `endpoint` - Configuration for reporting data
     pub fn new<F, N, V>(
         profiling_library_name: N,
@@ -156,8 +157,8 @@ impl ProfileExporter {
     ///
     /// For details on the `internal_metadata` parameter, please reference the Datadog-internal
     /// "RFC: Attaching internal metadata to pprof profiles".
-    /// If you use this parameter, please update the RFC with your use-case, so we can keep track of how this
-    /// is getting used.
+    /// If you use this parameter, please update the RFC with your use-case, so we can keep track of
+    /// how this is getting used.
     ///
     /// For details on the `info` parameter, please reference the Datadog-internal
     /// "RFC: Pprof System Info Support".
@@ -258,20 +259,20 @@ impl ProfileExporter {
             let mut encoder = FrameEncoder::new(buffer);
             encoder.write_all(file.bytes)?;
             let encoded = encoder.finish()?;
-            /* The Datadog RFC examples strip off the file extension, but the exact behavior isn't
-             * specified. This does the simple thing of using the filename without modification for
-             * the form name because intake does not care about these name of the form field for
-             * these attachments.
+            /* The Datadog RFC examples strip off the file extension, but the exact behavior
+             * isn't specified. This does the simple thing of using the filename
+             * without modification for the form name because intake does not care
+             * about these name of the form field for these attachments.
              */
             form.add_reader_file(file.name, Cursor::new(encoded), file.name);
         }
 
         for file in files_to_export_unmodified {
             let encoded = file.bytes.to_vec();
-            /* The Datadog RFC examples strip off the file extension, but the exact behavior isn't
-             * specified. This does the simple thing of using the filename without modification for
-             * the form name because intake does not care about these name of the form field for
-             * these attachments.
+            /* The Datadog RFC examples strip off the file extension, but the exact behavior
+             * isn't specified. This does the simple thing of using the filename
+             * without modification for the form name because intake does not care
+             * about these name of the form field for these attachments.
              */
             form.add_reader_file(file.name, Cursor::new(encoded), file.name)
         }

--- a/profiling/src/internal/endpoint_stats.rs
+++ b/profiling/src/internal/endpoint_stats.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
 

--- a/profiling/src/internal/endpoints.rs
+++ b/profiling/src/internal/endpoints.rs
@@ -1,5 +1,6 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
 use super::*;
 
 pub struct Endpoints {

--- a/profiling/src/internal/function.rs
+++ b/profiling/src/internal/function.rs
@@ -4,8 +4,7 @@
 use super::*;
 
 /// Represents a [pprof::Function] with some space-saving changes:
-///  - The id is not stored on the struct. It's stored in the container that
-///    holds the struct.
+///  - The id is not stored on the struct. It's stored in the container that holds the struct.
 ///  - ids for linked objects use 32-bit numbers instead of 64 bit ones.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub struct Function {

--- a/profiling/src/internal/function.rs
+++ b/profiling/src/internal/function.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use super::*;
 

--- a/profiling/src/internal/label.rs
+++ b/profiling/src/internal/label.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use super::*;
 

--- a/profiling/src/internal/location.rs
+++ b/profiling/src/internal/location.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use super::*;
 

--- a/profiling/src/internal/location.rs
+++ b/profiling/src/internal/location.rs
@@ -4,11 +4,10 @@
 use super::*;
 
 /// Represents a [pprof::Location] with some space-saving changes:
-///  - The id is not stored on the struct. It's stored in the container that
-///    holds the struct.
+///  - The id is not stored on the struct. It's stored in the container that holds the struct.
 ///  - ids for linked objects use 32-bit numbers instead of 64 bit ones.
-///  - in libdatadog, we always use 1 Line per Location, so this is directly
-///    inlined into the struct.
+///  - in libdatadog, we always use 1 Line per Location, so this is directly inlined into the
+///    struct.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub struct Location {
     pub mapping_id: MappingId,

--- a/profiling/src/internal/mapping.rs
+++ b/profiling/src/internal/mapping.rs
@@ -4,8 +4,7 @@
 use super::*;
 
 /// Represents a [pprof::Mapping] with some space-saving changes:
-///  - The id is not stored on the struct. It's stored in the container that
-///    holds the struct.
+///  - The id is not stored on the struct. It's stored in the container that holds the struct.
 ///  - ids for linked objects use 32-bit numbers instead of 64 bit ones.
 #[derive(Eq, PartialEq, Hash)]
 pub struct Mapping {

--- a/profiling/src/internal/mapping.rs
+++ b/profiling/src/internal/mapping.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use super::*;
 

--- a/profiling/src/internal/mod.rs
+++ b/profiling/src/internal/mod.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 mod endpoint_stats;
 mod endpoints;

--- a/profiling/src/internal/observation/mod.rs
+++ b/profiling/src/internal/observation/mod.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 //! The purpose of this module is to enable a profiler memory optimization.
 //! Each `Sample` in the profile is associated with a list of `i64` values,

--- a/profiling/src/internal/observation/observations.rs
+++ b/profiling/src/internal/observation/observations.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 //! See the mod.rs file comment for why this module and file exists.
 

--- a/profiling/src/internal/observation/observations.rs
+++ b/profiling/src/internal/observation/observations.rs
@@ -12,7 +12,8 @@ use std::collections::HashMap;
 struct NonEmptyObservations {
     // Samples with no timestamps are aggregated in-place as each observation is added
     aggregated_data: HashMap<Sample, TrimmedObservation>,
-    // Samples with timestamps are all separately kept (so we can know the exact values at the given timestamp)
+    // Samples with timestamps are all separately kept (so we can know the exact values at the
+    // given timestamp)
     timestamped_data: TimestampedObservations,
     obs_len: ObservationLength,
     timestamped_samples_count: usize,

--- a/profiling/src/internal/observation/timestamped_observations.rs
+++ b/profiling/src/internal/observation/timestamped_observations.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 //! Used to store timestamped observations in a compressed buffer. Assumption is that we don't need this data until
 // serialization, so it's better to pack it in while we're holding it.

--- a/profiling/src/internal/observation/timestamped_observations.rs
+++ b/profiling/src/internal/observation/timestamped_observations.rs
@@ -1,7 +1,8 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-//! Used to store timestamped observations in a compressed buffer. Assumption is that we don't need this data until
+//! Used to store timestamped observations in a compressed buffer. Assumption is that we don't need
+//! this data until
 // serialization, so it's better to pack it in while we're holding it.
 
 use super::super::LabelSetId;
@@ -22,11 +23,11 @@ pub struct TimestampedObservations {
 }
 
 impl TimestampedObservations {
-    // As documented in the internal Datadog doc "Ruby timeline memory fragmentation impact investigation",
-    // allowing the timeline storage vec to slowly expand creates A LOT of memory fragmentation for apps that
-    // employ multiple threads.
-    // To avoid this, we've picked a default buffer size of 1MB that very rarely needs to grow, and when it does,
-    // is expected to grow in larger steps.
+    // As documented in the internal Datadog doc "Ruby timeline memory fragmentation impact
+    // investigation", allowing the timeline storage vec to slowly expand creates A LOT of
+    // memory fragmentation for apps that employ multiple threads.
+    // To avoid this, we've picked a default buffer size of 1MB that very rarely needs to grow, and
+    // when it does, is expected to grow in larger steps.
     const DEFAULT_BUFFER_SIZE: usize = 1_048_576;
 
     pub fn new(sample_types_len: usize) -> Self {
@@ -47,9 +48,9 @@ impl TimestampedObservations {
 
     pub fn add(&mut self, sample: Sample, ts: Timestamp, values: Vec<i64>) -> anyhow::Result<()> {
         // We explicitly turn the data into a stream of bytes, feeding it to the compressor.
-        // @ivoanjo: I played with introducing a structure to serialize it all-at-once, but it seems to be a lot of
-        // boilerplate (of which cost I'm not sure) to basically do the same as these few lines so in the end I came
-        // back to this.
+        // @ivoanjo: I played with introducing a structure to serialize it all-at-once, but it seems
+        // to be a lot of boilerplate (of which cost I'm not sure) to basically do the same
+        // as these few lines so in the end I came back to this.
 
         let stack_trace_id: u32 = sample.stacktrace.into();
         let labels_id: u32 = sample.labels.into();

--- a/profiling/src/internal/observation/trimmed_observation.rs
+++ b/profiling/src/internal/observation/trimmed_observation.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 //! This file contains the internal structures used by `ObservationMap` and `TimestampedObservationMap`.
 //! See the comment on mod.rs for more explanation.

--- a/profiling/src/internal/observation/trimmed_observation.rs
+++ b/profiling/src/internal/observation/trimmed_observation.rs
@@ -1,8 +1,8 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-//! This file contains the internal structures used by `ObservationMap` and `TimestampedObservationMap`.
-//! See the comment on mod.rs for more explanation.
+//! This file contains the internal structures used by `ObservationMap` and
+//! `TimestampedObservationMap`. See the comment on mod.rs for more explanation.
 
 use std::mem;
 

--- a/profiling/src/internal/profile.rs
+++ b/profiling/src/internal/profile.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use self::api::UpscalingInfo;
 use super::*;

--- a/profiling/src/internal/profile.rs
+++ b/profiling/src/internal/profile.rs
@@ -215,10 +215,9 @@ impl Profile {
     /// # Arguments
     /// * `end_time` - Optional end time of the profile. Passing None will use the current time.
     /// * `duration` - Optional duration of the profile. Passing None will try to calculate the
-    ///                duration based on the end time minus the start time, but under anomalous
-    ///                conditions this may fail as system clocks can be adjusted. The programmer
-    ///                may also accidentally pass an earlier time. The duration will be set to zero
-    ///                these cases.
+    ///   duration based on the end time minus the start time, but under anomalous conditions this
+    ///   may fail as system clocks can be adjusted. The programmer may also accidentally pass an
+    ///   earlier time. The duration will be set to zero these cases.
     pub fn serialize_into_compressed_pprof(
         mut self,
         end_time: Option<SystemTime>,
@@ -1011,7 +1010,8 @@ mod api_test {
 
         let s2 = samples.get(1).expect("sample");
 
-        // The trace endpoint label shouldn't be added to second sample because the span id doesn't match
+        // The trace endpoint label shouldn't be added to second sample because the span id doesn't
+        // match
         assert_eq!(s2.labels.len(), 2);
     }
 

--- a/profiling/src/internal/sample.rs
+++ b/profiling/src/internal/sample.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use super::*;
 use std::hash::Hash;

--- a/profiling/src/internal/stack_trace.rs
+++ b/profiling/src/internal/stack_trace.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use super::*;
 

--- a/profiling/src/internal/timestamp.rs
+++ b/profiling/src/internal/timestamp.rs
@@ -1,4 +1,4 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 pub type Timestamp = std::num::NonZeroI64;

--- a/profiling/src/internal/upscaling.rs
+++ b/profiling/src/internal/upscaling.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use super::*;
 use crate::api::UpscalingInfo;

--- a/profiling/src/internal/value_type.rs
+++ b/profiling/src/internal/value_type.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use super::*;
 

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 pub mod api;
 pub mod collections;

--- a/profiling/src/pprof/mod.rs
+++ b/profiling/src/pprof/mod.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 mod proto;
 

--- a/profiling/src/pprof/proto.rs
+++ b/profiling/src/pprof/proto.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use derivative::Derivative;
 use prost::EncodeError;

--- a/profiling/src/pprof/sliced_proto.rs
+++ b/profiling/src/pprof/sliced_proto.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 //! This file is a companion to the standard pprof protobuf definition.
 //!

--- a/profiling/src/pprof/sliced_proto.rs
+++ b/profiling/src/pprof/sliced_proto.rs
@@ -10,12 +10,10 @@
 //! 3. which is then compressed.
 //!
 //! This operation is memory inefficient:
-//! 1. `pprof::Profile` does not deduplicate stack traces or labels, causing
-//!    significant memory blow-up compared to `internal::Profile` for timelined
-//!    traces.
-//! 2. The `pprof` protobuf is highly compressible, particularly when timeline
-//!    is enabled.  We are storing in memory a large buffer, that could have
-//!    easily been compressed to a small one.  
+//! 1. `pprof::Profile` does not deduplicate stack traces or labels, causing significant memory
+//!    blow-up compared to `internal::Profile` for timelined traces.
+//! 2. The `pprof` protobuf is highly compressible, particularly when timeline is enabled.  We are
+//!    storing in memory a large buffer, that could have easily been compressed to a small one.
 //! 3. Only at this point do we have a small in-memory buffer.
 //!
 //! If we stream the creation of the protobuf, we can avoid this memory blowup.

--- a/profiling/src/pprof/test_utils.rs
+++ b/profiling/src/pprof/test_utils.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 pub fn deserialize_compressed_pprof(encoded: &[u8]) -> anyhow::Result<super::Profile> {
     use prost::Message;

--- a/profiling/src/serializer/compressed_streaming_encoder.rs
+++ b/profiling/src/serializer/compressed_streaming_encoder.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use bytes::BufMut;
 use lz4_flex::frame::FrameEncoder;

--- a/profiling/src/serializer/mod.rs
+++ b/profiling/src/serializer/mod.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 mod compressed_streaming_encoder;
 

--- a/profiling/tests/form.rs
+++ b/profiling/tests/form.rs
@@ -71,9 +71,10 @@ mod tests {
     }
 
     fn parsed_event_json(request: Request) -> serde_json::Value {
-        // Really hacky way of getting the event.json file contents, because I didn't want to implement a full multipart parser
-        // and didn't find a particularly good alternative.
-        // If you do figure out a better way, there's another copy of this code in the profiling-ffi tests, please update there too :)
+        // Really hacky way of getting the event.json file contents, because I didn't want to
+        // implement a full multipart parser and didn't find a particularly good
+        // alternative. If you do figure out a better way, there's another copy of this code
+        // in the profiling-ffi tests, please update there too :)
         let body = request.body();
         let body_bytes: String = String::from_utf8_lossy(
             &futures::executor::block_on(hyper::body::to_bytes(body)).unwrap(),

--- a/profiling/tests/form.rs
+++ b/profiling/tests/form.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use datadog_profiling::exporter::{File, ProfileExporter, Request};
 use std::error::Error;

--- a/profiling/tests/wordpress.rs
+++ b/profiling/tests/wordpress.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use datadog_profiling::api;
 use datadog_profiling::pprof;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,7 +1,14 @@
 unstable_features = true
 
-format_macro_matchers = true
 ignore = [
   # embedded project waiting for upstream fixes
   "ipc/tarpc/",
 ]
+
+format_macro_matchers = true
+
+format_code_in_doc_comments=true
+wrap_comments = true
+max_width=100
+comment_width=100
+doc_comment_code_block_width=100

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,7 @@
+unstable_features = true
+
 format_macro_matchers = true
+ignore = [
+  # embedded project waiting for upstream fixes
+  "ipc/tarpc/",
+]

--- a/scripts/reformat_copyright.sh
+++ b/scripts/reformat_copyright.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+fname=$1
+ftmp="${fname}.tmp"
+# preserve file attributes
+cp -p "${fname}" "${ftmp}"
+# process the file
+cat "${fname}" | sed 's/^\([^a-zA-Z]*\).*Datadog.*Copyright \([0-9]*\)-Present.*$/\1Copyright \2-Present Datadog, Inc\. https\:\/\/www\.datadoghq\.com\/\n\1SPDX-License-Identifier: Apache-2.0/' | sed '/^\([^a-zA-Z]*\)Unless explicitly stated/d' | sed '/^\([^a-zA-Z]*\)under the Apache/d' | sed '/^\([^a-zA-Z]*\)Datadog, Inc.$/d' >| "${ftmp}" && mv "${ftmp}" "${fname}"

--- a/serverless/src/main.rs
+++ b/serverless/src/main.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use env_logger::{Builder, Env, Target};
 use log::{error, info};

--- a/sidecar-ffi/Cargo.toml
+++ b/sidecar-ffi/Cargo.toml
@@ -1,5 +1,5 @@
-# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+# Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
 
 [package]
 name = "datadog-sidecar-ffi"

--- a/sidecar-ffi/build.rs
+++ b/sidecar-ffi/build.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 fn main() {
     // ensure symbols are properly exported for dlsym to be able to look them up

--- a/sidecar-ffi/cbindgen.toml
+++ b/sidecar-ffi/cbindgen.toml
@@ -1,10 +1,10 @@
-# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+# Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
 
 language = "C"
 tab_width = 2
-header = """// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+header = """// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 """
 include_guard = "DDOG_SIDECAR_H"
 style = "both"

--- a/sidecar-ffi/src/lib.rs
+++ b/sidecar-ffi/src/lib.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use datadog_ipc::platform::{
     FileBackedHandle, MappedMem, NamedShmHandle, PlatformHandle, ShmHandle,

--- a/sidecar-ffi/tests/sidecar.rs
+++ b/sidecar-ffi/tests/sidecar.rs
@@ -55,8 +55,10 @@ fn test_ddog_ph_file_handling() {
 
 #[test]
 #[cfg_attr(not(windows), ignore)]
-// run all tests that can fork in a separate run, to avoid any race conditions with default rust test harness
-/// run with: RUSTFLAGS="-C prefer-dynamic" cargo test --package test_spawn_from_lib --features prefer-dynamic -- --ignored
+// run all tests that can fork in a separate run, to avoid any race conditions with default rust
+// test harness
+/// run with: RUSTFLAGS="-C prefer-dynamic" cargo test --package test_spawn_from_lib --features
+/// prefer-dynamic -- --ignored
 #[cfg_attr(windows, ignore = "requires -C prefer-dynamic")]
 #[cfg_attr(windows, cfg(feature = "prefer_dynamic"))]
 fn test_ddog_sidecar_connection() {
@@ -117,8 +119,8 @@ fn test_ddog_sidecar_register_app() {
             "dependency_version".into(),
         );
 
-        // ddog_sidecar_telemetry_addIntegration(&mut transport, instance_id, &queue_id, integration_name, integration_version)
-        // TODO add ability to add configuration
+        // ddog_sidecar_telemetry_addIntegration(&mut transport, instance_id, &queue_id,
+        // integration_name, integration_version) TODO add ability to add configuration
 
         assert_maybe_no_error!(ddog_sidecar_telemetry_flushServiceData(
             &mut transport,
@@ -145,7 +147,8 @@ fn test_ddog_sidecar_register_app() {
 
         //TODO: Shutdown the service
         // enough case: have C api that shutsdown telemetry worker
-        // ideal case : when connection socket is closed by the client the telemetry worker shuts down automatically
+        // ideal case : when connection socket is closed by the client the telemetry worker shuts
+        // down automatically
         ddog_sidecar_instanceId_drop(instance_id);
         ddog_sidecar_runtimeMeta_drop(meta);
     };

--- a/sidecar-ffi/tests/sidecar.rs
+++ b/sidecar-ffi/tests/sidecar.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 use datadog_sidecar_ffi::*;
 
 macro_rules! assert_maybe_no_error {

--- a/sidecar/macros/src/lib.rs
+++ b/sidecar/macros/src/lib.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};

--- a/sidecar/src/agent_remote_config.rs
+++ b/sidecar/src/agent_remote_config.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::one_way_shared_memory::{
     open_named_shm, OneWayShmReader, OneWayShmWriter, ReaderOpener,

--- a/sidecar/src/config.rs
+++ b/sidecar/src/config.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use http::uri::{PathAndQuery, Scheme};
 use serde::{Deserialize, Serialize};

--- a/sidecar/src/dump.rs
+++ b/sidecar/src/dump.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 #[cfg(tokio_taskdump)]
 use chrono::{DateTime, Utc};

--- a/sidecar/src/entry.rs
+++ b/sidecar/src/entry.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Context;
 use spawn_worker::{entrypoint, Stdio};

--- a/sidecar/src/interface.rs
+++ b/sidecar/src/interface.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 // Lint removed from stable clippy after rust 1.60 - this allow can be removed once we update rust version
 #![allow(clippy::needless_collect)]

--- a/sidecar/src/interface.rs
+++ b/sidecar/src/interface.rs
@@ -1,7 +1,8 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-// Lint removed from stable clippy after rust 1.60 - this allow can be removed once we update rust version
+// Lint removed from stable clippy after rust 1.60 - this allow can be removed once we update rust
+// version
 #![allow(clippy::needless_collect)]
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashSet};

--- a/sidecar/src/lib.rs
+++ b/sidecar/src/lib.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 pub mod agent_remote_config;
 pub mod config;
 mod dump;

--- a/sidecar/src/log.rs
+++ b/sidecar/src/log.rs
@@ -326,7 +326,8 @@ pub(crate) fn enable_logging() -> anyhow::Result<()> {
 
     // Set initial log level if provided
     if let Ok(env) = env::var("DD_TRACE_LOG_LEVEL") {
-        MULTI_LOG_FILTER.add(env); // this also immediately drops it, but will retain it for few seconds during startup
+        MULTI_LOG_FILTER.add(env); // this also immediately drops it, but will retain it for few
+                                   // seconds during startup
     }
     MULTI_LOG_WRITER.add(config::Config::get().log_method); // same than MULTI_LOG_FILTER
 

--- a/sidecar/src/log.rs
+++ b/sidecar/src/log.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::config;
 use chrono::{DateTime, Utc};

--- a/sidecar/src/one_way_shared_memory.rs
+++ b/sidecar/src/one_way_shared_memory.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use datadog_ipc::platform::{FileBackedHandle, MappedMem, NamedShmHandle, ShmHandle};
 use std::ffi::CString;

--- a/sidecar/src/one_way_shared_memory.rs
+++ b/sidecar/src/one_way_shared_memory.rs
@@ -142,7 +142,8 @@ where
                     unsafe { reinterpret_u8_as_u64_slice(handle.as_slice()) }.into();
                 let copied_data: &RawData = new_mem.as_slice().into();
 
-                // Ensure the next write hasn't started yet *and* the data is from the expected generation
+                // Ensure the next write hasn't started yet *and* the data is from the expected
+                // generation
                 if !source_data.meta.writing.load(Ordering::SeqCst)
                     && new_generation == source_data.meta.generation.load(Ordering::Acquire)
                 {
@@ -191,7 +192,8 @@ impl<T: FileBackedHandle + From<MappedMem<T>>> OneWayShmWriter<T> {
         mapped = mapped.ensure_space(std::mem::size_of::<RawMetaData>() + size);
 
         // Safety: ShmHandle is always big enough
-        // Actually &mut mapped.as_slice_mut() as RawData seems safe, but unsized locals are unstable
+        // Actually &mut mapped.as_slice_mut() as RawData seems safe, but unsized locals are
+        // unstable
         let data = unsafe { &mut *(mapped.as_slice_mut() as *mut [u8] as *mut RawData) };
         data.meta.writing.store(true, Ordering::SeqCst);
         data.meta.size = size;

--- a/sidecar/src/self_telemetry.rs
+++ b/sidecar/src/self_telemetry.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 use crate::config::Config;
 use crate::interface::SidecarServer;
 use crate::watchdog::WatchdogHandle;

--- a/sidecar/src/setup/mod.rs
+++ b/sidecar/src/setup/mod.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 #[cfg(unix)]
 mod unix;

--- a/sidecar/src/setup/mod.rs
+++ b/sidecar/src/setup/mod.rs
@@ -15,8 +15,8 @@ pub use self::windows::*;
 use datadog_ipc::platform::Channel;
 use std::io;
 
-/// Implementations of this interface must provide behavior repeatable across processes with the same version
-/// of library.
+/// Implementations of this interface must provide behavior repeatable across processes with the
+/// same version of library.
 /// Allowing all instances of the same version of the library to establish a shared connection
 pub trait Liaison: Sized {
     fn connect_to_server(&self) -> io::Result<Channel>;

--- a/sidecar/src/setup/unix.rs
+++ b/sidecar/src/setup/unix.rs
@@ -207,8 +207,9 @@ mod tests {
             let listener = liaison.attempt_listen().unwrap().unwrap();
             // can't listen twice when some listener is active
             assert!(liaison.attempt_listen().unwrap().is_none());
-            // a liaison can try connecting to existing socket to ensure its valid, adding connection to accept queue
-            // but we can drain any preexisting connections in the queue
+            // a liaison can try connecting to existing socket to ensure its valid, adding
+            // connection to accept queue but we can drain any preexisting connections
+            // in the queue
             listener.set_nonblocking(true).unwrap();
             loop {
                 match listener.accept() {

--- a/sidecar/src/setup/unix.rs
+++ b/sidecar/src/setup/unix.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::{
     env, fs, io,

--- a/sidecar/src/setup/windows.rs
+++ b/sidecar/src/setup/windows.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::one_way_shared_memory::open_named_shm;
 use arrayref::array_ref;

--- a/sidecar/src/setup/windows.rs
+++ b/sidecar/src/setup/windows.rs
@@ -66,8 +66,8 @@ impl Liaison for NamedPipeLiaison {
         };
 
         let socket_path = self.socket_path.clone();
-        // Have a ProcessHandle::Getter() so that we don't immediately block in case the sidecar is still starting up,
-        // but only the first time we want to submit shared memory
+        // Have a ProcessHandle::Getter() so that we don't immediately block in case the sidecar is
+        // still starting up, but only the first time we want to submit shared memory
         Ok(Channel::from_client_handle_and_pid(
             unsafe { OwnedHandle::from_raw_handle(pipe) },
             ProcessHandle::Getter(Box::new(move || {
@@ -157,8 +157,9 @@ impl Liaison for NamedPipeLiaison {
 
 impl NamedPipeLiaison {
     pub fn new<P: AsRef<str>>(prefix: P) -> Self {
-        // Due to the restriction on Global\ namespace for shared memory we have to distinguish individual sidecar sessions.
-        // Fetch the session_id to effectively namespace the Named Pipe names too.
+        // Due to the restriction on Global\ namespace for shared memory we have to distinguish
+        // individual sidecar sessions. Fetch the session_id to effectively namespace the
+        // Named Pipe names too.
         let session_id = unsafe { WTSGetActiveConsoleSessionId() };
         Self {
             socket_path: CString::new(format!(
@@ -216,8 +217,9 @@ mod tests {
 
             // can't listen twice when some listener is active
             //assert!(liaison.attempt_listen().unwrap().is_none());
-            // a liaison can try connecting to existing socket to ensure its valid, adding connection to accept queue
-            // but we can drain any preexisting connections in the queue
+            // a liaison can try connecting to existing socket to ensure its valid, adding
+            // connection to accept queue but we can drain any preexisting connections
+            // in the queue
             let (_, result) = future::join(
                 srv.connect(),
                 tokio::spawn(async move { (liaison.connect_to_server().unwrap(), liaison) }),
@@ -228,7 +230,8 @@ mod tests {
             let mut buf = [0; 1];
             assert_eq!(1, srv.read(&mut buf).await.unwrap());
 
-            // for this test: Somehow, NamedPipeServer remains tangled with the event-loop and won't free itself in time
+            // for this test: Somehow, NamedPipeServer remains tangled with the event-loop and won't
+            // free itself in time
             unsafe { CloseHandle(raw_handle) };
             std::mem::forget(srv);
 

--- a/sidecar/src/tracer.rs
+++ b/sidecar/src/tracer.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use datadog_trace_utils::config_utils::trace_intake_url_prefixed;
 use ddcommon::Endpoint;

--- a/sidecar/src/unix.rs
+++ b/sidecar/src/unix.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use spawn_worker::{getpid, SpawnWorker, Stdio};
 

--- a/sidecar/src/unix.rs
+++ b/sidecar/src/unix.rs
@@ -35,11 +35,13 @@ pub extern "C" fn ddog_daemon_entry_point() {
             listener.set_nonblocking(true)?;
             let listener = UnixListener::from_std(listener)?;
 
-            // shutdown to gracefully dequeue, and immediately relinquish ownership of the socket while shutting down
+            // shutdown to gracefully dequeue, and immediately relinquish ownership of the socket
+            // while shutting down
             let cancel = {
                 let listener_fd = listener.as_raw_fd();
                 move || {
-                    // We need to drop O_NONBLOCK, as accept() on a shutdown socket will just give EAGAIN instead of EINVAL
+                    // We need to drop O_NONBLOCK, as accept() on a shutdown socket will just give
+                    // EAGAIN instead of EINVAL
                     let flags =
                         OFlag::from_bits_truncate(fcntl(listener_fd, F_GETFL).ok().unwrap());
                     _ = fcntl(listener_fd, F_SETFL(flags & !OFlag::O_NONBLOCK));

--- a/sidecar/src/watchdog.rs
+++ b/sidecar/src/watchdog.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 use std::{
     sync::{
         atomic::{AtomicUsize, Ordering},

--- a/sidecar/src/windows.rs
+++ b/sidecar/src/windows.rs
@@ -52,8 +52,8 @@ pub extern "C" fn ddog_daemon_entry_point() {
                 }
             };
 
-            // We pass the shm to ensure we drop the shm handle with the pid immediately after cancellation
-            // To avoid actual race conditions
+            // We pass the shm to ensure we drop the shm handle with the pid immediately after
+            // cancellation To avoid actual race conditions
             Ok((
                 |handler| accept_socket_loop(pipe, closed_future, handler, shm),
                 cancel,
@@ -96,7 +96,8 @@ async fn accept_socket_loop(
 }
 
 pub fn setup_daemon_process(listener: OwnedHandle, spawn_cfg: &mut SpawnWorker) -> io::Result<()> {
-    // Ensure unique process names - we spawn one sidecar per console session id (see setup/windows.rs for the reasoning)
+    // Ensure unique process names - we spawn one sidecar per console session id (see
+    // setup/windows.rs for the reasoning)
     spawn_cfg
         .process_name(format!("datadog-ipc-helper-{}", unsafe {
             WTSGetActiveConsoleSessionId()

--- a/sidecar/src/windows.rs
+++ b/sidecar/src/windows.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 use crate::enter_listener_loop;
 use crate::setup::pid_shm_path;
 use datadog_ipc::platform::{

--- a/spawn_worker/build.rs
+++ b/spawn_worker/build.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 pub use cc_utils::cc;
 

--- a/spawn_worker/src/ld_preload_trampoline.c
+++ b/spawn_worker/src/ld_preload_trampoline.c
@@ -1,6 +1,6 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache
-// License Version 2.0. This product includes software developed at Datadog
-// (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
 #ifndef _WIN32
 #define _GNU_SOURCE
 

--- a/spawn_worker/src/lib.rs
+++ b/spawn_worker/src/lib.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 pub(crate) const TRAMPOLINE_BIN: &[u8] =
     include_bytes!(concat!(env!("OUT_DIR"), "/trampoline.bin"));

--- a/spawn_worker/src/trampoline.c
+++ b/spawn_worker/src/trampoline.c
@@ -1,6 +1,6 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache
-// License Version 2.0. This product includes software developed at Datadog
-// (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/spawn_worker/src/unix/fork.rs
+++ b/spawn_worker/src/unix/fork.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use nix::libc;
 pub enum Fork {

--- a/spawn_worker/src/unix/fork.rs
+++ b/spawn_worker/src/unix/fork.rs
@@ -15,11 +15,11 @@ pub enum Fork {
 ///
 /// # Safety
 ///
-/// Existing state of the process must allow safe forking, e.g. no background threads should be running
-/// as any locks held by these threads will be locked forever
+/// Existing state of the process must allow safe forking, e.g. no background threads should be
+/// running as any locks held by these threads will be locked forever
 ///
-/// When forking a multithreaded application, no code should allocate or access other potentially locked resources
-/// until call to exec is executed
+/// When forking a multithreaded application, no code should allocate or access other potentially
+/// locked resources until call to exec is executed
 pub(crate) unsafe fn fork() -> Result<Fork, std::io::Error> {
     let res = libc::fork();
     match res {
@@ -33,11 +33,11 @@ pub(crate) unsafe fn fork() -> Result<Fork, std::io::Error> {
 ///
 /// # Safety
 ///
-/// Existing state of the process must allow safe forking, e.g. no background threads should be running
-/// as any locks held by these threads will be locked forever
+/// Existing state of the process must allow safe forking, e.g. no background threads should be
+/// running as any locks held by these threads will be locked forever
 ///
-/// When forking a multithreaded application, no code should allocate or access other potentially locked resources
-/// until call to exec is executed
+/// When forking a multithreaded application, no code should allocate or access other potentially
+/// locked resources until call to exec is executed
 #[cfg(test)]
 unsafe fn fork_fn<Args>(args: Args, f: fn(Args) -> ()) -> Result<libc::pid_t, std::io::Error> {
     match fork()? {

--- a/spawn_worker/src/unix/mod.rs
+++ b/spawn_worker/src/unix/mod.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use io_lifetimes::OwnedFd;
 use nix::libc;

--- a/spawn_worker/src/unix/spawn.rs
+++ b/spawn_worker/src/unix/spawn.rs
@@ -433,8 +433,9 @@ impl SpawnWorker {
                 let fd = linux::write_trampoline()?;
                 skip_close_fd = fd.as_raw_fd();
                 Box::new(move || {
-                    // not using nix crate here, as it would allocate args after fork, which will lead to crashes on systems
-                    // where allocator is not fork+thread safe
+                    // not using nix crate here, as it would allocate args after fork, which will
+                    // lead to crashes on systems where allocator is not
+                    // fork+thread safe
                     unsafe { libc::fexecve(fd.as_raw_fd(), argv.as_ptr(), envp.as_ptr()) };
                     // if we're here then exec has failed
                     panic!("{}", std::io::Error::last_os_error());
@@ -556,8 +557,9 @@ impl SpawnWorker {
 
         if self.daemonize {
             if let Fork::Parent(_) = do_fork()? {
-                // musl will try to "correct" offsets in an atexit handler (lseek a FILE* to the "true" position)
-                // Ensure all fds are closed so that musl cannot have side-effects
+                // musl will try to "correct" offsets in an atexit handler (lseek a FILE* to the
+                // "true" position) Ensure all fds are closed so that musl cannot
+                // have side-effects
                 for i in 0..4 {
                     unsafe {
                         libc::close(i);

--- a/spawn_worker/src/unix/spawn.rs
+++ b/spawn_worker/src/unix/spawn.rs
@@ -1,5 +1,6 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
 #![cfg(unix)]
 
 #[cfg(target_os = "linux")]

--- a/spawn_worker/src/win32.rs
+++ b/spawn_worker/src/win32.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Context;
 use kernel32::{CreateFileA, WaitForSingleObject};

--- a/spawn_worker/tests/trampoline_unix.rs
+++ b/spawn_worker/tests/trampoline_unix.rs
@@ -1,5 +1,6 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
 #![cfg(unix)]
 use std::{
     fs::File,

--- a/spawn_worker/tests/trampoline_windows.rs
+++ b/spawn_worker/tests/trampoline_windows.rs
@@ -1,5 +1,6 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
 #![cfg(windows)]
 use std::{fs, fs::OpenOptions};
 

--- a/tests/spawn_from_lib/build.rs
+++ b/tests/spawn_from_lib/build.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 fn main() {
     // ensure symbols are properly exported for dlsym to be able to look them up

--- a/tests/spawn_from_lib/src/lib.rs
+++ b/tests/spawn_from_lib/src/lib.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::io::Write;
 

--- a/tests/spawn_from_lib/tests/spawn.rs
+++ b/tests/spawn_from_lib/tests/spawn.rs
@@ -15,7 +15,8 @@ fn rewind_and_read(file: &mut std::fs::File) -> anyhow::Result<String> {
     Ok(buf)
 }
 
-/// run with: RUSTFLAGS="-C prefer-dynamic" cargo test --package test_spawn_from_lib --features prefer-dynamic -- --ignored
+/// run with: RUSTFLAGS="-C prefer-dynamic" cargo test --package test_spawn_from_lib --features
+/// prefer-dynamic -- --ignored
 #[test]
 #[ignore = "requires -C prefer-dynamic"]
 #[cfg(feature = "prefer_dynamic")]

--- a/tests/spawn_from_lib/tests/spawn.rs
+++ b/tests/spawn_from_lib/tests/spawn.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 // #![cfg(feature = "prefer-dynamic")]
 // use test_spawn_from_lib::spawn_self;
 

--- a/tests/spawn_from_lib/tests/spawn_unix.rs
+++ b/tests/spawn_from_lib/tests/spawn_unix.rs
@@ -1,5 +1,6 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
 #![cfg(unix)]
 
 use std::{

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -1,5 +1,5 @@
-# Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-# This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+# Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
 
 [package]
 name = "tools"

--- a/tools/cc_utils/src/lib.rs
+++ b/tools/cc_utils/src/lib.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::{
     env,

--- a/tools/sidecar_mockgen/src/bin/sidecar_mockgen.rs
+++ b/tools/sidecar_mockgen/src/bin/sidecar_mockgen.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use sidecar_mockgen::generate_mock_symbols;
 use std::path::Path;

--- a/tools/sidecar_mockgen/src/lib.rs
+++ b/tools/sidecar_mockgen/src/lib.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use object::{File, Object, ObjectSymbol, SymbolKind};
 use std::collections::HashSet;

--- a/tools/src/bin/dedup_headers.rs
+++ b/tools/src/bin/dedup_headers.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 /// Usage:
 /// ./dedup_headers <base_header> <child_headers>...

--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -1,2 +1,2 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0

--- a/trace-mini-agent/src/config.rs
+++ b/trace-mini-agent/src/config.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use ddcommon::Endpoint;
 use std::borrow::Cow;

--- a/trace-mini-agent/src/config.rs
+++ b/trace-mini-agent/src/config.rs
@@ -43,7 +43,8 @@ impl Config {
 
         let dd_site = env::var("DD_SITE").unwrap_or_else(|_| "datadoghq.com".to_string());
 
-        // construct the trace & trace stats intake urls based on DD_SITE env var (to flush traces & trace stats to)
+        // construct the trace & trace stats intake urls based on DD_SITE env var (to flush traces &
+        // trace stats to)
         let mut trace_intake_url = trace_intake_url(&dd_site);
         let mut trace_stats_intake_url = trace_stats_url(&dd_site);
 

--- a/trace-mini-agent/src/env_verifier.rs
+++ b/trace-mini-agent/src/env_verifier.rs
@@ -1,5 +1,6 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
 use async_trait::async_trait;
 use hyper::{Body, Client, Method, Request, Response};
 use log::{debug, error};

--- a/trace-mini-agent/src/env_verifier.rs
+++ b/trace-mini-agent/src/env_verifier.rs
@@ -129,7 +129,8 @@ fn get_region_from_gcp_region_string(str: String) -> String {
     }
 }
 
-/// GoogleMetadataClient trait is used so we can mock a google metadata server response in unit tests
+/// GoogleMetadataClient trait is used so we can mock a google metadata server response in unit
+/// tests
 #[async_trait]
 trait GoogleMetadataClient {
     async fn get_metadata(&self) -> anyhow::Result<Response<Body>>;
@@ -212,7 +213,8 @@ async fn verify_azure_environment_or_exit(os: &str) {
     );
 }
 
-/// AzureVerificationClient trait is used so we can mock the azure function local url response in unit tests
+/// AzureVerificationClient trait is used so we can mock the azure function local url response in
+/// unit tests
 trait AzureVerificationClient {
     fn get_function_root_files(&self, path: &Path) -> anyhow::Result<Vec<String>>;
 }

--- a/trace-mini-agent/src/http_utils.rs
+++ b/trace-mini-agent/src/http_utils.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use hyper::{
     header,

--- a/trace-mini-agent/src/http_utils.rs
+++ b/trace-mini-agent/src/http_utils.rs
@@ -10,7 +10,8 @@ use log::{error, info};
 use serde_json::json;
 
 /// Does two things:
-/// 1. Logs the given message. A success status code (within 200-299) will cause an info log to be written,
+/// 1. Logs the given message. A success status code (within 200-299) will cause an info log to be
+///    written,
 /// otherwise error will be written.
 /// 2. Returns the given message in the body of JSON response with the given status code.
 ///
@@ -31,11 +32,11 @@ pub fn log_and_create_http_response(
     Response::builder().status(status).body(Body::from(body))
 }
 
-/// Takes a request's header map, and verifies that the "content-length" header is present, valid, and less
-/// than the given max_content_length.
+/// Takes a request's header map, and verifies that the "content-length" header is present, valid,
+/// and less than the given max_content_length.
 ///
-/// Will return None if no issues are found. Otherwise logs an error (with the given prefix) and returns
-/// and HTTP Response with the appropriate error status code.
+/// Will return None if no issues are found. Otherwise logs an error (with the given prefix) and
+/// returns and HTTP Response with the appropriate error status code.
 pub fn verify_request_content_length(
     header_map: &HeaderMap,
     max_content_length: usize,

--- a/trace-mini-agent/src/lib.rs
+++ b/trace-mini-agent/src/lib.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 pub mod config;
 pub mod env_verifier;

--- a/trace-mini-agent/src/mini_agent.rs
+++ b/trace-mini-agent/src/mini_agent.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{http, Body, Method, Request, Response, Server, StatusCode};

--- a/trace-mini-agent/src/mini_agent.rs
+++ b/trace-mini-agent/src/mini_agent.rs
@@ -54,12 +54,14 @@ impl MiniAgent {
             now.elapsed().as_millis()
         );
 
-        // setup a channel to send processed traces to our flusher. tx is passed through each endpoint_handler
-        // to the trace processor, which uses it to send de-serialized processed trace payloads to our trace flusher.
+        // setup a channel to send processed traces to our flusher. tx is passed through each
+        // endpoint_handler to the trace processor, which uses it to send de-serialized
+        // processed trace payloads to our trace flusher.
         let (trace_tx, trace_rx): (Sender<SendData>, Receiver<SendData>) =
             mpsc::channel(TRACER_PAYLOAD_CHANNEL_BUFFER_SIZE);
 
-        // start our trace flusher. receives trace payloads and handles buffering + deciding when to flush to backend.
+        // start our trace flusher. receives trace payloads and handles buffering + deciding when to
+        // flush to backend.
         let trace_flusher = self.trace_flusher.clone();
         let trace_config = self.config.clone();
         tokio::spawn(async move {

--- a/trace-mini-agent/src/stats_flusher.rs
+++ b/trace-mini-agent/src/stats_flusher.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
 use log::{debug, error, info};

--- a/trace-mini-agent/src/stats_processor.rs
+++ b/trace-mini-agent/src/stats_processor.rs
@@ -49,7 +49,8 @@ impl StatsProcessor for ServerlessStatsProcessor {
             return response;
         }
 
-        // deserialize trace stats from the request body, convert to protobuf structs (see trace-protobuf crate)
+        // deserialize trace stats from the request body, convert to protobuf structs (see
+        // trace-protobuf crate)
         let mut stats: pb::ClientStatsPayload =
             match stats_utils::get_stats_from_request_body(body).await {
                 Ok(res) => res,

--- a/trace-mini-agent/src/stats_processor.rs
+++ b/trace-mini-agent/src/stats_processor.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};

--- a/trace-mini-agent/src/trace_flusher.rs
+++ b/trace-mini-agent/src/trace_flusher.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
 use log::{error, info};

--- a/trace-mini-agent/src/trace_processor.rs
+++ b/trace-mini-agent/src/trace_processor.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;
 

--- a/trace-mini-agent/src/trace_processor.rs
+++ b/trace-mini-agent/src/trace_processor.rs
@@ -19,7 +19,8 @@ use crate::{
 
 #[async_trait]
 pub trait TraceProcessor {
-    /// Deserializes traces from a hyper request body and sends them through the provided tokio mpsc Sender.
+    /// Deserializes traces from a hyper request body and sends them through the provided tokio mpsc
+    /// Sender.
     async fn process_traces(
         &self,
         config: Arc<Config>,
@@ -54,7 +55,8 @@ impl TraceProcessor for ServerlessTraceProcessor {
 
         let tracer_header_tags = (&parts.headers).into();
 
-        // deserialize traces from the request body, convert to protobuf structs (see trace-protobuf crate)
+        // deserialize traces from the request body, convert to protobuf structs (see trace-protobuf
+        // crate)
         let (body_size, traces) = match trace_utils::get_traces_from_request_body(body).await {
             Ok(res) => res,
             Err(err) => {

--- a/trace-normalization/src/lib.rs
+++ b/trace-normalization/src/lib.rs
@@ -1,7 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0. This product includes software
-// developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present
-// Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 #![deny(clippy::all)]
 

--- a/trace-normalization/src/normalize_utils.rs
+++ b/trace-normalization/src/normalize_utils.rs
@@ -1,7 +1,8 @@
 // Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-// DEFAULT_SERVICE_NAME is the default name we assign a service if it's missing and we have no reasonable fallback
+// DEFAULT_SERVICE_NAME is the default name we assign a service if it's missing and we have no
+// reasonable fallback
 const DEFAULT_SERVICE_NAME: &str = "unnamed-service";
 
 // MAX_NAME_LEN the maximum length a name can have

--- a/trace-normalization/src/normalize_utils.rs
+++ b/trace-normalization/src/normalize_utils.rs
@@ -1,7 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0. This product includes software
-// developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present
-// Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 // DEFAULT_SERVICE_NAME is the default name we assign a service if it's missing and we have no reasonable fallback
 const DEFAULT_SERVICE_NAME: &str = "unnamed-service";

--- a/trace-normalization/src/normalizer.rs
+++ b/trace-normalization/src/normalizer.rs
@@ -11,7 +11,8 @@ const MAX_TYPE_LEN: usize = 100;
 // nanoseconds since epoch on Jan 1, 2000
 const YEAR_2000_NANOSEC_TS: i64 = 946684800000000000;
 
-// DEFAULT_SPAN_NAME is the default name we assign a span if it's missing and we have no reasonable fallback
+// DEFAULT_SPAN_NAME is the default name we assign a span if it's missing and we have no reasonable
+// fallback
 const DEFAULT_SPAN_NAME: &str = "unnamed_operation";
 
 const TAG_SAMPLING_PRIORITY: &str = "_sampling_priority_v1";
@@ -37,8 +38,8 @@ fn normalize_span(s: &mut pb::Span) -> anyhow::Result<()> {
 
     s.service = normalized_service;
 
-    // TODO: component2name: check for a feature flag to determine the component tag to become the span name
-    // https://github.com/DataDog/datadog-agent/blob/dc88d14851354cada1d15265220a39dce8840dcc/pkg/trace/agent/normalizer.go#L64
+    // TODO: component2name: check for a feature flag to determine the component tag to become the
+    // span name https://github.com/DataDog/datadog-agent/blob/dc88d14851354cada1d15265220a39dce8840dcc/pkg/trace/agent/normalizer.go#L64
 
     let normalized_name = match normalize_utils::normalize_name(&s.name) {
         Ok(name) => name,
@@ -136,7 +137,8 @@ pub fn normalize_trace(trace: &mut [pb::Span]) -> anyhow::Result<()> {
 /// normalize_chunk takes a trace chunk and
 /// * populates origin field if it wasn't populated
 /// * populates priority field if it wasn't populated
-/// the root span is used to populate these fields, and it's index in TraceChunk spans vec must be passed.
+/// the root span is used to populate these fields, and it's index in TraceChunk spans vec must be
+/// passed.
 pub fn normalize_chunk(chunk: &mut pb::TraceChunk, root_span_index: usize) -> anyhow::Result<()> {
     // check if priority is not populated
     let root_span = match chunk.spans.get(root_span_index) {
@@ -361,7 +363,8 @@ mod tests {
 
         assert!(normalizer::normalize_span(&mut test_span).is_ok());
         assert!(test_span.start >= min_start); // start should have been reset to current time
-        assert!(test_span.start <= get_current_time()); //start should have been reset to current time
+        assert!(test_span.start <= get_current_time()); //start should have been reset to current
+                                                        // time
     }
 
     #[test]

--- a/trace-normalization/src/normalizer.rs
+++ b/trace-normalization/src/normalizer.rs
@@ -1,7 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0. This product includes software
-// developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present
-// Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::normalize_utils;
 use datadog_trace_protobuf::pb;

--- a/trace-obfuscation/benches/credit_cards_bench.rs
+++ b/trace-obfuscation/benches/credit_cards_bench.rs
@@ -1,7 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0. This product includes software
-// developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present
-// Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use criterion::Throughput::Elements;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};

--- a/trace-obfuscation/benches/replace_trace_tags_bench.rs
+++ b/trace-obfuscation/benches/replace_trace_tags_bench.rs
@@ -1,7 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0. This product includes software
-// developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present
-// Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
 

--- a/trace-obfuscation/src/credit_cards.rs
+++ b/trace-obfuscation/src/credit_cards.rs
@@ -1,8 +1,8 @@
 // Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-/// is_card_number checks if b could be a credit card number by checking the digit count and IIN prefix.
-/// If validateLuhn is true, the Luhn checksum is also applied to potential candidates.
+/// is_card_number checks if b could be a credit card number by checking the digit count and IIN
+/// prefix. If validateLuhn is true, the Luhn checksum is also applied to potential candidates.
 /// Note: This code is based on the code from datadog-agent/pkg/obfuscate/credit_cards.go
 pub fn is_card_number<T: AsRef<str>>(s: T, validate_luhn: bool) -> bool {
     let s = s.as_ref();
@@ -38,8 +38,8 @@ pub fn is_card_number<T: AsRef<str>>(s: T, validate_luhn: bool) -> bool {
     is_valid_iin == FuzzyBool::True
 }
 
-/// luhnValid checks that the number represented in the given vector validates the Luhn Checksum algorithm.
-/// nums must be non-empty
+/// luhnValid checks that the number represented in the given vector validates the Luhn Checksum
+/// algorithm. nums must be non-empty
 ///
 /// See:
 /// https://en.wikipedia.org/wiki/Luhn_algorithm

--- a/trace-obfuscation/src/credit_cards.rs
+++ b/trace-obfuscation/src/credit_cards.rs
@@ -1,7 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0. This product includes software
-// developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present
-// Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 /// is_card_number checks if b could be a credit card number by checking the digit count and IIN prefix.
 /// If validateLuhn is true, the Luhn checksum is also applied to potential candidates.

--- a/trace-obfuscation/src/http.rs
+++ b/trace-obfuscation/src/http.rs
@@ -1,7 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0. This product includes software
-// developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present
-// Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use percent_encoding::percent_decode_str;
 use url::Url;

--- a/trace-obfuscation/src/lib.rs
+++ b/trace-obfuscation/src/lib.rs
@@ -1,7 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0. This product includes software
-// developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present
-// Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 #![deny(clippy::all)]
 

--- a/trace-obfuscation/src/memcached.rs
+++ b/trace-obfuscation/src/memcached.rs
@@ -1,7 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0. This product includes software
-// developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present
-// Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 /// Obfuscates the memcached command cmd.
 pub fn obfuscate_memcached_string(cmd: &str) -> String {

--- a/trace-obfuscation/src/obfuscate.rs
+++ b/trace-obfuscation/src/obfuscate.rs
@@ -1,7 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0. This product includes software
-// developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present
-// Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use datadog_trace_protobuf::pb;
 

--- a/trace-obfuscation/src/obfuscation_config.rs
+++ b/trace-obfuscation/src/obfuscation_config.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use log::{debug, error};
 use std::env;

--- a/trace-obfuscation/src/redis.rs
+++ b/trace-obfuscation/src/redis.rs
@@ -49,8 +49,8 @@ fn obfuscate_redis_cmd(str: &mut String, cmd: String, mut args: Vec<String>) -> 
             // • APPEND key value
             // • GETSET key value
             // • LPUSHX key value
-            // • GEORADIUSBYMEMBER key member radius m|km|ft|mi [WITHCOORD] [WITHDIST] [WITHHASH] [COUNT count] [ASC|DESC] [STORE key] [STOREDIST key]
-            // • RPUSHX key value
+            // • GEORADIUSBYMEMBER key member radius m|km|ft|mi [WITHCOORD] [WITHDIST] [WITHHASH]
+            // [COUNT count] [ASC|DESC] [STORE key] [STOREDIST key] • RPUSHX key value
             // • SET key value [expiration EX seconds|PX milliseconds] [NX|XX]
             // • SETNX key value
             // • SISMEMBER key member
@@ -120,7 +120,8 @@ fn obfuscate_redis_cmd(str: &mut String, cmd: String, mut args: Vec<String>) -> 
         }
         "BITFIELD" => {
             // Obfuscate 3rd argument to SET sub-command:
-            // • BITFIELD key [GET type offset] [SET type offset value] [INCRBY type offset increment] [OVERFLOW WRAP|SAT|FAIL]
+            // • BITFIELD key [GET type offset] [SET type offset value] [INCRBY type offset
+            // increment] [OVERFLOW WRAP|SAT|FAIL]
             let mut n = 0;
             for (i, arg) in args.iter_mut().enumerate() {
                 if arg.to_uppercase() == "SET" {
@@ -180,7 +181,8 @@ pub fn remove_all_redis_args(redis_cmd: &str) -> String {
     };
     obfuscated_cmd.push_str(cmd);
 
-    // If there are no tokens left in the iterator, return the obfuscated result with just the command.
+    // If there are no tokens left in the iterator, return the obfuscated result with just the
+    // command.
     if redis_cmd_iter.peek().is_none() {
         return obfuscated_cmd;
     }

--- a/trace-obfuscation/src/redis.rs
+++ b/trace-obfuscation/src/redis.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::redis_tokenizer::{RedisTokenType, RedisTokenizer};
 

--- a/trace-obfuscation/src/redis_tokenizer.rs
+++ b/trace-obfuscation/src/redis_tokenizer.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 #[derive(Debug)]
 pub enum RedisTokenType {

--- a/trace-obfuscation/src/replacer.rs
+++ b/trace-obfuscation/src/replacer.rs
@@ -27,7 +27,8 @@ pub struct ReplaceRule {
     repl: String,
 }
 
-/// replace_trace_tags replaces the tag values of all spans within a trace with a given set of rules.
+/// replace_trace_tags replaces the tag values of all spans within a trace with a given set of
+/// rules.
 pub fn replace_trace_tags(trace: &mut [pb::Span], rules: &[ReplaceRule]) {
     for span in trace.iter_mut() {
         replace_span_tags(span, rules);

--- a/trace-obfuscation/src/replacer.rs
+++ b/trace-obfuscation/src/replacer.rs
@@ -1,7 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0. This product includes software
-// developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present
-// Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use datadog_trace_protobuf::pb;
 use regex::Regex;

--- a/trace-protobuf/build.rs
+++ b/trace-protobuf/build.rs
@@ -36,13 +36,14 @@ fn generate_protobuf() {
     // in the following ways:
 
     // - annotate generated structs to use PascalCase, expected in the trace stats intake.
-    //   deserialization will result in an empty stats payload otherwise (though will not explicitly fail).
+    //   deserialization will result in an empty stats payload otherwise (though will not explicitly
+    //   fail).
 
-    // - annotate certain Span fields so serde will use the default value of a field's type if the field
-    //   doesn't exist during deserialization.
+    // - annotate certain Span fields so serde will use the default value of a field's type if the
+    //   field doesn't exist during deserialization.
 
-    // - handle edge case struct field names that the trace stats intake expects.
-    //   example: the trace intake expects the name ContainerID rather than the PascalCase ContainerId
+    // - handle edge case struct field names that the trace stats intake expects. example: the trace
+    //   intake expects the name ContainerID rather than the PascalCase ContainerId
 
     config.type_attribute("TracerPayload", "#[derive(Deserialize, Serialize)]");
     config.type_attribute("TraceChunk", "#[derive(Deserialize, Serialize)]");
@@ -116,7 +117,8 @@ fn generate_protobuf() {
         )
         .unwrap();
 
-    // add license, serde imports, custom deserializer code to the top of the protobuf rust structs file
+    // add license, serde imports, custom deserializer code to the top of the protobuf rust structs
+    // file
     let add_to_top = "// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 

--- a/trace-protobuf/build.rs
+++ b/trace-protobuf/build.rs
@@ -117,11 +117,8 @@ fn generate_protobuf() {
         .unwrap();
 
     // add license, serde imports, custom deserializer code to the top of the protobuf rust structs file
-    let add_to_top =
-        "// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0. This product includes software
-// developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present
-// Datadog, Inc.
+    let add_to_top = "// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Deserializer, Serialize};
 
@@ -135,7 +132,7 @@ where
 }
 
 "
-        .as_bytes();
+    .as_bytes();
 
     prepend_to_file(add_to_top, &output_path.join("pb.rs"));
 }

--- a/trace-protobuf/src/lib.rs
+++ b/trace-protobuf/src/lib.rs
@@ -1,7 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0. This product includes software
-// developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present
-// Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 #[rustfmt::skip]
 pub mod pb;

--- a/trace-protobuf/src/pb.rs
+++ b/trace-protobuf/src/pb.rs
@@ -1,7 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0. This product includes software
-// developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present
-// Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use serde::{Deserialize, Deserializer, Serialize};
 

--- a/trace-utils/src/config_utils.rs
+++ b/trace-utils/src/config_utils.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::trace_utils;
 use std::env;

--- a/trace-utils/src/lib.rs
+++ b/trace-utils/src/lib.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 pub mod config_utils;
 pub mod stats_utils;

--- a/trace-utils/src/stats_utils.rs
+++ b/trace-utils/src/stats_utils.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use flate2::{write::GzEncoder, Compression};
 use hyper::{body::Buf, Body, Client, Method, Request, StatusCode};

--- a/trace-utils/src/trace_test_utils.rs
+++ b/trace-utils/src/trace_test_utils.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
 

--- a/trace-utils/src/trace_utils.rs
+++ b/trace-utils/src/trace_utils.rs
@@ -1,5 +1,5 @@
-// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023-Present Datadog, Inc.
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Context;
 use futures::stream::FuturesUnordered;

--- a/trace-utils/src/trace_utils.rs
+++ b/trace-utils/src/trace_utils.rs
@@ -64,9 +64,11 @@ pub struct TracerHeaderTags<'a> {
     pub lang_vendor: &'a str,
     pub tracer_version: &'a str,
     pub container_id: &'a str,
-    // specifies that the client has marked top-level spans, when set. Any non-empty value will mean 'yes'.
+    // specifies that the client has marked top-level spans, when set. Any non-empty value will
+    // mean 'yes'.
     pub client_computed_top_level: bool,
-    // specifies whether the client has computed stats so that the agent doesn't have to. Any non-empty value will mean 'yes'.
+    // specifies whether the client has computed stats so that the agent doesn't have to. Any
+    // non-empty value will mean 'yes'.
     pub client_computed_stats: bool,
 }
 
@@ -324,7 +326,8 @@ pub fn get_root_span_index(trace: &Vec<pb::Span>) -> anyhow::Result<usize> {
     // parent_id -> (child_span, index_of_child_span_in_trace)
     let mut parent_id_to_child_map: HashMap<u64, (&pb::Span, usize)> = HashMap::new();
 
-    // look for the span with parent_id == 0 (starting from the end) since some clients put the root span last.
+    // look for the span with parent_id == 0 (starting from the end) since some clients put the root
+    // span last.
     for i in (0..trace.len()).rev() {
         let cur_span = &trace[i];
         if cur_span.parent_id == 0 {
@@ -631,7 +634,8 @@ mod tests {
     fn test_get_root_span_index_from_partial_trace() {
         let trace = vec![
             create_test_span(1234, 12342, 12341, 1, false),
-            create_test_span(1234, 12341, 12340, 1, false), // this is the root span, it's parent is not in the trace
+            create_test_span(1234, 12341, 12340, 1, false), /* this is the root span, it's
+                                                             * parent is not in the trace */
             create_test_span(1234, 12343, 12342, 1, false),
         ];
 


### PR DESCRIPTION
# What does this PR do?

Updates the `rustfmt` rules to format comments and code in doc comments.

# Motivation

The more ppl/projects working in the repository, the more important it becomes to enforce common formatting for comments and doc comments as well, to avoid very long comment lines and other differences in comment style.

# Additional Notes

The biggest bulk of the changes are reformatting of the copyright headers (which rustfmt doesn't do in a nice way automatically, but will maintain).

The PR is split into 3 different commits for easier review, with the copyright header reformatting in a separate commit.

There is a helper script in `./scripts/reformat_copyright.sh` that can be used to update the copyright headers in new files in PRs.
```
fd --type f '\.(rs|toml|cpp|c|sh|in)$' | while read fname; do; echo $fname; ./scripts/reformat_copyright.sh $fname; done
```

# How to test the change?


## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
