### PR TITLE
Also move #defines when deduplicating headers

### DIFF
--- a/tools/src/bin/dedup_headers.rs
+++ b/tools/src/bin/dedup_headers.rs
@@ -13,7 +13,7 @@ use std::io::{self, BufReader, BufWriter, Read, Seek, Write};
 
 fn collect_definitions(header: &str) -> Vec<regex::Match<'_>> {
     lazy_static::lazy_static! {
-        static ref HEADER_TYPE_DECL_RE: Regex = RegexBuilder::new(r"^(/\*\*.*?\*/\n)?typedef (struct|enum) [a-zA-Z_0-9]+ +(\{.*?\} )?[a-zA-Z_0-9]+;\n+")
+        static ref HEADER_TYPE_DECL_RE: Regex = RegexBuilder::new(r"^(/\*\*.*?\*/\n)?(#define [a-zA-Z_0-9]+ [^\n]+|typedef (struct|enum) [a-zA-Z_0-9]+ +(\{.*?\} )?[a-zA-Z_0-9]+;)\n+")
             .multi_line(true)
             .dot_matches_new_line(true)
             .build()


### PR DESCRIPTION
Small change in dedup_headers, so that a pub const (translated as a #define) used in the definition of an enum will be in the same file than the enum.

```
pub const LOG_ONCE: isize = 1 << 3;

pub enum Log {
    Deprecated = 3 | LOG_ONCE,
}
```