### PR TITLE
[Crashtracker] Make crashtracker more resilient to failing signal handlers

### DIFF
--- a/crashtracker/src/api.rs
+++ b/crashtracker/src/api.rs
@@ -48,6 +48,7 @@ pub enum CrashtrackerResolveFrames {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CrashtrackerConfiguration {
+    pub collect_stacktrace: bool,
     pub create_alt_stack: bool,
     pub endpoint: Option<Endpoint>,
     pub path_to_receiver_binary: String,
@@ -58,6 +59,7 @@ pub struct CrashtrackerConfiguration {
 
 impl CrashtrackerConfiguration {
     pub fn new(
+        collect_stacktrace: bool,
         create_alt_stack: bool,
         endpoint: Option<Endpoint>,
         path_to_receiver_binary: String,
@@ -73,6 +75,7 @@ impl CrashtrackerConfiguration {
         "Can't give the same filename for stderr and stdout, they will conflict with each other"
     );
         Ok(Self {
+            collect_stacktrace,
             create_alt_stack,
             endpoint,
             path_to_receiver_binary,
@@ -190,6 +193,7 @@ fn test_crash() {
         api_key: None,
     });
 
+    let collect_stacktrace = true;
     let path_to_receiver_binary =
         "/tmp/libdatadog/bin/libdatadog-crashtracking-receiver".to_string();
     let create_alt_stack = true;
@@ -198,6 +202,7 @@ fn test_crash() {
     let stdout_filename = Some(format!("{dir}/stdout_{time}.txt"));
 
     let config = CrashtrackerConfiguration::new(
+        collect_stacktrace,
         create_alt_stack,
         endpoint,
         path_to_receiver_binary,

--- a/crashtracker/src/collectors.rs
+++ b/crashtracker/src/collectors.rs
@@ -133,6 +133,7 @@ pub fn emit_text_file(w: &mut impl Write, path: &str) -> anyhow::Result<()> {
         }
     }
     writeln!(w, "\n{DD_CRASHTRACK_END_FILE} \"{path}\"")?;
+    w.flush()?;
     Ok(())
 }
 

--- a/crashtracker/src/crash_handler.rs
+++ b/crashtracker/src/crash_handler.rs
@@ -265,7 +265,9 @@ fn handle_posix_signal_impl(signum: i32) -> anyhow::Result<()> {
     emit_metadata(pipe, metadata_string)?;
     emit_config(pipe, config_str)?;
     emit_siginfo(pipe, signum)?;
+    pipe.flush()?;
     emit_counters(pipe)?;
+    pipe.flush()?;
 
     #[cfg(target_os = "linux")]
     emit_proc_self_maps(pipe)?;

--- a/crashtracker/src/crash_handler.rs
+++ b/crashtracker/src/crash_handler.rs
@@ -276,12 +276,14 @@ fn handle_posix_signal_impl(signum: i32) -> anyhow::Result<()> {
     // In fact, if we look into the code here, we see mallocs.
     // https://doc.rust-lang.org/src/std/backtrace.rs.html#332
     // Do this last, so even if it crashes, we still get the other info.
-    unsafe {
-        emit_backtrace_by_frames(
-            pipe,
-            config.resolve_frames == CrashtrackerResolveFrames::ExperimentalInProcess,
-        )?
-    };
+    if config.collect_stacktrace {
+        unsafe {
+            emit_backtrace_by_frames(
+                pipe,
+                config.resolve_frames == CrashtrackerResolveFrames::ExperimentalInProcess,
+            )?
+        };
+    }
     writeln!(pipe, "{DD_CRASHTRACK_DONE}")?;
 
     pipe.flush()?;

--- a/crashtracker/src/crash_info.rs
+++ b/crashtracker/src/crash_info.rs
@@ -3,7 +3,7 @@
 use crate::stacktrace::StackFrame;
 use crate::CrashtrackerMetadata;
 use anyhow::Context;
-use blazesym::symbolize::{Source, Symbolizer};
+use blazesym::symbolize::{Process, Source, Symbolizer};
 use chrono::{DateTime, Utc};
 use datadog_profiling::exporter::{self, Endpoint, Tag};
 use serde::{Deserialize, Serialize};
@@ -23,6 +23,7 @@ pub struct CrashInfo {
     additional_stacktraces: HashMap<String, Vec<StackFrame>>,
     counters: HashMap<String, i64>,
     files: HashMap<String, Vec<String>>,
+    incomplete: bool,
     metadata: Option<CrashtrackerMetadata>,
     os_info: os_info::Info,
     siginfo: Option<SigInfo>,
@@ -57,6 +58,14 @@ impl CrashInfo {
         }
         Ok(())
     }
+
+    pub fn resolve_names_from_process(&mut self, pid: u32) -> anyhow::Result<()> {
+        let mut process = Process::new(pid.into());
+        // https://github.com/libbpf/blazesym/issues/518
+        process.map_files = false;
+        let src = Source::Process(process);
+        self.resolve_names(&src)
+    }
 }
 
 /// Constructor and setters
@@ -68,6 +77,7 @@ impl CrashInfo {
             additional_stacktraces: HashMap::new(),
             counters: HashMap::new(),
             files: HashMap::new(),
+            incomplete: false,
             metadata: None,
             os_info,
             siginfo: None,
@@ -101,6 +111,11 @@ impl CrashInfo {
             old.is_none(),
             "Attempted to add file that was already there {filename}"
         );
+        Ok(())
+    }
+
+    pub fn set_incomplete(&mut self, incomplete: bool) -> anyhow::Result<()> {
+        self.incomplete = incomplete;
         Ok(())
     }
 

--- a/crashtracker/src/receiver.rs
+++ b/crashtracker/src/receiver.rs
@@ -4,9 +4,22 @@
 use self::stacktrace::StackFrame;
 use super::*;
 use anyhow::Context;
-use blazesym::symbolize::{Process, Source};
 use nix::unistd::getppid;
 use std::time::Duration;
+
+pub fn resolve_frames(
+    config: &CrashtrackerConfiguration,
+    crash_info: &mut CrashInfo,
+) -> anyhow::Result<()> {
+    if config.resolve_frames == CrashtrackerResolveFrames::InReceiver {
+        // The receiver is the direct child of the crashing process
+        // TODO: This pid should be sent over the wire, so that
+        // it can be used in a sidecar.
+        let ppid: u32 = getppid().as_raw().try_into()?;
+        crash_info.resolve_names_from_process(ppid)?
+    }
+    Ok(())
+}
 
 /// Receives data from a crash collector via a pipe on `stdin`, formats it into
 /// `CrashInfo` json, and emits it to the endpoint/file defined in `config`.
@@ -21,25 +34,25 @@ pub fn receiver_entry_point() -> anyhow::Result<()> {
     match receive_report(std::io::stdin().lock())? {
         CrashReportStatus::NoCrash => Ok(()),
         CrashReportStatus::CrashReport(config, mut crash_info) => {
-            if config.resolve_frames == CrashtrackerResolveFrames::InReceiver {
-                // The receiver is the direct child of the crashing process
-                // TODO: This pid should be sent over the wire, so that
-                // it can be used in a sidecar.
-                let ppid: u32 = getppid().as_raw().try_into()?;
-                let mut process = Process::new(ppid.into());
-                // https://github.com/libbpf/blazesym/issues/518
-                process.map_files = false;
-                let src = Source::Process(process);
-                crash_info.resolve_names(&src)?;
-            }
+            resolve_frames(&config, &mut crash_info)?;
+
             if let Some(endpoint) = config.endpoint {
-                // Don't keep the endpoint waiting forever.
                 // TODO Experiment to see if 30 is the right number.
                 crash_info.upload_to_endpoint(endpoint, Duration::from_secs(30))?;
             }
             Ok(())
         }
-        CrashReportStatus::PartialCrashReport(..) => todo!(),
+        CrashReportStatus::PartialCrashReport(config, mut crash_info, stdin_state) => {
+            eprintln!("Failed to fully receive crash.  Exit state was: {stdin_state:?}");
+            resolve_frames(&config, &mut crash_info)?;
+
+            if let Some(endpoint) = config.endpoint {
+                // TODO Experiment to see if 30 is the right number.
+                crash_info.upload_to_endpoint(endpoint, Duration::from_secs(30))?;
+            }
+
+            Ok(())
+        }
     }
 }
 
@@ -198,6 +211,7 @@ fn receive_report(stream: impl std::io::BufRead) -> anyhow::Result<CrashReportSt
     if matches!(stdin_state, StdinState::Done) {
         Ok(CrashReportStatus::CrashReport(config, crashinfo))
     } else {
+        crashinfo.set_incomplete(true)?;
         Ok(CrashReportStatus::PartialCrashReport(
             config,
             crashinfo,

--- a/profiling-ffi/src/crashtracker.rs
+++ b/profiling-ffi/src/crashtracker.rs
@@ -13,6 +13,8 @@ pub use datadog_crashtracker::{CrashtrackerResolveFrames, ProfilingOpTypes};
 
 #[repr(C)]
 pub struct CrashtrackerConfiguration<'a> {
+    /// Should the crashtracker attempt to collect a stacktrace for the crash
+    pub collect_stacktrace: bool,
     pub create_alt_stack: bool,
     /// The endpoint to send the crash repor to (can be a file://)
     pub endpoint: Endpoint<'a>,
@@ -34,7 +36,7 @@ impl<'a> TryFrom<CrashtrackerConfiguration<'a>>
             let s = s.try_to_utf8()?.to_string();
             Ok(s.is_empty().not().then_some(s))
         }
-
+        let collect_stacktrace = value.collect_stacktrace;
         let create_alt_stack = value.create_alt_stack;
         let endpoint = unsafe { Some(exporter::try_to_endpoint(value.endpoint)?) };
         let path_to_receiver_binary = value.path_to_receiver_binary.try_to_utf8()?.to_string();
@@ -43,6 +45,7 @@ impl<'a> TryFrom<CrashtrackerConfiguration<'a>>
         let stdout_filename = option_from_char_slice(value.optional_stdout_filename)?;
 
         Self::new(
+            collect_stacktrace,
             create_alt_stack,
             endpoint,
             path_to_receiver_binary,


### PR DESCRIPTION
# What does this PR do?

1. Adds a new config option to allow crashtracking to avoid collecting stack traces
2. Makes a best-effort attempt to send crash-reports, even when the signal handler failed to complete

 # Motivation

signal handling in the context of a crash is inherently difficult: we're already in a crashing state, so signal handling operations themselves may also crash.  In particular, collecting the stacktrace is dangerous, as it may invoke non-signal-safe functionality.  This PR gives users of crashtracking two ways to handle this issue:

1. They can disable collecting stacktraces (likely controlled by an environment variable)
2. If the stack handler itself crashes, we can still make a best-effort attempt to send out the crash-report. Note that we do the most risks steps (collecting the stack trace) last to maximize the info we can collect.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
