### PR TITLE
(profiling-ffi) Expose telemetry through profiling ffi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,6 +775,7 @@ dependencies = [
  "datadog-profiling",
  "ddcommon",
  "ddcommon-ffi",
+ "ddtelemetry-ffi",
  "futures",
  "hyper",
  "libc",

--- a/LICENSE-3rdparty.yml
+++ b/LICENSE-3rdparty.yml
@@ -1,4 +1,4 @@
-root_name: datadog-crashtracker, datadog-profiling, ddcommon, ddtelemetry, datadog-profiling-ffi, ddcommon-ffi, build_common, datadog-profiling-replayer, ddtelemetry-ffi, tools, datadog-ipc, datadog-ipc-macros, tarpc, tarpc-plugins, spawn_worker, cc_utils, datadog-sidecar, datadog-sidecar-macros, datadog-trace-normalization, datadog-trace-protobuf, datadog-trace-utils, datadog-sidecar-ffi, sidecar_mockgen, datadog-trace-obfuscation, test_spawn_from_lib, datadog-serverless-trace-mini-agent, datadog-trace-mini-agent
+root_name: datadog-crashtracker, datadog-profiling, ddcommon, ddtelemetry, datadog-profiling-ffi, ddcommon-ffi, build_common, ddtelemetry-ffi, datadog-profiling-replayer, tools, datadog-ipc, datadog-ipc-macros, tarpc, tarpc-plugins, spawn_worker, cc_utils, datadog-sidecar, datadog-sidecar-macros, datadog-trace-normalization, datadog-trace-protobuf, datadog-trace-utils, datadog-sidecar-ffi, sidecar_mockgen, datadog-trace-obfuscation, test_spawn_from_lib, datadog-serverless-trace-mini-agent, datadog-trace-mini-agent
 third_party_libraries:
 - package_name: addr2line
   package_version: 0.21.0

--- a/build-profiling-ffi.sh
+++ b/build-profiling-ffi.sh
@@ -16,8 +16,7 @@ fi
 
 set -eu
 
-mkdir -v -p "$1"
-destdir=$(get_abs_filename "$1")
+destdir="$1"
 
 if [ $CARGO_TARGET_DIR = $destdir ]; then
     echo "Error: CARGO_TARGET_DIR and destdir cannot be the same"
@@ -104,9 +103,7 @@ export RUSTFLAGS="${RUSTFLAGS:- -C relocation-model=pic}"
 datadog_profiling_ffi="datadog-profiling-ffi"
 echo "Building the ${datadog_profiling_ffi} crate (may take some time)..."
 
-cd ./profiling-ffi
-DESTDIR="$destdir" cargo build --package="${datadog_profiling_ffi}" --features ddtelemetry-ffi --release --target "${target}"
-cd ..
+DESTDIR="$destdir" cargo build --package="${datadog_profiling_ffi}" --features datadog-profiling-ffi/ddtelemetry-ffi --release --target "${target}"
 
 # Remove _ffi suffix when copying
 shared_library_name="${library_prefix}datadog_profiling_ffi${shared_library_suffix}"

--- a/cmake/DatadogConfig.cmake.in
+++ b/cmake/DatadogConfig.cmake.in
@@ -42,7 +42,8 @@ if(Datadog_FOUND)
                 ws2_32
                 shlwapi
                 Secur32
-                Ncrypt)
+                Ncrypt
+                PowrProf)
   endif()
 
   add_library(Datadog::Profiling ALIAS datadog_profiling)

--- a/ddtelemetry-ffi/Cargo.toml
+++ b/ddtelemetry-ffi/Cargo.toml
@@ -12,8 +12,9 @@ license.workspace = true
 crate-type = ["lib", "staticlib", "cdylib"]
 
 [features]
-default = ["cbindgen"]
+default = ["cbindgen", "expanded_builder_macros"]
 cbindgen = ["build_common/cbindgen", "ddcommon-ffi/cbindgen"]
+expanded_builder_macros = []
 
 [build-dependencies]
 build_common = { path = "../build-common" }

--- a/ddtelemetry-ffi/Cargo.toml
+++ b/ddtelemetry-ffi/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["lib", "staticlib", "cdylib"]
 
 [features]
 default = ["cbindgen", "expanded_builder_macros"]
-cbindgen = ["build_common/cbindgen", "ddcommon-ffi/cbindgen"]
+cbindgen = ["build_common/cbindgen", "ddcommon-ffi/cbindgen", "expanded_builder_macros"]
 expanded_builder_macros = []
 
 [build-dependencies]

--- a/ddtelemetry-ffi/src/builder.rs
+++ b/ddtelemetry-ffi/src/builder.rs
@@ -1,6 +1,5 @@
 // Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
-use ddcommon::Endpoint;
 use ddcommon_ffi as ffi;
 use ddtelemetry::{
     data,
@@ -9,6 +8,16 @@ use ddtelemetry::{
 use ffi::slice::AsBytes;
 
 use crate::MaybeError;
+
+#[cfg(not(feature = "expanded_builder_macros"))]
+mod macros;
+#[cfg(not(feature = "expanded_builder_macros"))]
+pub use macros::*;
+
+#[cfg(feature = "expanded_builder_macros")]
+mod expanded;
+#[cfg(feature = "expanded_builder_macros")]
+pub use expanded::*;
 
 /// # Safety
 /// * builder should be a non null pointer to a null pointer to a builder
@@ -56,54 +65,6 @@ pub unsafe extern "C" fn ddog_builder_instantiate_with_hostname(
     *builder = Box::into_raw(new);
     MaybeError::None
 }
-
-crate::c_setters!(
-    object_name => builder,
-    object_type => TelemetryWorkerBuilder,
-    property_type => ffi::CharSlice,
-    property_type_name_snakecase => str,
-    property_type_name_camel_case => Str,
-    convert_fn => (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) }),
-    SETTERS {
-        application.service_version,
-        application.env,
-        application.runtime_name,
-        application.runtime_version,
-        application.runtime_patches,
-
-        host.container_id,
-        host.os,
-        host.kernel_name,
-        host.kernel_release,
-        host.kernel_version,
-
-        runtime_id
-    }
-);
-
-crate::c_setters!(
-    object_name => builder,
-    object_type => TelemetryWorkerBuilder,
-    property_type => bool,
-    property_type_name_snakecase => bool,
-    property_type_name_camel_case => Bool,
-    convert_fn => (|b: bool| -> Result<_, String> { Ok(b) }),
-    SETTERS {
-        config.telemetry_debug_logging_enabled,
-    }
-);
-
-crate::c_setters!(
-    object_name => builder,
-    object_type => TelemetryWorkerBuilder,
-    property_type => &Endpoint,
-    property_type_name_snakecase => endpoint,
-    property_type_name_camel_case => Endpoint,
-    convert_fn => (|e: &Endpoint| -> Result<_, String> { Ok(e.clone()) }),
-    SETTERS {
-        config.endpoint,
-    }
-);
 
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]

--- a/ddtelemetry-ffi/src/builder/expanded.rs
+++ b/ddtelemetry-ffi/src/builder/expanded.rs
@@ -1,0 +1,1043 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+
+pub use macros::*;
+mod macros {
+    use ddcommon::Endpoint;
+    use ddcommon_ffi as ffi;
+    use ddtelemetry::worker::TelemetryWorkerBuilder;
+    use ffi::slice::AsBytes;
+    #[no_mangle]
+    #[allow(clippy::redundant_closure_call)]
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe extern "C" fn ddog_builder_with_str_application_service_version(
+        builder: &mut TelemetryWorkerBuilder,
+        param: ffi::CharSlice,
+    ) -> crate::MaybeError {
+        builder.application.service_version = Some(
+            match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
+                param,
+            ) {
+                Ok(o) => o,
+                Err(e) => {
+                    return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                        {
+                            let res = std::fmt::format(format_args!("{0:?}", e));
+                            res
+                        }
+                        .into_bytes(),
+                    ));
+                }
+            },
+        );
+        crate::MaybeError::None
+    }
+    #[no_mangle]
+    #[allow(clippy::redundant_closure_call)]
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe extern "C" fn ddog_builder_with_str_application_env(
+        builder: &mut TelemetryWorkerBuilder,
+        param: ffi::CharSlice,
+    ) -> crate::MaybeError {
+        builder.application.env = Some(
+            match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
+                param,
+            ) {
+                Ok(o) => o,
+                Err(e) => {
+                    return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                        {
+                            let res = std::fmt::format(format_args!("{0:?}", e));
+                            res
+                        }
+                        .into_bytes(),
+                    ));
+                }
+            },
+        );
+        crate::MaybeError::None
+    }
+    #[no_mangle]
+    #[allow(clippy::redundant_closure_call)]
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe extern "C" fn ddog_builder_with_str_application_runtime_name(
+        builder: &mut TelemetryWorkerBuilder,
+        param: ffi::CharSlice,
+    ) -> crate::MaybeError {
+        builder.application.runtime_name =
+            Some(
+                match (|s: ffi::CharSlice| -> Result<_, String> {
+                    Ok(s.to_utf8_lossy().into_owned())
+                })(param)
+                {
+                    Ok(o) => o,
+                    Err(e) => {
+                        return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                            {
+                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                res
+                            }
+                            .into_bytes(),
+                        ));
+                    }
+                },
+            );
+        crate::MaybeError::None
+    }
+    #[no_mangle]
+    #[allow(clippy::redundant_closure_call)]
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe extern "C" fn ddog_builder_with_str_application_runtime_version(
+        builder: &mut TelemetryWorkerBuilder,
+        param: ffi::CharSlice,
+    ) -> crate::MaybeError {
+        builder.application.runtime_version = Some(
+            match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
+                param,
+            ) {
+                Ok(o) => o,
+                Err(e) => {
+                    return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                        {
+                            let res = std::fmt::format(format_args!("{0:?}", e));
+                            res
+                        }
+                        .into_bytes(),
+                    ));
+                }
+            },
+        );
+        crate::MaybeError::None
+    }
+    #[no_mangle]
+    #[allow(clippy::redundant_closure_call)]
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe extern "C" fn ddog_builder_with_str_application_runtime_patches(
+        builder: &mut TelemetryWorkerBuilder,
+        param: ffi::CharSlice,
+    ) -> crate::MaybeError {
+        builder.application.runtime_patches = Some(
+            match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
+                param,
+            ) {
+                Ok(o) => o,
+                Err(e) => {
+                    return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                        {
+                            let res = std::fmt::format(format_args!("{0:?}", e));
+                            res
+                        }
+                        .into_bytes(),
+                    ));
+                }
+            },
+        );
+        crate::MaybeError::None
+    }
+    #[no_mangle]
+    #[allow(clippy::redundant_closure_call)]
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe extern "C" fn ddog_builder_with_str_host_container_id(
+        builder: &mut TelemetryWorkerBuilder,
+        param: ffi::CharSlice,
+    ) -> crate::MaybeError {
+        builder.host.container_id = Some(
+            match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
+                param,
+            ) {
+                Ok(o) => o,
+                Err(e) => {
+                    return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                        {
+                            let res = std::fmt::format(format_args!("{0:?}", e));
+                            res
+                        }
+                        .into_bytes(),
+                    ));
+                }
+            },
+        );
+        crate::MaybeError::None
+    }
+    #[no_mangle]
+    #[allow(clippy::redundant_closure_call)]
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe extern "C" fn ddog_builder_with_str_host_os(
+        builder: &mut TelemetryWorkerBuilder,
+        param: ffi::CharSlice,
+    ) -> crate::MaybeError {
+        builder.host.os = Some(
+            match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
+                param,
+            ) {
+                Ok(o) => o,
+                Err(e) => {
+                    return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                        {
+                            let res = std::fmt::format(format_args!("{0:?}", e));
+                            res
+                        }
+                        .into_bytes(),
+                    ));
+                }
+            },
+        );
+        crate::MaybeError::None
+    }
+    #[no_mangle]
+    #[allow(clippy::redundant_closure_call)]
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe extern "C" fn ddog_builder_with_str_host_kernel_name(
+        builder: &mut TelemetryWorkerBuilder,
+        param: ffi::CharSlice,
+    ) -> crate::MaybeError {
+        builder.host.kernel_name = Some(
+            match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
+                param,
+            ) {
+                Ok(o) => o,
+                Err(e) => {
+                    return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                        {
+                            let res = std::fmt::format(format_args!("{0:?}", e));
+                            res
+                        }
+                        .into_bytes(),
+                    ));
+                }
+            },
+        );
+        crate::MaybeError::None
+    }
+    #[no_mangle]
+    #[allow(clippy::redundant_closure_call)]
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe extern "C" fn ddog_builder_with_str_host_kernel_release(
+        builder: &mut TelemetryWorkerBuilder,
+        param: ffi::CharSlice,
+    ) -> crate::MaybeError {
+        builder.host.kernel_release = Some(
+            match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
+                param,
+            ) {
+                Ok(o) => o,
+                Err(e) => {
+                    return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                        {
+                            let res = std::fmt::format(format_args!("{0:?}", e));
+                            res
+                        }
+                        .into_bytes(),
+                    ));
+                }
+            },
+        );
+        crate::MaybeError::None
+    }
+    #[no_mangle]
+    #[allow(clippy::redundant_closure_call)]
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe extern "C" fn ddog_builder_with_str_host_kernel_version(
+        builder: &mut TelemetryWorkerBuilder,
+        param: ffi::CharSlice,
+    ) -> crate::MaybeError {
+        builder.host.kernel_version = Some(
+            match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
+                param,
+            ) {
+                Ok(o) => o,
+                Err(e) => {
+                    return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                        {
+                            let res = std::fmt::format(format_args!("{0:?}", e));
+                            res
+                        }
+                        .into_bytes(),
+                    ));
+                }
+            },
+        );
+        crate::MaybeError::None
+    }
+    #[no_mangle]
+    #[allow(clippy::redundant_closure_call)]
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe extern "C" fn ddog_builder_with_str_runtime_id(
+        builder: &mut TelemetryWorkerBuilder,
+        param: ffi::CharSlice,
+    ) -> crate::MaybeError {
+        builder.runtime_id = Some(
+            match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
+                param,
+            ) {
+                Ok(o) => o,
+                Err(e) => {
+                    return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                        {
+                            let res = std::fmt::format(format_args!("{0:?}", e));
+                            res
+                        }
+                        .into_bytes(),
+                    ));
+                }
+            },
+        );
+        crate::MaybeError::None
+    }
+    #[repr(C)]
+    #[allow(dead_code)]
+    pub enum TelemetryWorkerBuilderStrProperty {
+        ApplicationServiceVersion,
+        ApplicationEnv,
+        ApplicationRuntimeName,
+        ApplicationRuntimeVersion,
+        ApplicationRuntimePatches,
+        HostContainerId,
+        HostOs,
+        HostKernelName,
+        HostKernelRelease,
+        HostKernelVersion,
+        RuntimeId,
+    }
+    #[no_mangle]
+    #[allow(clippy::redundant_closure_call)]
+    #[allow(clippy::missing_safety_doc)]
+    /**
+     Sets a property from it's string value.
+
+     Available properties:
+
+     * application.service_version
+
+     * application.env
+
+     * application.runtime_name
+
+     * application.runtime_version
+
+     * application.runtime_patches
+
+     * host.container_id
+
+     * host.os
+
+     * host.kernel_name
+
+     * host.kernel_release
+
+     * host.kernel_version
+
+     * runtime_id
+
+    */
+    pub unsafe extern "C" fn ddog_builder_with_property_str(
+        builder: &mut TelemetryWorkerBuilder,
+        property: TelemetryWorkerBuilderStrProperty,
+        param: ffi::CharSlice,
+    ) -> crate::MaybeError {
+        use TelemetryWorkerBuilderStrProperty::*;
+        match property {
+            ApplicationServiceVersion => {
+                builder.application.service_version = Some(
+                    match (|s: ffi::CharSlice| -> Result<_, String> {
+                        Ok(s.to_utf8_lossy().into_owned())
+                    })(param)
+                    {
+                        Ok(o) => o,
+                        Err(e) => {
+                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                                {
+                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    res
+                                }
+                                .into_bytes(),
+                            ));
+                        }
+                    },
+                );
+            }
+            ApplicationEnv => {
+                builder.application.env = Some(
+                    match (|s: ffi::CharSlice| -> Result<_, String> {
+                        Ok(s.to_utf8_lossy().into_owned())
+                    })(param)
+                    {
+                        Ok(o) => o,
+                        Err(e) => {
+                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                                {
+                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    res
+                                }
+                                .into_bytes(),
+                            ));
+                        }
+                    },
+                );
+            }
+            ApplicationRuntimeName => {
+                builder.application.runtime_name = Some(
+                    match (|s: ffi::CharSlice| -> Result<_, String> {
+                        Ok(s.to_utf8_lossy().into_owned())
+                    })(param)
+                    {
+                        Ok(o) => o,
+                        Err(e) => {
+                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                                {
+                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    res
+                                }
+                                .into_bytes(),
+                            ));
+                        }
+                    },
+                );
+            }
+            ApplicationRuntimeVersion => {
+                builder.application.runtime_version = Some(
+                    match (|s: ffi::CharSlice| -> Result<_, String> {
+                        Ok(s.to_utf8_lossy().into_owned())
+                    })(param)
+                    {
+                        Ok(o) => o,
+                        Err(e) => {
+                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                                {
+                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    res
+                                }
+                                .into_bytes(),
+                            ));
+                        }
+                    },
+                );
+            }
+            ApplicationRuntimePatches => {
+                builder.application.runtime_patches = Some(
+                    match (|s: ffi::CharSlice| -> Result<_, String> {
+                        Ok(s.to_utf8_lossy().into_owned())
+                    })(param)
+                    {
+                        Ok(o) => o,
+                        Err(e) => {
+                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                                {
+                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    res
+                                }
+                                .into_bytes(),
+                            ));
+                        }
+                    },
+                );
+            }
+            HostContainerId => {
+                builder.host.container_id =
+                    Some(
+                        match (|s: ffi::CharSlice| -> Result<_, String> {
+                            Ok(s.to_utf8_lossy().into_owned())
+                        })(param)
+                        {
+                            Ok(o) => o,
+                            Err(e) => {
+                                return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                                    {
+                                        let res = std::fmt::format(format_args!("{0:?}", e));
+                                        res
+                                    }
+                                    .into_bytes(),
+                                ));
+                            }
+                        },
+                    );
+            }
+            HostOs => {
+                builder.host.os = Some(
+                    match (|s: ffi::CharSlice| -> Result<_, String> {
+                        Ok(s.to_utf8_lossy().into_owned())
+                    })(param)
+                    {
+                        Ok(o) => o,
+                        Err(e) => {
+                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                                {
+                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    res
+                                }
+                                .into_bytes(),
+                            ));
+                        }
+                    },
+                );
+            }
+            HostKernelName => {
+                builder.host.kernel_name =
+                    Some(
+                        match (|s: ffi::CharSlice| -> Result<_, String> {
+                            Ok(s.to_utf8_lossy().into_owned())
+                        })(param)
+                        {
+                            Ok(o) => o,
+                            Err(e) => {
+                                return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                                    {
+                                        let res = std::fmt::format(format_args!("{0:?}", e));
+                                        res
+                                    }
+                                    .into_bytes(),
+                                ));
+                            }
+                        },
+                    );
+            }
+            HostKernelRelease => {
+                builder.host.kernel_release = Some(
+                    match (|s: ffi::CharSlice| -> Result<_, String> {
+                        Ok(s.to_utf8_lossy().into_owned())
+                    })(param)
+                    {
+                        Ok(o) => o,
+                        Err(e) => {
+                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                                {
+                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    res
+                                }
+                                .into_bytes(),
+                            ));
+                        }
+                    },
+                );
+            }
+            HostKernelVersion => {
+                builder.host.kernel_version = Some(
+                    match (|s: ffi::CharSlice| -> Result<_, String> {
+                        Ok(s.to_utf8_lossy().into_owned())
+                    })(param)
+                    {
+                        Ok(o) => o,
+                        Err(e) => {
+                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                                {
+                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    res
+                                }
+                                .into_bytes(),
+                            ));
+                        }
+                    },
+                );
+            }
+            RuntimeId => {
+                builder.runtime_id = Some(
+                    match (|s: ffi::CharSlice| -> Result<_, String> {
+                        Ok(s.to_utf8_lossy().into_owned())
+                    })(param)
+                    {
+                        Ok(o) => o,
+                        Err(e) => {
+                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                                {
+                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    res
+                                }
+                                .into_bytes(),
+                            ));
+                        }
+                    },
+                );
+            }
+        }
+        crate::MaybeError::None
+    }
+    #[no_mangle]
+    #[allow(clippy::redundant_closure_call)]
+    #[allow(clippy::missing_safety_doc)]
+    /**
+     Sets a property from it's string value.
+
+     Available properties:
+
+     * application.service_version
+
+     * application.env
+
+     * application.runtime_name
+
+     * application.runtime_version
+
+     * application.runtime_patches
+
+     * host.container_id
+
+     * host.os
+
+     * host.kernel_name
+
+     * host.kernel_release
+
+     * host.kernel_version
+
+     * runtime_id
+
+    */
+    pub unsafe extern "C" fn ddog_builder_with_str_named_property(
+        builder: &mut TelemetryWorkerBuilder,
+        property: ffi::CharSlice,
+        param: ffi::CharSlice,
+    ) -> crate::MaybeError {
+        let property = match property.try_to_utf8() {
+            Ok(o) => o,
+            Err(e) => {
+                return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                    {
+                        let res = std::fmt::format(format_args!("{0:?}", e));
+                        res
+                    }
+                    .into_bytes(),
+                ));
+            }
+        };
+        match property {
+            "application.service_version" => {
+                builder.application.service_version = Some(
+                    match (|s: ffi::CharSlice| -> Result<_, String> {
+                        Ok(s.to_utf8_lossy().into_owned())
+                    })(param)
+                    {
+                        Ok(o) => o,
+                        Err(e) => {
+                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                                {
+                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    res
+                                }
+                                .into_bytes(),
+                            ));
+                        }
+                    },
+                );
+            }
+            "application.env" => {
+                builder.application.env = Some(
+                    match (|s: ffi::CharSlice| -> Result<_, String> {
+                        Ok(s.to_utf8_lossy().into_owned())
+                    })(param)
+                    {
+                        Ok(o) => o,
+                        Err(e) => {
+                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                                {
+                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    res
+                                }
+                                .into_bytes(),
+                            ));
+                        }
+                    },
+                );
+            }
+            "application.runtime_name" => {
+                builder.application.runtime_name = Some(
+                    match (|s: ffi::CharSlice| -> Result<_, String> {
+                        Ok(s.to_utf8_lossy().into_owned())
+                    })(param)
+                    {
+                        Ok(o) => o,
+                        Err(e) => {
+                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                                {
+                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    res
+                                }
+                                .into_bytes(),
+                            ));
+                        }
+                    },
+                );
+            }
+            "application.runtime_version" => {
+                builder.application.runtime_version = Some(
+                    match (|s: ffi::CharSlice| -> Result<_, String> {
+                        Ok(s.to_utf8_lossy().into_owned())
+                    })(param)
+                    {
+                        Ok(o) => o,
+                        Err(e) => {
+                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                                {
+                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    res
+                                }
+                                .into_bytes(),
+                            ));
+                        }
+                    },
+                );
+            }
+            "application.runtime_patches" => {
+                builder.application.runtime_patches = Some(
+                    match (|s: ffi::CharSlice| -> Result<_, String> {
+                        Ok(s.to_utf8_lossy().into_owned())
+                    })(param)
+                    {
+                        Ok(o) => o,
+                        Err(e) => {
+                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                                {
+                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    res
+                                }
+                                .into_bytes(),
+                            ));
+                        }
+                    },
+                );
+            }
+            "host.container_id" => {
+                builder.host.container_id =
+                    Some(
+                        match (|s: ffi::CharSlice| -> Result<_, String> {
+                            Ok(s.to_utf8_lossy().into_owned())
+                        })(param)
+                        {
+                            Ok(o) => o,
+                            Err(e) => {
+                                return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                                    {
+                                        let res = std::fmt::format(format_args!("{0:?}", e));
+                                        res
+                                    }
+                                    .into_bytes(),
+                                ));
+                            }
+                        },
+                    );
+            }
+            "host.os" => {
+                builder.host.os = Some(
+                    match (|s: ffi::CharSlice| -> Result<_, String> {
+                        Ok(s.to_utf8_lossy().into_owned())
+                    })(param)
+                    {
+                        Ok(o) => o,
+                        Err(e) => {
+                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                                {
+                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    res
+                                }
+                                .into_bytes(),
+                            ));
+                        }
+                    },
+                );
+            }
+            "host.kernel_name" => {
+                builder.host.kernel_name =
+                    Some(
+                        match (|s: ffi::CharSlice| -> Result<_, String> {
+                            Ok(s.to_utf8_lossy().into_owned())
+                        })(param)
+                        {
+                            Ok(o) => o,
+                            Err(e) => {
+                                return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                                    {
+                                        let res = std::fmt::format(format_args!("{0:?}", e));
+                                        res
+                                    }
+                                    .into_bytes(),
+                                ));
+                            }
+                        },
+                    );
+            }
+            "host.kernel_release" => {
+                builder.host.kernel_release = Some(
+                    match (|s: ffi::CharSlice| -> Result<_, String> {
+                        Ok(s.to_utf8_lossy().into_owned())
+                    })(param)
+                    {
+                        Ok(o) => o,
+                        Err(e) => {
+                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                                {
+                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    res
+                                }
+                                .into_bytes(),
+                            ));
+                        }
+                    },
+                );
+            }
+            "host.kernel_version" => {
+                builder.host.kernel_version = Some(
+                    match (|s: ffi::CharSlice| -> Result<_, String> {
+                        Ok(s.to_utf8_lossy().into_owned())
+                    })(param)
+                    {
+                        Ok(o) => o,
+                        Err(e) => {
+                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                                {
+                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    res
+                                }
+                                .into_bytes(),
+                            ));
+                        }
+                    },
+                );
+            }
+            "runtime_id" => {
+                builder.runtime_id = Some(
+                    match (|s: ffi::CharSlice| -> Result<_, String> {
+                        Ok(s.to_utf8_lossy().into_owned())
+                    })(param)
+                    {
+                        Ok(o) => o,
+                        Err(e) => {
+                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                                {
+                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    res
+                                }
+                                .into_bytes(),
+                            ));
+                        }
+                    },
+                );
+            }
+            _ => return crate::MaybeError::None,
+        }
+        crate::MaybeError::None
+    }
+    #[no_mangle]
+    #[allow(clippy::redundant_closure_call)]
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe extern "C" fn ddog_builder_with_bool_config_telemetry_debug_logging_enabled(
+        builder: &mut TelemetryWorkerBuilder,
+        param: bool,
+    ) -> crate::MaybeError {
+        builder.config.telemetry_debug_logging_enabled =
+            Some(match (|b: bool| -> Result<_, String> { Ok(b) })(param) {
+                Ok(o) => o,
+                Err(e) => {
+                    return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                        {
+                            let res = std::fmt::format(format_args!("{0:?}", e));
+                            res
+                        }
+                        .into_bytes(),
+                    ));
+                }
+            });
+        crate::MaybeError::None
+    }
+    #[repr(C)]
+    #[allow(dead_code)]
+    pub enum TelemetryWorkerBuilderBoolProperty {
+        ConfigTelemetryDebugLoggingEnabled,
+    }
+    #[no_mangle]
+    #[allow(clippy::redundant_closure_call)]
+    #[allow(clippy::missing_safety_doc)]
+    /**
+     Sets a property from it's string value.
+
+     Available properties:
+
+     * config.telemetry_debug_logging_enabled
+
+    */
+    pub unsafe extern "C" fn ddog_builder_with_property_bool(
+        builder: &mut TelemetryWorkerBuilder,
+        property: TelemetryWorkerBuilderBoolProperty,
+        param: bool,
+    ) -> crate::MaybeError {
+        use TelemetryWorkerBuilderBoolProperty::*;
+        match property {
+            ConfigTelemetryDebugLoggingEnabled => {
+                builder.config.telemetry_debug_logging_enabled =
+                    Some(match (|b: bool| -> Result<_, String> { Ok(b) })(param) {
+                        Ok(o) => o,
+                        Err(e) => {
+                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                                {
+                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    res
+                                }
+                                .into_bytes(),
+                            ));
+                        }
+                    });
+            }
+        }
+        crate::MaybeError::None
+    }
+    #[no_mangle]
+    #[allow(clippy::redundant_closure_call)]
+    #[allow(clippy::missing_safety_doc)]
+    /**
+     Sets a property from it's string value.
+
+     Available properties:
+
+     * config.telemetry_debug_logging_enabled
+
+    */
+    pub unsafe extern "C" fn ddog_builder_with_bool_named_property(
+        builder: &mut TelemetryWorkerBuilder,
+        property: ffi::CharSlice,
+        param: bool,
+    ) -> crate::MaybeError {
+        let property = match property.try_to_utf8() {
+            Ok(o) => o,
+            Err(e) => {
+                return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                    {
+                        let res = std::fmt::format(format_args!("{0:?}", e));
+                        res
+                    }
+                    .into_bytes(),
+                ));
+            }
+        };
+        match property {
+            "config.telemetry_debug_logging_enabled" => {
+                builder.config.telemetry_debug_logging_enabled =
+                    Some(match (|b: bool| -> Result<_, String> { Ok(b) })(param) {
+                        Ok(o) => o,
+                        Err(e) => {
+                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                                {
+                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    res
+                                }
+                                .into_bytes(),
+                            ));
+                        }
+                    });
+            }
+            _ => return crate::MaybeError::None,
+        }
+        crate::MaybeError::None
+    }
+    #[no_mangle]
+    #[allow(clippy::redundant_closure_call)]
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe extern "C" fn ddog_builder_with_endpoint_config_endpoint(
+        builder: &mut TelemetryWorkerBuilder,
+        param: &Endpoint,
+    ) -> crate::MaybeError {
+        builder.config.endpoint = Some(
+            match (|e: &Endpoint| -> Result<_, String> { Ok(e.clone()) })(param) {
+                Ok(o) => o,
+                Err(e) => {
+                    return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                        {
+                            let res = std::fmt::format(format_args!("{0:?}", e));
+                            res
+                        }
+                        .into_bytes(),
+                    ));
+                }
+            },
+        );
+        crate::MaybeError::None
+    }
+    #[repr(C)]
+    #[allow(dead_code)]
+    pub enum TelemetryWorkerBuilderEndpointProperty {
+        ConfigEndpoint,
+    }
+    #[no_mangle]
+    #[allow(clippy::redundant_closure_call)]
+    #[allow(clippy::missing_safety_doc)]
+    /**
+     Sets a property from it's string value.
+
+     Available properties:
+
+     * config.endpoint
+
+    */
+    pub unsafe extern "C" fn ddog_builder_with_property_endpoint(
+        builder: &mut TelemetryWorkerBuilder,
+        property: TelemetryWorkerBuilderEndpointProperty,
+        param: &Endpoint,
+    ) -> crate::MaybeError {
+        use TelemetryWorkerBuilderEndpointProperty::*;
+        match property {
+            ConfigEndpoint => {
+                builder.config.endpoint = Some(
+                    match (|e: &Endpoint| -> Result<_, String> { Ok(e.clone()) })(param) {
+                        Ok(o) => o,
+                        Err(e) => {
+                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                                {
+                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    res
+                                }
+                                .into_bytes(),
+                            ));
+                        }
+                    },
+                );
+            }
+        }
+        crate::MaybeError::None
+    }
+    #[no_mangle]
+    #[allow(clippy::redundant_closure_call)]
+    #[allow(clippy::missing_safety_doc)]
+    /**
+     Sets a property from it's string value.
+
+     Available properties:
+
+     * config.endpoint
+
+    */
+    pub unsafe extern "C" fn ddog_builder_with_endpoint_named_property(
+        builder: &mut TelemetryWorkerBuilder,
+        property: ffi::CharSlice,
+        param: &Endpoint,
+    ) -> crate::MaybeError {
+        let property = match property.try_to_utf8() {
+            Ok(o) => o,
+            Err(e) => {
+                return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                    {
+                        let res = std::fmt::format(format_args!("{0:?}", e));
+                        res
+                    }
+                    .into_bytes(),
+                ));
+            }
+        };
+        match property {
+            "config.endpoint" => {
+                builder.config.endpoint = Some(
+                    match (|e: &Endpoint| -> Result<_, String> { Ok(e.clone()) })(param) {
+                        Ok(o) => o,
+                        Err(e) => {
+                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                                {
+                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    res
+                                }
+                                .into_bytes(),
+                            ));
+                        }
+                    },
+                );
+            }
+            _ => return crate::MaybeError::None,
+        }
+        crate::MaybeError::None
+    }
+}

--- a/ddtelemetry-ffi/src/builder/macros.rs
+++ b/ddtelemetry-ffi/src/builder/macros.rs
@@ -3,7 +3,6 @@
 
 // To regenerate expanded.rs run
 // ```bash
-// 
 // HEADER=$(cat ddtelemetry-ffi/src/builder/macros.rs | sed '/^$/q') EXPANDED=ddtelemetry-ffi/src/builder/expanded.rs &&
 //   echo $HEADER '\n' > $EXPANDED && cargo expand -p ddtelemetry-ffi --no-default-features builder::macros |
 //   sed 's/#\[cfg(not(feature = "expanded_builder_macros"))\]/pub use macros::*;/' |

--- a/ddtelemetry-ffi/src/builder/macros.rs
+++ b/ddtelemetry-ffi/src/builder/macros.rs
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present Datadog, Inc.
+
+// To regenerate expanded.rs run
+// ```bash
+//
+// HEADER=$(cat ddtelemetry-ffi/src/builder/macros.rs | sed '/^$/q') EXPANDED=ddtelemetry-ffi/src/builder/expanded.rs &&
+//   echo $HEADER '\n' > $EXPANDED && cargo expand -p ddtelemetry-ffi --no-default-features builder::macros |
+//   sed 's/#\[cfg(not(feature = "expanded_builder_macros"))\]/pub use macros::*;/' |
+//   sed 's/::alloc::fmt::format/std::fmt::format/' >> $EXPANDED && cargo fmt
+//
+// ```
+
+use ddcommon::Endpoint;
+use ddcommon_ffi as ffi;
+use ddtelemetry::worker::TelemetryWorkerBuilder;
+use ffi::slice::AsBytes;
+
+crate::c_setters!(
+    object_name => builder,
+    object_type => TelemetryWorkerBuilder,
+    property_type => ffi::CharSlice,
+    property_type_name_snakecase => str,
+    property_type_name_camel_case => Str,
+    convert_fn => (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) }),
+    SETTERS {
+        application.service_version,
+        application.env,
+        application.runtime_name,
+        application.runtime_version,
+        application.runtime_patches,
+
+        host.container_id,
+        host.os,
+        host.kernel_name,
+        host.kernel_release,
+        host.kernel_version,
+
+        runtime_id
+    }
+);
+
+crate::c_setters!(
+    object_name => builder,
+    object_type => TelemetryWorkerBuilder,
+    property_type => bool,
+    property_type_name_snakecase => bool,
+    property_type_name_camel_case => Bool,
+    convert_fn => (|b: bool| -> Result<_, String> { Ok(b) }),
+    SETTERS {
+        config.telemetry_debug_logging_enabled,
+    }
+);
+
+crate::c_setters!(
+    object_name => builder,
+    object_type => TelemetryWorkerBuilder,
+    property_type => &Endpoint,
+    property_type_name_snakecase => endpoint,
+    property_type_name_camel_case => Endpoint,
+    convert_fn => (|e: &Endpoint| -> Result<_, String> { Ok(e.clone()) }),
+    SETTERS {
+        config.endpoint,
+    }
+);

--- a/ddtelemetry-ffi/src/lib.rs
+++ b/ddtelemetry-ffi/src/lib.rs
@@ -6,6 +6,7 @@ use ddcommon_ffi as ffi;
 pub mod builder;
 pub mod worker_handle;
 
+#[allow(unused_macros)]
 macro_rules! c_setters {
     (
         object_name => $object_name:ident,
@@ -24,9 +25,9 @@ macro_rules! c_setters {
                 pub unsafe extern "C" fn [<ddog_ $object_name _with_ $property_type_name_snakecase _ $path $(_ $path_rest)* >](
                     $object_name: &mut $object_ty,
                     param: $property_type,
-                ) -> MaybeError {
+                ) -> crate::MaybeError {
                     $object_name . $path $(.  $path_rest)* = Some(crate::try_c!($convert_fn (param)));
-                    MaybeError::None
+                    crate::MaybeError::None
                 }
             )+
 
@@ -40,15 +41,15 @@ macro_rules! c_setters {
             #[allow(clippy::redundant_closure_call)]
             #[allow(clippy::missing_safety_doc)]
             #[doc=concat!(
-                " Sets a property from it's string value.\n\n",
-                " # Available properties:\n\n",
+                "\n Sets a property from it's string value.\n\n",
+                " Available properties:\n\n",
                 $(" * ", stringify!($path $(. $path_rest)*) , "\n\n",)+
             )]
             pub unsafe extern "C" fn [<ddog_ $object_name _with_property_ $property_type_name_snakecase>](
                 $object_name: &mut $object_ty,
                 property: [<$object_ty $property_type_name_camel_case Property >],
                 param: $property_type,
-            ) -> MaybeError {
+            ) -> crate::MaybeError {
                 use [<$object_ty $property_type_name_camel_case Property >] ::*;
                 match property {
                     $(
@@ -57,15 +58,15 @@ macro_rules! c_setters {
                         }
                     )+
                 }
-                MaybeError::None
+                crate::MaybeError::None
             }
 
             #[no_mangle]
             #[allow(clippy::redundant_closure_call)]
             #[allow(clippy::missing_safety_doc)]
             #[doc=concat!(
-                " Sets a property from it's string value.\n\n",
-                " # Available properties:\n\n",
+                "\n Sets a property from it's string value.\n\n",
+                " Available properties:\n\n",
                 $(
                     " * ", stringify!($path $(. $path_rest)*) , "\n\n",
                 )+
@@ -74,7 +75,7 @@ macro_rules! c_setters {
                 $object_name: &mut $object_ty,
                 property: ffi::CharSlice,
                 param: $property_type,
-            ) -> MaybeError {
+            ) -> crate::MaybeError {
                 let property = crate::try_c!(property.try_to_utf8());
                 match property {
                     $(
@@ -83,9 +84,9 @@ macro_rules! c_setters {
                         }
                     )+
                     // TODO this is an error
-                    _ => return MaybeError::None,
+                    _ => return crate::MaybeError::None,
                 }
-                MaybeError::None
+                crate::MaybeError::None
             }
         }
 
@@ -106,6 +107,7 @@ macro_rules! try_c {
     };
 }
 
+#[allow(unused_imports)]
 pub(crate) use c_setters;
 
 pub type MaybeError = ffi::Option<ffi::Vec<u8>>;
@@ -133,7 +135,7 @@ mod test_c_ffi {
                     ffi::CharSlice::from("language_version"),
                     ffi::CharSlice::from("tracer_version"),
                 ),
-                MaybeError::None
+                crate::MaybeError::None
             );
             assert!(!builder.is_null());
             let mut builder = Box::from_raw(builder);
@@ -144,7 +146,7 @@ mod test_c_ffi {
                     ffi::CharSlice::from("runtime_id"),
                     ffi::CharSlice::from("abcd")
                 ),
-                MaybeError::None,
+                crate::MaybeError::None,
             );
             assert_eq!(builder.runtime_id.as_deref(), Some("abcd"));
 
@@ -154,7 +156,7 @@ mod test_c_ffi {
                     ffi::CharSlice::from("application.runtime_name"),
                     ffi::CharSlice::from("rust")
                 ),
-                MaybeError::None,
+                crate::MaybeError::None,
             );
             assert_eq!(builder.application.runtime_name.as_deref(), Some("rust"));
 
@@ -164,7 +166,7 @@ mod test_c_ffi {
                     ffi::CharSlice::from("host.kernel_version"),
                     ffi::CharSlice::from("ダタドグ")
                 ),
-                MaybeError::None,
+                crate::MaybeError::None,
             );
             assert_eq!(builder.host.kernel_version.as_deref(), Some("ダタドグ"));
 
@@ -192,7 +194,7 @@ mod test_c_ffi {
                     ffi::CharSlice::from("language_version"),
                     ffi::CharSlice::from("tracer_version"),
                 ),
-                MaybeError::None,
+                crate::MaybeError::None,
             );
             assert!(!builder.is_null());
             let mut builder = Box::from_raw(builder);
@@ -203,7 +205,7 @@ mod test_c_ffi {
                     TelemetryWorkerBuilderStrProperty::RuntimeId,
                     ffi::CharSlice::from("abcd")
                 ),
-                MaybeError::None,
+                crate::MaybeError::None,
             );
             assert_eq!(builder.runtime_id.as_deref(), Some("abcd"));
 
@@ -213,7 +215,7 @@ mod test_c_ffi {
                     TelemetryWorkerBuilderStrProperty::ApplicationRuntimeName,
                     ffi::CharSlice::from("rust")
                 ),
-                MaybeError::None,
+                crate::MaybeError::None,
             );
             assert_eq!(builder.application.runtime_name.as_deref(), Some("rust"));
 
@@ -223,7 +225,7 @@ mod test_c_ffi {
                     TelemetryWorkerBuilderStrProperty::HostKernelVersion,
                     ffi::CharSlice::from("ダタドグ")
                 ),
-                MaybeError::None,
+                crate::MaybeError::None,
             );
             assert_eq!(builder.host.kernel_version.as_deref(), Some("ダタドグ"));
         }

--- a/examples/ffi/CMakeLists.txt
+++ b/examples/ffi/CMakeLists.txt
@@ -14,3 +14,6 @@ endif()
 
 add_executable(profiles profiles.c)
 target_link_libraries(profiles PRIVATE Datadog::Profiling)
+
+add_executable(telemetry telemetry.c)
+target_link_libraries(telemetry PRIVATE Datadog::Profiling)

--- a/examples/ffi/telemetry.c
+++ b/examples/ffi/telemetry.c
@@ -1,0 +1,48 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0. This product includes software
+// developed at Datadog (https://www.datadoghq.com/). Copyright 2021-Present
+// Datadog, Inc.
+
+#include <datadog/common.h>
+#include <datadog/telemetry.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define TRY(expr)                                                                                  \
+  {                                                                                                \
+    ddog_MaybeError err = expr;                                                                    \
+    if (err.tag == DDOG_OPTION_VEC_U8_SOME_VEC_U8) {                                               \
+      fprintf("ERROR: %.*s", err.some.ptr, err.some.len);                                          \
+      return 1;                                                                                    \
+    }                                                                                              \
+  }
+
+int main(void) {
+  ddog_TelemetryWorkerBuilder *builder;
+  ddog_CharSlice service = DDOG_CHARSLICE_C("rust"), lang = DDOG_CHARSLICE_C("libdatadog-example"),
+                 lang_version = DDOG_CHARSLICE_C("1.69.0"),
+                 tracer_version = DDOG_CHARSLICE_C("0.0.0");
+  TRY(ddog_builder_instantiate(&builder, service, lang, lang_version, tracer_version));
+
+  ddog_CharSlice endpoint_char = DDOG_CHARSLICE_C("file://./examples_telemetry.out");
+  struct ddog_Endpoint *endpoint = ddog_endpoint_from_url(endpoint_char);
+  TRY(ddog_builder_with_endpoint_config_endpoint(builder, endpoint));
+  ddog_endpoint_drop(endpoint);
+
+  ddog_CharSlice runtime_id = DDOG_CHARSLICE_C("fa1f0ed0-8a3a-49e8-8f23-46fb44e24579"),
+                 service_version = DDOG_CHARSLICE_C("1.0"), env = DDOG_CHARSLICE_C("test");
+  TRY(ddog_builder_with_str_runtime_id(builder, runtime_id));
+  TRY(ddog_builder_with_str_application_service_version(builder, service_version));
+  TRY(ddog_builder_with_str_application_env(builder, env));
+
+  TRY(ddog_builder_with_bool_config_telemetry_debug_logging_enabled(builder, true));
+
+  ddog_TelemetryWorkerHandle *handle;
+  TRY(ddog_builder_run(builder, &handle));
+  TRY(ddog_handle_start(handle));
+
+  TRY(ddog_handle_stop(handle));
+  ddog_handle_wait_for_shutdown(handle);
+
+  return 0;
+}

--- a/profiling-ffi/Cargo.toml
+++ b/profiling-ffi/Cargo.toml
@@ -15,7 +15,8 @@ crate-type = ["staticlib", "cdylib"]
 
 [features]
 default = ["cbindgen"]
-cbindgen = ["build_common/cbindgen", "ddcommon-ffi/cbindgen"]
+cbindgen = ["build_common/cbindgen", "ddcommon-ffi/cbindgen", "ddtelemetry-ffi?/cbindgen"]
+ddtelemetry-ffi = ["dep:ddtelemetry-ffi"]
 
 [build-dependencies]
 build_common = { path = "../build-common" }
@@ -28,6 +29,7 @@ datadog-profiling = { path = "../profiling" }
 hyper = { version = "0.14", default-features = false }
 ddcommon = { path = "../ddcommon"}
 ddcommon-ffi = { path = "../ddcommon-ffi", default-features = false }
+ddtelemetry-ffi = { path = "../ddtelemetry-ffi", default-features = false, optional = true, features = ["expanded_builder_macros"] }
 libc = "0.2"
 tokio-util = "0.7.1"
 serde_json = { version = "1.0" }

--- a/profiling-ffi/src/lib.rs
+++ b/profiling-ffi/src/lib.rs
@@ -10,6 +10,10 @@ mod crashtracker;
 mod exporter;
 mod profiles;
 
+// re-export telemetry ffi
+#[cfg(feature = "ddtelemetry-ffi")]
+pub use ddtelemetry_ffi::*;
+
 /// Represents time since the Unix Epoch in seconds plus nanoseconds.
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]

--- a/windows/build-artifacts.ps1
+++ b/windows/build-artifacts.ps1
@@ -20,10 +20,10 @@ if (![System.IO.Path]::IsPathRooted($output_dir)) {
 
 Write-Host "Building project into $($output_dir)" -ForegroundColor Magenta
 
-Invoke-Call -ScriptBlock { cargo build --target i686-pc-windows-msvc --release --target-dir $output_dir }
-Invoke-Call -ScriptBlock { cargo build --target i686-pc-windows-msvc --target-dir $output_dir }
-Invoke-Call -ScriptBlock { cargo build --target x86_64-pc-windows-msvc --release --target-dir $output_dir }
-Invoke-Call -ScriptBlock { cargo build --target x86_64-pc-windows-msvc --target-dir $output_dir }
+Invoke-Call -ScriptBlock { cargo build --features datadog-profiling-ffi/ddtelemetry-ffi --target i686-pc-windows-msvc --release --target-dir $output_dir }
+Invoke-Call -ScriptBlock { cargo build --features datadog-profiling-ffi/ddtelemetry-ffi --target i686-pc-windows-msvc --target-dir $output_dir }
+Invoke-Call -ScriptBlock { cargo build --features datadog-profiling-ffi/ddtelemetry-ffi --target x86_64-pc-windows-msvc --release --target-dir $output_dir }
+Invoke-Call -ScriptBlock { cargo build --features datadog-profiling-ffi/ddtelemetry-ffi --target x86_64-pc-windows-msvc --target-dir $output_dir }
 
 Write-Host "Building tools" -ForegroundColor Magenta
 Set-Location tools
@@ -33,6 +33,7 @@ Set-Location ..
 Write-Host "Generating headers" -ForegroundColor Magenta
 Invoke-Call -ScriptBlock { cbindgen --crate ddcommon-ffi --config ddcommon-ffi/cbindgen.toml --output $output_dir\common.h }
 Invoke-Call -ScriptBlock { cbindgen --crate datadog-profiling-ffi --config profiling-ffi/cbindgen.toml --output $output_dir\profiling.h }
-Invoke-Call -ScriptBlock { .\target\release\dedup_headers $output_dir"\common.h"  $output_dir"\profiling.h" }
+Invoke-Call -ScriptBlock { cbindgen --crate ddtelemetry-ffi --config ddtelemetry-ffi/cbindgen.toml --output $output_dir\telemetry.h }
+Invoke-Call -ScriptBlock { .\target\release\dedup_headers $output_dir"\common.h"  $output_dir"\profiling.h" $output_dir"\telemetry.h" }
 
 Write-Host "Build finished"  -ForegroundColor Magenta

--- a/windows/libdatadog.csproj
+++ b/windows/libdatadog.csproj
@@ -31,6 +31,8 @@
       PackagePath="include\native\datadog\common.h" />
     <None Include="$(LibDatadogBinariesOutputDir)\profiling.h" Pack="true"
       PackagePath="include\native\datadog\profiling.h" />
+    <None Include="$(LibDatadogBinariesOutputDir)\telemetry.h" Pack="true"
+      PackagePath="include\native\datadog\telemetry.h" />
 
     <None Include="$(LibDatadogBinariesOutputDir)\x86_64-pc-windows-msvc\debug\datadog_profiling_ffi.lib"
       Pack="true" PackagePath="build\native\lib\x64\debug\datadog_profiling_ffi.lib" />


### PR DESCRIPTION
# What does this PR do?

* Expose telemetry-ffi from profiling-ffi
* Add a feature flag to disable it if necessary
* Expand telemetry builder macros to generate declarations from them with cbindgen
* Add a telemetry C example

# Motivation


# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
