### PR TITLE
Introduce `DDOG_CHARSLICE_C_BARE` and undo change to `DDOG_CHARSLICE_C` helper

### DIFF
--- a/ddcommon-ffi/cbindgen.toml
+++ b/ddcommon-ffi/cbindgen.toml
@@ -17,7 +17,10 @@ sys_includes = ["stdbool.h", "stddef.h", "stdint.h"]
 after_includes = """
 
 #define DDOG_CHARSLICE_C(string) \\
-/* NOTE: Compilation fails if you pass in a char* instead of a literal */ {.ptr = "" string, .len = sizeof(string) - 1}
+/* NOTE: Compilation fails if you pass in a char* instead of a literal */ ((ddog_CharSlice){ .ptr = "" string, .len = sizeof(string) - 1 })
+
+#define DDOG_CHARSLICE_C_BARE(string) \\
+/* NOTE: Compilation fails if you pass in a char* instead of a literal */ { .ptr = "" string, .len = sizeof(string) - 1 }
 
 #if defined __GNUC__
 #  define DDOG_GNUC_VERSION(major) __GNUC__ >= major

--- a/examples/ffi/exporter.cpp
+++ b/examples/ffi/exporter.cpp
@@ -32,8 +32,8 @@ int main(int argc, char *argv[]) {
   const auto service = argv[1];
 
   const ddog_prof_ValueType wall_time = {
-      .type_ = DDOG_CHARSLICE_C("wall-time"),
-      .unit = DDOG_CHARSLICE_C("nanoseconds"),
+      .type_ = DDOG_CHARSLICE_C_BARE("wall-time"),
+      .unit = DDOG_CHARSLICE_C_BARE("nanoseconds"),
   };
 
   const ddog_prof_Slice_ValueType sample_types = {&wall_time, 1};
@@ -52,15 +52,15 @@ int main(int argc, char *argv[]) {
       .mapping = {},
       .function =
           {
-              .name = DDOG_CHARSLICE_C("{main}"),
-              .filename = DDOG_CHARSLICE_C("/srv/example/index.php"),
+              .name = DDOG_CHARSLICE_C_BARE("{main}"),
+              .filename = DDOG_CHARSLICE_C_BARE("/srv/example/index.php"),
           },
   };
 
   int64_t value = 10;
   const ddog_prof_Label label = {
-      .key = DDOG_CHARSLICE_C("language"),
-      .str = DDOG_CHARSLICE_C("php"),
+      .key = DDOG_CHARSLICE_C_BARE("language"),
+      .str = DDOG_CHARSLICE_C_BARE("php"),
   };
   ddog_prof_Sample sample = {
       .locations = {&root_location, 1},
@@ -76,7 +76,7 @@ int main(int argc, char *argv[]) {
 
   uintptr_t offset[1] = {0};
   ddog_prof_Slice_Usize offsets_slice = {.ptr = offset, .len = 1};
-  ddog_CharSlice empty_charslice = DDOG_CHARSLICE_C("");
+  ddog_CharSlice empty_charslice = DDOG_CHARSLICE_C_BARE("");
 
   auto upscaling_addresult = ddog_prof_Profile_add_upscaling_rule_proportional(
       profile.get(), offsets_slice, empty_charslice, empty_charslice, 1, 1);
@@ -99,11 +99,11 @@ int main(int argc, char *argv[]) {
   ddog_prof_EncodedProfile *encoded_profile = &serialize_result.ok;
 
   ddog_Endpoint endpoint =
-      ddog_Endpoint_agentless(DDOG_CHARSLICE_C("datad0g.com"), to_slice_c_char(api_key));
+      ddog_Endpoint_agentless(DDOG_CHARSLICE_C_BARE("datad0g.com"), to_slice_c_char(api_key));
 
   ddog_Vec_Tag tags = ddog_Vec_Tag_new();
   ddog_Vec_Tag_PushResult tag_result =
-      ddog_Vec_Tag_push(&tags, DDOG_CHARSLICE_C("service"), to_slice_c_char(service));
+      ddog_Vec_Tag_push(&tags, DDOG_CHARSLICE_C_BARE("service"), to_slice_c_char(service));
   if (tag_result.tag == DDOG_VEC_TAG_PUSH_RESULT_ERR) {
     print_error("Failed to push tag: ", tag_result.err);
     ddog_Error_drop(&tag_result.err);
@@ -111,8 +111,8 @@ int main(int argc, char *argv[]) {
   }
 
   ddog_prof_Exporter_NewResult exporter_new_result =
-      ddog_prof_Exporter_new(DDOG_CHARSLICE_C("exporter-example"), DDOG_CHARSLICE_C("1.2.3"),
-                             DDOG_CHARSLICE_C("native"), &tags, endpoint);
+      ddog_prof_Exporter_new(DDOG_CHARSLICE_C_BARE("exporter-example"), DDOG_CHARSLICE_C_BARE("1.2.3"),
+                             DDOG_CHARSLICE_C_BARE("native"), &tags, endpoint);
   ddog_Vec_Tag_drop(tags);
 
   if (exporter_new_result.tag == DDOG_PROF_EXPORTER_NEW_RESULT_ERR) {
@@ -124,7 +124,7 @@ int main(int argc, char *argv[]) {
   auto exporter = exporter_new_result.ok;
 
   ddog_prof_Exporter_File files_to_compress_and_export_[] = {{
-      .name = DDOG_CHARSLICE_C("auto.pprof"),
+      .name = DDOG_CHARSLICE_C_BARE("auto.pprof"),
       .file = ddog_Vec_U8_as_slice(&encoded_profile->buffer),
   }};
   ddog_prof_Exporter_Slice_File files_to_compress_and_export = {
@@ -134,10 +134,10 @@ int main(int argc, char *argv[]) {
 
   ddog_prof_Exporter_Slice_File files_to_export_unmodified = ddog_prof_Exporter_Slice_File_empty();
 
-  ddog_CharSlice internal_metadata_example = DDOG_CHARSLICE_C(
+  ddog_CharSlice internal_metadata_example = DDOG_CHARSLICE_C_BARE(
       "{\"no_signals_workaround_enabled\": \"true\", \"execution_trace_enabled\": \"false\"}");
 
-  ddog_CharSlice info_example = DDOG_CHARSLICE_C(
+  ddog_CharSlice info_example = DDOG_CHARSLICE_C_BARE(
       "{\"application\": {\"start_time\": \"2024-01-24T11:17:22+0000\"}, \"platform\": {\"kernel\": \"Darwin Kernel 22.5.0\"}}");
 
   ddog_prof_Exporter_Request_BuildResult build_result = ddog_prof_Exporter_Request_build(

--- a/examples/ffi/telemetry_metrics.c
+++ b/examples/ffi/telemetry_metrics.c
@@ -22,7 +22,7 @@
     }                                                                                              \
   }
 #define STR(x) #x
-#define LOG_LOCATION_IDENTIFIER() (ddog_CharSlice) DDOG_CHARSLICE_C(STR(__FILE__) ":" STR(__LINE__))
+#define LOG_LOCATION_IDENTIFIER() DDOG_CHARSLICE_C(STR(__FILE__) ":" STR(__LINE__))
 
 #ifdef _WIN32
 unsigned int sleep(unsigned int seconds) {
@@ -80,8 +80,8 @@ int main(void) {
   for (int i = 0; i < 10; i++) {
     TRY(ddog_handle_add_log(
         handle, LOG_LOCATION_IDENTIFIER(),
-        (ddog_CharSlice)DDOG_CHARSLICE_C("no kinder bueno left in the cafetaria"),
-        DDOG_LOG_LEVEL_ERROR, (ddog_CharSlice)DDOG_CHARSLICE_C("")));
+        DDOG_CHARSLICE_C("no kinder bueno left in the cafetaria"),
+        DDOG_LOG_LEVEL_ERROR, DDOG_CHARSLICE_C("")));
   }
 
   sleep(11);


### PR DESCRIPTION
# What does this PR do?

This PR introduces a new `DDOG_CHARSLICE_C_BARE` helper, as well as undoes the change to `DDOG_CHARSLICE_C` from
https://github.com/DataDog/libdatadog/pull/305/files#diff-5c00b9c49c81bf0d0a754e0bcc6e0add4fe849bf0ea4a4d1ebfac8f698150f0b

There are now two helpers: `DDOG_CHARSLICE_C` that includes the `(ddog_CharSlice)` cast and `DDOG_CHARSLICE_C_BARE` which doesn't.

# Motivation

In a nutshell @bwoebi explained to me that on Windows there's times where you need to use `(ddog_CharSlice) {.ptr = ..., .len = ...}` and others where you need to use `{.ptr = ..., .len = ...}` and cannot include the cast.

Thus in #305 we tweaked the helper to never have `(ddog_CharSlice)`, with the intention of using `(ddog_CharSlice) DDOG_CHARSLICE_C(...)` some times, and `DDOG_CHARSLICE_C(...)` the other times.

But... this had the downside of making some of our Ruby Profiler code really ugly, as we'd need to move from `DDOG_CHARSLICE_C` to `(CharSlice) DDOG_CHARSLICE_C` in a lot of cases.

Thus, this PR introduces one helper for each variant, so that we always have a nice user-friendly option for each case, and avoid needing to sprinkle casts.

# Additional Notes

Arghhh C/C++ you always manage to be weird and annoying.

# How to test the change?

I've tested this change by compiling the Ruby profiler to use this branch of libdatadog, and validating that it compiles successfully on Linux.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
