### PR TITLE
[data-pipeline] Fix ffi generation and Add CI build

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -16,7 +16,7 @@ mini-agent:
 - trace-mini-agent/**/*
 - serverless/**/*
 - trace-normalization/**/*
-- trace-obfuscaiton/**/*
+- trace-obfuscation/**/*
 - trace-utils/**/*
 
 telemetry:
@@ -29,3 +29,7 @@ dogstatsd:
 sidecar:
 - sidecar/**/*
 - sidecar-ffi/**/*
+
+data-pipeline:
+- data-pipeline/**/*
+- data-pipeline-ffi/**/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,6 +106,11 @@ jobs:
            chmod +x build-telemetry-ffi.sh
            ./build-telemetry-ffi.sh ${OUTPUT_FOLDER}/telemetry
 
+      - name: "Generate Data Pipeline FFI"
+        shell: bash
+        run: |
+           ./build-data-pipeline-ffi.sh ${OUTPUT_FOLDER}/data-pipeline
+
       - name: 'Publish libdatadog'
         uses: actions/upload-artifact@v3
         if: '${{ always() }}'
@@ -115,7 +120,7 @@ jobs:
           path: ${{ github.workspace }}/artifacts
           retention-days: 1
 
-      - name: "Test building C bindings"
+      - name: "Test building Profiling C bindings"
         shell: bash
         run: |
           set -e
@@ -130,6 +135,15 @@ jobs:
             cmake -S .. -DDatadog_ROOT=$OUTPUT_FOLDER/profiling
             cmake --build .
           fi
+
+      - name: "Test building Data Pipeline C bindings"
+        shell: bash
+        run: |
+          set -e
+          cd examples/ffi/data-pipeline
+          cmake -S . -B build -DDataPipeline_ROOT=$OUTPUT_FOLDER/data-pipeline
+          cmake --build build
+
   cross-centos7:
     name: build and test using cross - on centos7
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,7 +742,6 @@ version = "6.0.0"
 dependencies = [
  "build_common",
  "bytes",
- "cbindgen",
  "data-pipeline",
  "ddcommon-ffi",
  "libc",

--- a/build-data-pipeline-ffi.sh
+++ b/build-data-pipeline-ffi.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+
+# Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+destdir="$1"
+
+mkdir -v -p "$destdir/include/datadog" "$destdir/lib/pkgconfig" "$destdir/cmake"
+
+version=$(awk -F\" '$1 ~ /^version/ { print $2 }' < data-pipeline-ffi/Cargo.toml)
+target="$(rustc -vV | awk '/^host:/ { print $2 }')"
+shared_library_suffix=".so"
+static_library_suffix=".a"
+library_prefix="lib"
+remove_rpath=0
+fix_macos_rpath=0
+
+# Rust provides this note about the link libraries:
+# note: Link against the following native artifacts when linking against this
+# static library. The order and any duplication can be significant on some
+# platforms.
+#
+# We've decided to strip out -lgcc_s because if it's provided then it will
+# always make it into the final runtime dependencies, even if -static-libgcc is
+# provided. At least on Alpine, libgcc_s may not even exist in the users'
+# images, so -static-libgcc is recommended there.
+case "$target" in
+    "x86_64-alpine-linux-musl"|"aarch64-alpine-linux-musl")
+        expected_native_static_libs=" -lssp_nonshared -lgcc_s -lc"
+        native_static_libs=" -lssp_nonshared -lc"
+        # on alpine musl, Rust adds some weird runpath to cdylibs
+        remove_rpath=1
+        ;;
+
+    "x86_64-apple-darwin"|"aarch64-apple-darwin")
+        expected_native_static_libs=" -framework Security -framework CoreFoundation -liconv -lSystem -lresolv -lc -lm -liconv"
+        native_static_libs="${expected_native_static_libs}"
+        shared_library_suffix=".dylib"
+        # fix usage of library in macos via rpath
+        fix_macos_rpath=1
+        ;;
+
+    "x86_64-unknown-linux-gnu"|"aarch64-unknown-linux-gnu")
+        expected_native_static_libs=" -lgcc_s -lutil -lrt -lpthread -lm -ldl -lc"
+        native_static_libs=" -ldl -lrt -lpthread -lc -lm -lrt -lpthread -lutil -ldl -lutil"
+        ;;
+
+    "x86_64-pc-windows-msvc")
+        expected_native_static_libs="" # I don't know what to expect
+        native_static_libs="" # I don't know what to expect
+        shared_library_suffix=".dll"
+        static_library_suffix=".lib"
+        library_prefix=""
+        ;;
+
+    *)
+        >&2 echo "Unknown platform '${target}'"
+        exit 1
+        ;;
+esac
+
+# strip leading white space as per CMake policy CMP0004.
+ffi_libraries="$(echo "${native_static_libs}" | sed -e 's/^[[:space:]]*//')"
+
+sed < cmake/DataPipelineConfig.cmake.in \
+    > "$destdir/cmake/DataPipelineConfig.cmake" \
+    "s/@Datadog_LIBRARIES@/${ffi_libraries}/g"
+
+cp -v LICENSE LICENSE-3rdparty.yml NOTICE "$destdir/"
+
+export RUSTFLAGS="${RUSTFLAGS:- -C relocation-model=pic}"
+
+data_pipeline_ffi="data-pipeline-ffi"
+echo "Building the ${data_pipeline_ffi} crate (may take some time)..."
+DESTDIR="$destdir" cargo build --package="${data_pipeline_ffi}" --release --target "${target}"
+
+# Remove _ffi suffix when copying
+shared_library_name="${library_prefix}data_pipeline_ffi${shared_library_suffix}"
+shared_library_rename="${library_prefix}data_pipeline${shared_library_suffix}"
+
+static_library_name="${library_prefix}data_pipeline_ffi${static_library_suffix}"
+static_library_rename="${library_prefix}data_pipeline${static_library_suffix}"
+
+cp -v "target/${target}/release/${shared_library_name}" "$destdir/lib/${shared_library_rename}"
+cp -v "target/${target}/release/${static_library_name}" "$destdir/lib/${static_library_rename}"
+
+shared_library_name="${shared_library_rename}"
+static_library_name="${static_library_rename}"
+
+if [[ "$remove_rpath" -eq 1 ]]; then
+    patchelf --remove-rpath "$destdir/lib/${shared_library_name}"
+fi
+
+if [[ "$fix_macos_rpath" -eq 1 ]]; then
+    install_name_tool -id @rpath/${shared_library_name} "$destdir/lib/${shared_library_name}"
+fi
+
+# objcopy might not be available on macOS
+if command -v objcopy > /dev/null && [[ "$target" != "x86_64-pc-windows-msvc" ]]; then
+    # Remove .llvmbc section which is not useful for clients
+    objcopy --remove-section .llvmbc "$destdir/lib/${static_library_name}"
+
+    # Ship debug information separate from shared library, so that downstream packages can selectively include it
+    # https://sourceware.org/gdb/onlinedocs/gdb/Separate-Debug-Files.html
+    objcopy --only-keep-debug "$destdir/lib/$shared_library_name" "$destdir/lib/$shared_library_name.debug"
+    strip -S "$destdir/lib/$shared_library_name"
+    objcopy --add-gnu-debuglink="$destdir/lib/$shared_library_name.debug" "$destdir/lib/$shared_library_name"
+fi
+
+echo "Checking that native-static-libs are as expected for this platform..."
+cd data-pipeline-ffi
+actual_native_static_libs="$(cargo rustc --release --target "${target}" -- --print=native-static-libs 2>&1 | awk -F ':' '/note: native-static-libs:/ { print $3 }')"
+echo "Actual native-static-libs:${actual_native_static_libs}"
+echo "Expected native-static-libs:${expected_native_static_libs}"
+
+# Compare unique elements between expected and actual native static libs.
+# If actual libs is different from expected libs but still a subset of expected libs
+# (ie. we will overlink compared to what is actually needed), this is not considered as an error.
+# Raise an error only if some libs are in actual libs but not in expected libs.
+
+# trim leading and trailing spaces, then split the string on " -" by inserting new lines and sort lines while removing duplicates
+unique_expected_libs=$(echo "$expected_native_static_libs "| awk '{ gsub(/^[ \t]+|[ \t]+$/, "");gsub(/ +-/,"\n-")};1' | sort -u)
+unique_libs=$(echo "$actual_native_static_libs "| awk '{ gsub(/^[ \t]+|[ \t]+$/, "");gsub(/ +-/,"\n-")};1' | sort -u)
+
+unexpected_native_libs=$(comm -13 <(echo "$unique_expected_libs") <(echo "$unique_libs"))
+if [ -n "$unexpected_native_libs" ]; then
+    echo "Error - More native static libraries are required for linking than expected:" 1>&2
+    echo "$unexpected_native_libs" 1>&2
+    exit 1
+fi
+cd -
+
+echo "Building tools"
+cargo build --package tools --bins
+
+echo "Generating $destdir/include/libdatadog headers..."
+./target/debug/dedup_headers "${destdir}/include/datadog/common.h" "${destdir}/include/datadog/data-pipeline.h"
+
+echo "Done."

--- a/cmake/DataPipelineConfig.cmake.in
+++ b/cmake/DataPipelineConfig.cmake.in
@@ -1,0 +1,54 @@
+# Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+include(FindPackageHandleStandardArgs)
+
+if(DEFINED ENV{DataPipeline_ROOT})
+  set(DataPipeline_ROOT "$ENV{DataPipeline_ROOT}")
+else()
+  # If the environment variable is not set, maybe we are part of a build
+  set(DataPipeline_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/..")
+endif()
+
+find_path(DataPipeline_INCLUDE_DIR datadog/data-pipeline.h HINTS ${DataPipeline_ROOT}/include)
+
+find_library(
+  DataPipeline_LIBRARY
+  NAMES data_pipeline
+  HINTS ${DataPipeline_ROOT}/lib)
+
+find_package_handle_standard_args(DataPipeline DEFAULT_MSG DataPipeline_LIBRARY
+                                  DataPipeline_INCLUDE_DIR)
+
+if(DataPipeline_FOUND)
+  set(DataPipeline_INCLUDE_DIRS ${DataPipeline_INCLUDE_DIR})
+  set(DataPipeline_LIBRARIES ${DataPipeline_LIBRARY} "@Datadog_LIBRARIES@")
+  mark_as_advanced(DataPipeline_ROOT DataPipeline_LIBRARY DataPipeline_INCLUDE_DIR)
+
+  add_library(data_pipeline INTERFACE)
+  target_include_directories(data_pipeline
+                             INTERFACE ${DataPipeline_INCLUDE_DIRS})
+  target_link_libraries(data_pipeline INTERFACE ${DataPipeline_LIBRARIES})
+  target_compile_features(data_pipeline INTERFACE c_std_11)
+
+  if(CMAKE_C_COMPILER_ID MATCHES "MSVC")
+    target_link_libraries(
+      data_pipeline
+      INTERFACE NtDll
+                UserEnv
+                Bcrypt
+                crypt32
+                wsock32
+                ws2_32
+                shlwapi
+                Secur32
+                Ncrypt
+                PowrProf)
+  endif()
+
+  add_library(Datadog::DataPipeline ALIAS data_pipeline)
+
+else()
+  set(DataPipeline_ROOT
+      ""
+      CACHE STRING "Directory containing libdatadog")
+endif()

--- a/data-pipeline-ffi/Cargo.toml
+++ b/data-pipeline-ffi/Cargo.toml
@@ -8,15 +8,14 @@ license.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["staticlib", "cdylib"]
 
 [features]
-default = []
+default = ["cbindgen"]
 cbindgen = ["build_common/cbindgen", "ddcommon-ffi/cbindgen"]
 
 [build-dependencies]
 build_common = { path = "../build-common" }
-cbindgen = "0.26.0"
 
 [dependencies]
 data-pipeline = { path = "../data-pipeline" }

--- a/data-pipeline-ffi/cbindgen.toml
+++ b/data-pipeline-ffi/cbindgen.toml
@@ -15,6 +15,11 @@ prefix = "ddog_"
 renaming_overrides_prefixing = true
 
 [export.rename]
+"ByteSlice" = "ddog_ByteSlice"
+"CharSlice" = "ddog_CharSlice"
+"Slice_U8" = "ddog_Slice_U8"
+"Slice_CChar" = "ddog_Slice_CChar"
+"Error" = "ddog_Error"
 
 [export.mangle]
 rename_types = "PascalCase"
@@ -28,4 +33,4 @@ must_use = "DDOG_CHECK_RETURN"
 
 [parse]
 parse_deps = true
-include = ["ddcommon", "ddcommon-ffi"]
+include = ["ddcommon", "ddcommon-ffi", "data-pipeline"]

--- a/examples/ffi/data-pipeline/CMakeLists.txt
+++ b/examples/ffi/data-pipeline/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 3.19)
+project(data_pipeline_ffi_examples LANGUAGES C)
+
+find_package(DataPipeline REQUIRED)
+
+# Uncomment to debug build commands
+# set(CMAKE_VERBOSE_MAKEFILE ON)
+
+add_executable(trace_exporter trace_exporter.c)
+target_link_libraries(trace_exporter PRIVATE Datadog::DataPipeline)
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+  target_compile_definitions(trace_exporter PUBLIC _CRT_SECURE_NO_WARNINGS)
+endif()
+

--- a/examples/ffi/data-pipeline/trace_exporter.c
+++ b/examples/ffi/data-pipeline/trace_exporter.c
@@ -1,0 +1,41 @@
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <datadog/common.h>
+#include <datadog/data-pipeline.h>
+
+int main(int argc, char** argv)
+{
+    ddog_CharSlice host = DDOG_CHARSLICE_C("localhost");
+    uint16_t port = 8126;
+    ddog_CharSlice tracer_version = DDOG_CHARSLICE_C("v0.1");
+    ddog_CharSlice language = DDOG_CHARSLICE_C("dotnet");
+    ddog_CharSlice language_version = DDOG_CHARSLICE_C("10.0");
+    ddog_CharSlice language_interpreter = DDOG_CHARSLICE_C("X");
+    ddog_TraceExporter* trace_exporter = ddog_trace_exporter_new(
+        host,
+        port,
+        tracer_version,
+        language,
+        language_version,
+        language_interpreter
+        );
+
+    if (trace_exporter == NULL)
+    {
+        printf("unable to build the trace exporter");
+        return 1;
+    }
+
+    ddog_ByteSlice buffer = { .ptr = NULL, .len=0 };
+    char* str_result = ddog_trace_exporter_send(trace_exporter, buffer, 0);
+
+    free(str_result);
+
+
+    ddog_trace_exporter_free(trace_exporter);
+
+    return 0;
+}

--- a/windows/build-artifacts.ps1
+++ b/windows/build-artifacts.ps1
@@ -20,10 +20,10 @@ if (![System.IO.Path]::IsPathRooted($output_dir)) {
 
 Write-Host "Building project into $($output_dir)" -ForegroundColor Magenta
 
-Invoke-Call -ScriptBlock { cargo build --features datadog-profiling-ffi/ddtelemetry-ffi --target i686-pc-windows-msvc --release --target-dir $output_dir }
-Invoke-Call -ScriptBlock { cargo build --features datadog-profiling-ffi/ddtelemetry-ffi --target i686-pc-windows-msvc --target-dir $output_dir }
-Invoke-Call -ScriptBlock { cargo build --features datadog-profiling-ffi/ddtelemetry-ffi --target x86_64-pc-windows-msvc --release --target-dir $output_dir }
-Invoke-Call -ScriptBlock { cargo build --features datadog-profiling-ffi/ddtelemetry-ffi --target x86_64-pc-windows-msvc --target-dir $output_dir }
+Invoke-Call -ScriptBlock { cargo build -p datadog-profiling-ffi -p data-pipeline-ffi --features datadog-profiling-ffi/ddtelemetry-ffi --target i686-pc-windows-msvc --release --target-dir $output_dir }
+Invoke-Call -ScriptBlock { cargo build -p datadog-profiling-ffi -p data-pipeline-ffi --features datadog-profiling-ffi/ddtelemetry-ffi --target i686-pc-windows-msvc --target-dir $output_dir }
+Invoke-Call -ScriptBlock { cargo build -p datadog-profiling-ffi -p data-pipeline-ffi --features datadog-profiling-ffi/ddtelemetry-ffi --target x86_64-pc-windows-msvc --release --target-dir $output_dir }
+Invoke-Call -ScriptBlock { cargo build -p datadog-profiling-ffi -p data-pipeline-ffi --features datadog-profiling-ffi/ddtelemetry-ffi --target x86_64-pc-windows-msvc --target-dir $output_dir }
 
 Write-Host "Building tools" -ForegroundColor Magenta
 Set-Location tools
@@ -34,6 +34,7 @@ Write-Host "Generating headers" -ForegroundColor Magenta
 Invoke-Call -ScriptBlock { cbindgen --crate ddcommon-ffi --config ddcommon-ffi/cbindgen.toml --output $output_dir\common.h }
 Invoke-Call -ScriptBlock { cbindgen --crate datadog-profiling-ffi --config profiling-ffi/cbindgen.toml --output $output_dir\profiling.h }
 Invoke-Call -ScriptBlock { cbindgen --crate ddtelemetry-ffi --config ddtelemetry-ffi/cbindgen.toml --output $output_dir\telemetry.h }
-Invoke-Call -ScriptBlock { .\target\release\dedup_headers $output_dir"\common.h"  $output_dir"\profiling.h" $output_dir"\telemetry.h" }
+Invoke-Call -ScriptBlock { cbindgen --crate data-pipeline-ffi --config data-pipeline-ffi/cbindgen.toml --output $output_dir"\data-pipeline.h" }
+Invoke-Call -ScriptBlock { .\target\release\dedup_headers $output_dir"\common.h"  $output_dir"\profiling.h" $output_dir"\telemetry.h" $output_dir"\data-pipeline.h" }
 
 Write-Host "Build finished"  -ForegroundColor Magenta

--- a/windows/libdatadog.csproj
+++ b/windows/libdatadog.csproj
@@ -33,6 +33,8 @@
       PackagePath="include\native\datadog\profiling.h" />
     <None Include="$(LibDatadogBinariesOutputDir)\telemetry.h" Pack="true"
       PackagePath="include\native\datadog\telemetry.h" />
+    <None Include="$(LibDatadogBinariesOutputDir)\data-pipeline.h" Pack="true"
+      PackagePath="include\native\datadog\data-pipeline.h" />
 
     <None Include="$(LibDatadogBinariesOutputDir)\x86_64-pc-windows-msvc\debug\datadog_profiling_ffi.lib"
       Pack="true" PackagePath="build\native\lib\x64\debug\datadog_profiling_ffi.lib" />
@@ -61,5 +63,33 @@
       Pack="true" PackagePath="build\native\lib\x86\release\datadog_profiling_ffi.dll" />
     <None Include="$(LibDatadogBinariesOutputDir)\i686-pc-windows-msvc\release\datadog_profiling_ffi.pdb"
       Pack="true" PackagePath="build\native\lib\x86\release\datadog_profiling_ffi.pdb" />
+
+    <None Include="$(LibDatadogBinariesOutputDir)\x86_64-pc-windows-msvc\debug\data_pipeline_ffi.lib"
+      Pack="true" PackagePath="build\native\lib\x64\debug\data_pipeline_ffi.lib" />
+    <None Include="$(LibDatadogBinariesOutputDir)\x86_64-pc-windows-msvc\debug\data_pipeline_ffi.dll"
+      Pack="true" PackagePath="build\native\lib\x64\debug\data_pipeline_ffi.dll" />
+    <None Include="$(LibDatadogBinariesOutputDir)\x86_64-pc-windows-msvc\debug\data_pipeline_ffi.pdb"
+      Pack="true" PackagePath="build\native\lib\x64\debug\data_pipeline_ffi.pdb" />
+
+    <None Include="$(LibDatadogBinariesOutputDir)\x86_64-pc-windows-msvc\release\data_pipeline_ffi.lib"
+      Pack="true" PackagePath="build\native\lib\x64\release\data_pipeline_ffi.lib" />
+    <None Include="$(LibDatadogBinariesOutputDir)\x86_64-pc-windows-msvc\release\data_pipeline_ffi.dll"
+      Pack="true" PackagePath="build\native\lib\x64\release\data_pipeline_ffi.dll" />
+    <None Include="$(LibDatadogBinariesOutputDir)\x86_64-pc-windows-msvc\release\data_pipeline_ffi.pdb"
+      Pack="true" PackagePath="build\native\lib\x64\release\data_pipeline_ffi.lpdb" />
+
+    <None Include="$(LibDatadogBinariesOutputDir)\i686-pc-windows-msvc\debug\data_pipeline_ffi.lib"
+      Pack="true" PackagePath="build\native\lib\x64\debug\data_pipeline_ffi.lib" />
+    <None Include="$(LibDatadogBinariesOutputDir)\i686-pc-windows-msvc\debug\data_pipeline_ffi.dll"
+      Pack="true" PackagePath="build\native\lib\x64\debug\data_pipeline_ffi.dll" />
+    <None Include="$(LibDatadogBinariesOutputDir)\i686-pc-windows-msvc\debug\data_pipeline_ffi.pdb"
+      Pack="true" PackagePath="build\native\lib\x64\debug\data_pipeline_ffi.pdb" />
+
+    <None Include="$(LibDatadogBinariesOutputDir)\i686-pc-windows-msvc\release\data_pipeline_ffi.lib"
+      Pack="true" PackagePath="build\native\lib\x64\release\data_pipeline_ffi.lib" />
+    <None Include="$(LibDatadogBinariesOutputDir)\i686-pc-windows-msvc\release\data_pipeline_ffi.dll"
+      Pack="true" PackagePath="build\native\lib\x64\release\data_pipeline_ffi.dll" />
+    <None Include="$(LibDatadogBinariesOutputDir)\i686-pc-windows-msvc\release\data_pipeline_ffi.pdb"
+      Pack="true" PackagePath="build\native\lib\x64\release\data_pipeline_ffi.lpdb" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
# What does this PR do?

This PR fix the C code generation from Rust and add support to build the `data-pipeline` crate in CI.

# Motivation

For fun and profit

