### PR TITLE
Rename profiling-ffi Endpoint to ProfilingEndpoint/prof_Endpoint to remove confusion with ddcommon::Endpoint

### DIFF
--- a/bin_tests/src/bin/crashtracker_bin_test.rs
+++ b/bin_tests/src/bin/crashtracker_bin_test.rs
@@ -33,7 +33,7 @@ mod unix {
         crashtracker::init(
             CrashtrackerConfiguration {
                 create_alt_stack: true,
-                endpoint: Some(datadog_profiling::exporter::Endpoint {
+                endpoint: Some(ddcommon::Endpoint {
                     url: ddcommon::parse_uri(&format!("file://{}", output_filename))?,
                     api_key: None,
                 }),

--- a/build-common/src/cbindgen.rs
+++ b/build-common/src/cbindgen.rs
@@ -114,7 +114,7 @@ pub fn generate_header(crate_dir: PathBuf, header_name: &str, output_base_dir: P
         .expect("Unable to generate bindings")
         .write_to_file(output_path);
 
-    // println!("cargo:rerun-if-changed=cbindgen.toml");
+    println!("cargo:rerun-if-changed=cbindgen.toml");
 }
 
 /// Copies header files from the source directory to the destination directory.

--- a/build-common/src/cbindgen.rs
+++ b/build-common/src/cbindgen.rs
@@ -114,7 +114,7 @@ pub fn generate_header(crate_dir: PathBuf, header_name: &str, output_base_dir: P
         .expect("Unable to generate bindings")
         .write_to_file(output_path);
 
-    println!("cargo:rerun-if-changed=cbindgen.toml");
+    // println!("cargo:rerun-if-changed=cbindgen.toml");
 }
 
 /// Copies header files from the source directory to the destination directory.

--- a/crashtracker/src/crash_info.rs
+++ b/crashtracker/src/crash_info.rs
@@ -6,12 +6,13 @@ use crate::CrashtrackerMetadata;
 use anyhow::Context;
 use blazesym::symbolize::{Process, Source, Symbolizer};
 use chrono::{DateTime, Utc};
-use datadog_profiling::exporter::{self, Endpoint, Tag};
+use datadog_profiling::exporter::{self, Tag};
 use serde::{Deserialize, Serialize};
 use std::io::BufRead;
 use std::time::Duration;
 use std::{collections::HashMap, fs::File, io::BufReader};
 use uuid::Uuid;
+use ddcommon::Endpoint;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SigInfo {

--- a/crashtracker/src/crash_info.rs
+++ b/crashtracker/src/crash_info.rs
@@ -7,12 +7,12 @@ use anyhow::Context;
 use blazesym::symbolize::{Process, Source, Symbolizer};
 use chrono::{DateTime, Utc};
 use datadog_profiling::exporter::{self, Tag};
+use ddcommon::Endpoint;
 use serde::{Deserialize, Serialize};
 use std::io::BufRead;
 use std::time::Duration;
 use std::{collections::HashMap, fs::File, io::BufReader};
 use uuid::Uuid;
-use ddcommon::Endpoint;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SigInfo {

--- a/examples/ffi/crashtracking.c
+++ b/examples/ffi/crashtracking.c
@@ -20,7 +20,7 @@ int main(int argc, char **argv) {
 
   ddog_prof_CrashtrackerConfiguration config = {
     .create_alt_stack = false,
-    .endpoint = ddog_Endpoint_agent(DDOG_CHARSLICE_C("http://localhost:8126")),
+    .endpoint = ddog_prof_Endpoint_agent(DDOG_CHARSLICE_C("http://localhost:8126")),
     .path_to_receiver_binary = DDOG_CHARSLICE_C("FIXME - point me to receiver binary path"),
     .resolve_frames = DDOG_PROF_CRASHTRACKER_RESOLVE_FRAMES_NEVER,
   };

--- a/examples/ffi/exporter.cpp
+++ b/examples/ffi/exporter.cpp
@@ -98,8 +98,8 @@ int main(int argc, char *argv[]) {
 
   ddog_prof_EncodedProfile *encoded_profile = &serialize_result.ok;
 
-  ddog_Endpoint endpoint =
-      ddog_Endpoint_agentless(DDOG_CHARSLICE_C_BARE("datad0g.com"), to_slice_c_char(api_key));
+  ddog_prof_Endpoint endpoint =
+      ddog_prof_Endpoint_agentless(DDOG_CHARSLICE_C_BARE("datad0g.com"), to_slice_c_char(api_key));
 
   ddog_Vec_Tag tags = ddog_Vec_Tag_new();
   ddog_Vec_Tag_PushResult tag_result =

--- a/profiling-ffi/cbindgen.toml
+++ b/profiling-ffi/cbindgen.toml
@@ -23,7 +23,6 @@ renaming_overrides_prefixing = true
 "ByteSlice" = "ddog_ByteSlice"
 "CancellationToken" = "ddog_CancellationToken"
 "CharSlice" = "ddog_CharSlice"
-"Endpoint" = "ddog_Endpoint"
 "Error" = "ddog_Error"
 "HttpStatus" = "ddog_HttpStatus"
 "Slice_CChar" = "ddog_Slice_CChar"
@@ -34,6 +33,7 @@ renaming_overrides_prefixing = true
 "Vec_Tag" = "ddog_Vec_Tag"
 "Vec_U8" = "ddog_Vec_U8"
 
+"ProfilingEndpoint" = "ddog_prof_Endpoint"
 "ExporterNewResult" = "ddog_prof_Exporter_NewResult"
 "File" = "ddog_prof_Exporter_File"
 "ProfileExporter" = "ddog_prof_Exporter"

--- a/profiling-ffi/src/crashtracker.rs
+++ b/profiling-ffi/src/crashtracker.rs
@@ -3,7 +3,7 @@
 
 #![cfg(unix)]
 
-use crate::exporter::{self, Endpoint};
+use crate::exporter::{self, ProfilingEndpoint};
 use crate::profiles::ProfileResult;
 use ddcommon::tag::Tag;
 use ddcommon_ffi::slice::{AsBytes, CharSlice};
@@ -18,7 +18,7 @@ pub struct CrashtrackerConfiguration<'a> {
     pub collect_stacktrace: bool,
     pub create_alt_stack: bool,
     /// The endpoint to send the crash repor to (can be a file://)
-    pub endpoint: Endpoint<'a>,
+    pub endpoint: ProfilingEndpoint<'a>,
     /// Optional filename to forward stderr to (useful for logging/debugging)
     pub optional_stderr_filename: CharSlice<'a>,
     /// Optional filename to forward stdout to (useful for logging/debugging)

--- a/profiling-ffi/src/exporter.rs
+++ b/profiling-ffi/src/exporter.rs
@@ -34,7 +34,7 @@ pub enum SendResult {
 }
 
 #[repr(C)]
-pub enum Endpoint<'a> {
+pub enum ProfilingEndpoint<'a> {
     Agent(CharSlice<'a>),
     Agentless(CharSlice<'a>, CharSlice<'a>),
 }
@@ -62,21 +62,21 @@ pub struct HttpStatus(u16);
 /// Creates an endpoint that uses the agent.
 /// # Arguments
 /// * `base_url` - Contains a URL with scheme, host, and port e.g. "https://agent:8126/".
-#[export_name = "ddog_Endpoint_agent"]
-pub extern "C" fn endpoint_agent(base_url: CharSlice) -> Endpoint {
-    Endpoint::Agent(base_url)
+#[no_mangle]
+pub extern "C" fn ddog_prof_Endpoint_agent(base_url: CharSlice) -> ProfilingEndpoint {
+    ProfilingEndpoint::Agent(base_url)
 }
 
 /// Creates an endpoint that uses the Datadog intake directly aka agentless.
 /// # Arguments
 /// * `site` - Contains a host and port e.g. "datadoghq.com".
 /// * `api_key` - Contains the Datadog API key.
-#[export_name = "ddog_Endpoint_agentless"]
-pub extern "C" fn endpoint_agentless<'a>(
+#[no_mangle]
+pub extern "C" fn ddog_prof_Endpoint_agentless<'a>(
     site: CharSlice<'a>,
     api_key: CharSlice<'a>,
-) -> Endpoint<'a> {
-    Endpoint::Agentless(site, api_key)
+) -> ProfilingEndpoint<'a> {
+    ProfilingEndpoint::Agentless(site, api_key)
 }
 
 unsafe fn try_to_url(slice: CharSlice) -> anyhow::Result<hyper::Uri> {
@@ -92,15 +92,15 @@ unsafe fn try_to_url(slice: CharSlice) -> anyhow::Result<hyper::Uri> {
     Ok(hyper::Uri::from_str(str)?)
 }
 
-pub unsafe fn try_to_endpoint(endpoint: Endpoint) -> anyhow::Result<exporter::Endpoint> {
+pub unsafe fn try_to_endpoint(endpoint: ProfilingEndpoint) -> anyhow::Result<ddcommon::Endpoint> {
     // convert to utf8 losslessly -- URLs and API keys should all be ASCII, so
     // a failed result is likely to be an error.
     match endpoint {
-        Endpoint::Agent(url) => {
+        ProfilingEndpoint::Agent(url) => {
             let base_url = try_to_url(url)?;
             exporter::config::agent(base_url)
         }
-        Endpoint::Agentless(site, api_key) => {
+        ProfilingEndpoint::Agentless(site, api_key) => {
             let site_str = site.try_to_utf8()?;
             let api_key_str = api_key.try_to_utf8()?;
             exporter::config::agentless(
@@ -133,7 +133,7 @@ pub unsafe extern "C" fn ddog_prof_Exporter_new(
     profiling_library_version: CharSlice,
     family: CharSlice,
     tags: Option<&ddcommon_ffi::Vec<Tag>>,
-    endpoint: Endpoint,
+    endpoint: ProfilingEndpoint,
 ) -> ExporterNewResult {
     // Use a helper function so we can use the ? operator.
     match ddog_prof_exporter_new_impl(
@@ -157,7 +157,7 @@ fn ddog_prof_exporter_new_impl(
     profiling_library_version: CharSlice,
     family: CharSlice,
     tags: Option<&ddcommon_ffi::Vec<Tag>>,
-    endpoint: Endpoint,
+    endpoint: ProfilingEndpoint,
 ) -> anyhow::Result<ProfileExporter> {
     let library_name = profiling_library_name.to_utf8_lossy().into_owned();
     let library_version = profiling_library_version.to_utf8_lossy().into_owned();
@@ -506,7 +506,7 @@ mod test {
                 profiling_library_version(),
                 family(),
                 Some(&tags),
-                endpoint_agent(endpoint()),
+                ddog_prof_Endpoint_agent(endpoint()),
             )
         };
 
@@ -532,7 +532,7 @@ mod test {
                 profiling_library_version(),
                 family(),
                 None,
-                endpoint_agent(endpoint()),
+                ddog_prof_Endpoint_agent(endpoint()),
             )
         };
 
@@ -603,7 +603,7 @@ mod test {
                 profiling_library_version(),
                 family(),
                 None,
-                endpoint_agent(endpoint()),
+                ddog_prof_Endpoint_agent(endpoint()),
             )
         };
 
@@ -675,7 +675,7 @@ mod test {
                 profiling_library_version(),
                 family(),
                 None,
-                endpoint_agent(endpoint()),
+                ddog_prof_Endpoint_agent(endpoint()),
             )
         };
 
@@ -735,7 +735,7 @@ mod test {
                 profiling_library_version(),
                 family(),
                 None,
-                endpoint_agent(endpoint()),
+                ddog_prof_Endpoint_agent(endpoint()),
             )
         };
 
@@ -849,7 +849,7 @@ mod test {
                 profiling_library_version(),
                 family(),
                 None,
-                endpoint_agent(endpoint()),
+                ddog_prof_Endpoint_agent(endpoint()),
             )
         };
 

--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -16,7 +16,7 @@ use serde_json::json;
 use tokio::runtime::Runtime;
 use tokio_util::sync::CancellationToken;
 
-use ddcommon::{azure_app_services, connector, HttpClient, HttpResponse, Endpoint};
+use ddcommon::{azure_app_services, connector, Endpoint, HttpClient, HttpResponse};
 
 pub mod config;
 mod errors;

--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -16,11 +16,10 @@ use serde_json::json;
 use tokio::runtime::Runtime;
 use tokio_util::sync::CancellationToken;
 
-use ddcommon::{azure_app_services, connector, HttpClient, HttpResponse};
+use ddcommon::{azure_app_services, connector, HttpClient, HttpResponse, Endpoint};
 
 pub mod config;
 mod errors;
-pub use ddcommon::Endpoint;
 
 #[cfg(unix)]
 pub use connector::uds::{socket_path_from_uri, socket_path_to_uri};


### PR DESCRIPTION
# What does this PR do?

We have currently have an issue with different types sharing the same name in the C headers, but no being the same.
Cbindgen doesn't understand rust modules, so two types sharing the same name in different modules will be considered as the same for cbindgen.
The ffi currently manipulates two Endpoint types which are roughly equivalent
* ddcommon::Endpoint [code](https://github.com/DataDog/libdatadog/blob/9f4f3cf58f57763c9ef22c6930597c69d5e44ad2/ddcommon/src/lib.rs#L34), used as an opaque pointer in ffi for telemetry and the sidecar
 * datadog_profiling_ffi::Endpoint [code](https://github.com/DataDog/libdatadog/blob/9f4f3cf58f57763c9ef22c6930597c69d5e44ad2/profiling-ffi/src/exporter.rs#L37) an repr(C) enum, which is passed through the ffi and eventually transformed into ddcommon::Endpoint

If you look at the common.h header, you'll see a definition for the ddog_Endpoint  struct and, void ddog_endpoint_drop(struct ddog_Endpoint*); but these types are not the same.

This PR renames the datadog_profiling_ffi::Endpoint type to datadog_profiling_ffi::ProfilingEndpoint and generates C definition with type name ddog_prof_Endpoint

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
