### PR TITLE
[NO-TICKET] Add validation for Ruby gem file permissions

### DIFF
--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -113,6 +113,15 @@ task package: [
   end
 end
 
+Rake::Task["package"].enhance { Rake::Task["spec_validate_permissions"].execute }
+
+task :spec_validate_permissions do
+  require "rspec"
+  RSpec.world.reset # If any other tests ran before, flushes them
+  ret = RSpec::Core::Runner.run(["spec/gem_packaging.rb"])
+  raise "Release tests failed! See error output above." if ret != 0
+end
+
 desc "Release all packaged gems"
 task push_to_rubygems: [
   :package,

--- a/ruby/spec/gem_packaging.rb
+++ b/ruby/spec/gem_packaging.rb
@@ -1,0 +1,37 @@
+# Note: This file does not end with _spec on purpose, it should only be run after packaging, e.g. with `rake spec_validate_permissions`
+
+require "rubygems"
+require "rubygems/package"
+require "rubygems/package/tar_reader"
+require "libdatadog"
+require "zlib"
+
+RSpec.describe "gem release process (after packaging)" do
+  let(:gem_version) { Libdatadog::VERSION }
+  let(:packaged_gem_file) { "pkg/libdatadog-#{gem_version}.gem" }
+  let(:executable_permissions) { ["libdatadog-crashtracking-receiver", "libdatadog_profiling.so"] }
+
+  it "sets the right permissions on the gem files" do
+    gem_files = Dir.glob("pkg/*.gem")
+    expect(gem_files).to include(packaged_gem_file)
+
+    gem_files.each do |gem_file|
+      Gem::Package::TarReader.new(File.open(gem_file)) do |tar|
+        data = tar.find { |entry| entry.header.name == "data.tar.gz" }
+
+        Gem::Package::TarReader.new(Zlib::GzipReader.new(StringIO.new(data.read))) do |data_tar|
+          data_tar.each do |entry|
+            filename = entry.header.name.split("/").last
+            octal_permissions = entry.header.mode.to_s(8)[-3..-1]
+
+            expected_permissions = executable_permissions.include?(filename) ? "755" : "644"
+
+            expect(octal_permissions).to eq(expected_permissions),
+              "Unexpected permissions for #{filename} inside #{gem_file} (got #{octal_permissions}, " \
+              "expected #{expected_permissions})"
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# What does this PR do?

This PR adds an additional file permission validation step while building the libdatadog Ruby packages.

This is effectively the same as
https://github.com/datadog/dd-trace-rb/pull/3531 , and I'm adding it to avoid the same potential issue.

# Motivation

Avoid issue we ran into with `ddtrace` packaging.

# Additional Notes

N/A

# How to test the change?

Running `bundle exec rake package` will trigger the packaging of the Ruby packages, and you'll see the test running. To see it failing, `chmod` the `.rb` files to something other than 644.

# For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.