### PR TITLE
Add 2 Sidecar actions to register and push metrics

### DIFF
--- a/ddtelemetry/src/data/metrics.rs
+++ b/ddtelemetry/src/data/metrics.rs
@@ -26,7 +26,7 @@ pub struct Distribution {
     pub interval: u64,
 }
 
-#[derive(Serialize, Debug, Clone, Copy)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 #[repr(C)]
 pub enum MetricNamespace {

--- a/ddtelemetry/src/metrics.rs
+++ b/ddtelemetry/src/metrics.rs
@@ -134,7 +134,7 @@ impl MetricBuckets {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct MetricContext {
     pub namespace: data::metrics::MetricNamespace,
     pub name: String,


### PR DESCRIPTION
# What does this PR do?

This PR adds 2 Sidecar actions:
- `RegisterTelemetryMetric`: Register a new Telemetry metric
- `AddTelemetryMetricPoint`: Send a Telemetry metric point

# Motivation

This is required for the clients to send telemetry metrics (https://datadoghq.atlassian.net/browse/AIT-4125)

# Additional Notes

This is my first PR on libdatadog, and also the first time I write Rust code 😄 

# How to test the change?

This is tested by a test in a dd-trace-php PR (https://github.com/DataDog/dd-trace-php/pull/2577)

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
