### PR TITLE
Fix a panic when spawning the sidecar worker.

### DIFF
--- a/spawn_worker/src/unix/spawn.rs
+++ b/spawn_worker/src/unix/spawn.rs
@@ -8,7 +8,7 @@ mod linux {
     use std::io::{Seek, Write};
 
     pub(crate) fn write_memfd(name: &str, contents: &[u8]) -> anyhow::Result<memfd::Memfd> {
-        let opts = memfd::MemfdOptions::default();
+        let opts = memfd::MemfdOptions::default().close_on_exec(false);
         let mfd = opts.create(name)?;
 
         mfd.as_file().set_len(contents.len() as u64)?;

--- a/spawn_worker/src/unix/spawn.rs
+++ b/spawn_worker/src/unix/spawn.rs
@@ -8,6 +8,8 @@ mod linux {
     use std::io::{Seek, Write};
 
     pub(crate) fn write_memfd(name: &str, contents: &[u8]) -> anyhow::Result<memfd::Memfd> {
+        // This leaks a fd, but a fd to the TXT segment, which is fine.
+        // And it will ensure that fexecve works with custom binfmts (rosetta or qemu).
         let opts = memfd::MemfdOptions::default().close_on_exec(false);
         let mfd = opts.create(name)?;
 


### PR DESCRIPTION
# What does this PR do?

Fix a panic when spawning the sidecar worker.

# Motivation

Discovered while running a linux/amd64 build of dd-trace-php in a Docker container on a Mac M1 machine.

panic details:
```
thread '<unnamed>' panicked at 'No such file or directory (os error 2)', libdatadog/spawn_worker/src/unix/spawn.rs:441:21 stack backtrace:
   0: rust_begin_unwind
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/std/src/panicking.rs:593:5
   1: core::panicking::panic_fmt
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/panicking.rs:67:14
   2: core::panicking::panic_display
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/panicking.rs:150:5
   3: spawn_worker::unix::spawn::SpawnWorker::do_spawn::{{closure}}
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/core/src/panic.rs:56:9
   4: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/eb26296b556cef10fb713a38f3d16b9886080f26/library/alloc/src/boxed.rs:1999:9
   5: spawn_worker::unix::spawn::SpawnWorker::do_spawn
             at ./libdatadog/spawn_worker/src/unix/spawn.rs:575:9
   6: spawn_worker::unix::spawn::SpawnWorker::spawn
             at ./libdatadog/spawn_worker/src/unix/spawn.rs:305:19
```

# Additional Notes

Credit goes to @bwoebi for the fix

# How to test the change?

Tested locally using the PHP system-tests

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
