### PR TITLE
[ddtelemetry] Prefix ffi functions with ddog_telemetry

### DIFF
--- a/ddtelemetry-ffi/src/builder.rs
+++ b/ddtelemetry-ffi/src/builder.rs
@@ -24,7 +24,7 @@ pub use expanded::*;
 /// # Safety
 /// * builder should be a non null pointer to a null pointer to a builder
 #[no_mangle]
-pub unsafe extern "C" fn ddog_builder_instantiate(
+pub unsafe extern "C" fn ddog_telemetry_builder_instantiate(
     out_builder: NonNull<Box<TelemetryWorkerBuilder>>,
     service_name: ffi::CharSlice,
     language_name: ffi::CharSlice,
@@ -44,7 +44,7 @@ pub unsafe extern "C" fn ddog_builder_instantiate(
 /// # Safety
 /// * builder should be a non null pointer to a null pointer to a builder
 #[no_mangle]
-pub unsafe extern "C" fn ddog_builder_instantiate_with_hostname(
+pub unsafe extern "C" fn ddog_telemetry_builder_instantiate_with_hostname(
     out_builder: NonNull<Box<TelemetryWorkerBuilder>>,
     hostname: ffi::CharSlice,
     service_name: ffi::CharSlice,
@@ -66,7 +66,7 @@ pub unsafe extern "C" fn ddog_builder_instantiate_with_hostname(
 
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub unsafe extern "C" fn ddog_builder_with_native_deps(
+pub unsafe extern "C" fn ddog_telemetry_builder_with_native_deps(
     builder: &mut TelemetryWorkerBuilder,
     include_native_deps: bool,
 ) -> MaybeError {
@@ -76,7 +76,7 @@ pub unsafe extern "C" fn ddog_builder_with_native_deps(
 
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub unsafe extern "C" fn ddog_builder_with_rust_shared_lib_deps(
+pub unsafe extern "C" fn ddog_telemetry_builder_with_rust_shared_lib_deps(
     builder: &mut TelemetryWorkerBuilder,
     include_rust_shared_lib_deps: bool,
 ) -> MaybeError {
@@ -86,7 +86,7 @@ pub unsafe extern "C" fn ddog_builder_with_rust_shared_lib_deps(
 
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub unsafe extern "C" fn ddog_builder_with_config(
+pub unsafe extern "C" fn ddog_telemetry_builder_with_config(
     builder: &mut TelemetryWorkerBuilder,
     name: ffi::CharSlice,
     value: ffi::CharSlice,
@@ -107,7 +107,7 @@ pub unsafe extern "C" fn ddog_builder_with_config(
 ///
 /// # Safety
 /// * handle should be a non null pointer to a null pointer
-pub unsafe extern "C" fn ddog_builder_run(
+pub unsafe extern "C" fn ddog_telemetry_builder_run(
     builder: Box<TelemetryWorkerBuilder>,
     out_handle: NonNull<Box<TelemetryWorkerHandle>>,
 ) -> MaybeError {
@@ -124,7 +124,7 @@ pub unsafe extern "C" fn ddog_builder_run(
 ///
 /// # Safety
 /// * handle should be a non null pointer to a null pointer
-pub unsafe extern "C" fn ddog_builder_run_metric_logs(
+pub unsafe extern "C" fn ddog_telemetry_builder_run_metric_logs(
     builder: Box<TelemetryWorkerBuilder>,
     out_handle: NonNull<Box<TelemetryWorkerHandle>>,
 ) -> MaybeError {

--- a/ddtelemetry-ffi/src/builder/expanded.rs
+++ b/ddtelemetry-ffi/src/builder/expanded.rs
@@ -10,11 +10,11 @@ mod macros {
     #[no_mangle]
     #[allow(clippy::redundant_closure_call)]
     #[allow(clippy::missing_safety_doc)]
-    pub unsafe extern "C" fn ddog_builder_with_str_application_service_version(
-        builder: &mut TelemetryWorkerBuilder,
+    pub unsafe extern "C" fn ddog_telemetry_builder_with_str_application_service_version(
+        telemetry_builder: &mut TelemetryWorkerBuilder,
         param: ffi::CharSlice,
     ) -> crate::MaybeError {
-        builder.application.service_version = Some(
+        telemetry_builder.application.service_version = Some(
             match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
                 param,
             ) {
@@ -35,36 +35,11 @@ mod macros {
     #[no_mangle]
     #[allow(clippy::redundant_closure_call)]
     #[allow(clippy::missing_safety_doc)]
-    pub unsafe extern "C" fn ddog_builder_with_str_application_env(
-        builder: &mut TelemetryWorkerBuilder,
+    pub unsafe extern "C" fn ddog_telemetry_builder_with_str_application_env(
+        telemetry_builder: &mut TelemetryWorkerBuilder,
         param: ffi::CharSlice,
     ) -> crate::MaybeError {
-        builder.application.env = Some(
-            match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
-                param,
-            ) {
-                Ok(o) => o,
-                Err(e) => {
-                    return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                        {
-                            let res = std::fmt::format(format_args!("{0:?}", e));
-                            res
-                        }
-                        .into_bytes(),
-                    ));
-                }
-            },
-        );
-        crate::MaybeError::None
-    }
-    #[no_mangle]
-    #[allow(clippy::redundant_closure_call)]
-    #[allow(clippy::missing_safety_doc)]
-    pub unsafe extern "C" fn ddog_builder_with_str_application_runtime_name(
-        builder: &mut TelemetryWorkerBuilder,
-        param: ffi::CharSlice,
-    ) -> crate::MaybeError {
-        builder.application.runtime_name =
+        telemetry_builder.application.env =
             Some(
                 match (|s: ffi::CharSlice| -> Result<_, String> {
                     Ok(s.to_utf8_lossy().into_owned())
@@ -87,11 +62,11 @@ mod macros {
     #[no_mangle]
     #[allow(clippy::redundant_closure_call)]
     #[allow(clippy::missing_safety_doc)]
-    pub unsafe extern "C" fn ddog_builder_with_str_application_runtime_version(
-        builder: &mut TelemetryWorkerBuilder,
+    pub unsafe extern "C" fn ddog_telemetry_builder_with_str_application_runtime_name(
+        telemetry_builder: &mut TelemetryWorkerBuilder,
         param: ffi::CharSlice,
     ) -> crate::MaybeError {
-        builder.application.runtime_version = Some(
+        telemetry_builder.application.runtime_name = Some(
             match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
                 param,
             ) {
@@ -112,11 +87,11 @@ mod macros {
     #[no_mangle]
     #[allow(clippy::redundant_closure_call)]
     #[allow(clippy::missing_safety_doc)]
-    pub unsafe extern "C" fn ddog_builder_with_str_application_runtime_patches(
-        builder: &mut TelemetryWorkerBuilder,
+    pub unsafe extern "C" fn ddog_telemetry_builder_with_str_application_runtime_version(
+        telemetry_builder: &mut TelemetryWorkerBuilder,
         param: ffi::CharSlice,
     ) -> crate::MaybeError {
-        builder.application.runtime_patches = Some(
+        telemetry_builder.application.runtime_version = Some(
             match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
                 param,
             ) {
@@ -137,11 +112,11 @@ mod macros {
     #[no_mangle]
     #[allow(clippy::redundant_closure_call)]
     #[allow(clippy::missing_safety_doc)]
-    pub unsafe extern "C" fn ddog_builder_with_str_host_container_id(
-        builder: &mut TelemetryWorkerBuilder,
+    pub unsafe extern "C" fn ddog_telemetry_builder_with_str_application_runtime_patches(
+        telemetry_builder: &mut TelemetryWorkerBuilder,
         param: ffi::CharSlice,
     ) -> crate::MaybeError {
-        builder.host.container_id = Some(
+        telemetry_builder.application.runtime_patches = Some(
             match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
                 param,
             ) {
@@ -162,11 +137,11 @@ mod macros {
     #[no_mangle]
     #[allow(clippy::redundant_closure_call)]
     #[allow(clippy::missing_safety_doc)]
-    pub unsafe extern "C" fn ddog_builder_with_str_host_os(
-        builder: &mut TelemetryWorkerBuilder,
+    pub unsafe extern "C" fn ddog_telemetry_builder_with_str_host_container_id(
+        telemetry_builder: &mut TelemetryWorkerBuilder,
         param: ffi::CharSlice,
     ) -> crate::MaybeError {
-        builder.host.os = Some(
+        telemetry_builder.host.container_id = Some(
             match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
                 param,
             ) {
@@ -187,11 +162,11 @@ mod macros {
     #[no_mangle]
     #[allow(clippy::redundant_closure_call)]
     #[allow(clippy::missing_safety_doc)]
-    pub unsafe extern "C" fn ddog_builder_with_str_host_kernel_name(
-        builder: &mut TelemetryWorkerBuilder,
+    pub unsafe extern "C" fn ddog_telemetry_builder_with_str_host_os(
+        telemetry_builder: &mut TelemetryWorkerBuilder,
         param: ffi::CharSlice,
     ) -> crate::MaybeError {
-        builder.host.kernel_name = Some(
+        telemetry_builder.host.os = Some(
             match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
                 param,
             ) {
@@ -212,11 +187,11 @@ mod macros {
     #[no_mangle]
     #[allow(clippy::redundant_closure_call)]
     #[allow(clippy::missing_safety_doc)]
-    pub unsafe extern "C" fn ddog_builder_with_str_host_kernel_release(
-        builder: &mut TelemetryWorkerBuilder,
+    pub unsafe extern "C" fn ddog_telemetry_builder_with_str_host_kernel_name(
+        telemetry_builder: &mut TelemetryWorkerBuilder,
         param: ffi::CharSlice,
     ) -> crate::MaybeError {
-        builder.host.kernel_release = Some(
+        telemetry_builder.host.kernel_name = Some(
             match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
                 param,
             ) {
@@ -237,11 +212,11 @@ mod macros {
     #[no_mangle]
     #[allow(clippy::redundant_closure_call)]
     #[allow(clippy::missing_safety_doc)]
-    pub unsafe extern "C" fn ddog_builder_with_str_host_kernel_version(
-        builder: &mut TelemetryWorkerBuilder,
+    pub unsafe extern "C" fn ddog_telemetry_builder_with_str_host_kernel_release(
+        telemetry_builder: &mut TelemetryWorkerBuilder,
         param: ffi::CharSlice,
     ) -> crate::MaybeError {
-        builder.host.kernel_version = Some(
+        telemetry_builder.host.kernel_release = Some(
             match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
                 param,
             ) {
@@ -262,11 +237,36 @@ mod macros {
     #[no_mangle]
     #[allow(clippy::redundant_closure_call)]
     #[allow(clippy::missing_safety_doc)]
-    pub unsafe extern "C" fn ddog_builder_with_str_runtime_id(
-        builder: &mut TelemetryWorkerBuilder,
+    pub unsafe extern "C" fn ddog_telemetry_builder_with_str_host_kernel_version(
+        telemetry_builder: &mut TelemetryWorkerBuilder,
         param: ffi::CharSlice,
     ) -> crate::MaybeError {
-        builder.runtime_id = Some(
+        telemetry_builder.host.kernel_version = Some(
+            match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
+                param,
+            ) {
+                Ok(o) => o,
+                Err(e) => {
+                    return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                        {
+                            let res = std::fmt::format(format_args!("{0:?}", e));
+                            res
+                        }
+                        .into_bytes(),
+                    ));
+                }
+            },
+        );
+        crate::MaybeError::None
+    }
+    #[no_mangle]
+    #[allow(clippy::redundant_closure_call)]
+    #[allow(clippy::missing_safety_doc)]
+    pub unsafe extern "C" fn ddog_telemetry_builder_with_str_runtime_id(
+        telemetry_builder: &mut TelemetryWorkerBuilder,
+        param: ffi::CharSlice,
+    ) -> crate::MaybeError {
+        telemetry_builder.runtime_id = Some(
             match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
                 param,
             ) {
@@ -330,15 +330,15 @@ mod macros {
      * runtime_id
 
     */
-    pub unsafe extern "C" fn ddog_builder_with_property_str(
-        builder: &mut TelemetryWorkerBuilder,
+    pub unsafe extern "C" fn ddog_telemetry_builder_with_property_str(
+        telemetry_builder: &mut TelemetryWorkerBuilder,
         property: TelemetryWorkerBuilderStrProperty,
         param: ffi::CharSlice,
     ) -> crate::MaybeError {
         use TelemetryWorkerBuilderStrProperty::*;
         match property {
             ApplicationServiceVersion => {
-                builder.application.service_version = Some(
+                telemetry_builder.application.service_version = Some(
                     match (|s: ffi::CharSlice| -> Result<_, String> {
                         Ok(s.to_utf8_lossy().into_owned())
                     })(param)
@@ -357,7 +357,7 @@ mod macros {
                 );
             }
             ApplicationEnv => {
-                builder.application.env = Some(
+                telemetry_builder.application.env = Some(
                     match (|s: ffi::CharSlice| -> Result<_, String> {
                         Ok(s.to_utf8_lossy().into_owned())
                     })(param)
@@ -376,7 +376,7 @@ mod macros {
                 );
             }
             ApplicationRuntimeName => {
-                builder.application.runtime_name = Some(
+                telemetry_builder.application.runtime_name = Some(
                     match (|s: ffi::CharSlice| -> Result<_, String> {
                         Ok(s.to_utf8_lossy().into_owned())
                     })(param)
@@ -395,7 +395,7 @@ mod macros {
                 );
             }
             ApplicationRuntimeVersion => {
-                builder.application.runtime_version = Some(
+                telemetry_builder.application.runtime_version = Some(
                     match (|s: ffi::CharSlice| -> Result<_, String> {
                         Ok(s.to_utf8_lossy().into_owned())
                     })(param)
@@ -414,7 +414,7 @@ mod macros {
                 );
             }
             ApplicationRuntimePatches => {
-                builder.application.runtime_patches = Some(
+                telemetry_builder.application.runtime_patches = Some(
                     match (|s: ffi::CharSlice| -> Result<_, String> {
                         Ok(s.to_utf8_lossy().into_owned())
                     })(param)
@@ -433,27 +433,7 @@ mod macros {
                 );
             }
             HostContainerId => {
-                builder.host.container_id =
-                    Some(
-                        match (|s: ffi::CharSlice| -> Result<_, String> {
-                            Ok(s.to_utf8_lossy().into_owned())
-                        })(param)
-                        {
-                            Ok(o) => o,
-                            Err(e) => {
-                                return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                                    {
-                                        let res = std::fmt::format(format_args!("{0:?}", e));
-                                        res
-                                    }
-                                    .into_bytes(),
-                                ));
-                            }
-                        },
-                    );
-            }
-            HostOs => {
-                builder.host.os = Some(
+                telemetry_builder.host.container_id = Some(
                     match (|s: ffi::CharSlice| -> Result<_, String> {
                         Ok(s.to_utf8_lossy().into_owned())
                     })(param)
@@ -471,8 +451,8 @@ mod macros {
                     },
                 );
             }
-            HostKernelName => {
-                builder.host.kernel_name =
+            HostOs => {
+                telemetry_builder.host.os =
                     Some(
                         match (|s: ffi::CharSlice| -> Result<_, String> {
                             Ok(s.to_utf8_lossy().into_owned())
@@ -491,8 +471,27 @@ mod macros {
                         },
                     );
             }
+            HostKernelName => {
+                telemetry_builder.host.kernel_name = Some(
+                    match (|s: ffi::CharSlice| -> Result<_, String> {
+                        Ok(s.to_utf8_lossy().into_owned())
+                    })(param)
+                    {
+                        Ok(o) => o,
+                        Err(e) => {
+                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                                {
+                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    res
+                                }
+                                .into_bytes(),
+                            ));
+                        }
+                    },
+                );
+            }
             HostKernelRelease => {
-                builder.host.kernel_release = Some(
+                telemetry_builder.host.kernel_release = Some(
                     match (|s: ffi::CharSlice| -> Result<_, String> {
                         Ok(s.to_utf8_lossy().into_owned())
                     })(param)
@@ -511,7 +510,7 @@ mod macros {
                 );
             }
             HostKernelVersion => {
-                builder.host.kernel_version = Some(
+                telemetry_builder.host.kernel_version = Some(
                     match (|s: ffi::CharSlice| -> Result<_, String> {
                         Ok(s.to_utf8_lossy().into_owned())
                     })(param)
@@ -530,7 +529,7 @@ mod macros {
                 );
             }
             RuntimeId => {
-                builder.runtime_id = Some(
+                telemetry_builder.runtime_id = Some(
                     match (|s: ffi::CharSlice| -> Result<_, String> {
                         Ok(s.to_utf8_lossy().into_owned())
                     })(param)
@@ -582,8 +581,8 @@ mod macros {
      * runtime_id
 
     */
-    pub unsafe extern "C" fn ddog_builder_with_str_named_property(
-        builder: &mut TelemetryWorkerBuilder,
+    pub unsafe extern "C" fn ddog_telemetry_builder_with_str_named_property(
+        telemetry_builder: &mut TelemetryWorkerBuilder,
         property: ffi::CharSlice,
         param: ffi::CharSlice,
     ) -> crate::MaybeError {
@@ -601,7 +600,7 @@ mod macros {
         };
         match property {
             "application.service_version" => {
-                builder.application.service_version = Some(
+                telemetry_builder.application.service_version = Some(
                     match (|s: ffi::CharSlice| -> Result<_, String> {
                         Ok(s.to_utf8_lossy().into_owned())
                     })(param)
@@ -620,7 +619,7 @@ mod macros {
                 );
             }
             "application.env" => {
-                builder.application.env = Some(
+                telemetry_builder.application.env = Some(
                     match (|s: ffi::CharSlice| -> Result<_, String> {
                         Ok(s.to_utf8_lossy().into_owned())
                     })(param)
@@ -639,7 +638,7 @@ mod macros {
                 );
             }
             "application.runtime_name" => {
-                builder.application.runtime_name = Some(
+                telemetry_builder.application.runtime_name = Some(
                     match (|s: ffi::CharSlice| -> Result<_, String> {
                         Ok(s.to_utf8_lossy().into_owned())
                     })(param)
@@ -658,7 +657,7 @@ mod macros {
                 );
             }
             "application.runtime_version" => {
-                builder.application.runtime_version = Some(
+                telemetry_builder.application.runtime_version = Some(
                     match (|s: ffi::CharSlice| -> Result<_, String> {
                         Ok(s.to_utf8_lossy().into_owned())
                     })(param)
@@ -677,7 +676,7 @@ mod macros {
                 );
             }
             "application.runtime_patches" => {
-                builder.application.runtime_patches = Some(
+                telemetry_builder.application.runtime_patches = Some(
                     match (|s: ffi::CharSlice| -> Result<_, String> {
                         Ok(s.to_utf8_lossy().into_owned())
                     })(param)
@@ -696,27 +695,7 @@ mod macros {
                 );
             }
             "host.container_id" => {
-                builder.host.container_id =
-                    Some(
-                        match (|s: ffi::CharSlice| -> Result<_, String> {
-                            Ok(s.to_utf8_lossy().into_owned())
-                        })(param)
-                        {
-                            Ok(o) => o,
-                            Err(e) => {
-                                return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                                    {
-                                        let res = std::fmt::format(format_args!("{0:?}", e));
-                                        res
-                                    }
-                                    .into_bytes(),
-                                ));
-                            }
-                        },
-                    );
-            }
-            "host.os" => {
-                builder.host.os = Some(
+                telemetry_builder.host.container_id = Some(
                     match (|s: ffi::CharSlice| -> Result<_, String> {
                         Ok(s.to_utf8_lossy().into_owned())
                     })(param)
@@ -734,8 +713,8 @@ mod macros {
                     },
                 );
             }
-            "host.kernel_name" => {
-                builder.host.kernel_name =
+            "host.os" => {
+                telemetry_builder.host.os =
                     Some(
                         match (|s: ffi::CharSlice| -> Result<_, String> {
                             Ok(s.to_utf8_lossy().into_owned())
@@ -754,8 +733,27 @@ mod macros {
                         },
                     );
             }
+            "host.kernel_name" => {
+                telemetry_builder.host.kernel_name = Some(
+                    match (|s: ffi::CharSlice| -> Result<_, String> {
+                        Ok(s.to_utf8_lossy().into_owned())
+                    })(param)
+                    {
+                        Ok(o) => o,
+                        Err(e) => {
+                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
+                                {
+                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    res
+                                }
+                                .into_bytes(),
+                            ));
+                        }
+                    },
+                );
+            }
             "host.kernel_release" => {
-                builder.host.kernel_release = Some(
+                telemetry_builder.host.kernel_release = Some(
                     match (|s: ffi::CharSlice| -> Result<_, String> {
                         Ok(s.to_utf8_lossy().into_owned())
                     })(param)
@@ -774,7 +772,7 @@ mod macros {
                 );
             }
             "host.kernel_version" => {
-                builder.host.kernel_version = Some(
+                telemetry_builder.host.kernel_version = Some(
                     match (|s: ffi::CharSlice| -> Result<_, String> {
                         Ok(s.to_utf8_lossy().into_owned())
                     })(param)
@@ -793,7 +791,7 @@ mod macros {
                 );
             }
             "runtime_id" => {
-                builder.runtime_id = Some(
+                telemetry_builder.runtime_id = Some(
                     match (|s: ffi::CharSlice| -> Result<_, String> {
                         Ok(s.to_utf8_lossy().into_owned())
                     })(param)
@@ -818,11 +816,11 @@ mod macros {
     #[no_mangle]
     #[allow(clippy::redundant_closure_call)]
     #[allow(clippy::missing_safety_doc)]
-    pub unsafe extern "C" fn ddog_builder_with_bool_config_telemetry_debug_logging_enabled(
-        builder: &mut TelemetryWorkerBuilder,
+    pub unsafe extern "C" fn ddog_telemetry_builder_with_bool_config_telemetry_debug_logging_enabled(
+        telemetry_builder: &mut TelemetryWorkerBuilder,
         param: bool,
     ) -> crate::MaybeError {
-        builder.config.telemetry_debug_logging_enabled =
+        telemetry_builder.config.telemetry_debug_logging_enabled =
             Some(match (|b: bool| -> Result<_, String> { Ok(b) })(param) {
                 Ok(o) => o,
                 Err(e) => {
@@ -853,15 +851,15 @@ mod macros {
      * config.telemetry_debug_logging_enabled
 
     */
-    pub unsafe extern "C" fn ddog_builder_with_property_bool(
-        builder: &mut TelemetryWorkerBuilder,
+    pub unsafe extern "C" fn ddog_telemetry_builder_with_property_bool(
+        telemetry_builder: &mut TelemetryWorkerBuilder,
         property: TelemetryWorkerBuilderBoolProperty,
         param: bool,
     ) -> crate::MaybeError {
         use TelemetryWorkerBuilderBoolProperty::*;
         match property {
             ConfigTelemetryDebugLoggingEnabled => {
-                builder.config.telemetry_debug_logging_enabled =
+                telemetry_builder.config.telemetry_debug_logging_enabled =
                     Some(match (|b: bool| -> Result<_, String> { Ok(b) })(param) {
                         Ok(o) => o,
                         Err(e) => {
@@ -889,8 +887,8 @@ mod macros {
      * config.telemetry_debug_logging_enabled
 
     */
-    pub unsafe extern "C" fn ddog_builder_with_bool_named_property(
-        builder: &mut TelemetryWorkerBuilder,
+    pub unsafe extern "C" fn ddog_telemetry_builder_with_bool_named_property(
+        telemetry_builder: &mut TelemetryWorkerBuilder,
         property: ffi::CharSlice,
         param: bool,
     ) -> crate::MaybeError {
@@ -908,7 +906,7 @@ mod macros {
         };
         match property {
             "config.telemetry_debug_logging_enabled" => {
-                builder.config.telemetry_debug_logging_enabled =
+                telemetry_builder.config.telemetry_debug_logging_enabled =
                     Some(match (|b: bool| -> Result<_, String> { Ok(b) })(param) {
                         Ok(o) => o,
                         Err(e) => {
@@ -929,11 +927,11 @@ mod macros {
     #[no_mangle]
     #[allow(clippy::redundant_closure_call)]
     #[allow(clippy::missing_safety_doc)]
-    pub unsafe extern "C" fn ddog_builder_with_endpoint_config_endpoint(
-        builder: &mut TelemetryWorkerBuilder,
+    pub unsafe extern "C" fn ddog_telemetry_builder_with_endpoint_config_endpoint(
+        telemetry_builder: &mut TelemetryWorkerBuilder,
         param: &Endpoint,
     ) -> crate::MaybeError {
-        builder.config.endpoint = Some(
+        telemetry_builder.config.endpoint = Some(
             match (|e: &Endpoint| -> Result<_, String> { Ok(e.clone()) })(param) {
                 Ok(o) => o,
                 Err(e) => {
@@ -965,15 +963,15 @@ mod macros {
      * config.endpoint
 
     */
-    pub unsafe extern "C" fn ddog_builder_with_property_endpoint(
-        builder: &mut TelemetryWorkerBuilder,
+    pub unsafe extern "C" fn ddog_telemetry_builder_with_property_endpoint(
+        telemetry_builder: &mut TelemetryWorkerBuilder,
         property: TelemetryWorkerBuilderEndpointProperty,
         param: &Endpoint,
     ) -> crate::MaybeError {
         use TelemetryWorkerBuilderEndpointProperty::*;
         match property {
             ConfigEndpoint => {
-                builder.config.endpoint = Some(
+                telemetry_builder.config.endpoint = Some(
                     match (|e: &Endpoint| -> Result<_, String> { Ok(e.clone()) })(param) {
                         Ok(o) => o,
                         Err(e) => {
@@ -1002,8 +1000,8 @@ mod macros {
      * config.endpoint
 
     */
-    pub unsafe extern "C" fn ddog_builder_with_endpoint_named_property(
-        builder: &mut TelemetryWorkerBuilder,
+    pub unsafe extern "C" fn ddog_telemetry_builder_with_endpoint_named_property(
+        telemetry_builder: &mut TelemetryWorkerBuilder,
         property: ffi::CharSlice,
         param: &Endpoint,
     ) -> crate::MaybeError {
@@ -1021,7 +1019,7 @@ mod macros {
         };
         match property {
             "config.endpoint" => {
-                builder.config.endpoint = Some(
+                telemetry_builder.config.endpoint = Some(
                     match (|e: &Endpoint| -> Result<_, String> { Ok(e.clone()) })(param) {
                         Ok(o) => o,
                         Err(e) => {

--- a/ddtelemetry-ffi/src/builder/macros.rs
+++ b/ddtelemetry-ffi/src/builder/macros.rs
@@ -15,7 +15,7 @@ use ddtelemetry::worker::TelemetryWorkerBuilder;
 use ffi::slice::AsBytes;
 
 crate::c_setters!(
-    object_name => builder,
+    object_name => telemetry_builder,
     object_type => TelemetryWorkerBuilder,
     property_type => ffi::CharSlice,
     property_type_name_snakecase => str,
@@ -39,7 +39,7 @@ crate::c_setters!(
 );
 
 crate::c_setters!(
-    object_name => builder,
+    object_name => telemetry_builder,
     object_type => TelemetryWorkerBuilder,
     property_type => bool,
     property_type_name_snakecase => bool,
@@ -51,7 +51,7 @@ crate::c_setters!(
 );
 
 crate::c_setters!(
-    object_name => builder,
+    object_name => telemetry_builder,
     object_type => TelemetryWorkerBuilder,
     property_type => &Endpoint,
     property_type_name_snakecase => endpoint,

--- a/ddtelemetry-ffi/src/lib.rs
+++ b/ddtelemetry-ffi/src/lib.rs
@@ -134,7 +134,7 @@ mod test_c_ffi {
         unsafe {
             let mut builder: MaybeUninit<Box<TelemetryWorkerBuilder>> = MaybeUninit::uninit();
             assert_eq!(
-                ddog_builder_instantiate(
+                ddog_telemetry_builder_instantiate(
                     NonNull::new(&mut builder).unwrap().cast(),
                     ffi::CharSlice::from("service_name"),
                     ffi::CharSlice::from("language_name"),
@@ -146,7 +146,7 @@ mod test_c_ffi {
             let mut builder = builder.assume_init();
 
             assert_eq!(
-                ddog_builder_with_str_named_property(
+                ddog_telemetry_builder_with_str_named_property(
                     &mut builder,
                     ffi::CharSlice::from("runtime_id"),
                     ffi::CharSlice::from("abcd")
@@ -156,7 +156,7 @@ mod test_c_ffi {
             assert_eq!(builder.runtime_id.as_deref(), Some("abcd"));
 
             assert_eq!(
-                ddog_builder_with_str_named_property(
+                ddog_telemetry_builder_with_str_named_property(
                     &mut builder,
                     ffi::CharSlice::from("application.runtime_name"),
                     ffi::CharSlice::from("rust")
@@ -166,7 +166,7 @@ mod test_c_ffi {
             assert_eq!(builder.application.runtime_name.as_deref(), Some("rust"));
 
             assert_eq!(
-                ddog_builder_with_str_named_property(
+                ddog_telemetry_builder_with_str_named_property(
                     &mut builder,
                     ffi::CharSlice::from("host.kernel_version"),
                     ffi::CharSlice::from("ダタドグ")
@@ -175,7 +175,7 @@ mod test_c_ffi {
             );
             assert_eq!(builder.host.kernel_version.as_deref(), Some("ダタドグ"));
 
-            assert!(ddog_builder_with_str_named_property(
+            assert!(ddog_telemetry_builder_with_str_named_property(
                 &mut builder,
                 ffi::CharSlice::from("doesnt exist"),
                 ffi::CharSlice::from("abc")
@@ -191,7 +191,7 @@ mod test_c_ffi {
         let mut builder: MaybeUninit<Box<TelemetryWorkerBuilder>> = MaybeUninit::uninit();
         unsafe {
             assert_eq!(
-                ddog_builder_instantiate(
+                ddog_telemetry_builder_instantiate(
                     NonNull::new(&mut builder).unwrap().cast(),
                     ffi::CharSlice::from("service_name"),
                     ffi::CharSlice::from("language_name"),
@@ -203,7 +203,7 @@ mod test_c_ffi {
             let mut builder = builder.assume_init();
 
             assert_eq!(
-                ddog_builder_with_property_str(
+                ddog_telemetry_builder_with_property_str(
                     &mut builder,
                     TelemetryWorkerBuilderStrProperty::RuntimeId,
                     ffi::CharSlice::from("abcd")
@@ -213,7 +213,7 @@ mod test_c_ffi {
             assert_eq!(builder.runtime_id.as_deref(), Some("abcd"));
 
             assert_eq!(
-                ddog_builder_with_property_str(
+                ddog_telemetry_builder_with_property_str(
                     &mut builder,
                     TelemetryWorkerBuilderStrProperty::ApplicationRuntimeName,
                     ffi::CharSlice::from("rust")
@@ -223,7 +223,7 @@ mod test_c_ffi {
             assert_eq!(builder.application.runtime_name.as_deref(), Some("rust"));
 
             assert_eq!(
-                ddog_builder_with_property_str(
+                ddog_telemetry_builder_with_property_str(
                     &mut builder,
                     TelemetryWorkerBuilderStrProperty::HostKernelVersion,
                     ffi::CharSlice::from("ダタドグ")
@@ -240,7 +240,7 @@ mod test_c_ffi {
         unsafe {
             let mut builder: MaybeUninit<Box<TelemetryWorkerBuilder>> = MaybeUninit::uninit();
             assert_eq!(
-                ddog_builder_instantiate(
+                ddog_telemetry_builder_instantiate(
                     NonNull::new(&mut builder).unwrap().cast(),
                     ffi::CharSlice::from("service_name"),
                     ffi::CharSlice::from("language_name"),
@@ -253,7 +253,7 @@ mod test_c_ffi {
 
             let f = tempfile::NamedTempFile::new().unwrap();
             assert_eq!(
-                ddog_builder_with_endpoint_config_endpoint(
+                ddog_telemetry_builder_with_endpoint_config_endpoint(
                     &mut builder,
                     &Endpoint {
                         api_key: None,
@@ -266,15 +266,18 @@ mod test_c_ffi {
                 ),
                 MaybeError::None
             );
-            ddog_builder_with_bool_config_telemetry_debug_logging_enabled(&mut builder, true);
+            ddog_telemetry_builder_with_bool_config_telemetry_debug_logging_enabled(
+                &mut builder,
+                true,
+            );
 
             let mut handle: MaybeUninit<Box<TelemetryWorkerHandle>> = MaybeUninit::uninit();
-            ddog_builder_run(builder, NonNull::new(&mut handle).unwrap().cast());
+            ddog_telemetry_builder_run(builder, NonNull::new(&mut handle).unwrap().cast());
             let handle = handle.assume_init();
 
-            ddog_handle_start(&handle);
-            ddog_handle_stop(&handle);
-            ddog_handle_wait_for_shutdown(handle);
+            ddog_telemetry_handle_start(&handle);
+            ddog_telemetry_handle_stop(&handle);
+            ddog_telemetry_handle_wait_for_shutdown(handle);
         }
     }
 
@@ -284,7 +287,7 @@ mod test_c_ffi {
         unsafe {
             let mut builder: MaybeUninit<Box<TelemetryWorkerBuilder>> = MaybeUninit::uninit();
             assert_eq!(
-                ddog_builder_instantiate(
+                ddog_telemetry_builder_instantiate(
                     NonNull::new(&mut builder).unwrap().cast(),
                     ffi::CharSlice::from("service_name"),
                     ffi::CharSlice::from("language_name"),
@@ -297,7 +300,7 @@ mod test_c_ffi {
 
             let f = tempfile::NamedTempFile::new().unwrap();
             assert_eq!(
-                ddog_builder_with_endpoint_config_endpoint(
+                ddog_telemetry_builder_with_endpoint_config_endpoint(
                     &mut builder,
                     &Endpoint {
                         api_key: None,
@@ -310,13 +313,22 @@ mod test_c_ffi {
                 ),
                 MaybeError::None
             );
-            ddog_builder_with_bool_config_telemetry_debug_logging_enabled(&mut builder, true);
+            ddog_telemetry_builder_with_bool_config_telemetry_debug_logging_enabled(
+                &mut builder,
+                true,
+            );
 
             let mut handle: MaybeUninit<Box<TelemetryWorkerHandle>> = MaybeUninit::uninit();
-            ddog_builder_run_metric_logs(builder, NonNull::new(&mut handle).unwrap().cast());
+            ddog_telemetry_builder_run_metric_logs(
+                builder,
+                NonNull::new(&mut handle).unwrap().cast(),
+            );
             let handle = handle.assume_init();
 
-            assert!(matches!(ddog_handle_start(&handle), MaybeError::None));
+            assert!(matches!(
+                ddog_telemetry_handle_start(&handle),
+                MaybeError::None
+            ));
 
             let mut tags = ddog_Vec_Tag_new();
             assert!(matches!(
@@ -328,7 +340,7 @@ mod test_c_ffi {
                 PushTagResult::Ok
             ));
 
-            let context_key = ddog_handle_register_metric_context(
+            let context_key = ddog_telemetry_handle_register_metric_context(
                 &handle,
                 ffi::CharSlice::from("test_metric"),
                 MetricType::Count,
@@ -336,10 +348,10 @@ mod test_c_ffi {
                 true,
                 MetricNamespace::Apm,
             );
-            ddog_handle_add_point(&handle, &context_key, 1.0);
+            ddog_telemetry_handle_add_point(&handle, &context_key, 1.0);
 
-            assert_eq!(ddog_handle_stop(&handle), MaybeError::None);
-            ddog_handle_wait_for_shutdown(handle);
+            assert_eq!(ddog_telemetry_handle_stop(&handle), MaybeError::None);
+            ddog_telemetry_handle_wait_for_shutdown(handle);
         }
     }
 }

--- a/ddtelemetry-ffi/src/worker_handle.rs
+++ b/ddtelemetry-ffi/src/worker_handle.rs
@@ -14,7 +14,7 @@ use crate::MaybeError;
 
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub unsafe extern "C" fn ddog_handle_add_dependency(
+pub unsafe extern "C" fn ddog_telemetry_handle_add_dependency(
     handle: &TelemetryWorkerHandle,
     dependency_name: ffi::CharSlice,
     dependency_version: ffi::CharSlice,
@@ -29,7 +29,7 @@ pub unsafe extern "C" fn ddog_handle_add_dependency(
 
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub unsafe extern "C" fn ddog_handle_add_integration(
+pub unsafe extern "C" fn ddog_telemetry_handle_add_integration(
     handle: &TelemetryWorkerHandle,
     dependency_name: ffi::CharSlice,
     dependency_version: ffi::CharSlice,
@@ -57,7 +57,7 @@ pub unsafe extern "C" fn ddog_handle_add_integration(
 ///   using for the log message or the concatenated file + line of the origin of the log
 /// * stack_trace: stack trace associated with the log. If no stack trace is available, an empty
 ///   string should be passed
-pub unsafe extern "C" fn ddog_handle_add_log(
+pub unsafe extern "C" fn ddog_telemetry_handle_add_log(
     handle: &TelemetryWorkerHandle,
     indentifier: ffi::CharSlice,
     message: ffi::CharSlice,
@@ -76,18 +76,20 @@ pub unsafe extern "C" fn ddog_handle_add_log(
 }
 
 #[no_mangle]
-pub extern "C" fn ddog_handle_start(handle: &TelemetryWorkerHandle) -> MaybeError {
+pub extern "C" fn ddog_telemetry_handle_start(handle: &TelemetryWorkerHandle) -> MaybeError {
     crate::try_c!(handle.send_start());
     MaybeError::None
 }
 
 #[no_mangle]
-pub extern "C" fn ddog_handle_clone(handle: &TelemetryWorkerHandle) -> Box<TelemetryWorkerHandle> {
+pub extern "C" fn ddog_telemetry_handle_clone(
+    handle: &TelemetryWorkerHandle,
+) -> Box<TelemetryWorkerHandle> {
     Box::new(handle.clone())
 }
 
 #[no_mangle]
-pub extern "C" fn ddog_handle_stop(handle: &TelemetryWorkerHandle) -> MaybeError {
+pub extern "C" fn ddog_telemetry_handle_stop(handle: &TelemetryWorkerHandle) -> MaybeError {
     crate::try_c!(handle.send_stop());
     MaybeError::None
 }
@@ -95,7 +97,7 @@ pub extern "C" fn ddog_handle_stop(handle: &TelemetryWorkerHandle) -> MaybeError
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 /// * compatible: should be false if the metric is language specific, true otherwise
-pub unsafe extern "C" fn ddog_handle_register_metric_context(
+pub unsafe extern "C" fn ddog_telemetry_handle_register_metric_context(
     handle: &TelemetryWorkerHandle,
     name: ffi::CharSlice,
     metric_type: MetricType,
@@ -114,7 +116,7 @@ pub unsafe extern "C" fn ddog_handle_register_metric_context(
 
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub unsafe extern "C" fn ddog_handle_add_point(
+pub unsafe extern "C" fn ddog_telemetry_handle_add_point(
     handle: &TelemetryWorkerHandle,
     context_key: &ContextKey,
     value: f64,
@@ -125,7 +127,7 @@ pub unsafe extern "C" fn ddog_handle_add_point(
 
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-pub unsafe extern "C" fn ddog_handle_add_point_with_tags(
+pub unsafe extern "C" fn ddog_telemetry_handle_add_point_with_tags(
     handle: &TelemetryWorkerHandle,
     context_key: &ContextKey,
     value: f64,
@@ -137,13 +139,13 @@ pub unsafe extern "C" fn ddog_handle_add_point_with_tags(
 
 #[no_mangle]
 /// This function takes ownership of the handle. It should not be used after calling it
-pub extern "C" fn ddog_handle_wait_for_shutdown(handle: Box<TelemetryWorkerHandle>) {
+pub extern "C" fn ddog_telemetry_handle_wait_for_shutdown(handle: Box<TelemetryWorkerHandle>) {
     handle.wait_for_shutdown()
 }
 
 #[no_mangle]
 /// This function takes ownership of the handle. It should not be used after calling it
-pub extern "C" fn ddog_handle_wait_for_shutdown_ms(
+pub extern "C" fn ddog_telemetry_handle_wait_for_shutdown_ms(
     handle: Box<TelemetryWorkerHandle>,
     wait_for_ms: u64,
 ) {
@@ -155,6 +157,6 @@ pub extern "C" fn ddog_handle_wait_for_shutdown_ms(
 #[no_mangle]
 /// Drops the handle without waiting for shutdown. The worker will continue running in the
 /// background until it exits by itself
-pub extern "C" fn ddog_handle_drop(handle: Box<TelemetryWorkerHandle>) {
+pub extern "C" fn ddog_telemetry_handle_drop(handle: Box<TelemetryWorkerHandle>) {
     drop(handle);
 }

--- a/examples/ffi/telemetry.c
+++ b/examples/ffi/telemetry.c
@@ -20,27 +20,27 @@ int main(void) {
   ddog_CharSlice service = DDOG_CHARSLICE_C("rust"), lang = DDOG_CHARSLICE_C("libdatadog-example"),
                  lang_version = DDOG_CHARSLICE_C("1.69.0"),
                  tracer_version = DDOG_CHARSLICE_C("0.0.0");
-  TRY(ddog_builder_instantiate(&builder, service, lang, lang_version, tracer_version));
+  TRY(ddog_telemetry_builder_instantiate(&builder, service, lang, lang_version, tracer_version));
 
   ddog_CharSlice endpoint_char = DDOG_CHARSLICE_C("file://./examples_telemetry.out");
   struct ddog_Endpoint *endpoint = ddog_endpoint_from_url(endpoint_char);
-  TRY(ddog_builder_with_endpoint_config_endpoint(builder, endpoint));
+  TRY(ddog_telemetry_builder_with_endpoint_config_endpoint(builder, endpoint));
   ddog_endpoint_drop(endpoint);
 
   ddog_CharSlice runtime_id = DDOG_CHARSLICE_C("fa1f0ed0-8a3a-49e8-8f23-46fb44e24579"),
                  service_version = DDOG_CHARSLICE_C("1.0"), env = DDOG_CHARSLICE_C("test");
-  TRY(ddog_builder_with_str_runtime_id(builder, runtime_id));
-  TRY(ddog_builder_with_str_application_service_version(builder, service_version));
-  TRY(ddog_builder_with_str_application_env(builder, env));
+  TRY(ddog_telemetry_builder_with_str_runtime_id(builder, runtime_id));
+  TRY(ddog_telemetry_builder_with_str_application_service_version(builder, service_version));
+  TRY(ddog_telemetry_builder_with_str_application_env(builder, env));
 
-  TRY(ddog_builder_with_bool_config_telemetry_debug_logging_enabled(builder, true));
+  TRY(ddog_telemetry_builder_with_bool_config_telemetry_debug_logging_enabled(builder, true));
 
   ddog_TelemetryWorkerHandle *handle;
-  TRY(ddog_builder_run(builder, &handle));
-  TRY(ddog_handle_start(handle));
+  TRY(ddog_telemetry_builder_run(builder, &handle));
+  TRY(ddog_telemetry_handle_start(handle));
 
-  TRY(ddog_handle_stop(handle));
-  ddog_handle_wait_for_shutdown(handle);
+  TRY(ddog_telemetry_handle_stop(handle));
+  ddog_telemetry_handle_wait_for_shutdown(handle);
 
   return 0;
 }

--- a/examples/ffi/telemetry_metrics.c
+++ b/examples/ffi/telemetry_metrics.c
@@ -44,49 +44,49 @@ int main(void) {
   ddog_CharSlice service = DDOG_CHARSLICE_C("rust"), lang = DDOG_CHARSLICE_C("libdatadog-example"),
                  lang_version = DDOG_CHARSLICE_C("1.69.0"),
                  tracer_version = DDOG_CHARSLICE_C("0.0.0");
-  TRY(ddog_builder_instantiate(&builder, service, lang, lang_version, tracer_version));
+  TRY(ddog_telemetry_builder_instantiate(&builder, service, lang, lang_version, tracer_version));
 
   ddog_CharSlice endpoint_char = DDOG_CHARSLICE_C("file://./examples_telemetry_metrics.out");
   struct ddog_Endpoint *endpoint = ddog_endpoint_from_url(endpoint_char);
-  TRY(ddog_builder_with_endpoint_config_endpoint(builder, endpoint));
+  TRY(ddog_telemetry_builder_with_endpoint_config_endpoint(builder, endpoint));
   ddog_endpoint_drop(endpoint);
 
   ddog_CharSlice runtime_id = DDOG_CHARSLICE_C("fa1f0ed0-8a3a-49e8-8f23-46fb44e24579"),
                  service_version = DDOG_CHARSLICE_C("1.0"), env = DDOG_CHARSLICE_C("test");
-  TRY(ddog_builder_with_str_runtime_id(builder, runtime_id));
-  TRY(ddog_builder_with_str_application_service_version(builder, service_version));
-  TRY(ddog_builder_with_str_application_env(builder, env));
+  TRY(ddog_telemetry_builder_with_str_runtime_id(builder, runtime_id));
+  TRY(ddog_telemetry_builder_with_str_application_service_version(builder, service_version));
+  TRY(ddog_telemetry_builder_with_str_application_env(builder, env));
 
-  TRY(ddog_builder_with_bool_config_telemetry_debug_logging_enabled(builder, true));
+  TRY(ddog_telemetry_builder_with_bool_config_telemetry_debug_logging_enabled(builder, true));
 
   ddog_TelemetryWorkerHandle *handle;
   // builder is consummed after the call to build
-  TRY(ddog_builder_run_metric_logs(builder, &handle));
-  TRY(ddog_handle_start(handle));
+  TRY(ddog_telemetry_builder_run_metric_logs(builder, &handle));
+  TRY(ddog_telemetry_handle_start(handle));
 
   ddog_CharSlice metric_name = DDOG_CHARSLICE_C("test.telemetry");
   ddog_Vec_Tag tags = ddog_Vec_Tag_new();
   ddog_Vec_Tag_push(&tags, charslice_from_ptr("foo"), charslice_from_ptr("bar"));
   // tags is consummed
-  struct ddog_ContextKey test_temetry = ddog_handle_register_metric_context(
+  struct ddog_ContextKey test_temetry = ddog_telemetry_handle_register_metric_context(
       handle, metric_name, DDOG_METRIC_TYPE_COUNT, tags, true, DDOG_METRIC_NAMESPACE_TELEMETRY);
 
-  TRY(ddog_handle_add_point(handle, &test_temetry, 1.0));
-  TRY(ddog_handle_add_point(handle, &test_temetry, 1.0));
+  TRY(ddog_telemetry_handle_add_point(handle, &test_temetry, 1.0));
+  TRY(ddog_telemetry_handle_add_point(handle, &test_temetry, 1.0));
 
   ddog_Vec_Tag extra_tags = ddog_Vec_Tag_new();
   ddog_Vec_Tag_push(&tags, charslice_from_ptr("baz"), charslice_from_ptr("bat"));
-  TRY(ddog_handle_add_point_with_tags(handle, &test_temetry, 1.0, extra_tags));
+  TRY(ddog_telemetry_handle_add_point_with_tags(handle, &test_temetry, 1.0, extra_tags));
   for (int i = 0; i < 10; i++) {
-    TRY(ddog_handle_add_log(
+    TRY(ddog_telemetry_handle_add_log(
         handle, LOG_LOCATION_IDENTIFIER(),
         DDOG_CHARSLICE_C("no kinder bueno left in the cafetaria"),
         DDOG_LOG_LEVEL_ERROR, DDOG_CHARSLICE_C("")));
   }
 
   sleep(11);
-  TRY(ddog_handle_stop(handle));
-  ddog_handle_wait_for_shutdown_ms(handle, 10);
+  TRY(ddog_telemetry_handle_stop(handle));
+  ddog_telemetry_handle_wait_for_shutdown_ms(handle, 10);
 
   return 0;
 }


### PR DESCRIPTION

# What does this PR do?

* Rename ddtelemetry ffi functions from ddog_handle_* to ddog_telemetr_handle_* and ddog_builder_* to ddog_telemetry_builder_*

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
