### PR TITLE
style(profiling): remove redundant imports

### DIFF
--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -11,7 +11,6 @@ pub use ddcommon::tag::Tag;
 pub use hyper::Uri;
 use hyper_multipart_rfc7578::client::multipart;
 use lz4_flex::frame::FrameEncoder;
-use mime;
 use serde_json::json;
 use tokio::runtime::Runtime;
 use tokio_util::sync::CancellationToken;

--- a/profiling/src/internal/profile.rs
+++ b/profiling/src/internal/profile.rs
@@ -5,7 +5,6 @@ use self::api::UpscalingInfo;
 use super::*;
 use crate::api;
 use crate::collections::identifiable::*;
-use crate::internal::ProfiledEndpointsStats;
 use crate::pprof::sliced_proto::*;
 use crate::serializer::CompressedProtobufSerializer;
 use std::borrow::Cow;
@@ -536,9 +535,7 @@ impl Profile {
 
 #[cfg(test)]
 mod api_test {
-
     use super::*;
-    use std::{borrow::Cow, collections::HashMap};
 
     #[test]
     fn interning() {

--- a/profiling/src/internal/upscaling.rs
+++ b/profiling/src/internal/upscaling.rs
@@ -3,8 +3,6 @@
 
 use super::*;
 use crate::api::UpscalingInfo;
-use crate::collections::identifiable::FxIndexMap;
-use crate::pprof;
 
 #[derive(Debug)]
 pub struct UpscalingRule {

--- a/profiling/tests/form.rs
+++ b/profiling/tests/form.rs
@@ -60,7 +60,6 @@ fn multipart(
 mod tests {
     use crate::multipart;
     use datadog_profiling::exporter::*;
-    use ddcommon::tag::Tag;
     use serde_json::json;
 
     fn default_tags() -> Vec<Tag> {


### PR DESCRIPTION
# What does this PR do?

This removes redundant imports in the `profiling/` subdir.

# Motivation

Miri was complaining about these for me on nightly. 

# Additional Notes

It is probable other crates will have similar warnings. I only worked on `profiling/`'s.

# How to test the change?

Everything should compile and work as normal, this should be a net-zero change.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
