### PR TITLE
Update protobuf files for stats for new trace root field

### DIFF
--- a/.github/workflows/verify-proto-files.yml
+++ b/.github/workflows/verify-proto-files.yml
@@ -4,7 +4,7 @@ on:
     types: [ opened, synchronize, reopened ]
 
 env:
-  DATADOG_AGENT_TAG: "7.52.0-rc.1"
+  DATADOG_AGENT_TAG: "7.53.0-rc.1"
 
 jobs:
   verify-proto-files:

--- a/trace-protobuf/src/pb.rs
+++ b/trace-protobuf/src/pb.rs
@@ -423,4 +423,36 @@ pub struct ClientGroupedStats {
     /// E.g., `grpc.target` to describe the name of a gRPC peer, or `db.hostname` to describe the name of peer DB
     #[prost(string, repeated, tag = "16")]
     pub peer_tags: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    /// this field's value is equal to span's ParentID == 0.
+    #[prost(enumeration = "TraceRootFlag", tag = "17")]
+    pub is_trace_root: i32,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum TraceRootFlag {
+    NotSet = 0,
+    True = 1,
+    False = 2,
+}
+impl TraceRootFlag {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            TraceRootFlag::NotSet => "NOT_SET",
+            TraceRootFlag::True => "TRUE",
+            TraceRootFlag::False => "FALSE",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "NOT_SET" => Some(Self::NotSet),
+            "TRUE" => Some(Self::True),
+            "FALSE" => Some(Self::False),
+            _ => None,
+        }
+    }
 }

--- a/trace-protobuf/src/pb/stats.proto
+++ b/trace-protobuf/src/pb/stats.proto
@@ -62,6 +62,12 @@ message ClientStatsBucket {
 	int64 agentTimeShift = 4;
 }
 
+enum TraceRootFlag {
+	NOT_SET = 0;
+	TRUE = 1;
+	FALSE = 2;
+}
+
 // ClientGroupedStats aggregate stats on spans grouped by service, name, resource, status_code, type
 message ClientGroupedStats {
 	string service = 1;
@@ -82,4 +88,5 @@ message ClientGroupedStats {
 	// peer_tags are supplementary tags that further describe a peer entity
 	// E.g., `grpc.target` to describe the name of a gRPC peer, or `db.hostname` to describe the name of peer DB
 	repeated string peer_tags = 16;
+	TraceRootFlag is_trace_root = 17; // this field's value is equal to span's ParentID == 0.
 }


### PR DESCRIPTION
# What does this PR do?

Updates the protobuf stats.pb file with a new trace root field to match the Datadog Agent files.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
