### PR TITLE
Don't serialize empty extra fields in spans

### DIFF
--- a/trace-protobuf/build.rs
+++ b/trace-protobuf/build.rs
@@ -55,6 +55,14 @@ fn generate_protobuf() {
         ".pb.Span",
         "#[serde(default)] #[serde(deserialize_with = \"deserialize_null_into_default\")]",
     );
+    config.field_attribute(
+        ".pb.Span.meta_struct",
+        "#[serde(skip_serializing_if = \"::std::collections::HashMap::is_empty\")]",
+    );
+    config.field_attribute(
+        ".pb.Span.spanLinks",
+        "#[serde(skip_serializing_if = \"::prost::alloc::vec::Vec::is_empty\")]",
+    );
 
     config.type_attribute("StatsPayload", "#[derive(Deserialize, Serialize)]");
     config.type_attribute("StatsPayload", "#[serde(rename_all = \"PascalCase\")]");

--- a/trace-protobuf/src/pb.rs
+++ b/trace-protobuf/src/pb.rs
@@ -134,6 +134,7 @@ pub struct Span {
     #[prost(map = "string, bytes", tag = "13")]
     #[serde(default)]
     #[serde(deserialize_with = "deserialize_null_into_default")]
+    #[serde(skip_serializing_if = "::std::collections::HashMap::is_empty")]
     pub meta_struct: ::std::collections::HashMap<
         ::prost::alloc::string::String,
         ::prost::alloc::vec::Vec<u8>,
@@ -143,6 +144,7 @@ pub struct Span {
     #[prost(message, repeated, tag = "14")]
     #[serde(default)]
     #[serde(deserialize_with = "deserialize_null_into_default")]
+    #[serde(skip_serializing_if = "::prost::alloc::vec::Vec::is_empty")]
     pub span_links: ::prost::alloc::vec::Vec<SpanLink>,
 }
 /// TraceChunk represents a list of spans with the same trace ID. In other words, a chunk of a trace.


### PR DESCRIPTION
# What does this PR do?

Avoids serializing empty extra fields in the spans.

# Motivation

A lot of code that expects v0.4 MessagePack don't respond well to unknown fields being present, even if they are empty. This allows the current messages to be used for v0.4 as well as v0.7 without adding the extra fields.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
