### PR TITLE
Fix linking issue on Windows

### DIFF
--- a/.github/actions/cache/action.yaml
+++ b/.github/actions/cache/action.yaml
@@ -21,9 +21,9 @@ runs:
           ~/.cargo/registry/cache/
           ~/.cargo/bin/
           target/
-        key: v2-${{ runner.os }}-cargo-${{ inputs.rust_version }}-${{ hashFiles('**/Cargo.toml') }}-${{ inputs.build_profile }}
+        key: v2-${{ runner.os }}-cargo-${{ inputs.rust_version }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/.cargo/config.toml') }}-${{ inputs.build_profile }}
         restore-keys: |
-          v2-${{ runner.os }}-cargo-${{ inputs.rust_version }}-${{ hashFiles('**/Cargo.toml') }}-
+          v2-${{ runner.os }}-cargo-${{ inputs.rust_version }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/.cargo/config.toml') }}-
 # Cache will restore cargo and target data  if cache with matching OS and Rust Version as well as matching Cargo.toml files will be found. 
 # previously we also restored cache for specific os and Rust Version but the target/ directory had only been growing over time - and we've reached the limits of GitHub Runners
 # 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,13 +97,11 @@ jobs:
       - name: "Generate profiling FFI"
         shell: bash
         run: |
-           chmod +x build-profiling-ffi.sh
            ./build-profiling-ffi.sh ${OUTPUT_FOLDER}/profiling
 
       - name: "Generate Telemetry FFI"
         shell: bash
         run: |
-           chmod +x build-telemetry-ffi.sh
            ./build-telemetry-ffi.sh ${OUTPUT_FOLDER}/telemetry
 
       - name: 'Publish libdatadog'
@@ -115,8 +113,29 @@ jobs:
           path: ${{ github.workspace }}/artifacts
           retention-days: 1
 
+      - name: "(Windows) Test building C bindings - dynamic link vc runtime"
+        if: ${{ matrix.platform == 'windows-latest' }}
+        shell: bash
+        run: |
+          set -e
+          mkdir examples/ffi/build_dll
+          cd examples/ffi/build_dll
+          cmake -S .. -DDatadog_ROOT=$OUTPUT_FOLDER/profiling -DVCRUNTIME_LINK_TYPE=DLL
+          cmake --build .
+
+      - name: "(Windows) Test building C bindings - static link vc runtime"
+        if: ${{ matrix.platform == 'windows-latest' }}
+        shell: bash
+        run: |
+          set -e
+          mkdir examples/ffi/build_static
+          cd examples/ffi/build_static
+          cmake -S .. -DDatadog_ROOT=$OUTPUT_FOLDER/profiling -DVCRUNTIME_LINK_TYPE=STATIC
+          cmake --build .
+
       - name: "Test building C bindings"
         shell: bash
+        if: ${{ matrix.platform != 'windows-latest' }}
         run: |
           set -e
           mkdir examples/ffi/build

--- a/build-profiling-ffi.sh
+++ b/build-profiling-ffi.sh
@@ -100,7 +100,6 @@ sed < cmake/DatadogConfig.cmake.in \
 
 cp -v LICENSE LICENSE-3rdparty.yml NOTICE "$destdir/"
 
-export RUSTFLAGS="${RUSTFLAGS:- -C relocation-model=pic}"
 
 datadog_profiling_ffi="datadog-profiling-ffi"
 FEATURES="--features cbindgen,datadog-profiling-ffi/ddtelemetry-ffi"
@@ -108,7 +107,10 @@ if [[ "$symbolizer" -eq 1 ]]; then
     FEATURES="--features cbindgen,datadog-profiling-ffi/ddtelemetry-ffi,symbolizer"
 fi
 
-DESTDIR="$destdir" cargo build --package="${datadog_profiling_ffi}" ${FEATURES} --release --target "${target}"
+# build inside the crate to use the config.toml file
+pushd profiling-ffi
+DESTDIR="$destdir" cargo build ${FEATURES} --release --target "${target}"
+popd
 
 # Remove _ffi suffix when copying
 shared_library_name="${library_prefix}datadog_profiling_ffi${shared_library_suffix}"

--- a/build-profiling-ffi.sh
+++ b/build-profiling-ffi.sh
@@ -108,9 +108,7 @@ if [[ "$symbolizer" -eq 1 ]]; then
 fi
 
 # build inside the crate to use the config.toml file
-pushd profiling-ffi
-DESTDIR="$destdir" cargo build ${FEATURES} --release --target "${target}"
-popd
+( cd profiling-ffi && DESTDIR="$destdir" cargo build ${FEATURES} --release --target "${target}")
 
 # Remove _ffi suffix when copying
 shared_library_name="${library_prefix}datadog_profiling_ffi${shared_library_suffix}"

--- a/examples/ffi/CMakeLists.txt
+++ b/examples/ffi/CMakeLists.txt
@@ -3,6 +3,18 @@ project(datadog_profiling_ffi_examples LANGUAGES C CXX)
 
 find_package(Datadog REQUIRED)
 
+set(VCRUNTIME_LINK_TYPE DLL CACHE STRING "Specify the Runtime Library to use when compiling with MSVC")
+
+function(set_vcruntime_link_type binary link_type)
+  if (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    if (link_type STREQUAL "DLL")
+      set_property(TARGET ${binary} PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+    else()
+      set_property(TARGET ${binary} PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+    endif()
+  endif()
+endfunction()
+
 # Uncomment to debug build commands
 # set(CMAKE_VERBOSE_MAKEFILE ON)
 
@@ -10,6 +22,7 @@ add_executable(exporter exporter.cpp)
 # needed for designated initializers
 target_compile_features(exporter PRIVATE cxx_std_20)
 target_link_libraries(exporter PRIVATE Datadog::Profiling)
+set_vcruntime_link_type(exporter ${VCRUNTIME_LINK_TYPE})
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   target_compile_definitions(exporter PUBLIC _CRT_SECURE_NO_WARNINGS)
@@ -17,17 +30,21 @@ endif()
 
 add_executable(profiles profiles.c)
 target_link_libraries(profiles PRIVATE Datadog::Profiling)
+set_vcruntime_link_type(profiles ${VCRUNTIME_LINK_TYPE})
 
 if(BUILD_SYMBOLIZER)
   add_executable(symbolizer symbolizer.cpp)
   target_link_libraries(symbolizer PRIVATE Datadog::Profiling)
+  set_vcruntime_link_type(symbolizer ${VCRUNTIME_LINK_TYPE})
 endif()
 
 add_executable(telemetry telemetry.c)
 target_link_libraries(telemetry PRIVATE Datadog::Profiling)
+set_vcruntime_link_type(telemetry ${VCRUNTIME_LINK_TYPE})
 
 add_executable(telemetry_metrics telemetry_metrics.c)
 target_link_libraries(telemetry_metrics PRIVATE Datadog::Profiling)
+set_vcruntime_link_type(telemetry_metrics ${VCRUNTIME_LINK_TYPE})
 
 if(NOT WIN32)
   add_executable(crashtracking crashtracking.c)

--- a/profiling-ffi/.cargo/config.toml
+++ b/profiling-ffi/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+rustflags = ["-C", "relocation-model=pic"]
+
+[target.'cfg(target_os = "windows")']
+rustflags = ["-C", "relocation-model=pic", "-C", "target-feature=+crt-static"]

--- a/windows/build-artifacts.ps1
+++ b/windows/build-artifacts.ps1
@@ -20,10 +20,13 @@ if (![System.IO.Path]::IsPathRooted($output_dir)) {
 
 Write-Host "Building project into $($output_dir)" -ForegroundColor Magenta
 
+# build inside the crate to use the config.toml file
+pushd profiling-ffi
 Invoke-Call -ScriptBlock { cargo build --features datadog-profiling-ffi/ddtelemetry-ffi --target i686-pc-windows-msvc --release --target-dir $output_dir }
 Invoke-Call -ScriptBlock { cargo build --features datadog-profiling-ffi/ddtelemetry-ffi --target i686-pc-windows-msvc --target-dir $output_dir }
 Invoke-Call -ScriptBlock { cargo build --features datadog-profiling-ffi/ddtelemetry-ffi --target x86_64-pc-windows-msvc --release --target-dir $output_dir }
 Invoke-Call -ScriptBlock { cargo build --features datadog-profiling-ffi/ddtelemetry-ffi --target x86_64-pc-windows-msvc --target-dir $output_dir }
+popd
 
 Write-Host "Building tools" -ForegroundColor Magenta
 Set-Location tools

--- a/windows/libdatadog.props
+++ b/windows/libdatadog.props
@@ -11,7 +11,7 @@
   <PropertyGroup>
     <!-- Expland the items to a property -->
     <LibdatadogLibraries>@(LibdatadogLibs)</LibdatadogLibraries>
-    <LibdatadogDependencies>NtDll.lib;UserEnv.lib;Bcrypt.lib;crypt32.lib;wsock32.lib;ws2_32.lib;shlwapi.lib;Secur32.lib;Ncrypt.lib</LibdatadogDependencies>
+    <LibdatadogDependencies>PowrProf.lib;NtDll.lib;UserEnv.lib;Bcrypt.lib;crypt32.lib;wsock32.lib;ws2_32.lib;shlwapi.lib;Secur32.lib;Ncrypt.lib</LibdatadogDependencies>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>


### PR DESCRIPTION
# What does this PR do?

This PR fixes a linking with for Windows native libraries that link against the VC runtime statically that was introduced by [the PR adding telemetry.
](https://github.com/DataDog/libdatadog/pull/339)
# Motivation

The .NET profiler links against the VC runtime statically so it can be deployed easily everywhere (on windows) without the customers having to install additional stuffs (VC runtime for example).

The PR that introduced the telemetry in the datadog_profiling lib, brought some new dependencies. Now the .NET profiler is unable to successfully build on windows.
The build produces this linking error:
```
datadog_profiling.lib(windows.o) : error LNK2019: unresolved external symbol __imp_strncpy referenced in function get_os_release [D:\a\libdatadog\libdatadog\examples\ffi\build_static\telemetry_metrics.vcxproj]
```

# Implementation

To fix this, I added a `.cargo/config.toml` file in the `profiling-ffi` crate and build the crate directly inside (not from the workspace, otherwise, we will have to move the `config.toml` in the workspace and it will apply to all crates)

# Additional Notes

Nop

# How to test the change?

I added in the CI 2 configurations when building and testing FFI:
- One where the projects are linked dynamically against the VC runtime
- One where the projects are linked statically against the VC runtime.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
