### PR TITLE
[crashtracker] Chain signal handlers 

### DIFF
--- a/crashtracker/src/crash_handler.rs
+++ b/crashtracker/src/crash_handler.rs
@@ -212,6 +212,8 @@ extern "C" fn handle_posix_sigaction(signum: i32, sig_info: *mut siginfo_t, ucon
     // Once we've handled the signal, chain to any previous handlers.
     // SAFETY: This was created by [register_crash_handlers].  There is a tiny
     // instant of time between when the handlers are registered, and the
+    // `OLD_HANDLERS` are set.  This should be very short, but is hard to fully
+    // eliminate given the existing POSIX APIs.
     let old_handlers = unsafe { &*OLD_HANDLERS.load(SeqCst) };
     let old_sigaction = if signum == libc::SIGSEGV {
         old_handlers.sigsegv


### PR DESCRIPTION
# What does this PR do?

Reworks the signal handler chaining code to properly handle cases where the signal was manually raised.

# Motivation

The example in `crashtracker.c` would fail to call the underlying handler in the case of a `raise(SEGV)` call, and then would continue past what ought to be a core-dump.  Now we don't do that anymore.

# Additional Notes

The POSIX signal infra is 🤯 

# How to test the change?

`crashtracking.c` now works the way its expected to.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
