### PR TITLE
Add windows_package project

### DIFF
--- a/run-package-tests.ps1
+++ b/run-package-tests.ps1
@@ -1,0 +1,107 @@
+param (
+    [Parameter(Mandatory=$true)][string]$ArtifactsPath
+)
+
+function Invoke-Call {
+    param (
+        [scriptblock]$ScriptBlock
+    )
+    & @ScriptBlock
+    if ($lastexitcode -ne 0) {
+        exit $lastexitcode
+    }
+}
+
+function Extract-Nupkg {
+    param (
+        [Parameter(Mandatory=$true)][string]$Package,
+        [Parameter(Mandatory=$true)][string]$OutDir
+    )
+    mkdir -p $OutDir 
+    pushd $OutDir
+    Invoke-Call -ScriptBlock { 7z x $Package }
+    popd
+}
+
+function GetRuntimeLibrary {
+    param (
+        [Parameter(Mandatory=$true)][string]$RT_LinkType,
+        [Parameter(Mandatory=$true)][string]$Configuration
+    )
+
+    if ( "$RT_LinkType" -ieq "static" ) {
+        if ( "$Configuration" -ieq "debug" ) {
+            return "MultiThreadedDebug"
+        }
+        else {
+            return "MultiThreaded"
+        }
+    }
+    else {
+        if ( "$Configuration" -ieq "debug" ) {
+            return "MultiThreadedDebugDLL"
+        }
+        else {
+            return "MultiThreadedDLL"
+        }
+    }
+}
+
+function BuildProject {
+    param (
+        [Parameter(Mandatory=$true)][string]$RT_LinkType,
+        [Parameter(Mandatory=$true)][string]$Configuration,
+        [Parameter(Mandatory=$true)][string]$Platform
+    )
+
+    if ("$RT_LinkType" -ine "static" -and "$RT_LinkType" -ine "dll") {
+        Write-Host "Incorrect Runtime Library Type: 'static' or 'dll'" -ForegroundColor Red
+        exit 1
+    }
+
+    if ("$Configuration" -ine "debug" -and "$Configuration" -ine "release") {
+        Write-Host "Incorrect Configuration: 'debug' or 'release'" -ForegroundColor Red
+        exit 1
+    }
+
+    if ("$Platform" -ine "x86" -and "$Platform" -ine "x64") {
+        Write-Host "Incorrect Platform: 'x86' or 'x64'" -ForegroundColor Red
+        exit 1
+    }
+
+    pushd tests\windows_package
+    $RuntimeLibrary=GetRuntimeLibrary -RT_LinkType $RT_LinkType -Configuration $Configuration
+    Invoke-Call -ScriptBlock { &$msbuild windows_package.vcxproj /p:RuntimeLibrary=$RuntimeLibrary /p:Configuration=$Configuration /p:Platform=$Platform }
+    popd
+}
+
+$msbuild = &"${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -prerelease  -products * -requires Microsoft.Component.MSBuild -find MSBuild\**\amd64\MSBuild.exe
+
+if ( [string]::IsNullOrEmpty($msbuild) )
+{
+    Write-Host "Failed to locate MSBuild" -ForegroundColor Red
+    exit 1
+}
+
+$libdatadog_nupkg = Get-ChildItem -Path $ArtifactsPath -Filter libdatadog*.nupkg -Recurse | %{ $_.FullName }
+
+if ( [string]::IsNullOrEmpty($libdatadog_nupkg) )
+{
+    Write-Host "Failed to locate libdatadog nuget package file in the artifact folder $ArtifactsPath" -ForegroundColor Red
+    exit 1
+}
+
+Extract-Nupkg -Package $libdatadog_nupkg -OutDir packages\libdatadog
+
+# Runtime library DLL
+BuildProject -RT_LinkType "dll" -Configuration "release" -Platform "x86"
+BuildProject -RT_LinkType "dll" -Configuration "debug" -Platform "x86"
+BuildProject -RT_LinkType "dll" -Configuration "release" -Platform "x64"
+BuildProject -RT_LinkType "dll" -Configuration "debug" -Platform "x64"
+
+
+# Runtime Library Static
+BuildProject -RT_LinkType "static" -Configuration "release" -Platform "x86"
+BuildProject -RT_LinkType "static" -Configuration "debug" -Platform "x86"
+BuildProject -RT_LinkType "static" -Configuration "release" -Platform "x64"
+BuildProject -RT_LinkType "static" -Configuration "debug" -Platform "x64"

--- a/tests/run-package-tests.ps1
+++ b/tests/run-package-tests.ps1
@@ -69,7 +69,7 @@ function BuildProject {
         exit 1
     }
 
-    pushd tests\windows_package
+    pushd $PSScriptRoot\windows_package
     $RuntimeLibrary=GetRuntimeLibrary -RT_LinkType $RT_LinkType -Configuration $Configuration
     Invoke-Call -ScriptBlock { &$msbuild windows_package.vcxproj /p:RuntimeLibrary=$RuntimeLibrary /p:Configuration=$Configuration /p:Platform=$Platform }
     popd

--- a/tests/windows_package/windows_package.vcxproj
+++ b/tests/windows_package/windows_package.vcxproj
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\packages\libdatadog\build\native\libdatadog.props" Condition="Exists('..\..\..\packages\libdatadog\build\native\libdatadog.props')" />
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\examples\ffi\exporter.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{d4ac517d-369b-40ef-889a-13ce58966a55}</ProjectGuid>
+    <RootNamespace>windowspackage</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <RuntimeLibrary Condition=" '$(RuntimeLibrary)' == 'dll' Or '$(RuntimeLibrary)' == '' ">MultiThreadedDebugDLL</RuntimeLibrary>
+      <RuntimeLibrary Condition=" '$(RuntimeLibrary)' == 'static' ">MultiThreadedDebug</RuntimeLibrary>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <RuntimeLibrary Condition=" '$(RuntimeLibrary)' == 'dll' Or '$(RuntimeLibrary)' == '' ">MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeLibrary Condition=" '$(RuntimeLibrary)' == 'static' ">MultiThreaded</RuntimeLibrary>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <RuntimeLibrary Condition=" '$(RuntimeLibrary)' == 'dll' Or '$(RuntimeLibrary)' == '' ">MultiThreadedDebug</RuntimeLibrary>
+      <RuntimeLibrary Condition=" '$(RuntimeLibrary)' == 'static' ">MultiThreadedDebug</RuntimeLibrary>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <RuntimeLibrary Condition=" '$(RuntimeLibrary)' == 'dll' Or '$(RuntimeLibrary)' == '' ">MultiThreadedDLL</RuntimeLibrary>
+      <RuntimeLibrary Condition=" '$(RuntimeLibrary)' == 'static' ">MultiThreaded</RuntimeLibrary>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\..\packages\libdatadog\build\native\libdatadog.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\packages\libdatadog\build\native\libdatadog.props'))" />
+  </Target>
+</Project>

--- a/tests/windows_package/windows_package.vcxproj.filters
+++ b/tests/windows_package/windows_package.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="windows_package.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
# What does this PR do?

Add a project package check test.

# Motivation

We would like to validate that the generated Nuget package can be used to build a C++ (Visual Studio) project.

# How to test the change?

/!\ You must have VS, and MSBuild tools installed

- Create an `artifacts` folder and put the libdatadog `nupkg` file in it.
- Start a Powershell command line
- run the script `run-package-tests.ps` : `. .\tests\run-package-tests.ps1 -ArtifactsPath <path to the artifacts folder>

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
