### PR TITLE
Use Cargo.lock file as part of the CI cache hash

### DIFF
--- a/.github/actions/cache/action.yaml
+++ b/.github/actions/cache/action.yaml
@@ -21,9 +21,9 @@ runs:
           ~/.cargo/registry/cache/
           ~/.cargo/bin/
           target/
-        key: v2-${{ runner.os }}-cargo-${{ inputs.rust_version }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/.cargo/config.toml') }}-${{ inputs.build_profile }}
+        key: v2-${{ runner.os }}-cargo-${{ inputs.rust_version }}-${{ hashFiles('**/Cargo.toml', '**/Cargo.lock', '**/.cargo/config.toml') }}-${{ inputs.build_profile }}
         restore-keys: |
-          v2-${{ runner.os }}-cargo-${{ inputs.rust_version }}-${{ hashFiles('**/Cargo.toml') }}-${{ hashFiles('**/.cargo/config.toml') }}-
+          v2-${{ runner.os }}-cargo-${{ inputs.rust_version }}-${{ hashFiles('**/Cargo.toml', '**/Cargo.lock', '**/.cargo/config.toml') }}-
 # Cache will restore cargo and target data  if cache with matching OS and Rust Version as well as matching Cargo.toml files will be found. 
 # previously we also restored cache for specific os and Rust Version but the target/ directory had only been growing over time - and we've reached the limits of GitHub Runners
 # 


### PR DESCRIPTION
# What does this PR do?

Adds the `Cargo.lock` file as part of the CI cache hash key.

# Motivation

CentOS 7 cross builds are close to the limit of the runner size, and changes in locked versions, even though there have been no changes in the `Cargo.toml` files easily tips the build over.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
