### PR TITLE
[profiling] Refactor FFI implementation to simplify error handling

### DIFF
--- a/profiling-ffi/src/profiles.rs
+++ b/profiling-ffi/src/profiles.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::Timespec;
+use anyhow::Context;
 use datadog_profiling::api;
 use datadog_profiling::internal;
 use datadog_profiling::internal::ProfiledEndpointsStats;
@@ -57,6 +58,15 @@ pub enum ProfileResult {
         bool,
     ),
     Err(Error),
+}
+
+impl From<anyhow::Result<()>> for ProfileResult {
+    fn from(value: anyhow::Result<()>) -> Self {
+        match value {
+            Ok(_) => Self::Ok(true),
+            Err(err) => Self::Err(err.into()),
+        }
+    }
 }
 
 /// Returned by [ddog_prof_Profile_new].
@@ -402,26 +412,13 @@ pub unsafe extern "C" fn ddog_prof_Profile_add(
     sample: Sample,
     timestamp: Option<NonZeroI64>,
 ) -> ProfileResult {
-    match ddog_prof_profile_add_impl(profile, sample, timestamp) {
-        Ok(_) => ProfileResult::Ok(true),
-        Err(err) => ProfileResult::Err(Error::from(err.context("ddog_prof_Profile_add failed"))),
-    }
-}
-
-unsafe fn ddog_prof_profile_add_impl(
-    profile_ptr: *mut Profile,
-    sample: Sample,
-    timestamp: Option<NonZeroI64>,
-) -> anyhow::Result<()> {
-    let profile = profile_ptr_to_inner(profile_ptr)?;
-
-    match sample.try_into().map(|s| profile.add_sample(s, timestamp)) {
-        Ok(r) => match r {
-            Ok(_) => Ok(()),
-            Err(err) => Err(err),
-        },
-        Err(err) => Err(anyhow::Error::from(err)),
-    }
+    (|| {
+        let profile = profile_ptr_to_inner(profile)?;
+        let sample = sample.try_into()?;
+        profile.add_sample(sample, timestamp)
+    })()
+    .context("ddog_prof_Profile_add failed")
+    .into()
 }
 
 unsafe fn profile_ptr_to_inner<'a>(
@@ -459,17 +456,13 @@ pub unsafe extern "C" fn ddog_prof_Profile_set_endpoint(
     local_root_span_id: u64,
     endpoint: CharSlice,
 ) -> ProfileResult {
-    let profile = match profile_ptr_to_inner(profile) {
-        Ok(p) => p,
-        Err(err) => {
-            return ProfileResult::Err(Error::from(
-                err.context("ddog_prof_Profile_set_endpoint failed"),
-            ))
-        }
-    };
-    let endpoint = endpoint.to_utf8_lossy();
-    profile.add_endpoint(local_root_span_id, endpoint);
-    ProfileResult::Ok(true)
+    (|| {
+        let profile = profile_ptr_to_inner(profile)?;
+        let endpoint = endpoint.to_utf8_lossy();
+        profile.add_endpoint(local_root_span_id, endpoint)
+    })()
+    .context("ddog_prof_Profile_set_endpoint failed")
+    .into()
 }
 
 /// Count the number of times an endpoint has been seen.
@@ -489,17 +482,13 @@ pub unsafe extern "C" fn ddog_prof_Profile_add_endpoint_count(
     endpoint: CharSlice,
     value: i64,
 ) -> ProfileResult {
-    let profile = match profile_ptr_to_inner(profile) {
-        Ok(p) => p,
-        Err(err) => {
-            return ProfileResult::Err(Error::from(
-                err.context("ddog_prof_Profile_add_endpoint_count failed"),
-            ))
-        }
-    };
-    let endpoint = endpoint.to_utf8_lossy();
-    profile.add_endpoint_count(endpoint, value);
-    ProfileResult::Ok(true)
+    (|| {
+        let profile = profile_ptr_to_inner(profile)?;
+        let endpoint = endpoint.to_utf8_lossy();
+        profile.add_endpoint_count(endpoint, value)
+    })()
+    .context("ddog_prof_Profile_set_endpoint failed")
+    .into()
 }
 
 /// Add a poisson-based upscaling rule which will be use to adjust values and make them
@@ -533,32 +522,24 @@ pub unsafe extern "C" fn ddog_prof_Profile_add_upscaling_rule_poisson(
     count_value_offset: usize,
     sampling_distance: u64,
 ) -> ProfileResult {
-    let profile = match profile_ptr_to_inner(profile) {
-        Ok(ok) => ok,
-        Err(err) => {
-            return ProfileResult::Err(Error::from(
-                err.context("ddog_prof_Profile_add_upscaling_rule_poisson failed"),
-            ))
-        }
-    };
-    if sampling_distance == 0 {
-        return ProfileResult::Err(ddcommon_ffi::Error::from(
-            "ddog_prof_Profile_add_upscaling_rule_poisson sampling_distance parameter must be greater than 0",
-        ));
-    }
-    let upscaling_info = api::UpscalingInfo::Poisson {
-        sum_value_offset,
-        count_value_offset,
-        sampling_distance,
-    };
-
-    add_upscaling_rule(
-        profile,
-        offset_values,
-        label_name,
-        label_value,
-        upscaling_info,
-    )
+    (|| {
+        let profile = profile_ptr_to_inner(profile)?;
+        anyhow::ensure!(sampling_distance != 0, "sampling_distance must not be 0");
+        let upscaling_info = api::UpscalingInfo::Poisson {
+            sum_value_offset,
+            count_value_offset,
+            sampling_distance,
+        };
+        add_upscaling_rule(
+            profile,
+            offset_values,
+            label_name,
+            label_value,
+            upscaling_info,
+        )
+    })()
+    .context("ddog_prof_Profile_add_upscaling_rule_proportional failed")
+    .into()
 }
 
 /// Add a proportional-based upscaling rule which will be use to adjust values and make them
@@ -589,30 +570,23 @@ pub unsafe extern "C" fn ddog_prof_Profile_add_upscaling_rule_proportional(
     total_sampled: u64,
     total_real: u64,
 ) -> ProfileResult {
-    let profile = match profile_ptr_to_inner(profile) {
-        Ok(ok) => ok,
-        Err(err) => {
-            return ProfileResult::Err(Error::from(
-                err.context("ddog_prof_Profile_add_upscaling_rule_poisson failed"),
-            ))
-        }
-    };
-    if total_sampled == 0 || total_real == 0 {
-        return ProfileResult::Err(ddcommon_ffi::Error::from(
-            "total_sampled and total_real parameters must not be equal to 0",
-        ));
-    }
-
-    let upscaling_info = api::UpscalingInfo::Proportional {
-        scale: total_real as f64 / total_sampled as f64,
-    };
-    add_upscaling_rule(
-        profile,
-        offset_values,
-        label_name,
-        label_value,
-        upscaling_info,
-    )
+    (|| {
+        let profile = profile_ptr_to_inner(profile)?;
+        anyhow::ensure!(total_sampled != 0, "total_sampled must not be 0");
+        anyhow::ensure!(total_real != 0, "total_real must not be 0");
+        let upscaling_info = api::UpscalingInfo::Proportional {
+            scale: total_real as f64 / total_sampled as f64,
+        };
+        add_upscaling_rule(
+            profile,
+            offset_values,
+            label_name,
+            label_value,
+            upscaling_info,
+        )
+    })()
+    .context("ddog_prof_Profile_add_upscaling_rule_proportional failed")
+    .into()
 }
 
 unsafe fn add_upscaling_rule(
@@ -621,18 +595,15 @@ unsafe fn add_upscaling_rule(
     label_name: CharSlice,
     label_value: CharSlice,
     upscaling_info: api::UpscalingInfo,
-) -> ProfileResult {
+) -> anyhow::Result<()> {
     let label_name_n = label_name.to_utf8_lossy();
     let label_value_n = label_value.to_utf8_lossy();
-    match profile.add_upscaling_rule(
+    profile.add_upscaling_rule(
         offset_values.as_slice(),
         label_name_n.as_ref(),
         label_value_n.as_ref(),
         upscaling_info,
-    ) {
-        Ok(_) => ProfileResult::Ok(true),
-        Err(err) => ProfileResult::Err(err.into()),
-    }
+    )
 }
 
 #[repr(C)]

--- a/profiling-replayer/src/main.rs
+++ b/profiling-replayer/src/main.rs
@@ -192,7 +192,7 @@ fn main() -> anyhow::Result<()> {
     }
 
     for (local_root_span_id, endpoint_value) in std::mem::take(&mut replayer.endpoints) {
-        outprof.add_endpoint(local_root_span_id, Cow::Borrowed(endpoint_value));
+        outprof.add_endpoint(local_root_span_id, Cow::Borrowed(endpoint_value))?;
     }
 
     println!("Replaying sample took {} ms", duration.as_millis());

--- a/profiling/src/internal/profile.rs
+++ b/profiling/src/internal/profile.rs
@@ -904,7 +904,7 @@ mod api_test {
     }
 
     #[test]
-    fn lazy_endpoints() {
+    fn lazy_endpoints() -> anyhow::Result<()> {
         let sample_types = vec![
             api::ValueType {
                 r#type: "samples",
@@ -955,7 +955,7 @@ mod api_test {
 
         profile.add_sample(sample2, None).expect("add to success");
 
-        profile.add_endpoint(10, Cow::from("my endpoint"));
+        profile.add_endpoint(10, Cow::from("my endpoint"))?;
 
         let serialized_profile = pprof::roundtrip_to_pprof(profile).unwrap();
         assert_eq!(serialized_profile.samples.len(), 2);
@@ -1016,6 +1016,7 @@ mod api_test {
         // The trace endpoint label shouldn't be added to second sample because the span id doesn't
         // match
         assert_eq!(s2.labels.len(), 2);
+        Ok(())
     }
 
     #[test]
@@ -1042,7 +1043,7 @@ mod api_test {
     }
 
     #[test]
-    fn endpoint_counts_test() {
+    fn endpoint_counts_test() -> anyhow::Result<()> {
         let sample_types = vec![
             api::ValueType {
                 r#type: "samples",
@@ -1057,11 +1058,11 @@ mod api_test {
         let mut profile: Profile = Profile::new(SystemTime::now(), &sample_types, None);
 
         let one_endpoint = "my endpoint";
-        profile.add_endpoint_count(Cow::from(one_endpoint), 1);
-        profile.add_endpoint_count(Cow::from(one_endpoint), 1);
+        profile.add_endpoint_count(Cow::from(one_endpoint), 1)?;
+        profile.add_endpoint_count(Cow::from(one_endpoint), 1)?;
 
         let second_endpoint = "other endpoint";
-        profile.add_endpoint_count(Cow::from(second_endpoint), 1);
+        profile.add_endpoint_count(Cow::from(second_endpoint), 1)?;
 
         let encoded_profile = profile
             .serialize_into_compressed_pprof(None, None)
@@ -1076,6 +1077,7 @@ mod api_test {
         let expected_endpoints_stats = ProfiledEndpointsStats::from(count);
 
         assert_eq!(endpoints_stats, expected_endpoints_stats);
+        Ok(())
     }
 
     #[test]
@@ -2048,7 +2050,7 @@ mod api_test {
     }
 
     #[test]
-    fn local_root_span_id_label_as_i64() {
+    fn local_root_span_id_label_as_i64() -> anyhow::Result<()> {
         let sample_types = vec![
             api::ValueType {
                 r#type: "samples",
@@ -2095,8 +2097,8 @@ mod api_test {
         profile.add_sample(sample1, None).expect("add to success");
         profile.add_sample(sample2, None).expect("add to success");
 
-        profile.add_endpoint(10, Cow::from("endpoint 10"));
-        profile.add_endpoint(large_span_id, Cow::from("large endpoint"));
+        profile.add_endpoint(10, Cow::from("endpoint 10"))?;
+        profile.add_endpoint(large_span_id, Cow::from("large endpoint"))?;
 
         let serialized_profile = pprof::roundtrip_to_pprof(profile).unwrap();
         assert_eq!(serialized_profile.samples.len(), 2);
@@ -2151,5 +2153,6 @@ mod api_test {
         {
             assert_eq!(sample.labels, labels);
         }
+        Ok(())
     }
 }

--- a/profiling/src/internal/profile.rs
+++ b/profiling/src/internal/profile.rs
@@ -39,18 +39,24 @@ pub struct EncodedProfile {
 impl Profile {
     /// Add the endpoint data to the endpoint mappings.
     /// The `endpoint` string will be interned.
-    pub fn add_endpoint(&mut self, local_root_span_id: u64, endpoint: Cow<str>) {
+    pub fn add_endpoint(
+        &mut self,
+        local_root_span_id: u64,
+        endpoint: Cow<str>,
+    ) -> anyhow::Result<()> {
         let interned_endpoint = self.intern(endpoint.as_ref());
 
         self.endpoints
             .mappings
             .insert(local_root_span_id, interned_endpoint);
+        Ok(())
     }
 
-    pub fn add_endpoint_count(&mut self, endpoint: Cow<str>, value: i64) {
+    pub fn add_endpoint_count(&mut self, endpoint: Cow<str>, value: i64) -> anyhow::Result<()> {
         self.endpoints
             .stats
             .add_endpoint_count(endpoint.into_owned(), value);
+        Ok(())
     }
 
     pub fn add_sample(


### PR DESCRIPTION
# What does this PR do?

Adds a `.into` method to the FFI error types to auto convert from Rust Error types, and then uses that to make cleaner error handling possible in the FFI functions.

# Motivation

The old way had cruft and was hard to read.  This is nicer.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
