### PR TITLE
Remove unused tools cache to make more space for cross

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,6 +149,7 @@ jobs:
             cmake -S .. -DDatadog_ROOT=$OUTPUT_FOLDER/profiling
             cmake --build .
           fi
+
   cross-centos7:
     name: build and test using cross - on centos7
     runs-on: ubuntu-latest
@@ -156,6 +157,8 @@ jobs:
       group: ci-${{ github.ref }}-cross-centos7
       cancel-in-progress: true
     steps:
+      - name: Remove unused tools cache
+        run: rm -rf /opt/hostedtoolcache
       - name: Checkout
         uses: actions/checkout@v3
       - name: Cache


### PR DESCRIPTION
# What does this PR do?

Removes an unused tools cache directory on the GitHub runner to make more space for cross compilation. Roughly 10GB is reclaimed.

# Motivation

Cross compilation is living close to the limit of the available disk space on the GitHub runner and keeps failing intermittently.

# Additional Notes

Thanks to @morrisonlevi that pointed me to this [discussion](https://github.com/orgs/community/discussions/25678#discussioncomment-5242449)

# How to test the change?

CI all the things...

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
