### PR TITLE
nit:  use correct type in crashtracker example

### DIFF
--- a/crashtracker/libdatadog-crashtracking-receiver.c
+++ b/crashtracker/libdatadog-crashtracking-receiver.c
@@ -8,7 +8,7 @@
 
 int main(void) {
   ddog_prof_CrashtrackerResult new_result = ddog_prof_Crashtracker_receiver_entry_point();
-  if (new_result.tag != DDOG_PROF_PROFILE_NEW_RESULT_OK) {
+  if (new_result.tag != DDOG_PROF_CRASHTRACKER_RESULT_OK) {
     ddog_CharSlice message = ddog_Error_message(&new_result.err);
     fprintf(stderr, "%*s", (int)message.len, message.ptr);
     ddog_Error_drop(&new_result.err);


### PR DESCRIPTION
# What does this PR do?

This just modifies a line in the crashtracker_receiver example application so that it uses the currect enum.

# Motivation

"Dive" by Tycho.  Oh wait, I thought it said "inspiration."  Well whatever.

# Additional Notes

This is mostly just for documentation/example.

# How to test the change?

This doesn't change the behavior of crashtracker in any way.

## For Reviewers
- [X] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
