### PR TITLE
[crashtracking] Add set_timestamp API

### DIFF
--- a/crashtracker/src/crash_info.rs
+++ b/crashtracker/src/crash_info.rs
@@ -186,10 +186,14 @@ impl CrashInfo {
         Ok(())
     }
 
-    pub fn set_timestamp_to_now(&mut self) -> anyhow::Result<()> {
+    pub fn set_timestamp(&mut self, ts: DateTime<Utc>) -> anyhow::Result<()> {
         anyhow::ensure!(self.timestamp.is_none());
-        self.timestamp = Some(Utc::now());
+        self.timestamp = Some(ts);
         Ok(())
+    }
+
+    pub fn set_timestamp_to_now(&mut self) -> anyhow::Result<()> {
+        self.set_timestamp(Utc::now())
     }
 }
 

--- a/examples/ffi/crashinfo.cpp
+++ b/examples/ffi/crashinfo.cpp
@@ -112,6 +112,10 @@ int main(void) {
 
   add_stacktrace(crashinfo);
 
+  // Datadog IPO at 2019-09-19T13:30:00Z = 1568899800 unix
+  check_result(ddog_crashinfo_set_timestamp(crashinfo.get(), 1568899800, 0),
+               "Failed to set timestamp");
+
   auto endpoint = ddog_Endpoint_file(to_slice_c_char("file://tmp/test.txt"));
   check_result(ddog_crashinfo_upload_to_endpoint(crashinfo.get(), endpoint, 1),
                "Failed to export to file");


### PR DESCRIPTION
# What does this PR do?

Adds an API to set the timestamp for a crashinfo object

# Motivation

We didn't have one, and .Net needed it.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
