### PR TITLE
Minor adjustments to the data-pipeline/TraceExporter

### DIFF
--- a/data-pipeline-ffi/src/trace_exporter.rs
+++ b/data-pipeline-ffi/src/trace_exporter.rs
@@ -18,7 +18,7 @@ pub unsafe extern "C" fn ddog_trace_exporter_new(
     language_version: CharSlice,
     language_interpreter: CharSlice,
 ) -> *mut TraceExporter {
-    let mut builder = TraceExporterBuilder::default();
+    let builder = TraceExporterBuilder::default();
 
     let exporter = builder
         .set_host(host.to_utf8_lossy().as_ref())

--- a/data-pipeline/src/trace_exporter.rs
+++ b/data-pipeline/src/trace_exporter.rs
@@ -239,6 +239,7 @@ impl TraceExporterBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
     #[test]
     fn new() {
@@ -284,6 +285,42 @@ mod tests {
         assert_eq!(exporter.tags.language, "nodejs");
         assert_eq!(exporter.tags.language_version, "1.0");
         assert_eq!(exporter.tags.language_interpreter, "v8");
+    }
+    #[test]
+    fn test_from_tracer_tags_to_tracer_header_tags() {
+        let tracer_tags = TracerTags {
+            tracer_version: "v0.1".to_string(),
+            language: "rust".to_string(),
+            language_version: "1.52.1".to_string(),
+            language_interpreter: "rustc".to_string(),
+        };
+
+        let tracer_header_tags: TracerHeaderTags = (&tracer_tags).into();
+
+        assert_eq!(tracer_header_tags.tracer_version, "v0.1");
+        assert_eq!(tracer_header_tags.lang, "rust");
+        assert_eq!(tracer_header_tags.lang_version, "1.52.1");
+        assert_eq!(tracer_header_tags.lang_interpreter, "rustc");
+    }
+
+    #[test]
+    fn test_from_tracer_tags_to_hashmap() {
+        let tracer_tags = TracerTags {
+            tracer_version: "v0.1".to_string(),
+            language: "rust".to_string(),
+            language_version: "1.52.1".to_string(),
+            language_interpreter: "rustc".to_string(),
+        };
+
+        let hashmap: HashMap<&'static str, String> = (&tracer_tags).into();
+
+        assert_eq!(hashmap.get("datadog-meta-tracer-version").unwrap(), "v0.1");
+        assert_eq!(hashmap.get("datadog-meta-lang").unwrap(), "rust");
+        assert_eq!(hashmap.get("datadog-meta-lang-version").unwrap(), "1.52.1");
+        assert_eq!(
+            hashmap.get("datadog-meta-lang-interpreter").unwrap(),
+            "rustc"
+        );
     }
 
     #[test]

--- a/data-pipeline/src/trace_exporter.rs
+++ b/data-pipeline/src/trace_exporter.rs
@@ -178,45 +178,42 @@ impl Default for TraceExporterBuilder {
 }
 
 impl TraceExporterBuilder {
-    pub fn set_host(&mut self, host: &str) -> &mut TraceExporterBuilder {
+    pub fn set_host(mut self, host: &str) -> TraceExporterBuilder {
         self.host = Some(String::from(host));
         self
     }
 
-    pub fn set_port(&mut self, port: u16) -> &mut TraceExporterBuilder {
+    pub fn set_port(mut self, port: u16) -> TraceExporterBuilder {
         self.port = Some(port);
         self
     }
 
-    pub fn set_tracer_version(&mut self, tracer_version: &str) -> &mut TraceExporterBuilder {
+    pub fn set_tracer_version(mut self, tracer_version: &str) -> TraceExporterBuilder {
         self.tracer_version = tracer_version.to_owned();
         self
     }
 
-    pub fn set_language(&mut self, lang: &str) -> &mut TraceExporterBuilder {
+    pub fn set_language(mut self, lang: &str) -> TraceExporterBuilder {
         self.language = lang.to_owned();
         self
     }
 
-    pub fn set_language_version(&mut self, lang_version: &str) -> &mut TraceExporterBuilder {
+    pub fn set_language_version(mut self, lang_version: &str) -> TraceExporterBuilder {
         self.language_version = lang_version.to_owned();
         self
     }
 
-    pub fn set_language_interpreter(
-        &mut self,
-        lang_interpreter: &str,
-    ) -> &mut TraceExporterBuilder {
+    pub fn set_language_interpreter(mut self, lang_interpreter: &str) -> TraceExporterBuilder {
         self.language_interpreter = lang_interpreter.to_owned();
         self
     }
 
-    pub fn set_proxy(&mut self, proxy: bool) -> &mut TraceExporterBuilder {
+    pub fn set_proxy(mut self, proxy: bool) -> TraceExporterBuilder {
         self.use_proxy = proxy;
         self
     }
 
-    pub fn build(&mut self) -> anyhow::Result<TraceExporter> {
+    pub fn build(mut self) -> anyhow::Result<TraceExporter> {
         let version = if self.use_proxy { "v0.4" } else { "v0.7" };
         let endpoint = Endpoint {
             url: hyper::Uri::from_str(
@@ -256,7 +253,7 @@ mod tests {
 
     #[test]
     fn new() {
-        let mut builder = TraceExporterBuilder::default();
+        let builder = TraceExporterBuilder::default();
         let exporter = builder
             .set_host("192.168.1.1")
             .set_port(8127)
@@ -281,7 +278,7 @@ mod tests {
 
     #[test]
     fn new_defaults() {
-        let mut builder = TraceExporterBuilder::default();
+        let builder = TraceExporterBuilder::default();
         let exporter = builder
             .set_tracer_version("v0.1")
             .set_language("nodejs")


### PR DESCRIPTION
# What does this PR do?

Just some minor changes to the TraceExporter.

- Added some tests around the `From` trait implementations for `TracerTags`. These were already tested indirectly. 
- Tweaked the unit tests to test the end result of calling the builder rather than the values of the builder struct fields.
- Changed `no_proxy` to `use_proxy` to be (possibly) clearer and added necessary default trait impl for the builder.
- Made the TracerTag fields on `TraceExporterBuilder` non-optional since they weren't actually optional. 

# Motivation

I incorrectly started to work on TraceExporter for APMSP-1020 before I was informed we should be implementing that ticket in the sidecar's trace export logic for now. (We'll address implementing in TraceExporter later). 

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Unit tests are in place

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
