### PR TITLE
Fix leaking metrics in the sidecar

### DIFF
--- a/ddtelemetry/src/config.rs
+++ b/ddtelemetry/src/config.rs
@@ -24,6 +24,8 @@ pub struct Config {
     pub telemetry_debug_logging_enabled: bool,
     pub telemetry_hearbeat_interval: Duration,
     pub direct_submission_enabled: bool,
+    /// Prevents LifecycleAction::Stop from terminating the worker (except if the WorkerHandle is
+    /// dropped)
     pub restartable: bool,
 }
 

--- a/ddtelemetry/src/config.rs
+++ b/ddtelemetry/src/config.rs
@@ -24,6 +24,7 @@ pub struct Config {
     pub telemetry_debug_logging_enabled: bool,
     pub telemetry_hearbeat_interval: Duration,
     pub direct_submission_enabled: bool,
+    pub restartable: bool,
 }
 
 fn endpoint_with_telemetry_path(
@@ -127,6 +128,7 @@ impl Default for Config {
             telemetry_debug_logging_enabled: false,
             telemetry_hearbeat_interval: Duration::from_secs(60),
             direct_submission_enabled: false,
+            restartable: false,
         }
     }
 }
@@ -178,6 +180,7 @@ impl Config {
             telemetry_debug_logging_enabled: settings.shared_lib_debug,
             telemetry_hearbeat_interval: settings.telemetry_heartbeat_interval,
             direct_submission_enabled: settings.direct_submission_enabled,
+            restartable: false,
         };
         if let Ok(url) = parse_uri(&url) {
             let _res = this.set_endpoint(Endpoint { url, api_key });

--- a/ddtelemetry/src/worker/builder.rs
+++ b/ddtelemetry/src/worker/builder.rs
@@ -24,6 +24,7 @@ impl ConfigBuilder {
                 .telemetry_hearbeat_interval
                 .unwrap_or(other.telemetry_hearbeat_interval),
             direct_submission_enabled: other.direct_submission_enabled,
+            restartable: other.restartable,
         }
     }
 }

--- a/ddtelemetry/src/worker/mod.rs
+++ b/ddtelemetry/src/worker/mod.rs
@@ -155,6 +155,7 @@ impl TelemetryWorker {
 
         // if no action is received, then it means the channel is stopped
         action.unwrap_or_else(|| {
+            // the worker handle no longer lives - we must remove restartable here to avoid leaks
             self.config.restartable = false;
             TelemetryActions::Lifecycle(LifecycleAction::Stop)
         })

--- a/ddtelemetry/src/worker/mod.rs
+++ b/ddtelemetry/src/worker/mod.rs
@@ -170,7 +170,11 @@ impl TelemetryWorker {
 
             match self.dispatch_metrics_logs_action(action).await {
                 ControlFlow::Continue(()) => {}
-                ControlFlow::Break(()) => if !self.config.restartable { break; },
+                ControlFlow::Break(()) => {
+                    if !self.config.restartable {
+                        break;
+                    }
+                }
             };
         }
     }
@@ -257,7 +261,11 @@ impl TelemetryWorker {
 
             match self.dispatch_action(action).await {
                 ControlFlow::Continue(()) => {}
-                ControlFlow::Break(()) => if !self.config.restartable { break; },
+                ControlFlow::Break(()) => {
+                    if !self.config.restartable {
+                        break;
+                    }
+                }
             };
         }
     }

--- a/ddtelemetry/src/worker/scheduler.rs
+++ b/ddtelemetry/src/worker/scheduler.rs
@@ -57,6 +57,10 @@ impl<T: Clone + Eq> Scheduler<T> {
     pub fn schedule_event(&mut self, event: T) -> Result<(), T> {
         self.schedule_event_with_from(event, self.now.now())
     }
+
+    pub fn clear_pending(&mut self) {
+        self.deadlines.clear();
+    }
 }
 
 #[derive(Debug)]

--- a/sidecar/src/interface.rs
+++ b/sidecar/src/interface.rs
@@ -392,7 +392,11 @@ impl AppInstance {
         &self,
         (name, val, tags): (String, f64, Vec<Tag>),
     ) -> TelemetryActions {
-        TelemetryActions::AddPoint((val, *self.telemetry_metrics.lock().unwrap().get(&name).unwrap(), tags))
+        TelemetryActions::AddPoint((
+            val,
+            *self.telemetry_metrics.lock().unwrap().get(&name).unwrap(),
+            tags,
+        ))
     }
 }
 

--- a/sidecar/src/interface.rs
+++ b/sidecar/src/interface.rs
@@ -934,12 +934,13 @@ impl SidecarServer {
         builder.runtime_id = Some(instance_id.runtime_id.clone());
         builder.application.env = Some(env_name.to_owned());
         let session_info = self.get_session(&instance_id.session_id);
-        let config = session_info
+        let mut config = session_info
             .session_config
             .lock()
             .unwrap()
             .clone()
             .unwrap_or_else(ddtelemetry::config::Config::from_env);
+        config.restartable = true;
 
         // TODO: log errors
         let instance_option = match builder.spawn_with_config(config.clone()).await {

--- a/sidecar/src/interface.rs
+++ b/sidecar/src/interface.rs
@@ -368,13 +368,14 @@ impl RuntimeInfo {
 struct AppInstance {
     telemetry: TelemetryWorkerHandle,
     telemetry_worker_shutdown: Shared<BoxFuture<'static, Option<()>>>,
-    telemetry_metrics: HashMap<String, ContextKey>,
+    telemetry_metrics: Arc<Mutex<HashMap<String, ContextKey>>>,
 }
 
 impl AppInstance {
     pub fn register_metric(&mut self, metric: MetricContext) {
-        if !self.telemetry_metrics.contains_key(&metric.name) {
-            self.telemetry_metrics.insert(
+        let mut metrics = self.telemetry_metrics.lock().unwrap();
+        if !metrics.contains_key(&metric.name) {
+            metrics.insert(
                 metric.name.clone(),
                 self.telemetry.register_metric_context(
                     metric.name,
@@ -391,7 +392,7 @@ impl AppInstance {
         &self,
         (name, val, tags): (String, f64, Vec<Tag>),
     ) -> TelemetryActions {
-        TelemetryActions::AddPoint((val, *self.telemetry_metrics.get(&name).unwrap(), tags))
+        TelemetryActions::AddPoint((val, *self.telemetry_metrics.lock().unwrap().get(&name).unwrap(), tags))
     }
 }
 
@@ -950,7 +951,7 @@ impl SidecarServer {
                 let instance = AppInstance {
                     telemetry: handle,
                     telemetry_worker_shutdown: worker_join.map(Result::ok).boxed().shared(),
-                    telemetry_metrics: HashMap::new(),
+                    telemetry_metrics: Default::default(),
                 };
 
                 instance.telemetry.send_msgs(inital_actions).await.ok();


### PR DESCRIPTION
AppInstance is apparently cloned each time when extracted from the Shared<ManualFuture<AppInstance>>.

Not having the guard telemetry_metrics HashTable in an Arc<> will cause the "already inserted" checks to always fail. And thus leak memory.

Also allow the telemetry worker to have a mode where it's continuing execution after a start-stop cycle, otherwise it won't send any more metrics afterwards.