### PR TITLE
Make verify timeout test in datadog-trace-mini-agent trigger timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,8 @@ jobs:
         if: ${{ matrix.rust_version != '' }}
         run: rustup install ${{ matrix.rust_version }} && rustup default ${{ matrix.rust_version }}
       - id: rust-version
-        run: echo "version=$(rustc --version)" >> $GITHUB_OUTPUT
+        # On Windows run happens in a PowerShell, so start bash explicitly
+        run: bash -c 'echo "version=$(rustc --version)" >> $GITHUB_OUTPUT'
       - name: Free Disk Space (Ubuntu only)
         if: runner.os == 'Linux' && matrix.platform == 'ubuntu-latest'
         uses: jlumbroso/free-disk-space@v1.3.1
@@ -54,6 +55,7 @@ jobs:
         env:
           RUSTFLAGS: "-C prefer-dynamic"
           RUST_BACKTRACE: 1
+
   ffi:
     name: "FFI #${{ matrix.platform }} ${{ matrix.rust_version }}"
     runs-on: ${{ matrix.platform }}

--- a/serverless/src/main.rs
+++ b/serverless/src/main.rs
@@ -16,7 +16,7 @@ pub fn main() {
 
     info!("Starting serverless trace mini agent");
 
-    let env_verifier = Arc::new(env_verifier::ServerlessEnvVerifier {});
+    let env_verifier = Arc::new(env_verifier::ServerlessEnvVerifier::default());
 
     let trace_flusher = Arc::new(trace_flusher::ServerlessTraceFlusher {});
     let trace_processor = Arc::new(trace_processor::ServerlessTraceProcessor {});


### PR DESCRIPTION
# What does this PR do?

Fixes a test in the `datadog-trace-mini-agent` that failed spuriously.

# Motivation

Flaky tests are bad™

# Additional Notes

Only setting the timeout to 0 ms is not enough, and there was a race in the test between the dns lookup and the timeout that intermittently failed the test (most likely on Windows).

# How to test the change?

Describe here in detail how the change can be validated.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [x] This PR doesn't touch any of that.
