### PR TITLE
Move MaybeError from ddtelemetry-ffi to ddcommon-ffi

### DIFF
--- a/ddcommon-ffi/src/error.rs
+++ b/ddcommon-ffi/src/error.rs
@@ -3,13 +3,13 @@
 
 use crate::slice::CharSlice;
 use crate::vec::Vec;
-use std::fmt::{Display, Formatter};
+use std::fmt::{Debug, Display, Formatter};
 
 /// Please treat this as opaque; do not reach into it, and especially don't
 /// write into it! The most relevant APIs are:
 /// * `ddog_Error_message`, to get the message as a slice.
 /// * `ddog_Error_drop`.
-#[derive(Debug)]
+#[derive(PartialEq, Eq)]
 #[repr(C)]
 pub struct Error {
     /// This is a String stuffed into the vec.
@@ -26,6 +26,12 @@ impl AsRef<str> for Error {
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.as_ref())
+    }
+}
+
+impl Debug for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("Error(\"{}\")", self.as_ref()))
     }
 }
 
@@ -100,3 +106,8 @@ pub unsafe extern "C" fn ddog_Error_message(error: Option<&Error>) -> CharSlice 
         Some(err) => CharSlice::from(err.as_ref()),
     }
 }
+
+pub type MaybeError = crate::Option<Error>;
+
+#[no_mangle]
+pub extern "C" fn ddog_MaybeError_drop(_: MaybeError) {}

--- a/ddtelemetry-ffi/src/builder.rs
+++ b/ddtelemetry-ffi/src/builder.rs
@@ -9,7 +9,7 @@ use ddtelemetry::{
 use ffi::slice::AsBytes;
 use std::ptr::NonNull;
 
-use crate::MaybeError;
+use ffi::MaybeError;
 
 #[cfg(not(feature = "expanded_builder_macros"))]
 mod macros;

--- a/ddtelemetry-ffi/src/builder/expanded.rs
+++ b/ddtelemetry-ffi/src/builder/expanded.rs
@@ -13,24 +13,21 @@ mod macros {
     pub unsafe extern "C" fn ddog_telemetry_builder_with_str_application_service_version(
         telemetry_builder: &mut TelemetryWorkerBuilder,
         param: ffi::CharSlice,
-    ) -> crate::MaybeError {
+    ) -> ffi::MaybeError {
         telemetry_builder.application.service_version = Some(
             match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
                 param,
             ) {
                 Ok(o) => o,
                 Err(e) => {
-                    return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                        {
-                            let res = std::fmt::format(format_args!("{0:?}", e));
-                            res
-                        }
-                        .into_bytes(),
-                    ));
+                    return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                        let res = std::fmt::format(format_args!("{0:?}", e));
+                        res
+                    }));
                 }
             },
         );
-        crate::MaybeError::None
+        ffi::MaybeError::None
     }
     #[no_mangle]
     #[allow(clippy::redundant_closure_call)]
@@ -38,7 +35,7 @@ mod macros {
     pub unsafe extern "C" fn ddog_telemetry_builder_with_str_application_env(
         telemetry_builder: &mut TelemetryWorkerBuilder,
         param: ffi::CharSlice,
-    ) -> crate::MaybeError {
+    ) -> ffi::MaybeError {
         telemetry_builder.application.env =
             Some(
                 match (|s: ffi::CharSlice| -> Result<_, String> {
@@ -47,17 +44,14 @@ mod macros {
                 {
                     Ok(o) => o,
                     Err(e) => {
-                        return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                            {
-                                let res = std::fmt::format(format_args!("{0:?}", e));
-                                res
-                            }
-                            .into_bytes(),
-                        ));
+                        return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                            let res = std::fmt::format(format_args!("{0:?}", e));
+                            res
+                        }));
                     }
                 },
             );
-        crate::MaybeError::None
+        ffi::MaybeError::None
     }
     #[no_mangle]
     #[allow(clippy::redundant_closure_call)]
@@ -65,24 +59,21 @@ mod macros {
     pub unsafe extern "C" fn ddog_telemetry_builder_with_str_application_runtime_name(
         telemetry_builder: &mut TelemetryWorkerBuilder,
         param: ffi::CharSlice,
-    ) -> crate::MaybeError {
+    ) -> ffi::MaybeError {
         telemetry_builder.application.runtime_name = Some(
             match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
                 param,
             ) {
                 Ok(o) => o,
                 Err(e) => {
-                    return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                        {
-                            let res = std::fmt::format(format_args!("{0:?}", e));
-                            res
-                        }
-                        .into_bytes(),
-                    ));
+                    return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                        let res = std::fmt::format(format_args!("{0:?}", e));
+                        res
+                    }));
                 }
             },
         );
-        crate::MaybeError::None
+        ffi::MaybeError::None
     }
     #[no_mangle]
     #[allow(clippy::redundant_closure_call)]
@@ -90,24 +81,21 @@ mod macros {
     pub unsafe extern "C" fn ddog_telemetry_builder_with_str_application_runtime_version(
         telemetry_builder: &mut TelemetryWorkerBuilder,
         param: ffi::CharSlice,
-    ) -> crate::MaybeError {
+    ) -> ffi::MaybeError {
         telemetry_builder.application.runtime_version = Some(
             match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
                 param,
             ) {
                 Ok(o) => o,
                 Err(e) => {
-                    return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                        {
-                            let res = std::fmt::format(format_args!("{0:?}", e));
-                            res
-                        }
-                        .into_bytes(),
-                    ));
+                    return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                        let res = std::fmt::format(format_args!("{0:?}", e));
+                        res
+                    }));
                 }
             },
         );
-        crate::MaybeError::None
+        ffi::MaybeError::None
     }
     #[no_mangle]
     #[allow(clippy::redundant_closure_call)]
@@ -115,24 +103,21 @@ mod macros {
     pub unsafe extern "C" fn ddog_telemetry_builder_with_str_application_runtime_patches(
         telemetry_builder: &mut TelemetryWorkerBuilder,
         param: ffi::CharSlice,
-    ) -> crate::MaybeError {
+    ) -> ffi::MaybeError {
         telemetry_builder.application.runtime_patches = Some(
             match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
                 param,
             ) {
                 Ok(o) => o,
                 Err(e) => {
-                    return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                        {
-                            let res = std::fmt::format(format_args!("{0:?}", e));
-                            res
-                        }
-                        .into_bytes(),
-                    ));
+                    return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                        let res = std::fmt::format(format_args!("{0:?}", e));
+                        res
+                    }));
                 }
             },
         );
-        crate::MaybeError::None
+        ffi::MaybeError::None
     }
     #[no_mangle]
     #[allow(clippy::redundant_closure_call)]
@@ -140,24 +125,21 @@ mod macros {
     pub unsafe extern "C" fn ddog_telemetry_builder_with_str_host_container_id(
         telemetry_builder: &mut TelemetryWorkerBuilder,
         param: ffi::CharSlice,
-    ) -> crate::MaybeError {
+    ) -> ffi::MaybeError {
         telemetry_builder.host.container_id = Some(
             match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
                 param,
             ) {
                 Ok(o) => o,
                 Err(e) => {
-                    return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                        {
-                            let res = std::fmt::format(format_args!("{0:?}", e));
-                            res
-                        }
-                        .into_bytes(),
-                    ));
+                    return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                        let res = std::fmt::format(format_args!("{0:?}", e));
+                        res
+                    }));
                 }
             },
         );
-        crate::MaybeError::None
+        ffi::MaybeError::None
     }
     #[no_mangle]
     #[allow(clippy::redundant_closure_call)]
@@ -165,24 +147,21 @@ mod macros {
     pub unsafe extern "C" fn ddog_telemetry_builder_with_str_host_os(
         telemetry_builder: &mut TelemetryWorkerBuilder,
         param: ffi::CharSlice,
-    ) -> crate::MaybeError {
+    ) -> ffi::MaybeError {
         telemetry_builder.host.os = Some(
             match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
                 param,
             ) {
                 Ok(o) => o,
                 Err(e) => {
-                    return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                        {
-                            let res = std::fmt::format(format_args!("{0:?}", e));
-                            res
-                        }
-                        .into_bytes(),
-                    ));
+                    return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                        let res = std::fmt::format(format_args!("{0:?}", e));
+                        res
+                    }));
                 }
             },
         );
-        crate::MaybeError::None
+        ffi::MaybeError::None
     }
     #[no_mangle]
     #[allow(clippy::redundant_closure_call)]
@@ -190,24 +169,21 @@ mod macros {
     pub unsafe extern "C" fn ddog_telemetry_builder_with_str_host_kernel_name(
         telemetry_builder: &mut TelemetryWorkerBuilder,
         param: ffi::CharSlice,
-    ) -> crate::MaybeError {
+    ) -> ffi::MaybeError {
         telemetry_builder.host.kernel_name = Some(
             match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
                 param,
             ) {
                 Ok(o) => o,
                 Err(e) => {
-                    return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                        {
-                            let res = std::fmt::format(format_args!("{0:?}", e));
-                            res
-                        }
-                        .into_bytes(),
-                    ));
+                    return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                        let res = std::fmt::format(format_args!("{0:?}", e));
+                        res
+                    }));
                 }
             },
         );
-        crate::MaybeError::None
+        ffi::MaybeError::None
     }
     #[no_mangle]
     #[allow(clippy::redundant_closure_call)]
@@ -215,24 +191,21 @@ mod macros {
     pub unsafe extern "C" fn ddog_telemetry_builder_with_str_host_kernel_release(
         telemetry_builder: &mut TelemetryWorkerBuilder,
         param: ffi::CharSlice,
-    ) -> crate::MaybeError {
+    ) -> ffi::MaybeError {
         telemetry_builder.host.kernel_release = Some(
             match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
                 param,
             ) {
                 Ok(o) => o,
                 Err(e) => {
-                    return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                        {
-                            let res = std::fmt::format(format_args!("{0:?}", e));
-                            res
-                        }
-                        .into_bytes(),
-                    ));
+                    return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                        let res = std::fmt::format(format_args!("{0:?}", e));
+                        res
+                    }));
                 }
             },
         );
-        crate::MaybeError::None
+        ffi::MaybeError::None
     }
     #[no_mangle]
     #[allow(clippy::redundant_closure_call)]
@@ -240,24 +213,21 @@ mod macros {
     pub unsafe extern "C" fn ddog_telemetry_builder_with_str_host_kernel_version(
         telemetry_builder: &mut TelemetryWorkerBuilder,
         param: ffi::CharSlice,
-    ) -> crate::MaybeError {
+    ) -> ffi::MaybeError {
         telemetry_builder.host.kernel_version = Some(
             match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
                 param,
             ) {
                 Ok(o) => o,
                 Err(e) => {
-                    return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                        {
-                            let res = std::fmt::format(format_args!("{0:?}", e));
-                            res
-                        }
-                        .into_bytes(),
-                    ));
+                    return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                        let res = std::fmt::format(format_args!("{0:?}", e));
+                        res
+                    }));
                 }
             },
         );
-        crate::MaybeError::None
+        ffi::MaybeError::None
     }
     #[no_mangle]
     #[allow(clippy::redundant_closure_call)]
@@ -265,24 +235,21 @@ mod macros {
     pub unsafe extern "C" fn ddog_telemetry_builder_with_str_runtime_id(
         telemetry_builder: &mut TelemetryWorkerBuilder,
         param: ffi::CharSlice,
-    ) -> crate::MaybeError {
+    ) -> ffi::MaybeError {
         telemetry_builder.runtime_id = Some(
             match (|s: ffi::CharSlice| -> Result<_, String> { Ok(s.to_utf8_lossy().into_owned()) })(
                 param,
             ) {
                 Ok(o) => o,
                 Err(e) => {
-                    return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                        {
-                            let res = std::fmt::format(format_args!("{0:?}", e));
-                            res
-                        }
-                        .into_bytes(),
-                    ));
+                    return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                        let res = std::fmt::format(format_args!("{0:?}", e));
+                        res
+                    }));
                 }
             },
         );
-        crate::MaybeError::None
+        ffi::MaybeError::None
     }
     #[repr(C)]
     #[allow(dead_code)]
@@ -334,7 +301,7 @@ mod macros {
         telemetry_builder: &mut TelemetryWorkerBuilder,
         property: TelemetryWorkerBuilderStrProperty,
         param: ffi::CharSlice,
-    ) -> crate::MaybeError {
+    ) -> ffi::MaybeError {
         use TelemetryWorkerBuilderStrProperty::*;
         match property {
             ApplicationServiceVersion => {
@@ -345,13 +312,10 @@ mod macros {
                     {
                         Ok(o) => o,
                         Err(e) => {
-                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                                {
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
-                                    res
-                                }
-                                .into_bytes(),
-                            ));
+                            return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                res
+                            }));
                         }
                     },
                 );
@@ -364,13 +328,10 @@ mod macros {
                     {
                         Ok(o) => o,
                         Err(e) => {
-                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                                {
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
-                                    res
-                                }
-                                .into_bytes(),
-                            ));
+                            return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                res
+                            }));
                         }
                     },
                 );
@@ -383,13 +344,10 @@ mod macros {
                     {
                         Ok(o) => o,
                         Err(e) => {
-                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                                {
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
-                                    res
-                                }
-                                .into_bytes(),
-                            ));
+                            return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                res
+                            }));
                         }
                     },
                 );
@@ -402,13 +360,10 @@ mod macros {
                     {
                         Ok(o) => o,
                         Err(e) => {
-                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                                {
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
-                                    res
-                                }
-                                .into_bytes(),
-                            ));
+                            return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                res
+                            }));
                         }
                     },
                 );
@@ -421,13 +376,10 @@ mod macros {
                     {
                         Ok(o) => o,
                         Err(e) => {
-                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                                {
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
-                                    res
-                                }
-                                .into_bytes(),
-                            ));
+                            return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                res
+                            }));
                         }
                     },
                 );
@@ -440,13 +392,10 @@ mod macros {
                     {
                         Ok(o) => o,
                         Err(e) => {
-                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                                {
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
-                                    res
-                                }
-                                .into_bytes(),
-                            ));
+                            return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                res
+                            }));
                         }
                     },
                 );
@@ -460,13 +409,10 @@ mod macros {
                         {
                             Ok(o) => o,
                             Err(e) => {
-                                return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                                    {
-                                        let res = std::fmt::format(format_args!("{0:?}", e));
-                                        res
-                                    }
-                                    .into_bytes(),
-                                ));
+                                return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    res
+                                }));
                             }
                         },
                     );
@@ -479,13 +425,10 @@ mod macros {
                     {
                         Ok(o) => o,
                         Err(e) => {
-                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                                {
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
-                                    res
-                                }
-                                .into_bytes(),
-                            ));
+                            return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                res
+                            }));
                         }
                     },
                 );
@@ -498,13 +441,10 @@ mod macros {
                     {
                         Ok(o) => o,
                         Err(e) => {
-                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                                {
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
-                                    res
-                                }
-                                .into_bytes(),
-                            ));
+                            return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                res
+                            }));
                         }
                     },
                 );
@@ -517,13 +457,10 @@ mod macros {
                     {
                         Ok(o) => o,
                         Err(e) => {
-                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                                {
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
-                                    res
-                                }
-                                .into_bytes(),
-                            ));
+                            return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                res
+                            }));
                         }
                     },
                 );
@@ -536,19 +473,16 @@ mod macros {
                     {
                         Ok(o) => o,
                         Err(e) => {
-                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                                {
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
-                                    res
-                                }
-                                .into_bytes(),
-                            ));
+                            return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                res
+                            }));
                         }
                     },
                 );
             }
         }
-        crate::MaybeError::None
+        ffi::MaybeError::None
     }
     #[no_mangle]
     #[allow(clippy::redundant_closure_call)]
@@ -585,17 +519,14 @@ mod macros {
         telemetry_builder: &mut TelemetryWorkerBuilder,
         property: ffi::CharSlice,
         param: ffi::CharSlice,
-    ) -> crate::MaybeError {
+    ) -> ffi::MaybeError {
         let property = match property.try_to_utf8() {
             Ok(o) => o,
             Err(e) => {
-                return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                    {
-                        let res = std::fmt::format(format_args!("{0:?}", e));
-                        res
-                    }
-                    .into_bytes(),
-                ));
+                return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                    let res = std::fmt::format(format_args!("{0:?}", e));
+                    res
+                }));
             }
         };
         match property {
@@ -607,13 +538,10 @@ mod macros {
                     {
                         Ok(o) => o,
                         Err(e) => {
-                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                                {
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
-                                    res
-                                }
-                                .into_bytes(),
-                            ));
+                            return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                res
+                            }));
                         }
                     },
                 );
@@ -626,13 +554,10 @@ mod macros {
                     {
                         Ok(o) => o,
                         Err(e) => {
-                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                                {
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
-                                    res
-                                }
-                                .into_bytes(),
-                            ));
+                            return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                res
+                            }));
                         }
                     },
                 );
@@ -645,13 +570,10 @@ mod macros {
                     {
                         Ok(o) => o,
                         Err(e) => {
-                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                                {
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
-                                    res
-                                }
-                                .into_bytes(),
-                            ));
+                            return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                res
+                            }));
                         }
                     },
                 );
@@ -664,13 +586,10 @@ mod macros {
                     {
                         Ok(o) => o,
                         Err(e) => {
-                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                                {
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
-                                    res
-                                }
-                                .into_bytes(),
-                            ));
+                            return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                res
+                            }));
                         }
                     },
                 );
@@ -683,13 +602,10 @@ mod macros {
                     {
                         Ok(o) => o,
                         Err(e) => {
-                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                                {
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
-                                    res
-                                }
-                                .into_bytes(),
-                            ));
+                            return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                res
+                            }));
                         }
                     },
                 );
@@ -702,13 +618,10 @@ mod macros {
                     {
                         Ok(o) => o,
                         Err(e) => {
-                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                                {
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
-                                    res
-                                }
-                                .into_bytes(),
-                            ));
+                            return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                res
+                            }));
                         }
                     },
                 );
@@ -722,13 +635,10 @@ mod macros {
                         {
                             Ok(o) => o,
                             Err(e) => {
-                                return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                                    {
-                                        let res = std::fmt::format(format_args!("{0:?}", e));
-                                        res
-                                    }
-                                    .into_bytes(),
-                                ));
+                                return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    res
+                                }));
                             }
                         },
                     );
@@ -741,13 +651,10 @@ mod macros {
                     {
                         Ok(o) => o,
                         Err(e) => {
-                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                                {
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
-                                    res
-                                }
-                                .into_bytes(),
-                            ));
+                            return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                res
+                            }));
                         }
                     },
                 );
@@ -760,13 +667,10 @@ mod macros {
                     {
                         Ok(o) => o,
                         Err(e) => {
-                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                                {
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
-                                    res
-                                }
-                                .into_bytes(),
-                            ));
+                            return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                res
+                            }));
                         }
                     },
                 );
@@ -779,13 +683,10 @@ mod macros {
                     {
                         Ok(o) => o,
                         Err(e) => {
-                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                                {
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
-                                    res
-                                }
-                                .into_bytes(),
-                            ));
+                            return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                res
+                            }));
                         }
                     },
                 );
@@ -798,20 +699,17 @@ mod macros {
                     {
                         Ok(o) => o,
                         Err(e) => {
-                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                                {
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
-                                    res
-                                }
-                                .into_bytes(),
-                            ));
+                            return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                res
+                            }));
                         }
                     },
                 );
             }
-            _ => return crate::MaybeError::None,
+            _ => return ffi::MaybeError::None,
         }
-        crate::MaybeError::None
+        ffi::MaybeError::None
     }
     #[no_mangle]
     #[allow(clippy::redundant_closure_call)]
@@ -819,21 +717,18 @@ mod macros {
     pub unsafe extern "C" fn ddog_telemetry_builder_with_bool_config_telemetry_debug_logging_enabled(
         telemetry_builder: &mut TelemetryWorkerBuilder,
         param: bool,
-    ) -> crate::MaybeError {
+    ) -> ffi::MaybeError {
         telemetry_builder.config.telemetry_debug_logging_enabled =
             Some(match (|b: bool| -> Result<_, String> { Ok(b) })(param) {
                 Ok(o) => o,
                 Err(e) => {
-                    return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                        {
-                            let res = std::fmt::format(format_args!("{0:?}", e));
-                            res
-                        }
-                        .into_bytes(),
-                    ));
+                    return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                        let res = std::fmt::format(format_args!("{0:?}", e));
+                        res
+                    }));
                 }
             });
-        crate::MaybeError::None
+        ffi::MaybeError::None
     }
     #[repr(C)]
     #[allow(dead_code)]
@@ -855,7 +750,7 @@ mod macros {
         telemetry_builder: &mut TelemetryWorkerBuilder,
         property: TelemetryWorkerBuilderBoolProperty,
         param: bool,
-    ) -> crate::MaybeError {
+    ) -> ffi::MaybeError {
         use TelemetryWorkerBuilderBoolProperty::*;
         match property {
             ConfigTelemetryDebugLoggingEnabled => {
@@ -863,18 +758,15 @@ mod macros {
                     Some(match (|b: bool| -> Result<_, String> { Ok(b) })(param) {
                         Ok(o) => o,
                         Err(e) => {
-                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                                {
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
-                                    res
-                                }
-                                .into_bytes(),
-                            ));
+                            return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                res
+                            }));
                         }
                     });
             }
         }
-        crate::MaybeError::None
+        ffi::MaybeError::None
     }
     #[no_mangle]
     #[allow(clippy::redundant_closure_call)]
@@ -891,17 +783,14 @@ mod macros {
         telemetry_builder: &mut TelemetryWorkerBuilder,
         property: ffi::CharSlice,
         param: bool,
-    ) -> crate::MaybeError {
+    ) -> ffi::MaybeError {
         let property = match property.try_to_utf8() {
             Ok(o) => o,
             Err(e) => {
-                return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                    {
-                        let res = std::fmt::format(format_args!("{0:?}", e));
-                        res
-                    }
-                    .into_bytes(),
-                ));
+                return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                    let res = std::fmt::format(format_args!("{0:?}", e));
+                    res
+                }));
             }
         };
         match property {
@@ -910,19 +799,16 @@ mod macros {
                     Some(match (|b: bool| -> Result<_, String> { Ok(b) })(param) {
                         Ok(o) => o,
                         Err(e) => {
-                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                                {
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
-                                    res
-                                }
-                                .into_bytes(),
-                            ));
+                            return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                res
+                            }));
                         }
                     });
             }
-            _ => return crate::MaybeError::None,
+            _ => return ffi::MaybeError::None,
         }
-        crate::MaybeError::None
+        ffi::MaybeError::None
     }
     #[no_mangle]
     #[allow(clippy::redundant_closure_call)]
@@ -930,22 +816,19 @@ mod macros {
     pub unsafe extern "C" fn ddog_telemetry_builder_with_endpoint_config_endpoint(
         telemetry_builder: &mut TelemetryWorkerBuilder,
         param: &Endpoint,
-    ) -> crate::MaybeError {
+    ) -> ffi::MaybeError {
         telemetry_builder.config.endpoint = Some(
             match (|e: &Endpoint| -> Result<_, String> { Ok(e.clone()) })(param) {
                 Ok(o) => o,
                 Err(e) => {
-                    return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                        {
-                            let res = std::fmt::format(format_args!("{0:?}", e));
-                            res
-                        }
-                        .into_bytes(),
-                    ));
+                    return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                        let res = std::fmt::format(format_args!("{0:?}", e));
+                        res
+                    }));
                 }
             },
         );
-        crate::MaybeError::None
+        ffi::MaybeError::None
     }
     #[repr(C)]
     #[allow(dead_code)]
@@ -967,7 +850,7 @@ mod macros {
         telemetry_builder: &mut TelemetryWorkerBuilder,
         property: TelemetryWorkerBuilderEndpointProperty,
         param: &Endpoint,
-    ) -> crate::MaybeError {
+    ) -> ffi::MaybeError {
         use TelemetryWorkerBuilderEndpointProperty::*;
         match property {
             ConfigEndpoint => {
@@ -975,19 +858,16 @@ mod macros {
                     match (|e: &Endpoint| -> Result<_, String> { Ok(e.clone()) })(param) {
                         Ok(o) => o,
                         Err(e) => {
-                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                                {
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
-                                    res
-                                }
-                                .into_bytes(),
-                            ));
+                            return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                res
+                            }));
                         }
                     },
                 );
             }
         }
-        crate::MaybeError::None
+        ffi::MaybeError::None
     }
     #[no_mangle]
     #[allow(clippy::redundant_closure_call)]
@@ -1004,17 +884,14 @@ mod macros {
         telemetry_builder: &mut TelemetryWorkerBuilder,
         property: ffi::CharSlice,
         param: &Endpoint,
-    ) -> crate::MaybeError {
+    ) -> ffi::MaybeError {
         let property = match property.try_to_utf8() {
             Ok(o) => o,
             Err(e) => {
-                return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                    {
-                        let res = std::fmt::format(format_args!("{0:?}", e));
-                        res
-                    }
-                    .into_bytes(),
-                ));
+                return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                    let res = std::fmt::format(format_args!("{0:?}", e));
+                    res
+                }));
             }
         };
         match property {
@@ -1023,19 +900,16 @@ mod macros {
                     match (|e: &Endpoint| -> Result<_, String> { Ok(e.clone()) })(param) {
                         Ok(o) => o,
                         Err(e) => {
-                            return crate::MaybeError::Some(ddcommon_ffi::Vec::from(
-                                {
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
-                                    res
-                                }
-                                .into_bytes(),
-                            ));
+                            return ffi::MaybeError::Some(ddcommon_ffi::Error::from({
+                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                res
+                            }));
                         }
                     },
                 );
             }
-            _ => return crate::MaybeError::None,
+            _ => return ffi::MaybeError::None,
         }
-        crate::MaybeError::None
+        ffi::MaybeError::None
     }
 }

--- a/ddtelemetry-ffi/src/worker_handle.rs
+++ b/ddtelemetry-ffi/src/worker_handle.rs
@@ -9,8 +9,7 @@ use ddtelemetry::{
     worker::TelemetryWorkerHandle,
 };
 use ffi::slice::AsBytes;
-
-use crate::MaybeError;
+use ffi::MaybeError;
 
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]

--- a/examples/ffi/telemetry.c
+++ b/examples/ffi/telemetry.c
@@ -9,8 +9,9 @@
 #define TRY(expr)                                                                                  \
   {                                                                                                \
     ddog_MaybeError err = expr;                                                                    \
-    if (err.tag == DDOG_OPTION_VEC_U8_SOME_VEC_U8) {                                               \
-      fprintf(stderr, "ERROR: %.*s", (int)err.some.len, (char *)err.some.ptr);                     \
+    if (err.tag == DDOG_OPTION_ERROR_SOME_ERROR) {                                                 \
+      ddog_CharSlice message = ddog_Error_message(&err.some);                                      \
+      fprintf(stderr, "ERROR: %.*s", (int)message.len, (char *)message.ptr);                       \
       return 1;                                                                                    \
     }                                                                                              \
   }

--- a/examples/ffi/telemetry_metrics.c
+++ b/examples/ffi/telemetry_metrics.c
@@ -12,15 +12,16 @@
 #include <windows.h>
 #endif
 
-
 #define TRY(expr)                                                                                  \
   {                                                                                                \
     ddog_MaybeError err = expr;                                                                    \
-    if (err.tag == DDOG_OPTION_VEC_U8_SOME_VEC_U8) {                                               \
-      fprintf(stderr, "ERROR: %.*s", (int)err.some.len, (char *)err.some.ptr);                     \
+    if (err.tag == DDOG_OPTION_ERROR_SOME_ERROR) {                                                 \
+      ddog_CharSlice message = ddog_Error_message(&err.some);                                      \
+      fprintf(stderr, "ERROR: %.*s", (int)message.len, (char *)message.ptr);                       \
       return 1;                                                                                    \
     }                                                                                              \
   }
+
 #define STR(x) #x
 #define LOG_LOCATION_IDENTIFIER() DDOG_CHARSLICE_C(STR(__FILE__) ":" STR(__LINE__))
 

--- a/sidecar-ffi/src/lib.rs
+++ b/sidecar-ffi/src/lib.rs
@@ -32,7 +32,8 @@ use ddtelemetry::{
 };
 use ffi::slice::AsBytes;
 
-use ddtelemetry_ffi::{try_c, MaybeError};
+use ddcommon_ffi::MaybeError;
+use ddtelemetry_ffi::try_c;
 
 #[repr(C)]
 pub struct NativeFile {

--- a/sidecar-ffi/tests/sidecar.rs
+++ b/sidecar-ffi/tests/sidecar.rs
@@ -5,15 +5,7 @@ use datadog_sidecar_ffi::*;
 macro_rules! assert_maybe_no_error {
     ($maybe_erroring:expr) => {
         match $maybe_erroring {
-            ddcommon_ffi::Option::Some(err) => panic!(
-                "{}",
-                String::from_utf8_lossy(
-                    #[allow(unused_unsafe)]
-                    unsafe {
-                        err.as_slice().into_slice()
-                    }
-                )
-            ),
+            ddcommon_ffi::Option::Some(err) => panic!("{}", err.to_string()),
             ddcommon_ffi::Option::None => {}
         }
     };


### PR DESCRIPTION
# What does this PR do?

Moves the `MaybeError` type from the `ddtelemetry-ffi` crate to the `ddcommon-ffi` crate, and changes it to use the `ddcommon-ffi::Error` type.

# Motivation

It's a nice convenience type that we want to usein the `data-pipeline-ffi`, and I don't understand why it didn't use the `ddcommon-ffi::Error` type.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
