### PR TITLE
[crashtracker] Simplify the stack collection options

### DIFF
--- a/bin_tests/src/bin/crashtracker_bin_test.rs
+++ b/bin_tests/src/bin/crashtracker_bin_test.rs
@@ -39,8 +39,7 @@ mod unix {
                     url: ddcommon::parse_uri(&format!("file://{}", output_filename))?,
                     api_key: None,
                 }),
-                resolve_frames: crashtracker::CrashtrackerResolveFrames::Never,
-                collect_stacktrace: true,
+                resolve_frames: crashtracker::CrashtrackerStacktraceCollectionOptions::CollectStacktraceButDoNotResolveSymbols,
                 timeout,
             },
             Some(CrashtrackerReceiverConfig::new(

--- a/bin_tests/src/bin/crashtracker_bin_test.rs
+++ b/bin_tests/src/bin/crashtracker_bin_test.rs
@@ -39,7 +39,7 @@ mod unix {
                     url: ddcommon::parse_uri(&format!("file://{}", output_filename))?,
                     api_key: None,
                 }),
-                resolve_frames: crashtracker::CrashtrackerStacktraceCollectionOptions::CollectStacktraceButDoNotResolveSymbols,
+                resolve_frames: crashtracker::StacktraceCollection::WithoutSymbols,
                 timeout,
             },
             Some(CrashtrackerReceiverConfig::new(

--- a/crashtracker/src/api.rs
+++ b/crashtracker/src/api.rs
@@ -10,7 +10,8 @@ use crate::{
         update_receiver_after_fork,
     },
     crash_info::CrashtrackerMetadata,
-    update_config, update_metadata, CrashtrackerConfiguration, CrashtrackerResolveFrames,
+    update_config, update_metadata, CrashtrackerConfiguration,
+    CrashtrackerStacktraceCollectionOptions,
 };
 use ddcommon::tag::Tag;
 use ddcommon::Endpoint;
@@ -127,11 +128,11 @@ fn test_crash() {
         api_key: None,
     });
 
-    let collect_stacktrace = true;
     let path_to_receiver_binary =
         "/tmp/libdatadog/bin/libdatadog-crashtracking-receiver".to_string();
     let create_alt_stack = true;
-    let resolve_frames = CrashtrackerResolveFrames::InReceiver;
+    let resolve_frames =
+        CrashtrackerStacktraceCollectionOptions::CollectStacktraceAndResolveSymbolsInReceiver;
     let stderr_filename = Some(format!("{dir}/stderr_{time}.txt"));
     let stdout_filename = Some(format!("{dir}/stdout_{time}.txt"));
     let timeout = Duration::from_secs(30);
@@ -145,14 +146,9 @@ fn test_crash() {
         )
         .expect("Not to fail"),
     );
-    let config = CrashtrackerConfiguration::new(
-        collect_stacktrace,
-        create_alt_stack,
-        endpoint,
-        resolve_frames,
-        timeout,
-    )
-    .expect("not to fail");
+    let config =
+        CrashtrackerConfiguration::new(create_alt_stack, endpoint, resolve_frames, timeout)
+            .expect("not to fail");
     let metadata = CrashtrackerMetadata::new(
         "libname".to_string(),
         "version".to_string(),

--- a/crashtracker/src/api.rs
+++ b/crashtracker/src/api.rs
@@ -10,8 +10,7 @@ use crate::{
         update_receiver_after_fork,
     },
     crash_info::CrashtrackerMetadata,
-    update_config, update_metadata, CrashtrackerConfiguration,
-    CrashtrackerStacktraceCollectionOptions,
+    update_config, update_metadata, CrashtrackerConfiguration, StacktraceCollection,
 };
 use ddcommon::tag::Tag;
 use ddcommon::Endpoint;
@@ -131,8 +130,7 @@ fn test_crash() {
     let path_to_receiver_binary =
         "/tmp/libdatadog/bin/libdatadog-crashtracking-receiver".to_string();
     let create_alt_stack = true;
-    let resolve_frames =
-        CrashtrackerStacktraceCollectionOptions::CollectStacktraceAndResolveSymbolsInReceiver;
+    let resolve_frames = StacktraceCollection::Enabled;
     let stderr_filename = Some(format!("{dir}/stderr_{time}.txt"));
     let stdout_filename = Some(format!("{dir}/stdout_{time}.txt"));
     let timeout = Duration::from_secs(30);

--- a/crashtracker/src/collectors.rs
+++ b/crashtracker/src/collectors.rs
@@ -22,10 +22,7 @@ use std::{
 ///     https://github.com/rust-lang/backtrace-rs/issues/414
 ///     Calculating the `ip` of the frames seems safe, but resolving the frames
 ///     sometimes crashes.
-pub unsafe fn emit_backtrace_by_frames(
-    w: &mut impl Write,
-    resolve_frames: bool,
-) -> anyhow::Result<()> {
+pub unsafe fn emit_backtrace_by_frames(w: &mut impl Write) -> anyhow::Result<()> {
     // https://docs.rs/backtrace/latest/backtrace/index.html
     writeln!(w, "{DD_CRASHTRACK_BEGIN_STACKTRACE}")?;
     backtrace::trace_unsynchronized(|frame| {
@@ -38,54 +35,6 @@ pub unsafe fn emit_backtrace_by_frames(
         }
         write!(w, "\"sp\": \"{:?}\", ", frame.sp()).unwrap();
         write!(w, "\"symbol_address\": \"{:?}\"", frame.symbol_address()).unwrap();
-
-        if resolve_frames {
-            write!(w, ", \"names\": [").unwrap();
-
-            let mut first = true;
-            // This can give multiple answers in the case of inlined functions
-            // https://docs.rs/backtrace/latest/backtrace/fn.resolve.html
-            // Store them all into an array of names
-            unsafe {
-                backtrace::resolve_frame_unsynchronized(frame, |symbol| {
-                    if !first {
-                        write!(w, ", ").unwrap();
-                    }
-                    write!(w, "{{").unwrap();
-                    let mut comma_needed = false;
-                    if let Some(name) = symbol.name() {
-                        write!(w, "\"name\": \"{}\"", name).unwrap();
-                        comma_needed = true;
-                    }
-                    if let Some(filename) = symbol.filename() {
-                        if comma_needed {
-                            write!(w, ", ").unwrap();
-                        }
-                        write!(w, "\"filename\": {:?}", filename).unwrap();
-                        comma_needed = true;
-                    }
-                    if let Some(colno) = symbol.colno() {
-                        if comma_needed {
-                            write!(w, ", ").unwrap();
-                        }
-                        write!(w, "\"colno\": {}", colno).unwrap();
-                        comma_needed = true;
-                    }
-
-                    if let Some(lineno) = symbol.lineno() {
-                        if comma_needed {
-                            write!(w, ", ").unwrap();
-                        }
-                        write!(w, "\"lineno\": {}", lineno).unwrap();
-                    }
-
-                    write!(w, "}}").unwrap();
-
-                    first = false;
-                });
-            }
-            write!(w, "]").unwrap();
-        }
         writeln!(w, "}}").unwrap();
         true // keep going to the next frame
     });

--- a/crashtracker/src/configuration.rs
+++ b/crashtracker/src/configuration.rs
@@ -4,19 +4,25 @@ use ddcommon::Endpoint;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
+/// Stacktrace collection occurs in the context of a crashing process.
+/// If the stack is sufficiently corruputed, it is possible (but unlikely),
+/// for stack trace collection itself to crash.
+/// We recommend fully enabling stacktrace collection, but having an environment
+/// variable to allow downgrading the collector.
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum CrashtrackerStacktraceCollectionOptions {
-    DontCollectStacktrace,
-    CollectStacktraceButDoNotResolveSymbols,
-    CollectStacktraceAndResolveSymbolsInReceiver,
+pub enum StacktraceCollection {
+    /// Stacktrace collection occurs in the
+    Disabled,
+    WithoutSymbols,
+    Enabled,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CrashtrackerConfiguration {
     pub create_alt_stack: bool,
     pub endpoint: Option<Endpoint>,
-    pub resolve_frames: CrashtrackerStacktraceCollectionOptions,
+    pub resolve_frames: StacktraceCollection,
     pub timeout: Duration,
 }
 
@@ -63,7 +69,7 @@ impl CrashtrackerConfiguration {
     pub fn new(
         create_alt_stack: bool,
         endpoint: Option<Endpoint>,
-        resolve_frames: CrashtrackerStacktraceCollectionOptions,
+        resolve_frames: StacktraceCollection,
         timeout: Duration,
     ) -> anyhow::Result<Self> {
         Ok(Self {

--- a/crashtracker/src/configuration.rs
+++ b/crashtracker/src/configuration.rs
@@ -6,19 +6,17 @@ use std::time::Duration;
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum CrashtrackerResolveFrames {
-    Never,
-    /// Resolving frames in process is experimental, and can fail/crash
-    ExperimentalInProcess,
-    InReceiver,
+pub enum CrashtrackerStacktraceCollectionOptions {
+    DontCollectStacktrace,
+    CollectStacktraceButDoNotResolveSymbols,
+    CollectStacktraceAndResolveSymbolsInReceiver,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CrashtrackerConfiguration {
-    pub collect_stacktrace: bool,
     pub create_alt_stack: bool,
     pub endpoint: Option<Endpoint>,
-    pub resolve_frames: CrashtrackerResolveFrames,
+    pub resolve_frames: CrashtrackerStacktraceCollectionOptions,
     pub timeout: Duration,
 }
 
@@ -63,14 +61,12 @@ impl CrashtrackerReceiverConfig {
 impl CrashtrackerConfiguration {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        collect_stacktrace: bool,
         create_alt_stack: bool,
         endpoint: Option<Endpoint>,
-        resolve_frames: CrashtrackerResolveFrames,
+        resolve_frames: CrashtrackerStacktraceCollectionOptions,
         timeout: Duration,
     ) -> anyhow::Result<Self> {
         Ok(Self {
-            collect_stacktrace,
             create_alt_stack,
             endpoint,
             resolve_frames,

--- a/crashtracker/src/crash_handler.rs
+++ b/crashtracker/src/crash_handler.rs
@@ -8,7 +8,7 @@ use crate::configuration::CrashtrackerReceiverConfig;
 use super::collectors::emit_backtrace_by_frames;
 #[cfg(target_os = "linux")]
 use super::collectors::emit_proc_self_maps;
-use super::configuration::{CrashtrackerConfiguration, CrashtrackerResolveFrames};
+use super::configuration::{CrashtrackerConfiguration, CrashtrackerStacktraceCollectionOptions};
 use super::constants::*;
 use super::counters::emit_counters;
 use super::crash_info::CrashtrackerMetadata;
@@ -331,13 +331,8 @@ fn handle_posix_signal_impl(signum: i32) -> anyhow::Result<()> {
     // In fact, if we look into the code here, we see mallocs.
     // https://doc.rust-lang.org/src/std/backtrace.rs.html#332
     // Do this last, so even if it crashes, we still get the other info.
-    if config.collect_stacktrace {
-        unsafe {
-            emit_backtrace_by_frames(
-                pipe,
-                config.resolve_frames == CrashtrackerResolveFrames::ExperimentalInProcess,
-            )?
-        };
+    if config.resolve_frames != CrashtrackerStacktraceCollectionOptions::DontCollectStacktrace {
+        unsafe { emit_backtrace_by_frames(pipe)? };
     }
     writeln!(pipe, "{DD_CRASHTRACK_DONE}")?;
 

--- a/crashtracker/src/crash_handler.rs
+++ b/crashtracker/src/crash_handler.rs
@@ -8,7 +8,7 @@ use crate::configuration::CrashtrackerReceiverConfig;
 use super::collectors::emit_backtrace_by_frames;
 #[cfg(target_os = "linux")]
 use super::collectors::emit_proc_self_maps;
-use super::configuration::{CrashtrackerConfiguration, CrashtrackerStacktraceCollectionOptions};
+use super::configuration::{CrashtrackerConfiguration, StacktraceCollection};
 use super::constants::*;
 use super::counters::emit_counters;
 use super::crash_info::CrashtrackerMetadata;
@@ -331,7 +331,7 @@ fn handle_posix_signal_impl(signum: i32) -> anyhow::Result<()> {
     // In fact, if we look into the code here, we see mallocs.
     // https://doc.rust-lang.org/src/std/backtrace.rs.html#332
     // Do this last, so even if it crashes, we still get the other info.
-    if config.resolve_frames != CrashtrackerStacktraceCollectionOptions::DontCollectStacktrace {
+    if config.resolve_frames != StacktraceCollection::Disabled {
         unsafe { emit_backtrace_by_frames(pipe)? };
     }
     writeln!(pipe, "{DD_CRASHTRACK_DONE}")?;

--- a/crashtracker/src/lib.rs
+++ b/crashtracker/src/lib.rs
@@ -60,7 +60,7 @@ mod telemetry;
 #[cfg(unix)]
 pub use api::*;
 pub use configuration::{
-    CrashtrackerConfiguration, CrashtrackerReceiverConfig, CrashtrackerStacktraceCollectionOptions,
+    CrashtrackerConfiguration, CrashtrackerReceiverConfig, StacktraceCollection,
 };
 pub use constants::*;
 pub use counters::{begin_profiling_op, end_profiling_op, reset_counters, ProfilingOpTypes};

--- a/crashtracker/src/lib.rs
+++ b/crashtracker/src/lib.rs
@@ -60,7 +60,7 @@ mod telemetry;
 #[cfg(unix)]
 pub use api::*;
 pub use configuration::{
-    CrashtrackerConfiguration, CrashtrackerReceiverConfig, CrashtrackerResolveFrames,
+    CrashtrackerConfiguration, CrashtrackerReceiverConfig, CrashtrackerStacktraceCollectionOptions,
 };
 pub use constants::*;
 pub use counters::{begin_profiling_op, end_profiling_op, reset_counters, ProfilingOpTypes};

--- a/crashtracker/src/receiver.rs
+++ b/crashtracker/src/receiver.rs
@@ -12,9 +12,7 @@ pub fn resolve_frames(
     config: &CrashtrackerConfiguration,
     crash_info: &mut CrashInfo,
 ) -> anyhow::Result<()> {
-    if config.resolve_frames
-        == CrashtrackerStacktraceCollectionOptions::CollectStacktraceAndResolveSymbolsInReceiver
-    {
+    if config.resolve_frames == StacktraceCollection::Enabled {
         // The receiver is the direct child of the crashing process
         // TODO: This pid should be sent over the wire, so that
         // it can be used in a sidecar.

--- a/crashtracker/src/receiver.rs
+++ b/crashtracker/src/receiver.rs
@@ -12,7 +12,9 @@ pub fn resolve_frames(
     config: &CrashtrackerConfiguration,
     crash_info: &mut CrashInfo,
 ) -> anyhow::Result<()> {
-    if config.resolve_frames == CrashtrackerResolveFrames::InReceiver {
+    if config.resolve_frames
+        == CrashtrackerStacktraceCollectionOptions::CollectStacktraceAndResolveSymbolsInReceiver
+    {
         // The receiver is the direct child of the crashing process
         // TODO: This pid should be sent over the wire, so that
         // it can be used in a sidecar.

--- a/crashtracker/src/telemetry.rs
+++ b/crashtracker/src/telemetry.rs
@@ -209,7 +209,7 @@ mod tests {
                     url: hyper::Uri::from_static("http://localhost:8126/profiling/v1/input"),
                     api_key: None,
                 }),
-                resolve_frames: crate::CrashtrackerStacktraceCollectionOptions::CollectStacktraceButDoNotResolveSymbols,
+                resolve_frames: crate::StacktraceCollection::WithoutSymbols,
                 timeout: time::Duration::from_secs(30),
             },
         )

--- a/crashtracker/src/telemetry.rs
+++ b/crashtracker/src/telemetry.rs
@@ -209,8 +209,7 @@ mod tests {
                     url: hyper::Uri::from_static("http://localhost:8126/profiling/v1/input"),
                     api_key: None,
                 }),
-                resolve_frames: crate::CrashtrackerResolveFrames::Never,
-                collect_stacktrace: true,
+                resolve_frames: crate::CrashtrackerStacktraceCollectionOptions::CollectStacktraceButDoNotResolveSymbols,
                 timeout: time::Duration::from_secs(30),
             },
         )

--- a/examples/ffi/crashtracking.c
+++ b/examples/ffi/crashtracking.c
@@ -29,7 +29,7 @@ int main(int argc, char **argv) {
   ddog_prof_CrashtrackerConfiguration config = {
       .create_alt_stack = false,
       .endpoint = ddog_prof_Endpoint_agent(DDOG_CHARSLICE_C("http://localhost:8126")),
-      .resolve_frames = DDOG_PROF_CRASHTRACKER_STACKTRACE_COLLECTION_OPTIONS_COLLECT_STACKTRACE_BUT_DO_NOT_RESOLVE_SYMBOLS,
+      .resolve_frames = DDOG_PROF_STACKTRACE_COLLECTION_WITHOUT_SYMBOLS,
   };
 
   ddog_prof_CrashtrackerMetadata metadata = {

--- a/examples/ffi/crashtracking.c
+++ b/examples/ffi/crashtracking.c
@@ -29,7 +29,7 @@ int main(int argc, char **argv) {
   ddog_prof_CrashtrackerConfiguration config = {
       .create_alt_stack = false,
       .endpoint = ddog_prof_Endpoint_agent(DDOG_CHARSLICE_C("http://localhost:8126")),
-      .resolve_frames = DDOG_PROF_CRASHTRACKER_RESOLVE_FRAMES_NEVER,
+      .resolve_frames = DDOG_PROF_CRASHTRACKER_STACKTRACE_COLLECTION_OPTIONS_COLLECT_STACKTRACE_BUT_DO_NOT_RESOLVE_SYMBOLS,
   };
 
   ddog_prof_CrashtrackerMetadata metadata = {

--- a/profiling-ffi/src/crashtracker/datatypes.rs
+++ b/profiling-ffi/src/crashtracker/datatypes.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::exporter::{self, ProfilingEndpoint};
-pub use datadog_crashtracker::{CrashtrackerStacktraceCollectionOptions, ProfilingOpTypes};
+pub use datadog_crashtracker::{ProfilingOpTypes, StacktraceCollection};
 use ddcommon::tag::Tag;
 use ddcommon_ffi::slice::{AsBytes, CharSlice};
 use ddcommon_ffi::{Error, Slice, StringWrapper};
@@ -31,7 +31,7 @@ pub struct CrashtrackerConfiguration<'a> {
     pub create_alt_stack: bool,
     /// The endpoint to send the crash report to (can be a file://)
     pub endpoint: ProfilingEndpoint<'a>,
-    pub resolve_frames: CrashtrackerStacktraceCollectionOptions,
+    pub resolve_frames: StacktraceCollection,
     pub timeout_secs: u64,
 }
 

--- a/profiling-ffi/src/crashtracker/datatypes.rs
+++ b/profiling-ffi/src/crashtracker/datatypes.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::exporter::{self, ProfilingEndpoint};
-pub use datadog_crashtracker::{CrashtrackerResolveFrames, ProfilingOpTypes};
+pub use datadog_crashtracker::{CrashtrackerStacktraceCollectionOptions, ProfilingOpTypes};
 use ddcommon::tag::Tag;
 use ddcommon_ffi::slice::{AsBytes, CharSlice};
 use ddcommon_ffi::{Error, Slice, StringWrapper};
@@ -28,13 +28,10 @@ pub struct CrashtrackerReceiverConfig<'a> {
 
 #[repr(C)]
 pub struct CrashtrackerConfiguration<'a> {
-    /// Should the crashtracker attempt to collect a stacktrace for the crash
-    pub collect_stacktrace: bool,
     pub create_alt_stack: bool,
     /// The endpoint to send the crash report to (can be a file://)
     pub endpoint: ProfilingEndpoint<'a>,
-    /// Whether/when we should attempt to resolve frames
-    pub resolve_frames: CrashtrackerResolveFrames,
+    pub resolve_frames: CrashtrackerStacktraceCollectionOptions,
     pub timeout_secs: u64,
 }
 
@@ -83,18 +80,11 @@ impl<'a> TryFrom<CrashtrackerConfiguration<'a>>
 {
     type Error = anyhow::Error;
     fn try_from(value: CrashtrackerConfiguration<'a>) -> anyhow::Result<Self> {
-        let collect_stacktrace = value.collect_stacktrace;
         let create_alt_stack = value.create_alt_stack;
         let endpoint = unsafe { Some(exporter::try_to_endpoint(value.endpoint)?) };
         let resolve_frames = value.resolve_frames;
         let timeout = Duration::from_secs(value.timeout_secs);
-        Self::new(
-            collect_stacktrace,
-            create_alt_stack,
-            endpoint,
-            resolve_frames,
-            timeout,
-        )
+        Self::new(create_alt_stack, endpoint, resolve_frames, timeout)
     }
 }
 


### PR DESCRIPTION
# What does this PR do?

Combines the "should we collect stack traces" and "should we symbolize them" into one enum

# Motivation

The current setup confused @ivoanjo. Hopefully this is clearer.
# Additional Notes

Naming things is hard. Feel free to suggest better names.

# How to test the change?

Describe here in detail how the change can be validated.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
