### PR TITLE
[crashtracker] fix fprintf formal string in receiver binary

### DIFF
--- a/crashtracker/libdatadog-crashtracking-receiver.c
+++ b/crashtracker/libdatadog-crashtracking-receiver.c
@@ -10,7 +10,7 @@ int main(void) {
   ddog_prof_CrashtrackerResult new_result = ddog_prof_Crashtracker_receiver_entry_point();
   if (new_result.tag != DDOG_PROF_CRASHTRACKER_RESULT_OK) {
     ddog_CharSlice message = ddog_Error_message(&new_result.err);
-    fprintf(stderr, "%*s", (int)message.len, message.ptr);
+    fprintf(stderr, "%.*s", (int)message.len, message.ptr);
     ddog_Error_drop(&new_result.err);
     exit(EXIT_FAILURE);
   }

--- a/examples/ffi/crashtracking.c
+++ b/examples/ffi/crashtracking.c
@@ -43,7 +43,7 @@ int main(int argc, char **argv) {
       ddog_prof_Crashtracker_init(config, receiver_config, metadata);
   if (result.tag == DDOG_PROF_PROFILE_RESULT_ERR) {
     ddog_CharSlice message = ddog_Error_message(&result.err);
-    fprintf(stderr, "%*s\n", (int)message.len, message.ptr);
+    fprintf(stderr, "%.*s\n", (int)message.len, message.ptr);
     ddog_Error_drop(&result.err);
     return -1;
   }

--- a/examples/ffi/profiles.c
+++ b/examples/ffi/profiles.c
@@ -17,7 +17,7 @@ int main(void) {
   ddog_prof_Profile_NewResult new_result = ddog_prof_Profile_new(sample_types, &period, NULL);
   if (new_result.tag != DDOG_PROF_PROFILE_NEW_RESULT_OK) {
     ddog_CharSlice message = ddog_Error_message(&new_result.err);
-    fprintf(stderr, "%*s", (int)message.len, message.ptr);
+    fprintf(stderr, "%.*s", (int)message.len, message.ptr);
     ddog_Error_drop(&new_result.err);
     exit(EXIT_FAILURE);
   }
@@ -50,7 +50,7 @@ int main(void) {
     ddog_prof_Profile_Result add_result = ddog_prof_Profile_add(profile, sample, 0);
     if (add_result.tag != DDOG_PROF_PROFILE_RESULT_OK) {
       ddog_CharSlice message = ddog_Error_message(&add_result.err);
-      fprintf(stderr, "%*s", (int)message.len, message.ptr);
+      fprintf(stderr, "%.*s", (int)message.len, message.ptr);
       ddog_Error_drop(&add_result.err);
     }
   }
@@ -61,7 +61,7 @@ int main(void) {
   ddog_prof_Profile_Result reset_result = ddog_prof_Profile_reset(profile, NULL);
   if (reset_result.tag != DDOG_PROF_PROFILE_RESULT_OK) {
     ddog_CharSlice message = ddog_Error_message(&reset_result.err);
-    fprintf(stderr, "%*s", (int)message.len, message.ptr);
+    fprintf(stderr, "%.*s", (int)message.len, message.ptr);
     ddog_Error_drop(&reset_result.err);
   }
   ddog_prof_Profile_drop(profile);


### PR DESCRIPTION
# What does this PR do?

Fixes the format to work with non null terminated strings

# Motivation

It was wrong before

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
