### PR TITLE
Add code coverage workflow.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,77 @@
+comment:
+  layout: "condensed_header, diff, flags, components"
+  
+component_management:
+  individual_components:
+    - component_id: crashtracker  # this is an identifier that should not be changed
+      name: crashtracker  # this is a display name, and can be changed freely
+      paths:
+        - crashtracker
+    - component_id: data-pipeline  # this is an identifier that should not be changed
+      name: data-pipeline  # this is a display name, and can be changed freely
+      paths:
+        - data-pipeline
+    - component_id: data-pipeline-ffi  # this is an identifier that should not be changed
+      name: data-pipeline-ffi  # this is a display name, and can be changed freely
+      paths:
+        - data-pipeline-ffi
+    - component_id: ddcommon  # this is an identifier that should not be changed
+      name: ddcommon  # this is a display name, and can be changed freely
+      paths:
+        - ddcommon
+    - component_id: ddcommon-ffi  # this is an identifier that should not be changed
+      name: ddcommon-ffi  # this is a display name, and can be changed freely
+      paths:
+        - ddcommon-ffi
+    - component_id: ddtelemetry  # this is an identifier that should not be changed
+      name: ddtelemetry  # this is a display name, and can be changed freely
+      paths:
+        - ddtelemetry
+    - component_id: ipc  # this is an identifier that should not be changed
+      name: ipc  # this is a display name, and can be changed freely
+      paths:
+        - ipc
+    - component_id: profiling  # this is an identifier that should not be changed
+      name: profiling  # this is a display name, and can be changed freely
+      paths:
+        - profiling
+    - component_id: profiling-ffi  # this is an identifier that should not be changed
+      name: profiling-ffi  # this is a display name, and can be changed freely
+      paths:
+        - profiling-ffi
+    - component_id: serverless  # this is an identifier that should not be changed
+      name: serverless  # this is a display name, and can be changed freely
+      paths:
+        - serverless
+    - component_id: sidecar  # this is an identifier that should not be changed
+      name: sidecar  # this is a display name, and can be changed freely
+      paths:
+        - sidecar
+    - component_id: sidecar-ffi  # this is an identifier that should not be changed
+      name: sidecar-ffi  # this is a display name, and can be changed freely
+      paths:
+        - sidecar-ffi
+    - component_id: spawn-worker  # this is an identifier that should not be changed
+      name: spawn-worker  # this is a display name, and can be changed freely
+      paths:
+        - spawn_worker
+    - component_id: trace-mini-agent  # this is an identifier that should not be changed
+      name: trace-mini-agent  # this is a display name, and can be changed freely
+      paths:
+        - trace-mini-agent
+    - component_id: trace-normalization  # this is an identifier that should not be changed
+      name: trace-normalization  # this is a display name, and can be changed freely
+      paths:
+        - trace-normalization
+    - component_id: trace-obfuscation  # this is an identifier that should not be changed
+      name: trace-obfuscation  # this is a display name, and can be changed freely
+      paths:
+        - trace-obfuscation
+    - component_id: trace-protobuf  # this is an identifier that should not be changed
+      name: trace-protobuf  # this is a display name, and can be changed freely
+      paths:
+        - trace-protobuf
+    - component_id: trace-utils  # this is an identifier that should not be changed
+      name: trace-utils  # this is a display name, and can be changed freely
+      paths:
+        - trace-utils

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,27 @@
+name: Coverage
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        run: rustup update stable
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate code coverage
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          fail_ci_if_error: true

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,9 @@ jobs:
       - name: Install Rust
         run: rustup update stable
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov@0.6.9
       - name: Generate code coverage
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
       - name: Upload coverage to Codecov


### PR DESCRIPTION
# What does this PR do?
This PR adds a new workflow file to generate code coverage reports and upload the results to codecov. Once the first report is uploaded each PR will have a comment showing the diff with the previous state. The diff will present changes in the following components:

- crashtracker
- data-pipeline
- data-pipeline-ffi
- ddcommon
- ddcommon-ffi
- ddtelemetry
- ipc
- profiling
- profiling-ffi
- serverless
- sidecar
- sidecar-ffi
- spawn_worker
- trace-mini-agent
- trace-normalization
- trace-obfuscation
- trace-protobuf
- trace-utils


