### PR TITLE
[crashtracker] Take a user defined list of additional files

### DIFF
--- a/bin_tests/src/bin/crashtracker_bin_test.rs
+++ b/bin_tests/src/bin/crashtracker_bin_test.rs
@@ -34,6 +34,7 @@ mod unix {
         let timeout = Duration::from_secs(30);
         crashtracker::init(
             CrashtrackerConfiguration {
+                additional_files: vec![],
                 create_alt_stack: true,
                 endpoint: Some(ddcommon::Endpoint {
                     url: ddcommon::parse_uri(&format!("file://{}", output_filename))?,

--- a/crashtracker/src/api.rs
+++ b/crashtracker/src/api.rs
@@ -145,7 +145,7 @@ fn test_crash() {
         .expect("Not to fail"),
     );
     let config =
-        CrashtrackerConfiguration::new(create_alt_stack, endpoint, resolve_frames, timeout)
+        CrashtrackerConfiguration::new(vec![], create_alt_stack, endpoint, resolve_frames, timeout)
             .expect("not to fail");
     let metadata = CrashtrackerMetadata::new(
         "libname".to_string(),

--- a/crashtracker/src/configuration.rs
+++ b/crashtracker/src/configuration.rs
@@ -20,6 +20,8 @@ pub enum StacktraceCollection {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CrashtrackerConfiguration {
+    // Paths to any additional files to track, if any
+    pub additional_files: Vec<String>,
     pub create_alt_stack: bool,
     pub endpoint: Option<Endpoint>,
     pub resolve_frames: StacktraceCollection,
@@ -65,14 +67,15 @@ impl CrashtrackerReceiverConfig {
 }
 
 impl CrashtrackerConfiguration {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
+        additional_files: Vec<String>,
         create_alt_stack: bool,
         endpoint: Option<Endpoint>,
         resolve_frames: StacktraceCollection,
         timeout: Duration,
     ) -> anyhow::Result<Self> {
         Ok(Self {
+            additional_files,
             create_alt_stack,
             endpoint,
             resolve_frames,

--- a/crashtracker/src/telemetry.rs
+++ b/crashtracker/src/telemetry.rs
@@ -204,6 +204,7 @@ mod tests {
         TelemetryCrashUploader::new(
             &new_test_prof_metadata(),
             &crate::CrashtrackerConfiguration {
+                additional_files: vec![],
                 create_alt_stack: true,
                 endpoint: Some(Endpoint {
                     url: hyper::Uri::from_static("http://localhost:8126/profiling/v1/input"),

--- a/profiling-ffi/src/crashtracker/datatypes.rs
+++ b/profiling-ffi/src/crashtracker/datatypes.rs
@@ -28,6 +28,7 @@ pub struct CrashtrackerReceiverConfig<'a> {
 
 #[repr(C)]
 pub struct CrashtrackerConfiguration<'a> {
+    pub additional_files: Slice<'a, CharSlice<'a>>,
     pub create_alt_stack: bool,
     /// The endpoint to send the crash report to (can be a file://)
     pub endpoint: ProfilingEndpoint<'a>,
@@ -80,11 +81,18 @@ impl<'a> TryFrom<CrashtrackerConfiguration<'a>>
 {
     type Error = anyhow::Error;
     fn try_from(value: CrashtrackerConfiguration<'a>) -> anyhow::Result<Self> {
+        let additional_files = {
+            let mut vec = Vec::with_capacity(value.additional_files.len());
+            for x in value.additional_files.iter() {
+                vec.push(x.try_to_utf8()?.to_string());
+            }
+            vec
+        };
         let create_alt_stack = value.create_alt_stack;
         let endpoint = unsafe { Some(exporter::try_to_endpoint(value.endpoint)?) };
         let resolve_frames = value.resolve_frames;
         let timeout = Duration::from_secs(value.timeout_secs);
-        Self::new(create_alt_stack, endpoint, resolve_frames, timeout)
+        Self::new(additional_files, create_alt_stack, endpoint, resolve_frames, timeout)
     }
 }
 

--- a/profiling-ffi/src/crashtracker/datatypes.rs
+++ b/profiling-ffi/src/crashtracker/datatypes.rs
@@ -92,7 +92,13 @@ impl<'a> TryFrom<CrashtrackerConfiguration<'a>>
         let endpoint = unsafe { Some(exporter::try_to_endpoint(value.endpoint)?) };
         let resolve_frames = value.resolve_frames;
         let timeout = Duration::from_secs(value.timeout_secs);
-        Self::new(additional_files, create_alt_stack, endpoint, resolve_frames, timeout)
+        Self::new(
+            additional_files,
+            create_alt_stack,
+            endpoint,
+            resolve_frames,
+            timeout,
+        )
     }
 }
 


### PR DESCRIPTION
# What does this PR do?

Allows the client to specify which files to record, rather than hard coding it.

# Motivation

Previously, we had hardcoded to use `/proc/meminfo` and `/proc/cpuinfo` as the additional files.  The client may not want these, or may want others.  Give them the choice.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.

## For Reviewers
- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [ ] This PR doesn't touch any of that.
