### PR TITLE
[ASEC-131] Remove reference to nonexisting team

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,3 @@ Anything else we should know when reviewing?
 # How to test the change?
 
 Describe here in detail how the change can be validated.
-
-## For Reviewers
-- [ ] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
-- [ ] This PR doesn't touch any of that.


### PR DESCRIPTION
# What does this PR do?

This makes the change which was done in early April for many other public repos at Datadog.  There is no longer an owner for this workflow, so the checkbox does nothing.

# Motivation

Conformance with internal policies and guidelines

# Additional Notes

I think this is an important part of the overall workflow and release process, but given that such an escalation has no owner, the checkbox is even more toothless than it was before.

# How to test the change?

Try to leak a credential and see what happens.  (kidding)

## For Reviewers
- [X] If this PR touches code that signs or publishes builds or packages, or handles credentials of any kind, I've requested a review from `@DataDog/security-design-and-guidance`.
- [X] This PR doesn't touch any of that.
