### PR TITLE
Collect some of the `trace_api.*` metrics in the trace flusher

### DIFF
--- a/data-pipeline/src/trace_exporter.rs
+++ b/data-pipeline/src/trace_exporter.rs
@@ -234,7 +234,7 @@ impl TraceExporter {
                 };
                 let send_data = SendData::new(size, tracer_payload, header_tags, &endpoint);
                 self.runtime.block_on(async {
-                    match send_data.send().await {
+                    match send_data.send().await.last_result {
                         Ok(response) => match hyper::body::to_bytes(response.into_body()).await {
                             Ok(body) => Ok(String::from_utf8_lossy(&body).to_string()),
                             Err(err) => {

--- a/sidecar/src/self_telemetry.rs
+++ b/sidecar/src/self_telemetry.rs
@@ -24,6 +24,9 @@ struct MetricData<'a> {
     active_sessions: ContextKey,
     memory_usage: ContextKey,
     logs_created: ContextKey,
+    trace_api_requests: ContextKey,
+    trace_api_responses: ContextKey,
+    trace_api_errors: ContextKey,
 }
 impl<'a> MetricData<'a> {
     async fn send(&self, key: ContextKey, value: f64, tags: Vec<Tag>) {
@@ -34,6 +37,8 @@ impl<'a> MetricData<'a> {
     }
 
     async fn collect_and_send(&self) {
+        let trace_metrics = self.server.trace_flusher.collect_metrics();
+
         let mut futures = vec![
             self.send(
                 self.submitted_payloads,
@@ -61,6 +66,42 @@ impl<'a> MetricData<'a> {
                 self.logs_created,
                 count as f64,
                 vec![Tag::new("level", level.as_str().to_lowercase()).unwrap()],
+            ));
+        }
+
+        if trace_metrics.api_requests > 0 {
+            futures.push(self.send(
+                self.trace_api_requests,
+                trace_metrics.api_requests as f64,
+                vec![],
+            ));
+        }
+        if trace_metrics.api_errors_network > 0 {
+            futures.push(self.send(
+                self.trace_api_errors,
+                trace_metrics.api_errors_network as f64,
+                vec![Tag::new("type", "network").unwrap()],
+            ));
+        }
+        if trace_metrics.api_errors_timeout > 0 {
+            futures.push(self.send(
+                self.trace_api_errors,
+                trace_metrics.api_errors_timeout as f64,
+                vec![Tag::new("type", "timeout").unwrap()],
+            ));
+        }
+        if trace_metrics.api_errors_status_code > 0 {
+            futures.push(self.send(
+                self.trace_api_errors,
+                trace_metrics.api_errors_status_code as f64,
+                vec![Tag::new("type", "status_code").unwrap()],
+            ));
+        }
+        for (status_code, count) in &trace_metrics.api_responses_count_per_code {
+            futures.push(self.send(
+                self.trace_api_responses,
+                *count as f64,
+                vec![Tag::new("status_code", status_code.to_string().as_str()).unwrap()],
             ));
         }
 
@@ -155,6 +196,27 @@ impl SelfTelemetry {
                 MetricType::Count,
                 true,
                 MetricNamespace::General,
+            ),
+            trace_api_requests: worker.register_metric_context(
+                "trace_api.requests".to_string(),
+                vec![],
+                MetricType::Count,
+                true,
+                MetricNamespace::Tracers,
+            ),
+            trace_api_responses: worker.register_metric_context(
+                "trace_api.responses".to_string(),
+                vec![],
+                MetricType::Count,
+                true,
+                MetricNamespace::Tracers,
+            ),
+            trace_api_errors: worker.register_metric_context(
+                "trace_api.errors".to_string(),
+                vec![],
+                MetricType::Count,
+                true,
+                MetricNamespace::Tracers,
             ),
         };
 

--- a/trace-mini-agent/src/trace_flusher.rs
+++ b/trace-mini-agent/src/trace_flusher.rs
@@ -56,7 +56,7 @@ impl TraceFlusher for ServerlessTraceFlusher {
         info!("Flushing {} traces", traces.len());
 
         for traces in trace_utils::coalesce_send_data(traces) {
-            match traces.send().await {
+            match traces.send().await.last_result {
                 Ok(_) => info!("Successfully flushed traces"),
                 Err(e) => {
                     error!("Error sending trace: {e:?}")

--- a/trace-mini-agent/src/trace_processor.rs
+++ b/trace-mini-agent/src/trace_processor.rs
@@ -213,7 +213,7 @@ mod tests {
 
         assert_eq!(
             expected_tracer_payload,
-            tracer_payload.unwrap().get_payloads()[0]
+            tracer_payload.unwrap().tracer_payloads[0]
         );
     }
 
@@ -283,7 +283,7 @@ mod tests {
         };
         assert_eq!(
             expected_tracer_payload,
-            tracer_payload.unwrap().get_payloads()[0]
+            tracer_payload.unwrap().tracer_payloads[0]
         );
     }
 }

--- a/trace-utils/src/lib.rs
+++ b/trace-utils/src/lib.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod config_utils;
+pub mod send_data;
 pub mod stats_utils;
 pub mod trace_test_utils;
 pub mod trace_utils;
+pub mod tracer_header_tags;

--- a/trace-utils/src/send_data.rs
+++ b/trace-utils/src/send_data.rs
@@ -1,0 +1,229 @@
+// Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{anyhow, Context};
+use futures::stream::FuturesUnordered;
+use futures::StreamExt;
+use hyper::{Body, Client, Method, Response, StatusCode};
+use std::collections::HashMap;
+
+use crate::tracer_header_tags::TracerHeaderTags;
+use datadog_trace_protobuf::pb;
+use ddcommon::{connector, Endpoint, HttpRequestBuilder};
+
+#[derive(Debug)]
+pub enum SendRequestError {
+    Hyper(hyper::Error),
+    Any(anyhow::Error),
+}
+
+pub struct SendDataResult {
+    pub last_result: anyhow::Result<Response<Body>>,
+    pub requests_count: u64,
+    pub responses_count_per_code: HashMap<u16, u64>,
+    pub errors_timeout: u64,
+    pub errors_network: u64,
+    pub errors_status_code: u64,
+}
+
+impl SendDataResult {
+    fn new() -> SendDataResult {
+        SendDataResult {
+            last_result: Err(anyhow!("No requests sent")),
+            requests_count: 0,
+            responses_count_per_code: Default::default(),
+            errors_timeout: 0,
+            errors_network: 0,
+            errors_status_code: 0,
+        }
+    }
+
+    async fn update(
+        &mut self,
+        res: Result<Response<Body>, SendRequestError>,
+        expected_status: StatusCode,
+    ) {
+        self.requests_count += 1;
+        match res {
+            Ok(response) => {
+                *self
+                    .responses_count_per_code
+                    .entry(response.status().as_u16())
+                    .or_default() += 1;
+                self.last_result = if response.status() == expected_status {
+                    Ok(response)
+                } else {
+                    self.errors_status_code += 1;
+
+                    let body_bytes = hyper::body::to_bytes(response.into_body()).await;
+                    let response_body = String::from_utf8(body_bytes.unwrap_or_default().to_vec())
+                        .unwrap_or_default();
+                    Err(anyhow::format_err!(
+                        "Server did not accept traces: {response_body}"
+                    ))
+                }
+            }
+            Err(e) => match e {
+                SendRequestError::Hyper(e) => {
+                    if e.is_timeout() {
+                        self.errors_timeout += 1;
+                    } else {
+                        self.errors_network += 1;
+                    }
+                    self.last_result = Err(anyhow!(e));
+                }
+                SendRequestError::Any(e) => {
+                    self.last_result = Err(e);
+                }
+            },
+        }
+    }
+
+    fn error(mut self, err: anyhow::Error) -> SendDataResult {
+        self.last_result = Err(err);
+        self
+    }
+}
+
+fn construct_agent_payload(tracer_payloads: Vec<pb::TracerPayload>) -> pb::AgentPayload {
+    pb::AgentPayload {
+        host_name: "".to_string(),
+        env: "".to_string(),
+        agent_version: "".to_string(),
+        error_tps: 60.0,
+        target_tps: 60.0,
+        tags: HashMap::new(),
+        tracer_payloads,
+        rare_sampler_enabled: false,
+    }
+}
+
+fn serialize_proto_payload<T>(payload: &T) -> anyhow::Result<Vec<u8>>
+where
+    T: prost::Message,
+{
+    let mut buf = Vec::with_capacity(payload.encoded_len());
+    payload.encode(&mut buf)?;
+    Ok(buf)
+}
+
+#[derive(Debug, Clone)]
+pub struct SendData {
+    pub tracer_payloads: Vec<pb::TracerPayload>,
+    pub size: usize, // have a rough size estimate to force flushing if it's large
+    pub target: Endpoint,
+    headers: HashMap<&'static str, String>,
+}
+
+impl SendData {
+    pub fn new(
+        size: usize,
+        tracer_payload: pb::TracerPayload,
+        tracer_header_tags: TracerHeaderTags,
+        target: &Endpoint,
+    ) -> SendData {
+        let headers = if let Some(api_key) = &target.api_key {
+            HashMap::from([("DD-API-KEY", api_key.as_ref().to_string())])
+        } else {
+            tracer_header_tags.into()
+        };
+
+        SendData {
+            tracer_payloads: vec![tracer_payload],
+            size,
+            target: target.clone(),
+            headers,
+        }
+    }
+
+    pub async fn send<'a>(self) -> SendDataResult {
+        let target = &self.target;
+
+        let mut req = hyper::Request::builder()
+            .uri(target.url.clone())
+            .header(
+                hyper::header::USER_AGENT,
+                concat!("Tracer/", env!("CARGO_PKG_VERSION")),
+            )
+            .method(Method::POST);
+
+        for (key, value) in &self.headers {
+            req = req.header(*key, value);
+        }
+
+        async fn send_request(
+            req: HttpRequestBuilder,
+            payload: Vec<u8>,
+        ) -> Result<Response<Body>, SendRequestError> {
+            let req = req
+                .body(Body::from(payload))
+                .map_err(|e| SendRequestError::Any(anyhow!(e)))?;
+
+            Client::builder()
+                .build(connector::Connector::default())
+                .request(req)
+                .await
+                .map_err(SendRequestError::Hyper)
+        }
+
+        let mut result = SendDataResult::new();
+
+        if target.api_key.is_some() {
+            req = req.header("Content-type", "application/x-protobuf");
+
+            let agent_payload = construct_agent_payload(self.tracer_payloads);
+            let serialized_trace_payload = match serialize_proto_payload(&agent_payload)
+                .context("Failed to serialize trace agent payload, dropping traces")
+            {
+                Ok(p) => p,
+                Err(e) => return result.error(e),
+            };
+
+            result
+                .update(
+                    send_request(req, serialized_trace_payload).await,
+                    StatusCode::ACCEPTED,
+                )
+                .await;
+            result
+        } else {
+            req = req.header("Content-type", "application/msgpack");
+
+            let (template, _) = req.body(()).unwrap().into_parts();
+
+            let mut futures = FuturesUnordered::new();
+            for tracer_payload in self.tracer_payloads.into_iter() {
+                let mut builder = HttpRequestBuilder::new()
+                    .method(template.method.clone())
+                    .uri(template.uri.clone())
+                    .version(template.version)
+                    .header(
+                        "X-Datadog-Trace-Count",
+                        tracer_payload.chunks.len().to_string(),
+                    );
+                builder
+                    .headers_mut()
+                    .unwrap()
+                    .extend(template.headers.clone());
+
+                let payload = match rmp_serde::to_vec_named(&tracer_payload) {
+                    Ok(p) => p,
+                    Err(e) => return result.error(anyhow!(e)),
+                };
+
+                futures.push(send_request(builder, payload));
+            }
+            loop {
+                match futures.next().await {
+                    Some(response) => {
+                        result.update(response, StatusCode::OK).await;
+                        if result.last_result.is_err() {
+                            return result;
+                        }
+                    }
+                    None => return result,
+                }
+            }
+        }
+    }
+}

--- a/trace-utils/src/trace_utils.rs
+++ b/trace-utils/src/trace_utils.rs
@@ -1,39 +1,21 @@
 // Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{anyhow, Context};
-use futures::stream::FuturesUnordered;
-use futures::StreamExt;
-use hyper::http::HeaderValue;
-use hyper::{body::Buf, Body, Client, HeaderMap, Method, Response, StatusCode};
+use hyper::{body::Buf, Body};
 use log::{error, info};
-use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+pub use crate::send_data::SendData;
+pub use crate::send_data::SendDataResult;
+pub use crate::tracer_header_tags::TracerHeaderTags;
 use datadog_trace_normalization::normalizer;
 use datadog_trace_protobuf::pb;
 use datadog_trace_protobuf::pb::TraceChunk;
-use ddcommon::{connector, Endpoint, HttpRequestBuilder};
 
 /// Span metric the mini agent must set for the backend to recognize top level span
 const TOP_LEVEL_KEY: &str = "_top_level";
 /// Span metric the tracer sets to denote a top level span
 const TRACER_TOP_LEVEL_KEY: &str = "_dd.top_level";
-
-macro_rules! parse_string_header {
-    (
-        $header_map:ident,
-        { $($header_key:literal => $($field:ident).+ ,)+ }
-    ) => {
-        $(
-            if let Some(header_value) = $header_map.get($header_key) {
-                if let Ok(h) = header_value.to_str() {
-                    $($field).+ = h;
-                }
-            }
-        )+
-    }
-}
 
 /// First value of returned tuple is the payload size
 pub async fn get_traces_from_request_body(
@@ -56,90 +38,16 @@ pub async fn get_traces_from_request_body(
     Ok((size, traces))
 }
 
-#[derive(Default, Debug, Serialize, Deserialize)]
-pub struct TracerHeaderTags<'a> {
-    pub lang: &'a str,
-    pub lang_version: &'a str,
-    pub lang_interpreter: &'a str,
-    pub lang_vendor: &'a str,
-    pub tracer_version: &'a str,
-    pub container_id: &'a str,
-    // specifies that the client has marked top-level spans, when set. Any non-empty value will
-    // mean 'yes'.
-    pub client_computed_top_level: bool,
-    // specifies whether the client has computed stats so that the agent doesn't have to. Any
-    // non-empty value will mean 'yes'.
-    pub client_computed_stats: bool,
-}
-
-impl<'a> From<TracerHeaderTags<'a>> for HashMap<&'static str, String> {
-    fn from(tags: TracerHeaderTags<'a>) -> HashMap<&'static str, String> {
-        let mut headers = HashMap::from([
-            ("datadog-meta-lang", tags.lang.to_string()),
-            ("datadog-meta-lang-version", tags.lang_version.to_string()),
-            (
-                "datadog-meta-lang-interpreter",
-                tags.lang_interpreter.to_string(),
-            ),
-            ("datadog-meta-lang-vendor", tags.lang_vendor.to_string()),
-            (
-                "datadog-meta-tracer-version",
-                tags.tracer_version.to_string(),
-            ),
-            ("datadog-container-id", tags.container_id.to_string()),
-        ]);
-        headers.retain(|_, v| !v.is_empty());
-        headers
-    }
-}
-
-impl<'a> From<&'a HeaderMap<HeaderValue>> for TracerHeaderTags<'a> {
-    fn from(headers: &'a HeaderMap<HeaderValue>) -> Self {
-        let mut tags = TracerHeaderTags::default();
-        parse_string_header!(
-            headers,
-            {
-                "datadog-meta-lang" => tags.lang,
-                "datadog-meta-lang-version" => tags.lang_version,
-                "datadog-meta-lang-interpreter" => tags.lang_interpreter,
-                "datadog-meta-lang-vendor" => tags.lang_vendor,
-                "datadog-meta-tracer-version" => tags.tracer_version,
-                "datadog-container-id" => tags.container_id,
-            }
-        );
-        if headers.get("datadog-client-computed-top-level").is_some() {
-            tags.client_computed_top_level = true;
-        }
-        if headers.get("datadog-client-computed-stats").is_some() {
-            tags.client_computed_stats = true;
-        }
-        tags
-    }
-}
-
 // Tags gathered from a trace's root span
 #[derive(Default)]
-pub struct RootSpanTags<'a> {
+struct RootSpanTags<'a> {
     pub env: &'a str,
     pub app_version: &'a str,
     pub hostname: &'a str,
     pub runtime_id: &'a str,
 }
 
-pub fn construct_agent_payload(tracer_payloads: Vec<pb::TracerPayload>) -> pb::AgentPayload {
-    pb::AgentPayload {
-        host_name: "".to_string(),
-        env: "".to_string(),
-        agent_version: "".to_string(),
-        error_tps: 60.0,
-        target_tps: 60.0,
-        tags: HashMap::new(),
-        tracer_payloads,
-        rare_sampler_enabled: false,
-    }
-}
-
-pub fn construct_trace_chunk(trace: Vec<pb::Span>) -> pb::TraceChunk {
+fn construct_trace_chunk(trace: Vec<pb::Span>) -> pb::TraceChunk {
     pb::TraceChunk {
         priority: normalizer::SamplerPriority::None as i32,
         origin: "".to_string(),
@@ -149,7 +57,7 @@ pub fn construct_trace_chunk(trace: Vec<pb::Span>) -> pb::TraceChunk {
     }
 }
 
-pub fn construct_tracer_payload(
+fn construct_tracer_payload(
     chunks: Vec<pb::TraceChunk>,
     tracer_tags: &TracerHeaderTags,
     root_span_tags: RootSpanTags,
@@ -168,219 +76,6 @@ pub fn construct_tracer_payload(
     }
 }
 
-pub fn serialize_proto_payload<T>(payload: &T) -> anyhow::Result<Vec<u8>>
-where
-    T: prost::Message,
-{
-    let mut buf = Vec::with_capacity(payload.encoded_len());
-    payload.encode(&mut buf)?;
-    Ok(buf)
-}
-
-#[derive(Debug)]
-pub enum SendRequestError {
-    Hyper(hyper::Error),
-    Any(anyhow::Error),
-}
-
-pub struct SendDataResult {
-    pub last_result: anyhow::Result<Response<Body>>,
-    pub requests_count: u64,
-    pub responses_count_per_code: HashMap<u16, u64>,
-    pub errors_timeout: u64,
-    pub errors_network: u64,
-    pub errors_status_code: u64,
-}
-
-impl SendDataResult {
-    fn new() -> SendDataResult {
-        SendDataResult {
-            last_result: Err(anyhow!("No requests sent")),
-            requests_count: 0,
-            responses_count_per_code: Default::default(),
-            errors_timeout: 0,
-            errors_network: 0,
-            errors_status_code: 0,
-        }
-    }
-
-    async fn update(
-        &mut self,
-        res: Result<Response<Body>, SendRequestError>,
-        expected_status: StatusCode,
-    ) {
-        self.requests_count += 1;
-        match res {
-            Ok(response) => {
-                *self
-                    .responses_count_per_code
-                    .entry(response.status().as_u16())
-                    .or_default() += 1;
-                self.last_result = if response.status() == expected_status {
-                    Ok(response)
-                } else {
-                    self.errors_status_code += 1;
-
-                    let body_bytes = hyper::body::to_bytes(response.into_body()).await;
-                    let response_body = String::from_utf8(body_bytes.unwrap_or_default().to_vec())
-                        .unwrap_or_default();
-                    Err(anyhow::format_err!(
-                        "Server did not accept traces: {response_body}"
-                    ))
-                }
-            }
-            Err(e) => match e {
-                SendRequestError::Hyper(e) => {
-                    if e.is_timeout() {
-                        self.errors_timeout += 1;
-                    } else {
-                        self.errors_network += 1;
-                    }
-                    self.last_result = Err(anyhow!(e));
-                }
-                SendRequestError::Any(e) => {
-                    self.last_result = Err(e);
-                }
-            },
-        }
-    }
-
-    fn error(mut self, err: anyhow::Error) -> SendDataResult {
-        self.last_result = Err(err);
-        self
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct SendData {
-    tracer_payloads: Vec<pb::TracerPayload>,
-    size: usize, // have a rough size estimate to force flushing if it's large
-    pub target: Endpoint,
-    headers: HashMap<&'static str, String>,
-}
-
-impl SendData {
-    pub fn new(
-        size: usize,
-        tracer_payload: pb::TracerPayload,
-        tracer_header_tags: TracerHeaderTags,
-        target: &Endpoint,
-    ) -> SendData {
-        let headers = if let Some(api_key) = &target.api_key {
-            HashMap::from([("DD-API-KEY", api_key.as_ref().to_string())])
-        } else {
-            tracer_header_tags.into()
-        };
-
-        SendData {
-            tracer_payloads: vec![tracer_payload],
-            size,
-            target: target.clone(),
-            headers,
-        }
-    }
-
-    pub fn size(&self) -> usize {
-        self.size
-    }
-
-    pub async fn send<'a>(self) -> SendDataResult {
-        let target = &self.target;
-
-        let mut req = hyper::Request::builder()
-            .uri(target.url.clone())
-            .header(
-                hyper::header::USER_AGENT,
-                concat!("Tracer/", env!("CARGO_PKG_VERSION")),
-            )
-            .method(Method::POST);
-
-        for (key, value) in &self.headers {
-            req = req.header(*key, value);
-        }
-
-        async fn send_request(
-            req: HttpRequestBuilder,
-            payload: Vec<u8>,
-        ) -> Result<Response<Body>, SendRequestError> {
-            let req = req
-                .body(Body::from(payload))
-                .map_err(|e| SendRequestError::Any(anyhow!(e)))?;
-
-            Client::builder()
-                .build(connector::Connector::default())
-                .request(req)
-                .await
-                .map_err(SendRequestError::Hyper)
-        }
-
-        let mut result = SendDataResult::new();
-
-        if target.api_key.is_some() {
-            req = req.header("Content-type", "application/x-protobuf");
-
-            let agent_payload = construct_agent_payload(self.tracer_payloads);
-            let serialized_trace_payload = match serialize_proto_payload(&agent_payload)
-                .context("Failed to serialize trace agent payload, dropping traces")
-            {
-                Ok(p) => p,
-                Err(e) => return result.error(e),
-            };
-
-            result
-                .update(
-                    send_request(req, serialized_trace_payload).await,
-                    StatusCode::ACCEPTED,
-                )
-                .await;
-            result
-        } else {
-            req = req.header("Content-type", "application/msgpack");
-
-            let (template, _) = req.body(()).unwrap().into_parts();
-
-            let mut futures = FuturesUnordered::new();
-            for tracer_payload in self.tracer_payloads.into_iter() {
-                let mut builder = HttpRequestBuilder::new()
-                    .method(template.method.clone())
-                    .uri(template.uri.clone())
-                    .version(template.version)
-                    .header(
-                        "X-Datadog-Trace-Count",
-                        tracer_payload.chunks.len().to_string(),
-                    );
-                builder
-                    .headers_mut()
-                    .unwrap()
-                    .extend(template.headers.clone());
-
-                let payload = match rmp_serde::to_vec_named(&tracer_payload) {
-                    Ok(p) => p,
-                    Err(e) => return result.error(anyhow!(e)),
-                };
-
-                futures.push(send_request(builder, payload));
-            }
-            loop {
-                match futures.next().await {
-                    Some(response) => {
-                        result.update(response, StatusCode::OK).await;
-                        if result.last_result.is_err() {
-                            return result;
-                        }
-                    }
-                    None => return result,
-                }
-            }
-        }
-    }
-
-    // For testing
-    pub fn get_payloads(&self) -> &Vec<pb::TracerPayload> {
-        &self.tracer_payloads
-    }
-}
-
 pub fn coalesce_send_data(mut data: Vec<SendData>) -> Vec<SendData> {
     // TODO trace payloads with identical data except for chunk could be merged?
 
@@ -396,7 +91,7 @@ pub fn coalesce_send_data(mut data: Vec<SendData>) -> Vec<SendData> {
     data
 }
 
-pub fn get_root_span_index(trace: &Vec<pb::Span>) -> anyhow::Result<usize> {
+fn get_root_span_index(trace: &Vec<pb::Span>) -> anyhow::Result<usize> {
     if trace.is_empty() {
         anyhow::bail!("Cannot find root span index in an empty trace.");
     }

--- a/trace-utils/src/tracer_header_tags.rs
+++ b/trace-utils/src/tracer_header_tags.rs
@@ -1,0 +1,83 @@
+// Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+use hyper::http::HeaderValue;
+use hyper::HeaderMap;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+macro_rules! parse_string_header {
+    (
+        $header_map:ident,
+        { $($header_key:literal => $($field:ident).+ ,)+ }
+    ) => {
+        $(
+            if let Some(header_value) = $header_map.get($header_key) {
+                if let Ok(h) = header_value.to_str() {
+                    $($field).+ = h;
+                }
+            }
+        )+
+    }
+}
+
+#[derive(Default, Debug, Serialize, Deserialize)]
+pub struct TracerHeaderTags<'a> {
+    pub lang: &'a str,
+    pub lang_version: &'a str,
+    pub lang_interpreter: &'a str,
+    pub lang_vendor: &'a str,
+    pub tracer_version: &'a str,
+    pub container_id: &'a str,
+    // specifies that the client has marked top-level spans, when set. Any non-empty value will
+    // mean 'yes'.
+    pub client_computed_top_level: bool,
+    // specifies whether the client has computed stats so that the agent doesn't have to. Any
+    // non-empty value will mean 'yes'.
+    pub client_computed_stats: bool,
+}
+
+impl<'a> From<TracerHeaderTags<'a>> for HashMap<&'static str, String> {
+    fn from(tags: TracerHeaderTags<'a>) -> HashMap<&'static str, String> {
+        let mut headers = HashMap::from([
+            ("datadog-meta-lang", tags.lang.to_string()),
+            ("datadog-meta-lang-version", tags.lang_version.to_string()),
+            (
+                "datadog-meta-lang-interpreter",
+                tags.lang_interpreter.to_string(),
+            ),
+            ("datadog-meta-lang-vendor", tags.lang_vendor.to_string()),
+            (
+                "datadog-meta-tracer-version",
+                tags.tracer_version.to_string(),
+            ),
+            ("datadog-container-id", tags.container_id.to_string()),
+        ]);
+        headers.retain(|_, v| !v.is_empty());
+        headers
+    }
+}
+
+impl<'a> From<&'a HeaderMap<HeaderValue>> for TracerHeaderTags<'a> {
+    fn from(headers: &'a HeaderMap<HeaderValue>) -> Self {
+        let mut tags = TracerHeaderTags::default();
+        parse_string_header!(
+            headers,
+            {
+                "datadog-meta-lang" => tags.lang,
+                "datadog-meta-lang-version" => tags.lang_version,
+                "datadog-meta-lang-interpreter" => tags.lang_interpreter,
+                "datadog-meta-lang-vendor" => tags.lang_vendor,
+                "datadog-meta-tracer-version" => tags.tracer_version,
+                "datadog-container-id" => tags.container_id,
+            }
+        );
+        if headers.get("datadog-client-computed-top-level").is_some() {
+            tags.client_computed_top_level = true;
+        }
+        if headers.get("datadog-client-computed-stats").is_some() {
+            tags.client_computed_stats = true;
+        }
+        tags
+    }
+}


### PR DESCRIPTION
# What does this PR do?

This PR splits the `tracer_utils` into smaller parts and collects metrics for:
* trace_api.requests.
* trace_api.errors.
* trace_api.responses.
These metrics are then sent by the "self telemetry" worker of the sidecar.

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
