### PR TITLE
[PROF-8917] Add Ruby helper to get `ld_library_path` for libdatadog

### DIFF
--- a/ruby/lib/libdatadog.rb
+++ b/ruby/lib/libdatadog.rb
@@ -64,4 +64,12 @@ module Libdatadog
 
     File.absolute_path("#{pkgconfig_folder}/../../bin/libdatadog-crashtracking-receiver")
   end
+
+  def self.ld_library_path
+    pkgconfig_folder = self.pkgconfig_folder
+
+    return unless pkgconfig_folder
+
+    File.absolute_path("#{pkgconfig_folder}/../")
+  end
 end

--- a/ruby/spec/libdatadog_spec.rb
+++ b/ruby/spec/libdatadog_spec.rb
@@ -30,11 +30,7 @@ RSpec.describe Libdatadog do
       end
     end
 
-    context "when no binaries are available in the vendor directory" do
-      describe ".available_binaries" do
-        it { expect(Libdatadog.available_binaries).to be_empty }
-      end
-
+    shared_examples_for "libdatadog not in usable state" do
       describe ".pkgconfig_folder" do
         it { expect(Libdatadog.pkgconfig_folder).to be nil }
       end
@@ -42,6 +38,18 @@ RSpec.describe Libdatadog do
       describe ".path_to_crashtracking_receiver_binary" do
         it { expect(Libdatadog.path_to_crashtracking_receiver_binary).to be nil }
       end
+
+      describe ".ld_library_path" do
+        it { expect(Libdatadog.ld_library_path).to be nil }
+      end
+    end
+
+    context "when no binaries are available in the vendor directory" do
+      describe ".available_binaries" do
+        it { expect(Libdatadog.available_binaries).to be_empty }
+      end
+
+      it_behaves_like "libdatadog not in usable state"
     end
 
     context "when vendor directory does not exist" do
@@ -51,13 +59,7 @@ RSpec.describe Libdatadog do
         it { expect(Libdatadog.available_binaries).to be_empty }
       end
 
-      describe ".pkgconfig_folder" do
-        it { expect(Libdatadog.pkgconfig_folder).to be nil }
-      end
-
-      describe ".path_to_crashtracking_receiver_binary" do
-        it { expect(Libdatadog.path_to_crashtracking_receiver_binary).to be nil }
-      end
+      it_behaves_like "libdatadog not in usable state"
     end
 
     context "when binaries are available in the vendor directory" do
@@ -71,7 +73,7 @@ RSpec.describe Libdatadog do
       end
 
       context "for the current platform" do
-        let(:pkgconfig_folder) { "#{temporary_directory}/#{Gem::Platform.local}/some/folder/containing/the/pkgconfig/file" }
+        let(:pkgconfig_folder) { "#{temporary_directory}/#{Gem::Platform.local}/some/folder/containing/the/lib/pkgconfig" }
 
         before do
           create_dummy_pkgconfig_file(pkgconfig_folder)
@@ -130,16 +132,18 @@ RSpec.describe Libdatadog do
             )
           end
         end
+
+        describe ".ld_library_path" do
+          it "returns the full path to the libdatadog lib directory" do
+            expect(Libdatadog.ld_library_path).to eq(
+              "#{temporary_directory}/#{Gem::Platform.local}/some/folder/containing/the/lib"
+            )
+          end
+        end
       end
 
       context "but not for the current platform" do
-        describe ".pkgconfig_folder" do
-          it { expect(Libdatadog.pkgconfig_folder).to be nil }
-        end
-
-        describe ".path_to_crashtracking_receiver_binary" do
-          it { expect(Libdatadog.path_to_crashtracking_receiver_binary).to be nil }
-        end
+        it_behaves_like "libdatadog not in usable state"
       end
     end
   end


### PR DESCRIPTION
# What does this PR do?

This PR adds a `Libdatadog.ld_library_path` helper to the libdatadog Ruby support code.

This helper returns the full path to the `lib/` folder where the libdatadog `.so` files are contained.

# Motivation

I'm adding this to support the crashtracker for Ruby: we need this information when starting the crashtracker, and rather than having the knowledge of folder layouts inside dd-trace-rb, I think it makes sense for the libdatadog Ruby code to keep this knowledge.

# Additional Notes

I'm planning to include this change in the libdatadog 9 release for Ruby.

# How to test the change?

Test coverage is included (and CI runs these tests).