### PR TITLE
[PROF-9744] Propagate errors from expect calls

### DIFF
--- a/profiling/src/internal/profile.rs
+++ b/profiling/src/internal/profile.rs
@@ -374,13 +374,10 @@ impl Profile {
         let label = self.get_label_set(label_set_id)?.iter().find_map(|id| {
             if let Ok(label) = self.get_label(*id) {
                 if label.get_key() == self.endpoints.local_root_span_id_label {
-                    Some(label)
-                } else {
-                    None
+                    return Some(label);
                 }
-            } else {
-                None
             }
+            None
         });
         if let Some(label) = label {
             self.get_endpoint_for_label(label)

--- a/profiling/src/internal/profile.rs
+++ b/profiling/src/internal/profile.rs
@@ -381,7 +381,6 @@ impl Profile {
                 None
             }
         });
-
         if let Some(label) = label {
             self.get_endpoint_for_label(label)
         } else {

--- a/profiling/src/internal/profile.rs
+++ b/profiling/src/internal/profile.rs
@@ -372,8 +372,9 @@ impl Profile {
     fn get_endpoint_for_labels(&self, label_set_id: LabelSetId) -> anyhow::Result<Option<Label>> {
         let label = self.get_label_set(label_set_id)?.iter().find_map(|id| {
             let label = self.get_label(*id);
-            if label.is_ok()
-                && label.as_ref().unwrap().get_key() == self.endpoints.local_root_span_id_label
+            if label
+                .as_ref()
+                .is_ok_and(|l| l.get_key() == self.endpoints.local_root_span_id_label)
             {
                 Some(label.unwrap())
             } else {

--- a/profiling/src/internal/profile.rs
+++ b/profiling/src/internal/profile.rs
@@ -213,7 +213,7 @@ impl Profile {
         for (sample, timestamp, mut values) in std::mem::take(&mut self.observations).into_iter() {
             let labels = self.translate_and_enrich_sample_labels(sample, timestamp)?;
             let location_ids: Vec<_> = self
-                .get_stacktrace(sample.stacktrace)
+                .get_stacktrace(sample.stacktrace)?
                 .locations
                 .iter()
                 .map(Id::to_raw_id)
@@ -370,14 +370,17 @@ impl Profile {
     }
 
     fn get_endpoint_for_labels(&self, label_set_id: LabelSetId) -> anyhow::Result<Option<Label>> {
-        let label = self.get_label_set(label_set_id).iter().find_map(|id| {
+        let label = self.get_label_set(label_set_id)?.iter().find_map(|id| {
             let label = self.get_label(*id);
-            if label.get_key() == self.endpoints.local_root_span_id_label {
-                Some(label)
+            if label.is_ok()
+                && label.as_ref().unwrap().get_key() == self.endpoints.local_root_span_id_label
+            {
+                Some(label.unwrap())
             } else {
                 None
             }
         });
+
         if let Some(label) = label {
             self.get_endpoint_for_label(label)
         } else {
@@ -385,22 +388,22 @@ impl Profile {
         }
     }
 
-    fn get_label(&self, id: LabelId) -> &Label {
+    fn get_label(&self, id: LabelId) -> anyhow::Result<&Label> {
         self.labels
             .get_index(id.to_offset())
-            .expect("LabelId to have a valid interned index")
+            .ok_or(anyhow::anyhow!("LabelId to have a valid interned index"))
     }
 
-    fn get_label_set(&self, id: LabelSetId) -> &LabelSet {
+    fn get_label_set(&self, id: LabelSetId) -> anyhow::Result<&LabelSet> {
         self.label_sets
             .get_index(id.to_offset())
-            .expect("LabelSetId to have a valid interned index")
+            .ok_or(anyhow::anyhow!("LabelSetId to have a valid interned index"))
     }
 
-    fn get_stacktrace(&self, st: StackTraceId) -> &StackTrace {
+    fn get_stacktrace(&self, st: StackTraceId) -> anyhow::Result<&StackTrace> {
         self.stack_traces
             .get_index(st.to_raw_id())
-            .expect("StackTraceId {st} to exist in profile")
+            .ok_or(anyhow::anyhow!("StackTraceId {:?} to exist in profile", st))
     }
 
     /// Interns the `str` as a string, returning the id in the string table.
@@ -494,18 +497,16 @@ impl Profile {
         sample: Sample,
         timestamp: Option<Timestamp>,
     ) -> anyhow::Result<Vec<pprof::Label>> {
-        let labels: Vec<_> = self
-            .get_label_set(sample.labels)
+        self.get_label_set(sample.labels)?
             .iter()
-            .map(|l| self.get_label(*l).into())
+            .map(|l| self.get_label(*l).map(pprof::Label::from))
             .chain(
-                self.get_endpoint_for_labels(sample.labels)?
-                    .map(pprof::Label::from),
+                self.get_endpoint_for_labels(sample.labels)
+                    .transpose()
+                    .map(|res| res.map(pprof::Label::from)),
             )
-            .chain(timestamp.map(|ts| Label::num(self.timestamp_key, ts.get(), None).into()))
-            .collect();
-
-        Ok(labels)
+            .chain(timestamp.map(|ts| Ok(Label::num(self.timestamp_key, ts.get(), None).into())))
+            .collect()
     }
 
     /// Validates labels

--- a/profiling/src/internal/upscaling.rs
+++ b/profiling/src/internal/upscaling.rs
@@ -85,7 +85,7 @@ impl UpscalingRules {
                 let (_, rules) = self
                     .rules
                     .get_index_mut(index)
-                    .expect("Already existing rules");
+                    .ok_or(anyhow::anyhow!("Already existing rules"))?;
                 rules.push(rule);
             }
         };

--- a/profiling/src/internal/upscaling.rs
+++ b/profiling/src/internal/upscaling.rs
@@ -3,6 +3,7 @@
 
 use super::*;
 use crate::api::UpscalingInfo;
+use anyhow::Context;
 
 #[derive(Debug)]
 pub struct UpscalingRule {
@@ -85,7 +86,7 @@ impl UpscalingRules {
                 let (_, rules) = self
                     .rules
                     .get_index_mut(index)
-                    .ok_or(anyhow::anyhow!("Already existing rules"))?;
+                    .context("Already existing rules")?;
                 rules.push(rule);
             }
         };

--- a/profiling/src/internal/upscaling.rs
+++ b/profiling/src/internal/upscaling.rs
@@ -84,7 +84,7 @@ impl UpscalingRules {
             }
             Some(index) => {
                 let (_, rules) = self.rules.get_index_mut(index).with_context(|| {
-                    format!("Expected upscaling rules to exist for index {}", index)
+                    format!("Expected upscaling rules to exist for index {index}")
                 })?;
                 rules.push(rule);
             }

--- a/profiling/src/internal/upscaling.rs
+++ b/profiling/src/internal/upscaling.rs
@@ -83,10 +83,9 @@ impl UpscalingRules {
                 self.rules.insert((label_name_id, label_value_id), rules);
             }
             Some(index) => {
-                let (_, rules) = self
-                    .rules
-                    .get_index_mut(index)
-                    .context("Already existing rules")?;
+                let (_, rules) = self.rules.get_index_mut(index).with_context(|| {
+                    format!("Expected upscaling rules to exist for index {}", index)
+                })?;
                 rules.push(rule);
             }
         };


### PR DESCRIPTION
# What does this PR do?

Propagates errors from unwrap/expect calls instead of panicking right away. 

# Motivation

These might help reducing crashes from our profilers. 

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

`cargo test`