### PR TITLE
Move nightly Datadog agent protobuf validation to weekly

### DIFF
--- a/.github/workflows/weekly-verify-proto-files.yml
+++ b/.github/workflows/weekly-verify-proto-files.yml
@@ -1,14 +1,14 @@
-name: 'Nightly verify trace-protobuf'
+name: 'Weekly verify trace-protobuf'
 
 on:
   schedule:
-    - cron: '0 2 * * 1-5'
+    - cron: '0 2 * * 1'
 
 env:
   DATADOG_AGENT_TAG: "main"
 
 jobs:
-  nightly-verify-proto-files:
+  weekly-verify-proto-files:
     name: "Verify trace-protobuf .proto files are in sync with datadog-agent"        
     runs-on: ubuntu-latest
     environment: nightlies


### PR DESCRIPTION
# What does this PR do?

Moves the nightly validation of the protobuf files against Datadog agent `master` to a weekly cadence.

# Motivation

Changes to the protobuf files can't be reflected in `libdatadog` until there is a stable tag that the PR validation can compare against, and the Datadog agent doesn't release that often, so we don't need to be reminded every night about it.
