### PR TITLE
[crashtracker] Don't serialize unset fields

### DIFF
--- a/crashtracker/src/crash_info.rs
+++ b/crashtracker/src/crash_info.rs
@@ -42,21 +42,39 @@ impl CrashtrackerMetadata {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SigInfo {
     pub signum: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub signame: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CrashInfo {
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    #[serde(default)]
     pub additional_stacktraces: HashMap<String, Vec<StackFrame>>,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    #[serde(default)]
     pub counters: HashMap<String, i64>,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    #[serde(default)]
     pub files: HashMap<String, Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub metadata: Option<CrashtrackerMetadata>,
     pub os_info: os_info::Info,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub siginfo: Option<SigInfo>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default)]
     pub stacktrace: Vec<StackFrame>,
     pub incomplete: bool,
     /// Any additional data goes here
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    #[serde(default)]
     pub tags: HashMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub timestamp: Option<DateTime<Utc>>,
     pub uuid: Uuid,
 }

--- a/crashtracker/src/stacktrace.rs
+++ b/crashtracker/src/stacktrace.rs
@@ -5,19 +5,37 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct StackFrameNames {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub colno: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub filename: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub lineno: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub name: Option<String>,
 }
 
 /// All fields are hex encoded integers.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct StackFrame {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub ip: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub module_base_address: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub names: Option<Vec<StackFrameNames>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub sp: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub symbol_address: Option<String>,
 }
 


### PR DESCRIPTION
# What does this PR do?

Skips serializing unset fields in the crashtracker

# Motivation

Currently, we serialize empty fields as `null`, which leads to much larger serialized jsons than necessary.  Not doing this saves bytes on the wire, and makes things easier to read.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Using the `crashtracking.c` test example.  In this case the change is not huge, but its more noticeable in larger examples.

Before: 

```json
{
  "additional_stacktraces": {},
  "counters": {
    "not_profiling": 0,
    "serializing": 0,
    "collecting_sample": 0,
    "unwinding": 0
  },
  "files": {},
  "metadata": {
    "profiling_library_name": "crashtracking-test",
    "profiling_library_version": "12.34.56",
    "family": "crashtracking-test",
    "tags": []
  },
  "os_info": {
    "os_type": "Macos",
    "version": {
      "Semantic": [
        13,
        6,
        6
      ]
    },
    "edition": null,
    "codename": null,
    "bitness": "X64",
    "architecture": "arm64"
  },
  "siginfo": {
    "signum": 11,
    "signame": "SIGSEGV"
  },
  "stacktrace": [
    {
      "ip": "0x10514901c",
      "module_base_address": null,
      "names": null,
      "sp": "0x16b225ab0",
      "symbol_address": "0x10514901c"
    },
    {
      "ip": "0x105148b30",
      "module_base_address": null,
      "names": null,
      "sp": "0x16b225b20",
      "symbol_address": "0x105148b30"
    },
    {
      "ip": "0x1a8002a24",
      "module_base_address": null,
      "names": null,
      "sp": "0x16b225be0",
      "symbol_address": "0x1a8002a24"
    },
    {
      "ip": "0x104bdbd90",
      "module_base_address": null,
      "names": null,
      "sp": "0x16b225c10",
      "symbol_address": "0x104bdbd90"
    }
  ],
  "incomplete": false,
  "tags": {},
  "timestamp": "2024-05-15T14:25:03.099920Z",
  "uuid": "97861d3a-00bb-4b0c-975d-6a3ca6aceb09"
}
```
After
```json
{
  "counters": {
    "not_profiling": 0,
    "unwinding": 0,
    "serializing": 0,
    "collecting_sample": 0
  },
  "metadata": {
    "profiling_library_name": "crashtracking-test",
    "profiling_library_version": "12.34.56",
    "family": "crashtracking-test",
    "tags": []
  },
  "os_info": {
    "os_type": "Macos",
    "version": {
      "Semantic": [
        13,
        6,
        6
      ]
    },
    "edition": null,
    "codename": null,
    "bitness": "X64",
    "architecture": "arm64"
  },
  "siginfo": {
    "signum": 11,
    "signame": "SIGSEGV"
  },
  "stacktrace": [
    {
      "ip": "0x1035003d8",
      "sp": "0x16ce6dab0",
      "symbol_address": "0x1035003d8"
    },
    {
      "ip": "0x1034ffeec",
      "sp": "0x16ce6db20",
      "symbol_address": "0x1034ffeec"
    },
    {
      "ip": "0x1a8002a24",
      "sp": "0x16ce6dbe0",
      "symbol_address": "0x1a8002a24"
    },
    {
      "ip": "0x102f93d94",
      "sp": "0x16ce6dc10",
      "symbol_address": "0x102f93d94"
    }
  ],
  "incomplete": false,
  "timestamp": "2024-05-15T14:18:46.542785Z",
  "uuid": "2b3ee4c2-3216-4856-86c8-d5a49ba540cc"
}
```