### PR TITLE
[crashtracker] Add option to collect symbols in process

### DIFF
--- a/crashtracker/src/api.rs
+++ b/crashtracker/src/api.rs
@@ -126,7 +126,7 @@ fn test_crash() {
     let path_to_receiver_binary =
         "/tmp/libdatadog/bin/libdatadog-crashtracking-receiver".to_string();
     let create_alt_stack = true;
-    let resolve_frames = StacktraceCollection::Enabled;
+    let resolve_frames = StacktraceCollection::EnabledWithInprocessSymbols;
     let stderr_filename = Some(format!("{dir}/stderr_{time}.txt"));
     let stdout_filename = Some(format!("{dir}/stdout_{time}.txt"));
     let timeout = Duration::from_secs(30);

--- a/crashtracker/src/configuration.rs
+++ b/crashtracker/src/configuration.rs
@@ -15,7 +15,8 @@ pub enum StacktraceCollection {
     /// Stacktrace collection occurs in the
     Disabled,
     WithoutSymbols,
-    Enabled,
+    EnabledWithInprocessSymbols,
+    EnabledWithSymbolsInReceiver,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crashtracker/src/crash_handler.rs
+++ b/crashtracker/src/crash_handler.rs
@@ -332,7 +332,7 @@ fn handle_posix_signal_impl(signum: i32) -> anyhow::Result<()> {
     // https://doc.rust-lang.org/src/std/backtrace.rs.html#332
     // Do this last, so even if it crashes, we still get the other info.
     if config.resolve_frames != StacktraceCollection::Disabled {
-        unsafe { emit_backtrace_by_frames(pipe)? };
+        unsafe { emit_backtrace_by_frames(pipe, config.resolve_frames)? };
     }
     writeln!(pipe, "{DD_CRASHTRACK_DONE}")?;
 

--- a/crashtracker/src/receiver.rs
+++ b/crashtracker/src/receiver.rs
@@ -11,7 +11,7 @@ pub fn resolve_frames(
     config: &CrashtrackerConfiguration,
     crash_info: &mut CrashInfo,
 ) -> anyhow::Result<()> {
-    if config.resolve_frames == StacktraceCollection::Enabled {
+    if config.resolve_frames == StacktraceCollection::EnabledWithSymbolsInReceiver {
         // The receiver is the direct child of the crashing process
         // TODO: This pid should be sent over the wire, so that
         // it can be used in a sidecar.


### PR DESCRIPTION
# What does this PR do?

Restores the option to collect symbols in process that was removed in https://github.com/DataDog/libdatadog/pull/401

# Motivation

I removed it because I thought nobody was using it. Turns out Python was.  Putting it back in.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Modified `crashtracker.c` to use the new enum, and got this output

```json
{
  "counters": {
    "unwinding": 0,
    "not_profiling": 0,
    "collecting_sample": 0,
    "serializing": 0
  },
  "metadata": {
    "profiling_library_name": "crashtracking-test",
    "profiling_library_version": "12.34.56",
    "family": "crashtracking-test",
    "tags": []
  },
  "os_info": {
    "os_type": "Macos",
    "version": {
      "Semantic": [
        13,
        6,
        6
      ]
    },
    "edition": null,
    "codename": null,
    "bitness": "X64",
    "architecture": "arm64"
  },
  "siginfo": {
    "signum": 11,
    "signame": "SIGSEGV"
  },
  "stacktrace": [
    {
      "ip": "0x1050eb8b0",
      "names": [
        {
          "colno": 5,
          "filename": "/Users/daniel.schwartznarbonne/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.71/src/backtrace/libunwind.rs",
          "lineno": 105,
          "name": "backtrace::backtrace::libunwind::trace::hcb64546259faca6e"
        },
        {
          "colno": 5,
          "filename": "/Users/daniel.schwartznarbonne/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.71/src/backtrace/mod.rs",
          "lineno": 66,
          "name": "backtrace::backtrace::trace_unsynchronized::h449c2c234be2c879"
        },
        {
          "colno": 5,
          "filename": "/Users/daniel.schwartznarbonne/go/src/github.com/DataDog/libdatadog/crashtracker/src/collectors.rs",
          "lineno": 33,
          "name": "datadog_crashtracker::collectors::emit_backtrace_by_frames::h20a469c27d4d2bc2"
        }
      ],
      "sp": "0x16b2adaa0",
      "symbol_address": "0x1050eb8b0"
    },
    {
      "ip": "0x1050eb3bc",
      "names": [
        {
          "colno": 18,
          "filename": "/Users/daniel.schwartznarbonne/go/src/github.com/DataDog/libdatadog/crashtracker/src/crash_handler.rs",
          "lineno": 335,
          "name": "datadog_crashtracker::crash_handler::handle_posix_signal_impl::h3172de2881f81748"
        },
        {
          "colno": 13,
          "filename": "/Users/daniel.schwartznarbonne/go/src/github.com/DataDog/libdatadog/crashtracker/src/crash_handler.rs",
          "lineno": 214,
          "name": "datadog_crashtracker::crash_handler::handle_posix_sigaction::h79e38b5f86459741"
        }
      ],
      "sp": "0x16b2adb20",
      "symbol_address": "0x1050eb3bc"
    },
    {
      "ip": "0x1a8002a24",
      "names": [
        {
          "name": "__platform_memmove"
        }
      ],
      "sp": "0x16b2adbe0",
      "symbol_address": "0x1a8002a24"
    },
    {
      "ip": "0x104b53d90",
      "names": [
        {
          "name": "_main"
        }
      ],
      "sp": "0x16b2adc10",
      "symbol_address": "0x104b53d90"
    }
  ],
  "incomplete": false,
  "timestamp": "2024-05-15T16:30:02.475145Z",
  "uuid": "4b30b3b0-16c1-422d-a3a7-6471fede99a0"
}
```