### PR TITLE
Fix telemetry shutdown and log max filter

### DIFF
--- a/sidecar/src/log.rs
+++ b/sidecar/src/log.rs
@@ -243,7 +243,7 @@ impl<S: Subscriber> Filter<S> for &MultiEnvFilter {
             .unwrap()
             .values()
             .map(|f| f.max_level_hint())
-            .min()
+            .max()
             .flatten()
     }
 
@@ -393,10 +393,13 @@ mod tests {
     use super::{
         enable_logging, TemporarilyRetainedKeyParser, TemporarilyRetainedMap, MULTI_LOG_FILTER,
     };
+    use crate::log::MultiEnvFilter;
     use lazy_static::lazy_static;
     use std::sync::atomic::{AtomicI32, Ordering};
     use std::time::Duration;
+    use tracing::subscriber::NoSubscriber;
     use tracing::{debug, error, warn, Level};
+    use tracing_subscriber::layer::Filter;
 
     lazy_static! {
         static ref ENABLED: AtomicI32 = AtomicI32::default();
@@ -469,5 +472,16 @@ mod tests {
         let map = MULTI_LOG_FILTER.collect_logs_created_count();
         assert_eq!(1, map.len());
         assert_eq!(map[&Level::WARN], 1);
+    }
+
+    #[test]
+    fn test_multi_env_filter() {
+        let filter = MultiEnvFilter::default();
+        filter.add("warn".to_string());
+        filter.add("debug".to_string());
+        assert_eq!(
+            Level::DEBUG,
+            <&MultiEnvFilter as Filter<NoSubscriber>>::max_level_hint(&(&filter)).unwrap()
+        );
     }
 }

--- a/sidecar/src/service/runtime_info.rs
+++ b/sidecar/src/service/runtime_info.rs
@@ -5,7 +5,6 @@ use crate::service::{
     telemetry::{AppInstance, AppOrQueue},
     InstanceId, QueueId,
 };
-use ddtelemetry::worker::{LifecycleAction, TelemetryActions};
 use futures::{
     future::{self, join_all, Shared},
     FutureExt,
@@ -88,11 +87,7 @@ impl RuntimeInfo {
             .map(|instance| {
                 tokio::spawn(async move {
                     if let Some(instance) = instance {
-                        instance
-                            .telemetry
-                            .send_msg(TelemetryActions::Lifecycle(LifecycleAction::Stop))
-                            .await
-                            .ok();
+                        drop(instance.telemetry); // start shutdown
                         instance.telemetry_worker_shutdown.await;
                     }
                 })


### PR DESCRIPTION
Fixing max() in max_level_hint().

And properly dropping the telemetry worker:
When the runtime is shutdown with pending apps, it will send Stop, but never actually shutdown the telemetry instances. This regressed with d1fb3bc934e4b51b2ba1cb45818717351ad43b0. Now we simply drop the telemetry handle, which implicitly stops the worker as well causes the worker to be joined properly.

At least this led to the occasional deadlocked sidecar.