### PR TITLE
Make PHP and common components teams co-owners of the sidecar

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,4 +18,6 @@ trace-protobuf          @Datadog/serverless @Datadog/libdatadog-apm
 trace-mini-agent        @Datadog/serverless
 trace-utils             @Datadog/serverless @Datadog/libdatadog-apm
 serverless              @Datadog/serverless
+sidecar                 @Datadog/libdatadog-php @Datadog/libdatadog-apm
+sidecar-ffi             @Datadog/libdatadog-php @Datadog/libdatadog-apm
 data-pipeline*/         @Datadog/libdatadog-apm


### PR DESCRIPTION
# What does this PR do?

Gives co-ownership of the sidecar to @DataDog/libdatadog-apm and @DataDog/libdatadog-php 

# Motivation

Sidecar does not currently have any code ownership.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
