### PR TITLE
Add metrics

### DIFF
--- a/sidecar/src/self_telemetry.rs
+++ b/sidecar/src/self_telemetry.rs
@@ -28,9 +28,10 @@ struct MetricData<'a> {
     trace_api_requests: ContextKey,
     trace_api_responses: ContextKey,
     trace_api_errors: ContextKey,
-    trace_api_bytes: ContextKey,
-    trace_chunk_sent: ContextKey,
-    trace_chunk_dropped: ContextKey,
+    // TODO: APMSP-1157 - Enable this metric when support is enabled.
+    // trace_api_bytes: ContextKey,
+    trace_chunks_sent: ContextKey,
+    trace_chunks_dropped: ContextKey,
 }
 impl<'a> MetricData<'a> {
     async fn send(&self, key: ContextKey, value: f64, tags: Vec<Tag>) {
@@ -112,23 +113,24 @@ impl<'a> MetricData<'a> {
                 ],
             ));
         }
-        if trace_metrics.bytes_sent > 0 {
-            futures.push(self.send(
-                self.trace_api_bytes,
-                trace_metrics.bytes_sent as f64,
-                vec![tag!("src_library", "libdatadog")],
-            ));
-        }
+        // TODO: APMSP-1157 - Enable this metric when support is enabled.
+        // if trace_metrics.bytes_sent > 0 {
+        //     futures.push(self.send(
+        //         self.trace_api_bytes,
+        //         trace_metrics.bytes_sent as f64,
+        //         vec![tag!("src_library", "libdatadog")],
+        //     ));
+        // }
         if trace_metrics.chunks_sent > 0 {
             futures.push(self.send(
-                self.trace_chunk_sent,
+                self.trace_chunks_sent,
                 trace_metrics.chunks_sent as f64,
                 vec![tag!("src_library", "libdatadog")],
             ));
         }
         if trace_metrics.chunks_dropped > 0 {
             futures.push(self.send(
-                self.trace_chunk_dropped,
+                self.trace_chunks_dropped,
                 trace_metrics.chunks_dropped as f64,
                 vec![tag!("src_library", "libdatadog")],
             ));
@@ -257,22 +259,23 @@ impl SelfTelemetry {
                 true,
                 MetricNamespace::Tracers,
             ),
-            trace_api_bytes: worker.register_metric_context(
-                "trace_api_bytes".to_string(),
+            // TODO: APMSP-1157 - Enable this metric when support is enabled.
+            // trace_api_bytes: worker.register_metric_context(
+            //     "trace_api_bytes".to_string(),
+            //     vec![],
+            //     MetricType::Distribution,
+            //     true,
+            //     MetricNamespace::Tracers,
+            // ),
+            trace_chunks_sent: worker.register_metric_context(
+                "trace_chunks_sent".to_string(),
                 vec![],
                 MetricType::Count,
                 true,
                 MetricNamespace::Tracers,
             ),
-            trace_chunk_sent: worker.register_metric_context(
-                "trace_chunk_sent".to_string(),
-                vec![],
-                MetricType::Count,
-                true,
-                MetricNamespace::Tracers,
-            ),
-            trace_chunk_dropped: worker.register_metric_context(
-                "trace_chunk_dropped".to_string(),
+            trace_chunks_dropped: worker.register_metric_context(
+                "trace_chunks_dropped".to_string(),
                 vec![],
                 MetricType::Count,
                 true,

--- a/sidecar/src/self_telemetry.rs
+++ b/sidecar/src/self_telemetry.rs
@@ -69,63 +69,78 @@ impl<'a> MetricData<'a> {
             futures.push(self.send(
                 self.logs_created,
                 count as f64,
-                vec![Tag::new("level", level.as_str().to_lowercase()).unwrap()],
+                vec![
+                    Tag::new("level", level.as_str().to_lowercase()).unwrap(),
+                    tag!("src_library", "libdatadog"),
+                ],
             ));
         }
         if trace_metrics.api_requests > 0 {
             futures.push(self.send(
                 self.trace_api_requests,
                 trace_metrics.api_requests as f64,
-                vec![],
+                vec![Tag::new("src_library", "libdatadog").unwrap()],
             ));
         }
         if trace_metrics.api_errors_network > 0 {
             futures.push(self.send(
                 self.trace_api_errors,
                 trace_metrics.api_errors_network as f64,
-                vec![tag!("type", "network")],
+                vec![
+                    tag!("type", "network"),
+                    tag!("src_library", "libdatadog"),
+                ],
             ));
         }
         if trace_metrics.api_errors_timeout > 0 {
             futures.push(self.send(
                 self.trace_api_errors,
                 trace_metrics.api_errors_timeout as f64,
-                vec![tag!("type", "timeout")],
+                vec![
+                    tag!("type", "timeout"),
+                    tag!("src_library", "libdatadog"),
+                ],
             ));
         }
         if trace_metrics.api_errors_status_code > 0 {
             futures.push(self.send(
                 self.trace_api_errors,
                 trace_metrics.api_errors_status_code as f64,
-                vec![tag!("type", "status_code")],
+                vec![
+                    tag!("type", "status_code"),
+                    tag!("src_library", "libdatadog"),
+                ],
             ));
         }
         if trace_metrics.bytes_sent > 0 {
             futures.push(self.send(
                 self.trace_api_bytes,
                 trace_metrics.bytes_sent as f64,
-                vec![],
+                vec![tag!("src_library", "libdatadog")],
             ));
         }
         if trace_metrics.chunks_sent > 0 {
             futures.push(self.send(
                 self.trace_chunk_sent,
                 trace_metrics.chunks_sent as f64,
-                vec![],
+                vec![tag!("src_library", "libdatadog")],
             ));
         }
         if trace_metrics.chunks_dropped > 0 {
             futures.push(self.send(
                 self.trace_chunk_dropped,
                 trace_metrics.chunks_dropped as f64,
-                vec![],
+                vec![tag!("src_library", "libdatadog")],
             ));
         }
         for (status_code, count) in &trace_metrics.api_responses_count_per_code {
             futures.push(self.send(
                 self.trace_api_responses,
                 *count as f64,
-                vec![Tag::new("status_code", status_code.to_string().as_str()).unwrap()],
+                vec![
+                    Tag::new("status_code", status_code.to_string().as_str()).unwrap(),
+                    tag!("src_library", "libdatadog"),
+                ],
             ));
         }
 

--- a/sidecar/src/self_telemetry.rs
+++ b/sidecar/src/self_telemetry.rs
@@ -87,20 +87,14 @@ impl<'a> MetricData<'a> {
             futures.push(self.send(
                 self.trace_api_errors,
                 trace_metrics.api_errors_network as f64,
-                vec![
-                    tag!("type", "network"),
-                    tag!("src_library", "libdatadog"),
-                ],
+                vec![tag!("type", "network"), tag!("src_library", "libdatadog")],
             ));
         }
         if trace_metrics.api_errors_timeout > 0 {
             futures.push(self.send(
                 self.trace_api_errors,
                 trace_metrics.api_errors_timeout as f64,
-                vec![
-                    tag!("type", "timeout"),
-                    tag!("src_library", "libdatadog"),
-                ],
+                vec![tag!("type", "timeout"), tag!("src_library", "libdatadog")],
             ));
         }
         if trace_metrics.api_errors_status_code > 0 {

--- a/trace-mini-agent/src/trace_processor.rs
+++ b/trace-mini-agent/src/trace_processor.rs
@@ -213,7 +213,7 @@ mod tests {
 
         assert_eq!(
             expected_tracer_payload,
-            tracer_payload.unwrap().tracer_payloads[0]
+            tracer_payload.unwrap().get_payloads()[0]
         );
     }
 
@@ -283,7 +283,7 @@ mod tests {
         };
         assert_eq!(
             expected_tracer_payload,
-            tracer_payload.unwrap().tracer_payloads[0]
+            tracer_payload.unwrap().get_payloads()[0]
         );
     }
 }

--- a/trace-utils/Cargo.toml
+++ b/trace-utils/Cargo.toml
@@ -25,5 +25,6 @@ rand = "0.8.5"
 bytes = "1.6.0"
 
 [dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 httpmock = "0.7.0"
 serde_json = "1.0"

--- a/trace-utils/src/send_data.rs
+++ b/trace-utils/src/send_data.rs
@@ -7,7 +7,6 @@ use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use hyper::{Body, Client, Method, Response};
 use std::collections::HashMap;
-// use std::fmt::Result;
 use std::time::Duration;
 use tokio::time::sleep;
 
@@ -46,15 +45,15 @@ impl std::fmt::Display for RequestError {
 impl std::error::Error for RequestError {}
 
 pub enum RequestResult {
-    // Holds information from a succesful request.
+    /// Holds information from a succesful request.
     Success((Response<Body>, Attempts, BytesSent, ChunksSent)),
-    // Treats HTTP errors.
+    /// Treats HTTP errors.
     Error((Response<Body>, Attempts, ChunksDropped)),
-    // Treats timeout errors originated in the transport layer.
+    /// Treats timeout errors originated in the transport layer.
     TimeoutError((Attempts, ChunksDropped)),
-    // Treats errors coming from networking.
+    /// Treats errors coming from networking.
     NetworkError((Attempts, ChunksDropped)),
-    // Treats errors coming from building the request
+    /// Treats errors coming from building the request
     BuildError((Attempts, ChunksDropped)),
 }
 
@@ -110,9 +109,12 @@ impl SendDataResult {
     /// use datadog_trace_utils::send_data::RequestResult;
     /// use datadog_trace_utils::trace_utils::SendDataResult;
     ///
-    /// let result = RequestResult::NetworkError((1, 0));
-    /// let mut data_result = SendDataResult::default();
-    /// data_result.update(result);
+    /// #[cfg_attr(miri, ignore)]
+    /// async fn update_send_results_example() {
+    ///     let result = RequestResult::NetworkError((1, 0));
+    ///     let mut data_result = SendDataResult::default();
+    ///     data_result.update(result).await;
+    /// }
     /// ```
 
     pub async fn update(&mut self, res: RequestResult) {
@@ -517,6 +519,7 @@ impl SendData {
 }
 
 #[cfg(test)]
+// For RetryStrategy tests the observed delay should be approximate.
 mod tests {
     use super::*;
     use crate::trace_utils::construct_trace_chunk;
@@ -576,6 +579,7 @@ mod tests {
         let serialized_trace_payload = serialize_proto_payload(&agent_payload).unwrap();
         serialized_trace_payload.len()
     }
+
     fn rmp_compute_payload_len(payload: &Vec<pb::TracerPayload>) -> usize {
         let mut total: usize = 0;
         for payload in payload {
@@ -586,16 +590,7 @@ mod tests {
 
     #[test]
     fn send_data_new_api_key() {
-        let header_tags = TracerHeaderTags {
-            lang: "test-lang",
-            lang_version: "2.0",
-            lang_interpreter: "interpreter",
-            lang_vendor: "vendor",
-            tracer_version: "1.0",
-            container_id: "id",
-            client_computed_top_level: false,
-            client_computed_stats: false,
-        };
+        let header_tags = TracerHeaderTags::default();
 
         let payload = setup_payload(&header_tags);
         let data = SendData::new(
@@ -618,16 +613,7 @@ mod tests {
 
     #[test]
     fn send_data_new_no_api_key() {
-        let header_tags = TracerHeaderTags {
-            lang: "test-lang",
-            lang_version: "2.0",
-            lang_interpreter: "interpreter",
-            lang_vendor: "vendor",
-            tracer_version: "1.0",
-            container_id: "id",
-            client_computed_top_level: false,
-            client_computed_stats: false,
-        };
+        let header_tags = TracerHeaderTags::default();
 
         let payload = setup_payload(&header_tags);
         let data = SendData::new(
@@ -663,16 +649,7 @@ mod tests {
             })
             .await;
 
-        let header_tags = TracerHeaderTags {
-            lang: "test-lang",
-            lang_version: "2.0",
-            lang_interpreter: "interpreter",
-            lang_vendor: "vendor",
-            tracer_version: "1.0",
-            container_id: "id",
-            client_computed_top_level: false,
-            client_computed_stats: false,
-        };
+        let header_tags = TracerHeaderTags::default();
 
         let payload = setup_payload(&header_tags);
         let data = SendData::new(
@@ -714,16 +691,7 @@ mod tests {
             })
             .await;
 
-        let header_tags = TracerHeaderTags {
-            lang: "test-lang",
-            lang_version: "2.0",
-            lang_interpreter: "interpreter",
-            lang_vendor: "vendor",
-            tracer_version: "1.0",
-            container_id: "id",
-            client_computed_top_level: false,
-            client_computed_stats: false,
-        };
+        let header_tags = TracerHeaderTags::default();
 
         let payload = setup_payload(&header_tags);
         let mut data = SendData::new(
@@ -766,16 +734,7 @@ mod tests {
             })
             .await;
 
-        let header_tags = TracerHeaderTags {
-            lang: "test-lang",
-            lang_version: "2.0",
-            lang_interpreter: "interpreter",
-            lang_vendor: "vendor",
-            tracer_version: "1.0",
-            container_id: "id",
-            client_computed_top_level: false,
-            client_computed_stats: false,
-        };
+        let header_tags = TracerHeaderTags::default();
 
         let payload = setup_payload(&header_tags);
         let data = SendData::new(
@@ -817,16 +776,7 @@ mod tests {
             })
             .await;
 
-        let header_tags = TracerHeaderTags {
-            lang: "test-lang",
-            lang_version: "2.0",
-            lang_interpreter: "interpreter",
-            lang_vendor: "vendor",
-            tracer_version: "1.0",
-            container_id: "id",
-            client_computed_top_level: false,
-            client_computed_stats: false,
-        };
+        let header_tags = TracerHeaderTags::default();
 
         let payload = setup_payload(&header_tags);
         let mut data = SendData::new(

--- a/trace-utils/src/send_data.rs
+++ b/trace-utils/src/send_data.rs
@@ -5,32 +5,83 @@ use anyhow::{anyhow, Context};
 use bytes::Bytes;
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
-use hyper::{Body, Client, Method, Response, StatusCode};
+use hyper::{Body, Client, Method, Response};
 use std::collections::HashMap;
+// use std::fmt::Result;
 use std::time::Duration;
 use tokio::time::sleep;
 
 use crate::tracer_header_tags::TracerHeaderTags;
-use datadog_trace_protobuf::pb;
+use datadog_trace_protobuf::pb::{self, TracerPayload};
 use ddcommon::{connector, Endpoint, HttpRequestBuilder};
 
+const DD_API_KEY: &str = "DD-API-KEY";
+const HEADER_DD_TRACE_COUNT: &str = "X-Datadog-Trace-Count";
+const HEADER_HTTP_CTYPE: &str = "Content-Type";
+const HEADER_CTYPE_MSGPACK: &str = "application/msgpack";
+const HEADER_CTYPE_PROTOBUF: &str = "application/x-protobuf";
+
+type BytesSent = u64;
+type ChunksSent = u64;
+type ChunksDropped = u64;
+type Attempts = u32;
+
 #[derive(Debug)]
-pub enum SendRequestError {
-    Hyper(hyper::Error),
-    Any(anyhow::Error),
+enum RequestError {
+    Build,
+    Network,
+    Timeout,
 }
 
+impl std::fmt::Display for RequestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RequestError::Timeout => write!(f, "Connection timed out"),
+            RequestError::Network => write!(f, "Network error"),
+            RequestError::Build => write!(f, "Request failed due to invalid property"),
+        }
+    }
+}
+
+impl std::error::Error for RequestError {}
+
+pub enum RequestResult {
+    // Holds information from a succesful request.
+    Success((Response<Body>, Attempts, BytesSent, ChunksSent)),
+    // Treats HTTP errors.
+    Error((Response<Body>, Attempts, ChunksDropped)),
+    // Treats timeout errors originated in the transport layer.
+    TimeoutError((Attempts, ChunksDropped)),
+    // Treats errors coming from networking.
+    NetworkError((Attempts, ChunksDropped)),
+    // Treats errors coming from building the request
+    BuildError((Attempts, ChunksDropped)),
+}
+
+#[derive(Debug)]
 pub struct SendDataResult {
+    // Keeps track of the last request result.
     pub last_result: anyhow::Result<Response<Body>>,
+    // Count metric for 'trace_api.requests'.
     pub requests_count: u64,
+    // Count metric for 'trace_api.responses'. Each key maps  a different HTTP status code.
     pub responses_count_per_code: HashMap<u16, u64>,
+    // Count metric for 'trace_api.errors' (type: timeout).
     pub errors_timeout: u64,
+    // Count metric for 'trace_api.errors' (type: network).
     pub errors_network: u64,
+    // Count metric for 'trace_api.errors' (type: status_code).
     pub errors_status_code: u64,
+    // Count metric for 'trace_api.bytes'
+    pub bytes_sent: u64,
+    // Count metric for 'trace_chunk_sent'
+    pub chunks_sent: u64,
+    // Count metric for 'trace_chunks_dropped'
+    pub chunks_dropped: u64,
 }
 
-impl SendDataResult {
-    fn new() -> SendDataResult {
+impl Default for SendDataResult {
+    fn default() -> Self {
         SendDataResult {
             last_result: Err(anyhow!("No requests sent")),
             requests_count: 0,
@@ -38,50 +89,87 @@ impl SendDataResult {
             errors_timeout: 0,
             errors_network: 0,
             errors_status_code: 0,
+            bytes_sent: 0,
+            chunks_sent: 0,
+            chunks_dropped: 0,
         }
     }
+}
 
-    async fn update(
-        &mut self,
-        res: Result<Response<Body>, SendRequestError>,
-        expected_status: StatusCode,
-    ) {
-        self.requests_count += 1;
+impl SendDataResult {
+    ///
+    /// Updates `SendDataResult` internal information with the request's result information.
+    ///
+    /// # Arguments
+    ///
+    /// * `res` - Request result.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use datadog_trace_utils::send_data::RequestResult;
+    /// use datadog_trace_utils::trace_utils::SendDataResult;
+    ///
+    /// let result = RequestResult::NetworkError((1, 0));
+    /// let mut data_result = SendDataResult::default();
+    /// data_result.update(result);
+    /// ```
+
+    pub async fn update(&mut self, res: RequestResult) {
         match res {
-            Ok(response) => {
+            RequestResult::Success((response, attempts, bytes, chunks)) => {
                 *self
                     .responses_count_per_code
                     .entry(response.status().as_u16())
                     .or_default() += 1;
-                self.last_result = if response.status() == expected_status {
-                    Ok(response)
-                } else {
-                    self.errors_status_code += 1;
-
-                    let body_bytes = hyper::body::to_bytes(response.into_body()).await;
-                    let response_body = String::from_utf8(body_bytes.unwrap_or_default().to_vec())
-                        .unwrap_or_default();
-                    Err(anyhow::format_err!(
-                        "Server did not accept traces: {response_body}"
-                    ))
-                }
+                self.bytes_sent += bytes;
+                self.chunks_sent += chunks;
+                self.last_result = Ok(response);
+                self.requests_count += u64::from(attempts);
             }
-            Err(e) => match e {
-                SendRequestError::Hyper(e) => {
-                    if e.is_timeout() {
-                        self.errors_timeout += 1;
-                    } else {
-                        self.errors_network += 1;
-                    }
-                    self.last_result = Err(anyhow!(e));
-                }
-                SendRequestError::Any(e) => {
-                    self.last_result = Err(e);
-                }
-            },
+            RequestResult::Error((response, attempts, chunks)) => {
+                let status_code = response.status().as_u16();
+                self.errors_status_code += 1;
+                *self
+                    .responses_count_per_code
+                    .entry(status_code)
+                    .or_default() += 1;
+                self.chunks_dropped += chunks;
+                self.requests_count += u64::from(attempts);
+
+                let body_bytes = hyper::body::to_bytes(response.into_body()).await;
+                let response_body =
+                    String::from_utf8(body_bytes.unwrap_or_default().to_vec()).unwrap_or_default();
+                self.last_result = Err(anyhow::format_err!(
+                    "{} - Server did not accept traces: {}",
+                    status_code,
+                    response_body,
+                ));
+            }
+            RequestResult::TimeoutError((attempts, chunks)) => {
+                self.errors_timeout += 1;
+                self.chunks_dropped += chunks;
+                self.requests_count += u64::from(attempts);
+            }
+            RequestResult::NetworkError((attempts, chunks)) => {
+                self.errors_network += 1;
+                self.chunks_dropped += chunks;
+                self.requests_count += u64::from(attempts);
+            }
+            RequestResult::BuildError((attempts, chunks)) => {
+                self.chunks_dropped += chunks;
+                self.requests_count += u64::from(attempts);
+            }
         }
     }
 
+    ///
+    /// Sets `SendDataResult` last result information.
+    /// expected result.
+    ///
+    /// # Arguments
+    ///
+    /// * `err` - Error to be set.
     fn error(mut self, err: anyhow::Error) -> SendDataResult {
         self.last_result = Err(err);
         self
@@ -193,9 +281,9 @@ impl RetryStrategy {
 
 #[derive(Debug, Clone)]
 pub struct SendData {
-    pub tracer_payloads: Vec<pb::TracerPayload>,
-    pub size: usize, // have a rough size estimate to force flushing if it's large
-    pub target: Endpoint,
+    pub(crate) tracer_payloads: Vec<pb::TracerPayload>,
+    pub(crate) size: usize, // have a rough size estimate to force flushing if it's large
+    target: Endpoint,
     headers: HashMap<&'static str, String>,
     retry_strategy: RetryStrategy,
 }
@@ -208,7 +296,7 @@ impl SendData {
         target: &Endpoint,
     ) -> SendData {
         let headers = if let Some(api_key) = &target.api_key {
-            HashMap::from([("DD-API-KEY", api_key.as_ref().to_string())])
+            HashMap::from([(DD_API_KEY, api_key.as_ref().to_string())])
         } else {
             tracer_header_tags.into()
         };
@@ -222,6 +310,22 @@ impl SendData {
         }
     }
 
+    pub fn len(&self) -> usize {
+        self.size
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.size == 0
+    }
+
+    pub fn get_target(&self) -> &Endpoint {
+        &self.target
+    }
+
+    pub fn get_payloads(&self) -> &Vec<TracerPayload> {
+        &self.tracer_payloads
+    }
+
     /// Overrides the default RetryStrategy with user-defined values.
     ///
     /// # Arguments
@@ -229,6 +333,36 @@ impl SendData {
     /// * `retry_strategy`: The new retry strategy to be used.
     pub fn set_retry_strategy(&mut self, retry_strategy: RetryStrategy) {
         self.retry_strategy = retry_strategy;
+    }
+
+    async fn send_request(
+        &self,
+        req: HttpRequestBuilder,
+        payload: Bytes,
+    ) -> Result<Response<Body>, RequestError> {
+        let req = match req.body(Body::from(payload)) {
+            Ok(req) => req,
+            Err(_) => return Err(RequestError::Build),
+        };
+
+        match Client::builder()
+            .build(connector::Connector::default())
+            .request(req)
+            .await
+        {
+            Ok(resp) => Ok(resp),
+            Err(e) => {
+                if e.is_timeout() {
+                    Err(RequestError::Timeout)
+                } else {
+                    Err(RequestError::Network)
+                }
+            }
+        }
+    }
+
+    fn use_protobuf(&self) -> bool {
+        self.target.api_key.is_some()
     }
 
     pub async fn send(self) -> SendDataResult {
@@ -246,43 +380,59 @@ impl SendData {
         &self,
         content_type: &'static str,
         payload: Vec<u8>,
-    ) -> Result<Response<Body>, SendRequestError> {
+        payload_chunks: u64,
+    ) -> RequestResult {
         let mut request_attempt = 0;
         let payload = Bytes::from(payload);
         loop {
             request_attempt += 1;
             let mut req = self.create_request_builder();
-            req = req.header("Content-type", content_type);
+            req = req.header(HEADER_HTTP_CTYPE, content_type);
 
             let result = self.send_request(req, payload.clone()).await;
 
             // If the request was successful, or if we have exhausted retries then return the
             // result. Otherwise, delay and try again.
-            match &result {
+            match result {
                 Ok(response) => {
                     if response.status().is_client_error() || response.status().is_server_error() {
                         if request_attempt >= self.retry_strategy.max_retries {
-                            return result;
+                            return RequestResult::Error((
+                                response,
+                                request_attempt,
+                                payload_chunks,
+                            ));
                         } else {
                             self.retry_strategy.delay(request_attempt).await;
                         }
                     } else {
-                        return result;
+                        return RequestResult::Success((
+                            response,
+                            request_attempt,
+                            u64::try_from(payload.len()).unwrap(),
+                            payload_chunks,
+                        ));
                     }
                 }
-                Err(_) => {
+                Err(e) => {
                     if request_attempt >= self.retry_strategy.max_retries {
-                        return result;
+                        return match e {
+                            RequestError::Build => {
+                                RequestResult::BuildError((request_attempt, payload_chunks))
+                            }
+                            RequestError::Network => {
+                                RequestResult::NetworkError((request_attempt, payload_chunks))
+                            }
+                            RequestError::Timeout => {
+                                RequestResult::TimeoutError((request_attempt, payload_chunks))
+                            }
+                        };
                     } else {
                         self.retry_strategy.delay(request_attempt).await;
                     }
                 }
             }
         }
-    }
-
-    fn use_protobuf(&self) -> bool {
-        self.target.api_key.is_some()
     }
 
     fn create_request_builder(&self) -> HttpRequestBuilder {
@@ -301,25 +451,12 @@ impl SendData {
         req
     }
 
-    async fn send_request(
-        &self,
-        req: HttpRequestBuilder,
-        payload: Bytes,
-    ) -> Result<Response<Body>, SendRequestError> {
-        let req = req
-            .body(Body::from(payload))
-            .map_err(|e| SendRequestError::Any(anyhow!(e)))?;
-
-        Client::builder()
-            .build(connector::Connector::default())
-            .request(req)
-            .await
-            .map_err(SendRequestError::Hyper)
-    }
-
     async fn send_with_protobuf(&self) -> SendDataResult {
-        let mut result = SendDataResult::new();
-
+        let mut result = SendDataResult::default();
+        let mut chunks: u64 = 0;
+        for tracer_payload in &self.tracer_payloads {
+            chunks += u64::try_from(tracer_payload.chunks.len()).unwrap();
+        }
         let agent_payload = construct_agent_payload(self.tracer_payloads.clone());
         let serialized_trace_payload = match serialize_proto_payload(&agent_payload)
             .context("Failed to serialize trace agent payload, dropping traces")
@@ -330,9 +467,8 @@ impl SendData {
 
         result
             .update(
-                self.send_payload("application/x-protobuf", serialized_trace_payload)
+                self.send_payload(HEADER_CTYPE_PROTOBUF, serialized_trace_payload, chunks)
                     .await,
-                StatusCode::ACCEPTED,
             )
             .await;
 
@@ -340,23 +476,21 @@ impl SendData {
     }
 
     async fn send_with_msgpack(&self) -> SendDataResult {
-        let mut result = SendDataResult::new();
+        let mut result = SendDataResult::default();
 
         let mut req = self.create_request_builder();
-        req = req.header("Content-type", "application/msgpack");
+        req = req.header(HEADER_HTTP_CTYPE, HEADER_CTYPE_MSGPACK);
 
         let (template, _) = req.body(()).unwrap().into_parts();
 
         let mut futures = FuturesUnordered::new();
         for tracer_payload in self.tracer_payloads.iter() {
+            let chunks = u64::try_from(tracer_payload.chunks.len()).unwrap();
             let mut builder = HttpRequestBuilder::new()
                 .method(template.method.clone())
                 .uri(template.uri.clone())
                 .version(template.version)
-                .header(
-                    "X-Datadog-Trace-Count",
-                    tracer_payload.chunks.len().to_string(),
-                );
+                .header(HEADER_DD_TRACE_COUNT, chunks.to_string());
             builder
                 .headers_mut()
                 .unwrap()
@@ -366,12 +500,12 @@ impl SendData {
                 Ok(p) => p,
                 Err(e) => return result.error(anyhow!(e)),
             };
-            futures.push(self.send_payload("application/msgpack", payload));
+            futures.push(self.send_payload("application/msgpack", payload, chunks));
         }
         loop {
             match futures.next().await {
                 Some(response) => {
-                    result.update(response, StatusCode::OK).await;
+                    result.update(response).await;
                     if result.last_result.is_err() {
                         return result;
                     }
@@ -383,17 +517,410 @@ impl SendData {
 }
 
 #[cfg(test)]
-// For RetryStrategy tests the observed delay should be approximate.
-// There may be a small amount of overhead, so we check that the elapsed time is within
-// a tolerance of the expected delay.
-// TODO: APMSP-1079 - We should have more comprehensive tests for SendData logic beyond retry logic.
 mod tests {
     use super::*;
-    use httpmock::{Mock, MockServer};
-    use std::time::Duration;
+    use crate::trace_utils::construct_trace_chunk;
+    use crate::trace_utils::construct_tracer_payload;
+    use crate::trace_utils::RootSpanTags;
+    use crate::tracer_header_tags::TracerHeaderTags;
+    use datadog_trace_protobuf::pb;
+    use ddcommon::Endpoint;
+    use httpmock::prelude::*;
+    use httpmock::Mock;
+    use httpmock::MockServer;
+    use std::collections::HashMap;
     use tokio::time::Instant;
 
     const RETRY_STRATEGY_TIME_TOLERANCE_MS: u64 = 25;
+    const HEADER_TAGS: TracerHeaderTags = TracerHeaderTags {
+        lang: "test-lang",
+        lang_version: "2.0",
+        lang_interpreter: "interpreter",
+        lang_vendor: "vendor",
+        tracer_version: "1.0",
+        container_id: "id",
+        client_computed_top_level: false,
+        client_computed_stats: false,
+    };
+
+    fn setup_payload(header_tags: &TracerHeaderTags) -> pb::TracerPayload {
+        let root_tags = RootSpanTags {
+            env: "TEST",
+            app_version: "1.0",
+            hostname: "test_bench",
+            runtime_id: "id",
+        };
+
+        let chunk = construct_trace_chunk(vec![pb::Span {
+            service: "test-service".to_string(),
+            name: "test-service-name".to_string(),
+            resource: "test-service-resource".to_string(),
+            trace_id: 111,
+            span_id: 222,
+            parent_id: 333,
+            start: 1,
+            duration: 5,
+            error: 0,
+            meta: HashMap::new(),
+            metrics: HashMap::new(),
+            meta_struct: HashMap::new(),
+            r#type: "".to_string(),
+            span_links: vec![],
+        }]);
+
+        construct_tracer_payload(vec![chunk], header_tags, root_tags)
+    }
+
+    fn compute_payload_len(payload: &[pb::TracerPayload]) -> usize {
+        let agent_payload = construct_agent_payload(payload.to_vec());
+        let serialized_trace_payload = serialize_proto_payload(&agent_payload).unwrap();
+        serialized_trace_payload.len()
+    }
+    fn rmp_compute_payload_len(payload: &Vec<pb::TracerPayload>) -> usize {
+        let mut total: usize = 0;
+        for payload in payload {
+            total += rmp_serde::to_vec_named(payload).unwrap().len();
+        }
+        total
+    }
+
+    #[test]
+    fn send_data_new_api_key() {
+        let header_tags = TracerHeaderTags {
+            lang: "test-lang",
+            lang_version: "2.0",
+            lang_interpreter: "interpreter",
+            lang_vendor: "vendor",
+            tracer_version: "1.0",
+            container_id: "id",
+            client_computed_top_level: false,
+            client_computed_stats: false,
+        };
+
+        let payload = setup_payload(&header_tags);
+        let data = SendData::new(
+            100,
+            payload,
+            HEADER_TAGS,
+            &Endpoint {
+                api_key: Some(std::borrow::Cow::Borrowed("TEST-KEY")),
+                url: "/foo/bar?baz".parse::<hyper::Uri>().unwrap(),
+            },
+        );
+
+        assert_eq!(data.size, 100);
+
+        assert_eq!(data.target.api_key.unwrap(), "TEST-KEY");
+        assert_eq!(data.target.url.path(), "/foo/bar");
+
+        assert_eq!(data.headers.get("DD-API-KEY").unwrap(), "TEST-KEY");
+    }
+
+    #[test]
+    fn send_data_new_no_api_key() {
+        let header_tags = TracerHeaderTags {
+            lang: "test-lang",
+            lang_version: "2.0",
+            lang_interpreter: "interpreter",
+            lang_vendor: "vendor",
+            tracer_version: "1.0",
+            container_id: "id",
+            client_computed_top_level: false,
+            client_computed_stats: false,
+        };
+
+        let payload = setup_payload(&header_tags);
+        let data = SendData::new(
+            100,
+            payload,
+            header_tags.clone(),
+            &Endpoint {
+                api_key: None,
+                url: "/foo/bar?baz".parse::<hyper::Uri>().unwrap(),
+            },
+        );
+
+        assert_eq!(data.size, 100);
+
+        assert_eq!(data.target.api_key, None);
+        assert_eq!(data.target.url.path(), "/foo/bar");
+
+        assert_eq!(data.headers.get("DD-API-KEY"), None);
+        assert_eq!(data.headers, HashMap::from(header_tags));
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn request_protobuf() {
+        let server = MockServer::start_async().await;
+
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .header("Content-type", "application/x-protobuf")
+                    .path("/");
+                then.status(202).body("");
+            })
+            .await;
+
+        let header_tags = TracerHeaderTags {
+            lang: "test-lang",
+            lang_version: "2.0",
+            lang_interpreter: "interpreter",
+            lang_vendor: "vendor",
+            tracer_version: "1.0",
+            container_id: "id",
+            client_computed_top_level: false,
+            client_computed_stats: false,
+        };
+
+        let payload = setup_payload(&header_tags);
+        let data = SendData::new(
+            100,
+            payload.clone(),
+            header_tags,
+            &Endpoint {
+                api_key: Some(std::borrow::Cow::Borrowed("TEST-KEY")),
+                url: server.url("/").parse::<hyper::Uri>().unwrap(),
+            },
+        );
+
+        let data_payload_len = compute_payload_len(&data.tracer_payloads);
+        let res = data.send().await;
+
+        mock.assert_async().await;
+
+        assert_eq!(res.last_result.unwrap().status(), 202);
+        assert_eq!(res.errors_timeout, 0);
+        assert_eq!(res.errors_network, 0);
+        assert_eq!(res.errors_status_code, 0);
+        assert_eq!(res.requests_count, 1);
+        assert_eq!(res.chunks_sent, 1);
+        assert_eq!(res.bytes_sent, data_payload_len as u64);
+        assert_eq!(*res.responses_count_per_code.get(&202).unwrap(), 1_u64);
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn request_protobuf_several_payloads() {
+        let server = MockServer::start_async().await;
+
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .header("Content-type", "application/x-protobuf")
+                    .path("/");
+                then.status(202).body("");
+            })
+            .await;
+
+        let header_tags = TracerHeaderTags {
+            lang: "test-lang",
+            lang_version: "2.0",
+            lang_interpreter: "interpreter",
+            lang_vendor: "vendor",
+            tracer_version: "1.0",
+            container_id: "id",
+            client_computed_top_level: false,
+            client_computed_stats: false,
+        };
+
+        let payload = setup_payload(&header_tags);
+        let mut data = SendData::new(
+            100,
+            payload.clone(),
+            header_tags,
+            &Endpoint {
+                api_key: Some(std::borrow::Cow::Borrowed("TEST-KEY")),
+                url: server.url("/").parse::<hyper::Uri>().unwrap(),
+            },
+        );
+
+        data.tracer_payloads.push(payload.clone());
+        let data_payload_len = compute_payload_len(&data.tracer_payloads);
+        let res = data.send().await;
+
+        mock.assert_async().await;
+
+        assert_eq!(res.last_result.unwrap().status(), 202);
+        assert_eq!(res.errors_timeout, 0);
+        assert_eq!(res.errors_network, 0);
+        assert_eq!(res.errors_status_code, 0);
+        assert_eq!(res.requests_count, 1);
+        assert_eq!(res.chunks_sent, 2);
+        assert_eq!(res.bytes_sent, data_payload_len as u64);
+        assert_eq!(*res.responses_count_per_code.get(&202).unwrap(), 1_u64);
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn request_msgpack() {
+        let server = MockServer::start_async().await;
+
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .header("Content-type", "application/msgpack")
+                    .path("/");
+                then.status(200).body("");
+            })
+            .await;
+
+        let header_tags = TracerHeaderTags {
+            lang: "test-lang",
+            lang_version: "2.0",
+            lang_interpreter: "interpreter",
+            lang_vendor: "vendor",
+            tracer_version: "1.0",
+            container_id: "id",
+            client_computed_top_level: false,
+            client_computed_stats: false,
+        };
+
+        let payload = setup_payload(&header_tags);
+        let data = SendData::new(
+            100,
+            payload.clone(),
+            header_tags,
+            &Endpoint {
+                api_key: None,
+                url: server.url("/").parse::<hyper::Uri>().unwrap(),
+            },
+        );
+
+        let data_payload_len = rmp_compute_payload_len(&data.tracer_payloads);
+        let res = data.send().await;
+
+        mock.assert_async().await;
+
+        assert_eq!(res.last_result.unwrap().status(), 200);
+        assert_eq!(res.errors_timeout, 0);
+        assert_eq!(res.errors_network, 0);
+        assert_eq!(res.errors_status_code, 0);
+        assert_eq!(res.requests_count, 1);
+        assert_eq!(res.chunks_sent, 1);
+        assert_eq!(res.bytes_sent, data_payload_len as u64);
+        assert_eq!(*res.responses_count_per_code.get(&200).unwrap(), 1_u64);
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn request_msgpack_several_payloads() {
+        let server = MockServer::start_async().await;
+
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .header("Content-type", "application/msgpack")
+                    .path("/");
+                then.status(200).body("");
+            })
+            .await;
+
+        let header_tags = TracerHeaderTags {
+            lang: "test-lang",
+            lang_version: "2.0",
+            lang_interpreter: "interpreter",
+            lang_vendor: "vendor",
+            tracer_version: "1.0",
+            container_id: "id",
+            client_computed_top_level: false,
+            client_computed_stats: false,
+        };
+
+        let payload = setup_payload(&header_tags);
+        let mut data = SendData::new(
+            100,
+            payload.clone(),
+            header_tags,
+            &Endpoint {
+                api_key: None,
+                url: server.url("/").parse::<hyper::Uri>().unwrap(),
+            },
+        );
+
+        data.tracer_payloads.push(payload.clone());
+        let data_payload_len = rmp_compute_payload_len(&data.tracer_payloads);
+        let res = data.send().await;
+
+        mock.assert_hits_async(2).await;
+
+        assert_eq!(res.last_result.unwrap().status(), 200);
+        assert_eq!(res.errors_timeout, 0);
+        assert_eq!(res.errors_network, 0);
+        assert_eq!(res.errors_status_code, 0);
+        assert_eq!(res.requests_count, 2);
+        assert_eq!(res.chunks_sent, 2);
+        assert_eq!(res.bytes_sent, data_payload_len as u64);
+        assert_eq!(*res.responses_count_per_code.get(&200).unwrap(), 2_u64);
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn request_error_status_code() {
+        let server = MockServer::start_async().await;
+
+        let mock = server
+            .mock_async(|when, then| {
+                when.method(POST)
+                    .header("Content-type", "application/msgpack")
+                    .path("/");
+                then.status(500).body("");
+            })
+            .await;
+
+        let payload = setup_payload(&HEADER_TAGS);
+        let data = SendData::new(
+            100,
+            payload,
+            HEADER_TAGS,
+            &Endpoint {
+                api_key: None,
+                url: server.url("/").parse::<hyper::Uri>().unwrap(),
+            },
+        );
+
+        let res = data.send().await;
+
+        mock.assert_hits_async(5).await;
+
+        assert!(res.last_result.is_err());
+        assert_eq!(res.errors_timeout, 0);
+        assert_eq!(res.errors_network, 0);
+        assert_eq!(res.errors_status_code, 1);
+        assert_eq!(res.requests_count, 5);
+        assert_eq!(res.chunks_sent, 0);
+        assert_eq!(res.bytes_sent, 0);
+        assert_eq!(*res.responses_count_per_code.get(&500).unwrap(), 1_u64);
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn request_error_network() {
+        // Server not created in order to return a 'connection refused' error.
+        let payload = setup_payload(&HEADER_TAGS);
+        let data = SendData::new(
+            100,
+            payload,
+            HEADER_TAGS,
+            &Endpoint {
+                api_key: None,
+                url: "http://127.0.0.1:4321/".parse::<hyper::Uri>().unwrap(),
+            },
+        );
+
+        let res = data.send().await;
+
+        assert!(res.last_result.is_err());
+        assert_eq!(res.errors_timeout, 0);
+        assert_eq!(res.errors_network, 1);
+        assert_eq!(res.errors_status_code, 0);
+        assert_eq!(res.requests_count, 5);
+        assert_eq!(res.errors_status_code, 0);
+        assert_eq!(res.chunks_sent, 0);
+        assert_eq!(res.bytes_sent, 0);
+        assert_eq!(res.responses_count_per_code.len(), 0);
+    }
 
     #[cfg_attr(miri, ignore)]
     #[tokio::test]

--- a/trace-utils/src/trace_utils.rs
+++ b/trace-utils/src/trace_utils.rs
@@ -49,7 +49,7 @@ pub struct RootSpanTags<'a> {
     pub runtime_id: &'a str,
 }
 
-pub fn construct_trace_chunk(trace: Vec<pb::Span>) -> pb::TraceChunk {
+pub(crate) fn construct_trace_chunk(trace: Vec<pb::Span>) -> pb::TraceChunk {
     pb::TraceChunk {
         priority: normalizer::SamplerPriority::None as i32,
         origin: "".to_string(),
@@ -59,7 +59,7 @@ pub fn construct_trace_chunk(trace: Vec<pb::Span>) -> pb::TraceChunk {
     }
 }
 
-pub fn construct_tracer_payload(
+pub(crate) fn construct_tracer_payload(
     chunks: Vec<pb::TraceChunk>,
     tracer_tags: &TracerHeaderTags,
     root_span_tags: RootSpanTags,
@@ -211,7 +211,7 @@ pub fn set_serverless_root_span_tags(
     }
 }
 
-pub fn update_tracer_top_level(span: &mut pb::Span) {
+fn update_tracer_top_level(span: &mut pb::Span) {
     if span.metrics.contains_key(TRACER_TOP_LEVEL_KEY) {
         span.metrics.insert(TOP_LEVEL_KEY.to_string(), 1.0);
     }

--- a/trace-utils/src/trace_utils.rs
+++ b/trace-utils/src/trace_utils.rs
@@ -42,14 +42,14 @@ pub async fn get_traces_from_request_body(
 
 // Tags gathered from a trace's root span
 #[derive(Default)]
-struct RootSpanTags<'a> {
+pub struct RootSpanTags<'a> {
     pub env: &'a str,
     pub app_version: &'a str,
     pub hostname: &'a str,
     pub runtime_id: &'a str,
 }
 
-fn construct_trace_chunk(trace: Vec<pb::Span>) -> pb::TraceChunk {
+pub fn construct_trace_chunk(trace: Vec<pb::Span>) -> pb::TraceChunk {
     pb::TraceChunk {
         priority: normalizer::SamplerPriority::None as i32,
         origin: "".to_string(),
@@ -59,7 +59,7 @@ fn construct_trace_chunk(trace: Vec<pb::Span>) -> pb::TraceChunk {
     }
 }
 
-fn construct_tracer_payload(
+pub fn construct_tracer_payload(
     chunks: Vec<pb::TraceChunk>,
     tracer_tags: &TracerHeaderTags,
     root_span_tags: RootSpanTags,
@@ -81,9 +81,9 @@ fn construct_tracer_payload(
 pub fn coalesce_send_data(mut data: Vec<SendData>) -> Vec<SendData> {
     // TODO trace payloads with identical data except for chunk could be merged?
 
-    data.sort_unstable_by(|a, b| a.target.url.to_string().cmp(&b.target.url.to_string()));
+    data.sort_unstable_by(|a, b| a.get_target().url.to_string().cmp(&b.get_target().url.to_string()));
     data.dedup_by(|a, b| {
-        if a.target.url == b.target.url {
+        if a.get_target().url == b.get_target().url {
             // Size is only an approximation. In practice it won't vary much, but be safe here.
             // We also don't care about the exact maximum size, like two 25 MB or one 50 MB request
             // has similar results. The primary goal here is avoiding many small requests.

--- a/trace-utils/src/trace_utils.rs
+++ b/trace-utils/src/trace_utils.rs
@@ -81,7 +81,12 @@ pub fn construct_tracer_payload(
 pub fn coalesce_send_data(mut data: Vec<SendData>) -> Vec<SendData> {
     // TODO trace payloads with identical data except for chunk could be merged?
 
-    data.sort_unstable_by(|a, b| a.get_target().url.to_string().cmp(&b.get_target().url.to_string()));
+    data.sort_unstable_by(|a, b| {
+        a.get_target()
+            .url
+            .to_string()
+            .cmp(&b.get_target().url.to_string())
+    });
     data.dedup_by(|a, b| {
         if a.get_target().url == b.get_target().url {
             // Size is only an approximation. In practice it won't vary much, but be safe here.

--- a/trace-utils/src/tracer_header_tags.rs
+++ b/trace-utils/src/tracer_header_tags.rs
@@ -105,7 +105,10 @@ mod tests {
         assert_eq!(map.len(), 6);
         assert_eq!(map.get("datadog-meta-lang").unwrap(), "test-lang");
         assert_eq!(map.get("datadog-meta-lang-version").unwrap(), "2.0");
-        assert_eq!(map.get("datadog-meta-lang-interpreter").unwrap(), "interpreter");
+        assert_eq!(
+            map.get("datadog-meta-lang-interpreter").unwrap(),
+            "interpreter"
+        );
         assert_eq!(map.get("datadog-meta-lang-vendor").unwrap(), "vendor");
         assert_eq!(map.get("datadog-meta-tracer-version").unwrap(), "1.0");
         assert_eq!(map.get("datadog-container-id").unwrap(), "id");
@@ -128,7 +131,10 @@ mod tests {
         assert_eq!(map.len(), 5);
         assert_eq!(map.get("datadog-meta-lang").unwrap(), "test-lang");
         assert_eq!(map.get("datadog-meta-lang-version").unwrap(), "2.0");
-        assert_eq!(map.get("datadog-meta-lang-interpreter").unwrap(), "interpreter");
+        assert_eq!(
+            map.get("datadog-meta-lang-interpreter").unwrap(),
+            "interpreter"
+        );
         assert_eq!(map.get("datadog-meta-lang-vendor").unwrap(), "vendor");
         assert_eq!(map.get("datadog-meta-tracer-version").unwrap(), "1.0");
         assert_eq!(map.get("datadog-container-id"), None);
@@ -140,7 +146,10 @@ mod tests {
 
         header_map.insert("datadog-meta-lang", "test-lang".parse().unwrap());
         header_map.insert("datadog-meta-lang-version", "2.0".parse().unwrap());
-        header_map.insert("datadog-meta-lang-interpreter", "interpreter".parse().unwrap());
+        header_map.insert(
+            "datadog-meta-lang-interpreter",
+            "interpreter".parse().unwrap(),
+        );
         header_map.insert("datadog-meta-lang-vendor", "vendor".parse().unwrap());
         header_map.insert("datadog-meta-tracer-version", "1.0".parse().unwrap());
         header_map.insert("datadog-container-id", "id".parse().unwrap());


### PR DESCRIPTION
# What does this PR do?

Adds support for sending the following metrics:

- trace_api.bytes
- trace_chunks_sent
- trace_chunks_dropped

Aside from the introduction of those new metrics a small refactor has been done on send_data.rs in order to address some technical debt from previous PRs. This changes can be summarized in:

- Limit visibility of `SendData` fields.
- Add default trait implementation for `SendDataResult`.
- Add tests for both `TraceHeaderTags` and `SendData`.

# Motivation

In order to turn the sidecar on by default for PHP there is the need to support those metrics.
