### PR TITLE
Link libpthread into the spawn_worker trampoline

### DIFF
--- a/spawn_worker/build.rs
+++ b/spawn_worker/build.rs
@@ -18,7 +18,10 @@ fn main() {
         if cfg!(target_os = "linux") {
             builder.flag("-Wl,--no-as-needed");
         }
-        builder.link_dynamically("m"); // rust code generally requires libm. Just link against it.
+        // rust code generally requires libm. Just link against it.
+        builder.link_dynamically("m");
+        // some old libc versions are unhappy if it gets linked in dynamically later on
+        builder.link_dynamically("pthread");
     } else {
         builder.flag("-wd4996"); // disable deprecation warnings
     }


### PR DESCRIPTION
It apparently leads to race conditions if libpthread and libc aren't loaded at the same time. In this case a library linking against libpthread is dlopen()'ed dynamically from the trampoline.

It led to interesting libc memory corruptions, like in getaddrinfo:
```
#2  0x00007fe45328df67 in __libc_message (do_abort=do_abort@entry=2, fmt=fmt@entry=0x7fe4533a05d0 "*** Error in `%s': %s: 0x%s ***\n") at ../sysdeps/unix/sysv/linux/libc_fatal.c:196
#3  0x00007fe453296329 in malloc_printerr (ar_ptr=0x7fe4535dc760 <main_arena>, ptr=<optimized out>, str=0x7fe4533a06d8 "double free or corruption (out)", action=3) at malloc.c:4967
#4  _int_free (av=0x7fe4535dc760 <main_arena>, p=<optimized out>, have_lock=0) at malloc.c:3843
#5  0x00007fe453283247 in _IO_new_fclose (fp=0x7fe448001d20) at iofclose.c:84
```
etc. on older glibc versions.