### PR TITLE
[profiling] use internal Label instead of pprof::Label

### DIFF
--- a/profiling/src/collections/identifiable/string_id.rs
+++ b/profiling/src/collections/identifiable/string_id.rs
@@ -15,15 +15,6 @@ impl StringId {
         Self(0)
     }
 
-    // todo: remove when upscaling uses internal::* instead of pprof::*
-    pub fn new<T>(v: T) -> Self
-    where
-        T: TryInto<u32>,
-        T::Error: core::fmt::Debug,
-    {
-        Self(v.try_into().expect("StringId to fit into a u32"))
-    }
-
     #[inline]
     pub const fn is_zero(&self) -> bool {
         self.0 == 0
@@ -39,7 +30,7 @@ impl Id for StringId {
     type RawId = i64;
 
     fn from_offset(inner: usize) -> Self {
-        Self::new(inner)
+        Self(inner.try_into().expect("StringId to fit into a u32"))
     }
 
     fn to_raw_id(&self) -> Self::RawId {

--- a/profiling/src/internal/profile.rs
+++ b/profiling/src/internal/profile.rs
@@ -489,12 +489,8 @@ impl Profile {
     ) -> anyhow::Result<Vec<Label>> {
         self.get_label_set(sample.labels)?
             .iter()
-            .map(|l| self.get_label(*l).map(|l| l.clone()))
-            .chain(
-                self.get_endpoint_for_labels(sample.labels)
-                    .transpose()
-                    .map(|res| res.map(|l| l.clone())),
-            )
+            .map(|l| self.get_label(*l).copied())
+            .chain(self.get_endpoint_for_labels(sample.labels).transpose())
             .chain(timestamp.map(|ts| Ok(Label::num(self.timestamp_key, ts.get(), None))))
             .collect()
     }

--- a/profiling/src/internal/upscaling.rs
+++ b/profiling/src/internal/upscaling.rs
@@ -151,17 +151,20 @@ impl UpscalingRules {
         self.rules.is_empty()
     }
 
-    // TODO: Consider whether to use the internal Label here instead
-    pub fn upscale_values(
-        &self,
-        values: &mut [i64],
-        labels: &[pprof::Label],
-    ) -> anyhow::Result<()> {
+    pub fn upscale_values(&self, values: &mut [i64], labels: &[Label]) -> anyhow::Result<()> {
         if !self.is_empty() {
             // get bylabel rules first (if any)
             let mut group_of_rules = labels
                 .iter()
-                .filter_map(|label| self.get(&(StringId::new(label.key), StringId::new(label.str))))
+                .filter_map(|label| {
+                    self.get(&(
+                        label.get_key(),
+                        match label.get_value() {
+                            LabelValue::Str(str) => *str,
+                            LabelValue::Num { .. } => StringId::ZERO,
+                        },
+                    ))
+                })
                 .collect::<Vec<&Vec<UpscalingRule>>>();
 
             // get byvalue rules if any


### PR DESCRIPTION
# What does this PR do?

Resolves a TODO. Use `internal::Label` instead of `pprof::Label` to make it easier to fuzz test. Even though `pprof::Label` can also derive `bolero_generator::TypeGenerator` guarded by `cfg(test)`, it would be best to keep internal things internal.
 Also, this lets us use `pprof::Label` only when returning pprof.

# Motivation

TODO

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

`cargo nextest run`