### PR TITLE
Skip slow bin_tests during code coverage, since they time out the build

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -18,6 +18,13 @@ fail-fast = true
 filter = 'test(::single_threaded_tests::)'
 test-group = 'single-threaded'
 
+[profile.coverage]
+# Print out output for failing tests as soon as they fail, and also at the end
+# of the run (for easy scrollability).
+failure-output = "immediate-final"
+# Do not cancel the test run on the first failure.
+fail-fast = false
+
 [profile.ci]
 # Print out output for failing tests as soon as they fail, and also at the end
 # of the run (for easy scrollability).

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,7 @@ jobs:
           tool: cargo-llvm-cov@0.6.9,nextest@0.9.68
       - name: Generate code coverage (including doc tests)
         run: |
-          cargo llvm-cov --all-features --workspace --no-report nextest
+          cargo llvm-cov --all-features --workspace --no-report nextest run --profile coverage -E 'all() - package(bin_tests)'
           cargo llvm-cov --all-features --workspace --no-report --doc
           cargo llvm-cov report --doctests --lcov --output-path lcov.info
       - name: Upload coverage to Codecov


### PR DESCRIPTION
# What does this PR do?

Skips the `bin_tests` package when running code coverage.

# Motivation

Building and running those tests take so long that the code coverage task times out.
