### PR TITLE
Transmit size of data in send_trace_v04_shm

### DIFF
--- a/sidecar-ffi/src/lib.rs
+++ b/sidecar-ffi/src/lib.rs
@@ -493,6 +493,7 @@ pub unsafe extern "C" fn ddog_sidecar_send_trace_v04_shm(
     transport: &mut Box<SidecarTransport>,
     instance_id: &InstanceId,
     shm_handle: Box<ShmHandle>,
+    len: usize,
     tracer_header_tags: &TracerHeaderTags,
 ) -> MaybeError {
     let tracer_header_tags = try_c!(tracer_header_tags.try_into());
@@ -501,6 +502,7 @@ pub unsafe extern "C" fn ddog_sidecar_send_trace_v04_shm(
         transport,
         instance_id,
         *shm_handle,
+        len,
         tracer_header_tags,
     ));
 

--- a/sidecar/src/service/blocking.rs
+++ b/sidecar/src/service/blocking.rs
@@ -240,6 +240,7 @@ pub fn send_trace_v04_bytes(
 /// * `transport` - The transport used for communication.
 /// * `instance_id` - The ID of the instance.
 /// * `handle` - The handle to the shared memory.
+/// * `len` - The size of the shared memory data.
 /// * `headers` - The serialized headers from the tracer.
 ///
 /// # Returns
@@ -249,11 +250,13 @@ pub fn send_trace_v04_shm(
     transport: &mut SidecarTransport,
     instance_id: &InstanceId,
     handle: ShmHandle,
+    len: usize,
     headers: SerializedTracerHeaderTags,
 ) -> io::Result<()> {
     transport.send(SidecarInterfaceRequest::SendTraceV04Shm {
         instance_id: instance_id.clone(),
         handle,
+        len,
         headers,
     })
 }

--- a/sidecar/src/service/sidecar_interface.rs
+++ b/sidecar/src/service/sidecar_interface.rs
@@ -76,10 +76,12 @@ pub trait SidecarInterface {
     ///
     /// * `instance_id` - The ID of the instance.
     /// * `handle` - The handle to the shared memory.
+    /// * `len` - The size of the shared memory data.
     /// * `headers` - The serialized headers from the tracer.
     async fn send_trace_v04_shm(
         instance_id: InstanceId,
         #[SerializedHandle] handle: ShmHandle,
+        len: usize,
         headers: SerializedTracerHeaderTags,
     );
 

--- a/sidecar/src/service/sidecar_server.rs
+++ b/sidecar/src/service/sidecar_server.rs
@@ -647,6 +647,7 @@ impl SidecarInterface for SidecarServer {
         _: Context,
         instance_id: InstanceId,
         handle: ShmHandle,
+        len: usize,
         headers: SerializedTracerHeaderTags,
     ) -> Self::SendTraceV04ShmFut {
         if let Some(endpoint) = self
@@ -658,7 +659,7 @@ impl SidecarInterface for SidecarServer {
             tokio::spawn(async move {
                 match handle.map() {
                     Ok(mapped) => {
-                        self.send_trace_v04(&headers, mapped.as_slice(), &endpoint);
+                        self.send_trace_v04(&headers, &mapped.as_slice()[..len], &endpoint);
                     }
                     Err(e) => error!("Failed mapping shared trace data memory: {}", e),
                 }


### PR DESCRIPTION
ShmHandle.size() is an upper bound of the size rather than the actual size. This confuses the TraceFlusher and will thus flush for every single request.