### PR TITLE
Add explicit synchronous flush capability to sidecar

### DIFF
--- a/sidecar-ffi/src/lib.rs
+++ b/sidecar-ffi/src/lib.rs
@@ -213,6 +213,13 @@ pub extern "C" fn ddog_sidecar_ping(transport: &mut Box<SidecarTransport>) -> Ma
 }
 
 #[no_mangle]
+pub extern "C" fn ddog_sidecar_flush_traces(transport: &mut Box<SidecarTransport>) -> MaybeError {
+    try_c!(blocking::flush_traces(transport));
+
+    MaybeError::None
+}
+
+#[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn ddog_sidecar_instanceId_build(
     session_id: ffi::CharSlice,

--- a/sidecar/src/service/blocking.rs
+++ b/sidecar/src/service/blocking.rs
@@ -319,6 +319,20 @@ pub fn stats(transport: &mut SidecarTransport) -> io::Result<String> {
     }
 }
 
+/// Flushes the outstanding traces.
+///
+/// # Arguments
+///
+/// * `transport` - The transport used for communication.
+///
+/// # Returns
+///
+/// An `io::Result<()>` indicating the result of the operation.
+pub fn flush_traces(transport: &mut SidecarTransport) -> io::Result<()> {
+    transport.call(SidecarInterfaceRequest::FlushTraces {})?;
+    Ok(())
+}
+
 /// Sends a ping to the service.
 ///
 /// # Arguments

--- a/sidecar/src/service/sidecar_interface.rs
+++ b/sidecar/src/service/sidecar_interface.rs
@@ -106,6 +106,9 @@ pub trait SidecarInterface {
     /// * `actions` - The DogStatsD actions to send.
     async fn send_dogstatsd_actions(instance_id: InstanceId, actions: Vec<DogStatsDAction>);
 
+    /// Flushes any outstanding traces queued for sending.
+    async fn flush_traces();
+
     /// Sends a ping to the service.
     async fn ping();
 

--- a/sidecar/src/service/tracing/trace_send_data.rs
+++ b/sidecar/src/service/tracing/trace_send_data.rs
@@ -2,28 +2,46 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use datadog_trace_utils::trace_utils::SendData;
+use futures::future::Map;
+use futures::FutureExt;
 use manual_future::ManualFutureCompleter;
+use tokio::sync::mpsc::Sender;
+use tokio::task::{JoinError, JoinHandle};
 use tracing::debug;
 
 #[derive(Default)]
 pub(crate) struct TraceSendData {
     pub send_data: Vec<SendData>,
     pub send_data_size: usize,
-    pub force_flush: Option<ManualFutureCompleter<()>>,
+    pub force_flush: Option<ManualFutureCompleter<Option<Sender<()>>>>,
 }
 
 impl TraceSendData {
     /// Flush the traces. This method does not return any value. It triggers a flush of the traces
     /// and completes the future. If there is no future to complete, it does nothing.
     pub(crate) fn flush(&mut self) {
+        self.do_flush(None);
+    }
+
+    /// Flush the traces. It returns a future which can be awaited to determine when data has
+    /// actually been sent.
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn await_flush(&mut self) -> Map<JoinHandle<()>, fn(Result<(), JoinError>)> {
+        let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
+        self.do_flush(Some(sender));
+        tokio::spawn(async move {
+            receiver.recv().await;
+        })
+        .map(|_| ())
+    }
+
+    fn do_flush(&mut self, sender: Option<Sender<()>>) {
         if let Some(force_flush) = self.force_flush.take() {
             debug!(
                 "Emitted flush for traces with {} bytes in send_data buffer",
                 self.send_data_size
             );
-            tokio::spawn(async move {
-                force_flush.complete(()).await;
-            });
+            tokio::spawn(force_flush.complete(sender));
         }
     }
 }


### PR DESCRIPTION
It's important for reliability in testing; also parametric tests do actually rely on that being available.