### PR TITLE
[Serverless Mini Agent] Bump Serverless Mini Agent Version to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-mini-agent"
-version = "0.1.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/trace-mini-agent/Cargo.toml
+++ b/trace-mini-agent/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "datadog-trace-mini-agent"
-description = "A subset of the trace agent that is shipped alongside tracers in a few serverless use cases (GCF and Azure Consumptions plan)"
-version = "0.1.0"
+description = "A subset of the trace agent that is shipped alongside tracers in a few serverless use cases (Google Cloud Functions and Azure Functions)"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
# What does this PR do?

Bumps Serverless Mini Agent Version to 0.4.0.

# Motivation

`mini_agent_version` span tag should reflect the current version of the package: https://github.com/DataDog/libdatadog/blob/78551812d4ab0940e29e863b866e29fd9ab20e45/trace-mini-agent/src/config.rs#L65

# Additional Notes

Setting correctly for upcoming release of version 0.4.0.

# How to test the change?

Build mini agent locally
Deploy Azure Function with mini agent binary in root path
Set DD_MINI_AGENT_PATH to /home/site/wwwroot/datadog-serverless-trace-mini-agent
