### PR TITLE
ekump/APMSP-1076 break up trace utils send data file

### DIFF
--- a/sidecar/src/service/tracing/trace_flusher.rs
+++ b/sidecar/src/service/tracing/trace_flusher.rs
@@ -257,9 +257,6 @@ impl TraceFlusher {
             }
             Err(e) => {
                 error!("Error sending trace: {e:?}");
-                if endpoint.api_key.is_some() {
-                    // TODO: APMSP-1020 Retries when sending to intake
-                }
             }
         }
     }

--- a/trace-utils/src/send_data/retry_strategy.rs
+++ b/trace-utils/src/send_data/retry_strategy.rs
@@ -1,3 +1,6 @@
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
 use std::time::Duration;
 use tokio::time::sleep;
 

--- a/trace-utils/src/send_data/send_data_result.rs
+++ b/trace-utils/src/send_data/send_data_result.rs
@@ -1,3 +1,6 @@
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
 use crate::send_data::RequestResult;
 use anyhow::anyhow;
 use hyper::{Body, Response};
@@ -48,22 +51,7 @@ impl SendDataResult {
     /// # Arguments
     ///
     /// * `res` - Request result.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use datadog_trace_utils::send_data::RequestResult;
-    /// use datadog_trace_utils::trace_utils::SendDataResult;
-    ///
-    /// #[cfg_attr(miri, ignore)]
-    /// async fn update_send_results_example() {
-    ///     let result = RequestResult::NetworkError((1, 0));
-    ///     let mut data_result = SendDataResult::default();
-    ///     data_result.update(result).await;
-    /// }
-    /// ```
-
-    pub async fn update(&mut self, res: RequestResult) {
+    pub(crate) async fn update(&mut self, res: RequestResult) {
         match res {
             RequestResult::Success((response, attempts, bytes, chunks)) => {
                 *self

--- a/trace-utils/src/send_data/send_data_result.rs
+++ b/trace-utils/src/send_data/send_data_result.rs
@@ -1,0 +1,125 @@
+use crate::send_data::RequestResult;
+use anyhow::anyhow;
+use hyper::{Body, Response};
+use std::collections::HashMap;
+
+#[derive(Debug)]
+pub struct SendDataResult {
+    // Keeps track of the last request result.
+    pub last_result: anyhow::Result<Response<Body>>,
+    // Count metric for 'trace_api.requests'.
+    pub requests_count: u64,
+    // Count metric for 'trace_api.responses'. Each key maps  a different HTTP status code.
+    pub responses_count_per_code: HashMap<u16, u64>,
+    // Count metric for 'trace_api.errors' (type: timeout).
+    pub errors_timeout: u64,
+    // Count metric for 'trace_api.errors' (type: network).
+    pub errors_network: u64,
+    // Count metric for 'trace_api.errors' (type: status_code).
+    pub errors_status_code: u64,
+    // Count metric for 'trace_api.bytes'
+    pub bytes_sent: u64,
+    // Count metric for 'trace_chunk_sent'
+    pub chunks_sent: u64,
+    // Count metric for 'trace_chunks_dropped'
+    pub chunks_dropped: u64,
+}
+
+impl Default for SendDataResult {
+    fn default() -> Self {
+        SendDataResult {
+            last_result: Err(anyhow!("No requests sent")),
+            requests_count: 0,
+            responses_count_per_code: Default::default(),
+            errors_timeout: 0,
+            errors_network: 0,
+            errors_status_code: 0,
+            bytes_sent: 0,
+            chunks_sent: 0,
+            chunks_dropped: 0,
+        }
+    }
+}
+
+impl SendDataResult {
+    ///
+    /// Updates `SendDataResult` internal information with the request's result information.
+    ///
+    /// # Arguments
+    ///
+    /// * `res` - Request result.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use datadog_trace_utils::send_data::RequestResult;
+    /// use datadog_trace_utils::trace_utils::SendDataResult;
+    ///
+    /// #[cfg_attr(miri, ignore)]
+    /// async fn update_send_results_example() {
+    ///     let result = RequestResult::NetworkError((1, 0));
+    ///     let mut data_result = SendDataResult::default();
+    ///     data_result.update(result).await;
+    /// }
+    /// ```
+
+    pub async fn update(&mut self, res: RequestResult) {
+        match res {
+            RequestResult::Success((response, attempts, bytes, chunks)) => {
+                *self
+                    .responses_count_per_code
+                    .entry(response.status().as_u16())
+                    .or_default() += 1;
+                self.bytes_sent += bytes;
+                self.chunks_sent += chunks;
+                self.last_result = Ok(response);
+                self.requests_count += u64::from(attempts);
+            }
+            RequestResult::Error((response, attempts, chunks)) => {
+                let status_code = response.status().as_u16();
+                self.errors_status_code += 1;
+                *self
+                    .responses_count_per_code
+                    .entry(status_code)
+                    .or_default() += 1;
+                self.chunks_dropped += chunks;
+                self.requests_count += u64::from(attempts);
+
+                let body_bytes = hyper::body::to_bytes(response.into_body()).await;
+                let response_body =
+                    String::from_utf8(body_bytes.unwrap_or_default().to_vec()).unwrap_or_default();
+                self.last_result = Err(anyhow::format_err!(
+                    "{} - Server did not accept traces: {}",
+                    status_code,
+                    response_body,
+                ));
+            }
+            RequestResult::TimeoutError((attempts, chunks)) => {
+                self.errors_timeout += 1;
+                self.chunks_dropped += chunks;
+                self.requests_count += u64::from(attempts);
+            }
+            RequestResult::NetworkError((attempts, chunks)) => {
+                self.errors_network += 1;
+                self.chunks_dropped += chunks;
+                self.requests_count += u64::from(attempts);
+            }
+            RequestResult::BuildError((attempts, chunks)) => {
+                self.chunks_dropped += chunks;
+                self.requests_count += u64::from(attempts);
+            }
+        }
+    }
+
+    ///
+    /// Sets `SendDataResult` last result information.
+    /// expected result.
+    ///
+    /// # Arguments
+    ///
+    /// * `err` - Error to be set.
+    pub(crate) fn error(mut self, err: anyhow::Error) -> SendDataResult {
+        self.last_result = Err(err);
+        self
+    }
+}


### PR DESCRIPTION
# What does this PR do?

Moves `RetryStrategy` and `SendDataResult` to separate files and do some minor code cleanup. No functional changes.

# Motivation

A lot has been added to `SendData` recently and the file has become unwieldy. 

# How to test the change?

Existing unit tests remain unchanged and should still pass.
