### PR TITLE
Explicitly use the <string> header in crashinfo.cpp

### DIFF
--- a/examples/ffi/crashinfo.cpp
+++ b/examples/ffi/crashinfo.cpp
@@ -10,6 +10,7 @@ extern "C" {
 #include <cstdlib>
 #include <cstring>
 #include <memory>
+#include <string>
 #include <thread>
 #include <vector>
 


### PR DESCRIPTION
# What does this PR do?

Explicitly uses `<string>` as a header for `crashinfo.cpp`.

# Motivation

Windows CI was failing.  https://github.com/DataDog/libdatadog/actions/runs/9402609405/job/25900083549 This looked like it might fix the error 

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
