### PR TITLE
Skip normalization & obfuscation and coalesce instead

### DIFF
--- a/data-pipeline/src/trace_exporter.rs
+++ b/data-pipeline/src/trace_exporter.rs
@@ -226,6 +226,7 @@ impl TraceExporter {
                     traces,
                     &header_tags,
                     |_chunk, _root_span_index| {},
+                    self.endpoint.api_key.is_some(),
                 );
 
                 let endpoint = Endpoint {

--- a/sidecar/src/service/sidecar_server.rs
+++ b/sidecar/src/service/sidecar_server.rs
@@ -309,8 +309,12 @@ impl SidecarServer {
             return;
         }
 
-        let payload =
-            trace_utils::collect_trace_chunks(traces, &headers, |_chunk, _root_span_index| {});
+        let payload = trace_utils::collect_trace_chunks(
+            traces,
+            &headers,
+            |_chunk, _root_span_index| {},
+            target.api_key.is_some(),
+        );
 
         // send trace payload to our trace flusher
         let data = SendData::new(size, payload, headers, target);

--- a/trace-mini-agent/src/trace_processor.rs
+++ b/trace-mini-agent/src/trace_processor.rs
@@ -85,7 +85,7 @@ impl TraceProcessor for ServerlessTraceProcessor {
                     obfuscate_span(span, &config.obfuscation_config);
                 }
             },
-            true,
+            true, // In mini agent, we always send agentless
         );
 
         let send_data = SendData::new(body_size, payload, tracer_header_tags, &config.trace_intake);

--- a/trace-mini-agent/src/trace_processor.rs
+++ b/trace-mini-agent/src/trace_processor.rs
@@ -85,6 +85,7 @@ impl TraceProcessor for ServerlessTraceProcessor {
                     obfuscate_span(span, &config.obfuscation_config);
                 }
             },
+            true,
         );
 
         let send_data = SendData::new(body_size, payload, tracer_header_tags, &config.trace_intake);

--- a/trace-utils/Cargo.toml
+++ b/trace-utils/Cargo.toml
@@ -23,12 +23,12 @@ datadog-trace-normalization = { path = "../trace-normalization" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 rand = "0.8.5"
 bytes = "1.6.0"
-# This should only be used for testing. It isn't under dev-dependencies because test-utils can't be under #[cfg(test)].
-httpmock = {  version = "0.7.0", optional = true}
+httpmock = { version = "0.7.0", optional = true}
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 serde_json = "1.0"
+httpmock = { version = "0.7.0"}
 
 [features]
 test-utils = ["httpmock"]

--- a/trace-utils/Cargo.toml
+++ b/trace-utils/Cargo.toml
@@ -23,6 +23,7 @@ datadog-trace-normalization = { path = "../trace-normalization" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 rand = "0.8.5"
 bytes = "1.6.0"
+# This should only be used for testing. It isn't under dev-dependencies because test-utils can't be under #[cfg(test)].
 httpmock = { version = "0.7.0", optional = true}
 
 [dev-dependencies]

--- a/trace-utils/src/trace_utils.rs
+++ b/trace-utils/src/trace_utils.rs
@@ -320,7 +320,7 @@ pub fn collect_trace_chunks(
 ) -> pb::TracerPayload {
     let mut trace_chunks: Vec<pb::TraceChunk> = Vec::new();
 
-    // We'll skip setting the global metadata and reply on the agent to unpack these
+    // We'll skip setting the global metadata and rely on the agent to unpack these
     let mut gathered_root_span_tags = !is_agentless;
     let mut root_span_tags = RootSpanTags::default();
 

--- a/trace-utils/src/trace_utils.rs
+++ b/trace-utils/src/trace_utils.rs
@@ -124,6 +124,7 @@ pub fn coalesce_send_data(mut data: Vec<SendData>) -> Vec<SendData> {
             .sort_unstable_by(cmp_send_data_payloads);
         send_data.tracer_payloads.dedup_by(|a, b| {
             if cmp_send_data_payloads(a, b) == Ordering::Equal {
+                // Note: dedup_by drops a, and retains b.
                 b.chunks.append(&mut a.chunks);
                 return true;
             }


### PR DESCRIPTION
Turns out the agent ignores the root_span_tags for v0.7 anyway. This is useful to coalesce chunks with common data, allowing us to actually save us from doing redundant requests. As it was currently, the agentful trace sender always sent one trace per request, instead of merging them.

We also skip normalization and rely on the agent to do it, for sake of consistency with other tracers and reduce the potentially duplicated work across tracer and agent. We may change that back in future, but for now we've determined it to be the easiest way to work, also with respect to normalization-unaware testing.