### PR TITLE
[crashtracker] Add a 'wait_for_receiver' param, and use it in both the stdin and unix socket cases

### DIFF
--- a/bin_tests/src/bin/crashtracker_bin_test.rs
+++ b/bin_tests/src/bin/crashtracker_bin_test.rs
@@ -32,6 +32,7 @@ mod unix {
         let stderr_filename = args.next().context("Unexpected number of arguments")?;
         let stdout_filename = args.next().context("Unexpected number of arguments")?;
         let timeout = Duration::from_secs(30);
+        let wait_for_receiver = true;
 
         let endpoint = if output_url.is_empty() {
             None
@@ -49,6 +50,7 @@ mod unix {
                 resolve_frames: crashtracker::StacktraceCollection::WithoutSymbols,
                 endpoint,
                 timeout,
+                wait_for_receiver,
             },
             CrashtrackerReceiverConfig::new(
                 vec![],

--- a/crashtracker/src/api.rs
+++ b/crashtracker/src/api.rs
@@ -153,6 +153,7 @@ fn test_crash() -> anyhow::Result<()> {
     let stderr_filename = Some(format!("{dir}/stderr_{time}.txt"));
     let stdout_filename = Some(format!("{dir}/stdout_{time}.txt"));
     let timeout = Duration::from_secs(30);
+    let wait_for_receiver = true;
     let receiver_config = CrashtrackerReceiverConfig::new(
         vec![],
         vec![],
@@ -166,6 +167,7 @@ fn test_crash() -> anyhow::Result<()> {
         endpoint,
         resolve_frames,
         timeout,
+        wait_for_receiver,
     )?;
     let metadata = CrashtrackerMetadata::new(
         "libname".to_string(),

--- a/crashtracker/src/configuration.rs
+++ b/crashtracker/src/configuration.rs
@@ -27,6 +27,7 @@ pub struct CrashtrackerConfiguration {
     pub endpoint: Option<Endpoint>,
     pub resolve_frames: StacktraceCollection,
     pub timeout: Duration,
+    pub wait_for_receiver: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -74,6 +75,7 @@ impl CrashtrackerConfiguration {
         endpoint: Option<Endpoint>,
         resolve_frames: StacktraceCollection,
         timeout: Duration,
+        wait_for_receiver: bool,
     ) -> anyhow::Result<Self> {
         Ok(Self {
             additional_files,
@@ -81,6 +83,7 @@ impl CrashtrackerConfiguration {
             endpoint,
             resolve_frames,
             timeout,
+            wait_for_receiver,
         })
     }
 }

--- a/crashtracker/src/crash_handler.rs
+++ b/crashtracker/src/crash_handler.rs
@@ -415,9 +415,14 @@ fn handle_posix_signal_impl(signum: i32) -> anyhow::Result<()> {
         }
         ReceiverType::UnixSocket(path) => {
             let mut unix_stream = UnixStream::connect(path)?;
-            let pipe = &mut unix_stream;
-            let res = emit_crashreport(pipe, config, config_str, metadata_string, signum);
-            let _ = pipe.flush();
+            let res = emit_crashreport(
+                &mut unix_stream,
+                config,
+                config_str,
+                metadata_string,
+                signum,
+            );
+            let _ = unix_stream.flush();
             unix_stream
                 .shutdown(std::net::Shutdown::Write)
                 .context("Could not shutdown writing on the stream")?;

--- a/crashtracker/src/receiver.rs
+++ b/crashtracker/src/receiver.rs
@@ -41,6 +41,7 @@ pub fn reciever_entry_point_unix_socket(socket_path: impl AsRef<str>) -> anyhow:
     let (unix_stream, _) = listener.accept()?;
     let stream = BufReader::new(unix_stream);
     receiver_entry_point(stream)
+    // Dropping the stream closes it, allowing the collector to exit if it was waiting.
 }
 
 pub fn receiver_entry_point_stdin() -> anyhow::Result<()> {

--- a/crashtracker/src/telemetry.rs
+++ b/crashtracker/src/telemetry.rs
@@ -212,6 +212,7 @@ mod tests {
                 }),
                 resolve_frames: crate::StacktraceCollection::WithoutSymbols,
                 timeout: time::Duration::from_secs(30),
+                wait_for_receiver: true,
             },
         )
         .unwrap()

--- a/profiling-ffi/src/crashtracker/datatypes.rs
+++ b/profiling-ffi/src/crashtracker/datatypes.rs
@@ -37,6 +37,7 @@ pub struct CrashtrackerConfiguration<'a> {
     pub endpoint: ProfilingEndpoint<'a>,
     pub resolve_frames: StacktraceCollection,
     pub timeout_secs: u64,
+    pub wait_for_receiver: bool,
 }
 
 pub fn option_from_char_slice(s: CharSlice) -> anyhow::Result<Option<String>> {
@@ -95,12 +96,14 @@ impl<'a> TryFrom<CrashtrackerConfiguration<'a>>
         let endpoint = unsafe { exporter::try_to_endpoint(value.endpoint).ok() };
         let resolve_frames = value.resolve_frames;
         let timeout = Duration::from_secs(value.timeout_secs);
+        let wait_for_receiver = value.wait_for_receiver;
         Self::new(
             additional_files,
             create_alt_stack,
             endpoint,
             resolve_frames,
             timeout,
+            wait_for_receiver,
         )
     }
 }


### PR DESCRIPTION
# What does this PR do?

Adds a `wait_for_receiver` flag to the collector config.

# Motivation

In some cases, the client may wish the collector to wait until the receiver has uploaded before finishing crashing, e.g. to keep the pod alive, or to allow out-of-process symbolization.  In other cases, they may wish the process to die immediately.  This lets the client decide. 
# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
