### PR TITLE
style: avoid redundant imports

### DIFF
--- a/crashtracker/src/receiver.rs
+++ b/crashtracker/src/receiver.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 #![cfg(unix)]
 
-use self::stacktrace::StackFrame;
 use super::*;
 use anyhow::Context;
 use nix::unistd::getppid;

--- a/ipc/src/sequential.rs
+++ b/ipc/src/sequential.rs
@@ -7,10 +7,7 @@ use std::{
 };
 
 use futures::{ready, Future, Stream};
-use tarpc::{
-    self,
-    server::{Channel, InFlightRequest, Requests, Serve},
-};
+use tarpc::server::{Channel, InFlightRequest, Requests, Serve};
 
 #[allow(type_alias_bounds)]
 type Request<S, C: Channel> = (S, InFlightRequest<C::Req, C::Resp>);

--- a/ipc/tarpc/tarpc/src/client.rs
+++ b/ipc/tarpc/tarpc/src/client.rs
@@ -16,7 +16,6 @@ use futures::{prelude::*, ready, stream::Fuse, task::*};
 use in_flight_requests::{DeadlineExceededError, InFlightRequests};
 use pin_project::pin_project;
 use std::{
-    convert::TryFrom,
     error::Error,
     fmt,
     pin::Pin,

--- a/ipc/tarpc/tarpc/src/context.rs
+++ b/ipc/tarpc/tarpc/src/context.rs
@@ -11,10 +11,7 @@ use crate::trace::{self, TraceId};
 #[cfg(feature = "opentelemetry")]
 use opentelemetry::trace::TraceContextExt;
 use static_assertions::assert_impl_all;
-use std::{
-    convert::TryFrom,
-    time::{Duration, SystemTime},
-};
+use std::time::{Duration, SystemTime};
 #[cfg(feature = "opentelemetry")]
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 

--- a/ipc/tarpc/tarpc/src/server.rs
+++ b/ipc/tarpc/tarpc/src/server.rs
@@ -23,7 +23,7 @@ use futures::{
 };
 use in_flight_requests::{AlreadyExistsError, InFlightRequests};
 use pin_project::pin_project;
-use std::{convert::TryFrom, error::Error, fmt, marker::PhantomData, pin::Pin};
+use std::{error::Error, fmt, marker::PhantomData, pin::Pin};
 use tracing::{info_span, instrument::Instrument, Span};
 
 mod in_flight_requests;

--- a/ipc/tarpc/tarpc/src/server/limits/channels_per_key.rs
+++ b/ipc/tarpc/tarpc/src/server/limits/channels_per_key.rs
@@ -12,9 +12,7 @@ use fnv::FnvHashMap;
 use futures::{prelude::*, ready, stream::Fuse, task::*};
 use pin_project::pin_project;
 use std::sync::{Arc, Weak};
-use std::{
-    collections::hash_map::Entry, convert::TryFrom, fmt, hash::Hash, marker::Unpin, pin::Pin,
-};
+use std::{collections::hash_map::Entry, fmt, hash::Hash, pin::Pin};
 use tokio::sync::mpsc;
 use tracing::{debug, info, trace};
 

--- a/ipc/tarpc/tarpc/src/trace.rs
+++ b/ipc/tarpc/tarpc/src/trace.rs
@@ -20,7 +20,6 @@
 use opentelemetry::trace::TraceContextExt;
 use rand::Rng;
 use std::{
-    convert::TryFrom,
     fmt::{self, Formatter},
     num::{NonZeroU128, NonZeroU64},
 };

--- a/profiling-ffi/src/profiles.rs
+++ b/profiling-ffi/src/profiles.rs
@@ -8,7 +8,6 @@ use datadog_profiling::internal;
 use datadog_profiling::internal::ProfiledEndpointsStats;
 use ddcommon_ffi::slice::{AsBytes, CharSlice, Slice};
 use ddcommon_ffi::Error;
-use std::convert::{TryFrom, TryInto};
 use std::num::NonZeroI64;
 use std::str::Utf8Error;
 use std::time::{Duration, SystemTime};

--- a/sidecar-ffi/src/lib.rs
+++ b/sidecar-ffi/src/lib.rs
@@ -26,7 +26,6 @@ use ddtelemetry::{
 use ddtelemetry_ffi::try_c;
 use ffi::slice::AsBytes;
 use libc::c_char;
-use std::convert::TryInto;
 use std::ffi::c_void;
 use std::fs::File;
 #[cfg(unix)]

--- a/sidecar/src/service/serialized_tracer_header_tags.rs
+++ b/sidecar/src/service/serialized_tracer_header_tags.rs
@@ -3,7 +3,6 @@
 
 use datadog_trace_utils::trace_utils::TracerHeaderTags;
 use serde::{Deserialize, Serialize};
-use std::convert::TryFrom;
 use std::io;
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
# What does this PR do?

Removes redundant imports. For example, `TryFrom`, `TryInto`, and `Unpin` are all part of the 2021 prelude and do not need to be imported.

# Motivation

Some commands will warn about these, was annoying having them in my terminal output.

# Additional Notes

Nope.

# How to test the change?

Should only be a style change, everything should work as before (no change in testing).
