### PR TITLE
build: use `debug = "line-tables-only"`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ debug = 2 # full debug info
 
 [profile.release]
 codegen-units = 1
-debug = 1 # line tables only
+debug = "line-tables-only"
 lto = true
 opt-level = "s" # optimize for size
 


### PR DESCRIPTION
# What does this PR do?

Switches from `debug = 1` to `debug = "line-tables-only"`.

# Motivation

Was looking to try and shrink the builds for PHP (and libdatadog by extension) and noticed that since we're on Rust 1.71 now, we can make this small change.

# Additional Notes

For more information about `1` vs `line-tables-only`, see: https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html#named-levels-of-debug-information.

# How to test the change?

Everything should be the same.
