### PR TITLE
Drop fd acking in sidecar transport

### DIFF
--- a/ipc/src/platform/unix/channel.rs
+++ b/ipc/src/platform/unix/channel.rs
@@ -101,10 +101,7 @@ impl Write for Channel {
                         "failed to write whole buffer",
                     ));
                 }
-                Ok(n) => {
-                    self.metadata.defer_close_handles(handles);
-                    buf = &buf[n..]
-                }
+                Ok(n) => buf = &buf[n..],
                 Err(ref e) if e.kind() == ErrorKind::Interrupted => {}
                 Err(e) => {
                     self.metadata.reenqueue_for_sending(handles);

--- a/ipc/src/platform/unix/channel/async_channel.rs
+++ b/ipc/src/platform/unix/channel/async_channel.rs
@@ -61,14 +61,7 @@ impl AsyncWrite for AsyncChannel {
         if !handles.is_empty() {
             let fds: Vec<RawFd> = handles.iter().map(AsRawFd::as_raw_fd).collect();
             match project.inner.send_with_fd(buf, &fds) {
-                Ok(sent) => {
-                    project
-                        .metadata
-                        .lock()
-                        .unwrap()
-                        .defer_close_handles(handles);
-                    Poll::Ready(Ok(sent))
-                }
+                Ok(sent) => Poll::Ready(Ok(sent)),
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
                     project
                         .metadata

--- a/ipc/src/platform/unix/message.rs
+++ b/ipc/src/platform/unix/message.rs
@@ -1,8 +1,6 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use std::os::unix::prelude::RawFd;
-
 use serde::{Deserialize, Serialize};
 
 /// sendfd crate's API is not able to resize the received FD container.
@@ -13,6 +11,5 @@ pub const MAX_FDS: usize = 20;
 #[derive(Deserialize, Serialize)]
 pub struct Message<Item> {
     pub item: Item,
-    pub acked_handles: Vec<RawFd>,
     pub pid: libc::pid_t,
 }


### PR DESCRIPTION
This has effectively been never working - it probably got added in long times past, before unidirectional sending was added. There's no ack, and thus it would simply leak and stay unclosed forever.

And the functionality is simply not needed. It's not like linux would close file descriptions as long as they're referenced in sendmsg buffers.