### PR TITLE
Run clippy on windows in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,7 +34,7 @@ jobs:
         run: rustup install ${{ matrix.rust_version }} && rustup default ${{ matrix.rust_version }} && rustup component add clippy
       - name: Run clippy on ${{ matrix.platform }} ${{ matrix.rust_version }} 
         shell: bash
-        run: cargo clippy --all-targets --all-features -- -D warnings $([[ ${{ matrix.rust_version }} == "1.71.1" ]] && echo -A unknown-lints)
+        run: cargo clippy --all-targets --all-features -- -D warnings $([ ${{ matrix.rust_version }} = 1.71.1 ] && echo -Aunknown-lints)
   licensecheck:
     runs-on: ubuntu-latest
     name: "Presence of licence headers"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,13 +15,14 @@ jobs:
         run: rustup update nightly && rustup default nightly && rustup component add rustfmt
       - run: cargo fmt --all -- --check
   clippy:
-    name: "clippy #${{ matrix.rust_version }}"
+    name: "clippy #${{ matrix.platform }} ${{ matrix.rust_version }}"
+    runs-on: ${{ matrix.platform }}
     strategy:
       fail-fast: false
       matrix:
         # Ignore nightly for now, it fails too often
         rust_version: ["1.71.1", "stable"]
-    runs-on: ubuntu-latest
+        platform: [windows-latest, ubuntu-latest]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -31,7 +32,9 @@ jobs:
           rust_version: ${{ matrix.rust_version }}
       - name: Install ${{ matrix.version }} toolchain and clippy
         run: rustup install ${{ matrix.rust_version }} && rustup default ${{ matrix.rust_version }} && rustup component add clippy
-      - run: cargo clippy --all-targets --all-features -- -D warnings $([ ${{ matrix.rust_version }} = 1.71.1 ] && echo -Aunknown-lints)
+      - name: Run clippy on ${{ matrix.platform }} ${{ matrix.rust_version }} 
+        shell: bash
+        run: cargo clippy --all-targets --all-features -- -D warnings $([[ ${{ matrix.rust_version }} == "1.71.1" ]] && echo -A unknown-lints)
   licensecheck:
     runs-on: ubuntu-latest
     name: "Presence of licence headers"

--- a/profiling-ffi/src/lib.rs
+++ b/profiling-ffi/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(feature = "symbolizer")]
+#[cfg(all(feature = "symbolizer", not(target_os = "windows")))]
 pub use symbolizer_ffi::*;
 
 use std::fmt::Debug;

--- a/spawn_worker/src/win32.rs
+++ b/spawn_worker/src/win32.rs
@@ -416,8 +416,7 @@ pub fn recv_passed_handle() -> Option<OwnedHandle> {
 }
 
 fn get_module_file_name(h: HMODULE) -> anyhow::Result<String> {
-    let mut buf = Vec::new();
-    buf.resize(2000, 0);
+    let mut buf = vec![0; 2000];
     loop {
         let read: usize = unsafe { GetModuleFileNameW(h, &mut buf) } as usize;
         if read == 0 {


### PR DESCRIPTION
# What does this PR do?

Run clippy on windows, it is currently done in [gitlab](https://gitlab.ddbuild.io/DataDog/apm-reliability/libddprof-build/-/blob/main/.gitlab-ci.yml?ref_type=heads#L156). This allows us to remove the gitlab job to run clippy only once.

# Motivation

We need to run clippy on windows to check windows specific code