### PR TITLE
Add support for sending v0.4 traces.

### DIFF
--- a/data-pipeline/src/trace_exporter.rs
+++ b/data-pipeline/src/trace_exporter.rs
@@ -4,6 +4,7 @@
 use bytes::Bytes;
 use datadog_trace_protobuf::pb;
 use datadog_trace_utils::trace_utils::{self, SendData, TracerHeaderTags};
+use datadog_trace_utils::tracer_payload::TraceEncoding;
 use ddcommon::{connector, Endpoint};
 use hyper::http::uri::PathAndQuery;
 use hyper::{Body, Client, Method, Uri};
@@ -227,6 +228,7 @@ impl TraceExporter {
                     &header_tags,
                     |_chunk, _root_span_index| {},
                     self.endpoint.api_key.is_some(),
+                    TraceEncoding::V07,
                 );
 
                 let endpoint = Endpoint {

--- a/sidecar/src/service/sidecar_server.rs
+++ b/sidecar/src/service/sidecar_server.rs
@@ -19,6 +19,7 @@ use datadog_ipc::transport::Transport;
 use datadog_trace_protobuf::pb;
 use datadog_trace_utils::trace_utils;
 use datadog_trace_utils::trace_utils::SendData;
+use datadog_trace_utils::tracer_payload::TraceEncoding;
 use ddcommon::Endpoint;
 use ddtelemetry::worker::{
     LifecycleAction, TelemetryActions, TelemetryWorkerBuilder, TelemetryWorkerStats,
@@ -314,6 +315,7 @@ impl SidecarServer {
             &headers,
             |_chunk, _root_span_index| {},
             target.api_key.is_some(),
+            TraceEncoding::V04,
         );
 
         // send trace payload to our trace flusher

--- a/sidecar/src/tracer.rs
+++ b/sidecar/src/tracer.rs
@@ -17,7 +17,7 @@ impl Config {
             hyper::Uri::from_str(&trace_intake_url_prefixed(&endpoint.url.to_string()))?
         } else {
             let mut parts = endpoint.url.into_parts();
-            parts.path_and_query = Some(PathAndQuery::from_static("/v0.7/traces"));
+            parts.path_and_query = Some(PathAndQuery::from_static("/v0.4/traces"));
             hyper::Uri::from_parts(parts)?
         };
         self.endpoint = Some(Endpoint {

--- a/trace-utils/src/lib.rs
+++ b/trace-utils/src/lib.rs
@@ -8,3 +8,4 @@ pub mod stats_utils;
 pub mod test_utils;
 pub mod trace_utils;
 pub mod tracer_header_tags;
+pub mod tracer_payload;

--- a/trace-utils/src/test_utils.rs
+++ b/trace-utils/src/test_utils.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 
 use crate::send_data::SendData;
 use crate::trace_utils::TracerHeaderTags;
+use crate::tracer_payload::TracerPayloadCollection;
 use datadog_trace_protobuf::pb;
 use ddcommon::Endpoint;
 use httpmock::Mock;
@@ -201,5 +202,10 @@ pub fn create_send_data(size: usize, target_endpoint: &Endpoint) -> SendData {
         app_version: "2.0".to_owned(),
     };
 
-    SendData::new(size, tracer_payload, tracer_header_tags, target_endpoint)
+    SendData::new(
+        size,
+        TracerPayloadCollection::V07(vec![tracer_payload]),
+        tracer_header_tags,
+        target_endpoint,
+    )
 }

--- a/trace-utils/src/trace_utils.rs
+++ b/trace-utils/src/trace_utils.rs
@@ -9,6 +9,7 @@ use std::collections::HashMap;
 pub use crate::send_data::send_data_result::SendDataResult;
 pub use crate::send_data::SendData;
 pub use crate::tracer_header_tags::TracerHeaderTags;
+use crate::tracer_payload::{TraceEncoding, TracerPayloadCollection};
 use datadog_trace_normalization::normalizer;
 use datadog_trace_protobuf::pb::{self, Span, TraceChunk, TracerPayload};
 use ddcommon::azure_app_services;
@@ -77,7 +78,7 @@ pub(crate) fn construct_tracer_payload(
     }
 }
 
-fn cmp_send_data_payloads(a: &pb::TracerPayload, b: &pb::TracerPayload) -> Ordering {
+pub(crate) fn cmp_send_data_payloads(a: &pb::TracerPayload, b: &pb::TracerPayload) -> Ordering {
     a.tracer_version
         .cmp(&b.tracer_version)
         .then(a.language_version.cmp(&b.language_version))
@@ -116,17 +117,7 @@ pub fn coalesce_send_data(mut data: Vec<SendData>) -> Vec<SendData> {
     // Merge chunks with common properties. Reduces requests for agentful mode.
     // And reduces a little bit of data for agentless.
     for send_data in data.iter_mut() {
-        send_data
-            .tracer_payloads
-            .sort_unstable_by(cmp_send_data_payloads);
-        send_data.tracer_payloads.dedup_by(|a, b| {
-            if cmp_send_data_payloads(a, b) == Ordering::Equal {
-                // Note: dedup_by drops a, and retains b.
-                b.chunks.append(&mut a.chunks);
-                return true;
-            }
-            false
-        })
+        send_data.tracer_payloads.merge();
     }
     data
 }
@@ -314,65 +305,75 @@ pub fn collect_trace_chunks(
     tracer_header_tags: &TracerHeaderTags,
     process_chunk: impl Fn(&mut TraceChunk, usize),
     is_agentless: bool,
-) -> TracerPayload {
-    let mut trace_chunks: Vec<TraceChunk> = Vec::new();
+    encoding_type: TraceEncoding,
+) -> TracerPayloadCollection {
+    match encoding_type {
+        TraceEncoding::V04 => TracerPayloadCollection::V04(traces),
+        TraceEncoding::V07 => {
+            let mut trace_chunks: Vec<TraceChunk> = Vec::new();
 
-    // We'll skip setting the global metadata and rely on the agent to unpack these
-    let mut gathered_root_span_tags = !is_agentless;
-    let mut root_span_tags = RootSpanTags::default();
+            // We'll skip setting the global metadata and rely on the agent to unpack these
+            let mut gathered_root_span_tags = !is_agentless;
+            let mut root_span_tags = RootSpanTags::default();
 
-    for trace in traces.iter_mut() {
-        if is_agentless {
-            if let Err(e) = normalizer::normalize_trace(trace) {
-                error!("Error normalizing trace: {e}");
-            }
-        }
-
-        let mut chunk = construct_trace_chunk(trace.to_vec());
-
-        let root_span_index = match get_root_span_index(trace) {
-            Ok(res) => res,
-            Err(e) => {
-                error!("Error getting the root span index of a trace, skipping. {e}");
-                continue;
-            }
-        };
-
-        if let Err(e) = normalizer::normalize_chunk(&mut chunk, root_span_index) {
-            error!("Error normalizing trace chunk: {e}");
-        }
-
-        for span in chunk.spans.iter_mut() {
-            // TODO: obfuscate & truncate spans
-            if tracer_header_tags.client_computed_top_level {
-                update_tracer_top_level(span);
-            }
-        }
-
-        if !tracer_header_tags.client_computed_top_level {
-            compute_top_level_span(&mut chunk.spans);
-        }
-
-        process_chunk(&mut chunk, root_span_index);
-
-        trace_chunks.push(chunk);
-
-        if !gathered_root_span_tags {
-            gathered_root_span_tags = true;
-            let meta_map = &trace[root_span_index].meta;
-            parse_root_span_tags!(
-                meta_map,
-                {
-                    "env" => root_span_tags.env,
-                    "version" => root_span_tags.app_version,
-                    "_dd.hostname" => root_span_tags.hostname,
-                    "runtime-id" => root_span_tags.runtime_id,
+            for trace in traces.iter_mut() {
+                if is_agentless {
+                    if let Err(e) = normalizer::normalize_trace(trace) {
+                        error!("Error normalizing trace: {e}");
+                    }
                 }
-            );
+
+                let mut chunk = construct_trace_chunk(trace.to_vec());
+
+                let root_span_index = match get_root_span_index(trace) {
+                    Ok(res) => res,
+                    Err(e) => {
+                        error!("Error getting the root span index of a trace, skipping. {e}");
+                        continue;
+                    }
+                };
+
+                if let Err(e) = normalizer::normalize_chunk(&mut chunk, root_span_index) {
+                    error!("Error normalizing trace chunk: {e}");
+                }
+
+                for span in chunk.spans.iter_mut() {
+                    // TODO: obfuscate & truncate spans
+                    if tracer_header_tags.client_computed_top_level {
+                        update_tracer_top_level(span);
+                    }
+                }
+
+                if !tracer_header_tags.client_computed_top_level {
+                    compute_top_level_span(&mut chunk.spans);
+                }
+
+                process_chunk(&mut chunk, root_span_index);
+
+                trace_chunks.push(chunk);
+
+                if !gathered_root_span_tags {
+                    gathered_root_span_tags = true;
+                    let meta_map = &trace[root_span_index].meta;
+                    parse_root_span_tags!(
+                        meta_map,
+                        {
+                            "env" => root_span_tags.env,
+                            "version" => root_span_tags.app_version,
+                            "_dd.hostname" => root_span_tags.hostname,
+                            "runtime-id" => root_span_tags.runtime_id,
+                        }
+                    );
+                }
+            }
+
+            TracerPayloadCollection::V07(vec![construct_tracer_payload(
+                trace_chunks,
+                tracer_header_tags,
+                root_span_tags,
+            )])
         }
     }
-
-    construct_tracer_payload(trace_chunks, tracer_header_tags, root_span_tags)
 }
 
 #[cfg(test)]
@@ -383,6 +384,7 @@ mod tests {
 
     use super::{get_root_span_index, set_serverless_root_span_tags};
     use crate::trace_utils::{TracerHeaderTags, MAX_PAYLOAD_SIZE};
+    use crate::tracer_payload::TracerPayloadCollection;
     use crate::{
         test_utils::create_test_span,
         trace_utils::{self, SendData},
@@ -395,7 +397,7 @@ mod tests {
     fn test_coalescing_does_not_exceed_max_size() {
         let dummy = SendData::new(
             MAX_PAYLOAD_SIZE / 5 + 1,
-            TracerPayload {
+            TracerPayloadCollection::V07(vec![TracerPayload {
                 container_id: "".to_string(),
                 language_name: "".to_string(),
                 language_version: "".to_string(),
@@ -412,7 +414,7 @@ mod tests {
                 env: "".to_string(),
                 hostname: "".to_string(),
                 app_version: "".to_string(),
-            },
+            }]),
             TracerHeaderTags::default(),
             &Endpoint::default(),
         );
@@ -427,23 +429,20 @@ mod tests {
             5,
             coalesced
                 .iter()
-                .map(|s| s
-                    .tracer_payloads
-                    .iter()
-                    .map(|p| p.chunks.len())
-                    .sum::<usize>())
+                .map(|s| s.tracer_payloads.size())
                 .sum::<usize>()
         );
         // assert some chunks are actually coalesced
         assert!(
             coalesced
                 .iter()
-                .map(|s| s
-                    .tracer_payloads
-                    .iter()
-                    .map(|p| p.chunks.len())
-                    .max()
-                    .unwrap())
+                .map(|s| {
+                    if let TracerPayloadCollection::V07(collection) = &s.tracer_payloads {
+                        collection.iter().map(|s| s.chunks.len()).max().unwrap()
+                    } else {
+                        0
+                    }
+                })
                 .max()
                 .unwrap()
                 > 1

--- a/trace-utils/src/tracer_payload.rs
+++ b/trace-utils/src/tracer_payload.rs
@@ -10,17 +10,15 @@ type TracerPayloadV04 = Vec<Span>;
 
 #[derive(Debug, Clone)]
 /// Enumerates the different encoding types.
-/// ```
 pub enum TraceEncoding {
-    /// v0.4 endoding (TracerPayloadV04).
+    /// v0.4 encoding (TracerPayloadV04).
     V04,
-    /// v0.7 endoding (TracerPayload).
+    /// v0.7 encoding (TracerPayload).
     V07,
 }
 
 #[derive(Debug, Clone)]
 /// Enum representing a general abstraction for a collection of tracer payloads.
-/// ```
 pub enum TracerPayloadCollection {
     /// Collection of TracerPayloads.
     V07(Vec<TracerPayload>),

--- a/trace-utils/src/tracer_payload.rs
+++ b/trace-utils/src/tracer_payload.rs
@@ -1,0 +1,186 @@
+// Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+use std::cmp::Ordering;
+
+use crate::trace_utils::cmp_send_data_payloads;
+use datadog_trace_protobuf::pb::{Span, TracerPayload};
+
+type TracerPayloadV04 = Vec<Span>;
+
+#[derive(Debug, Clone)]
+/// Enumerates the different encoding types.
+/// ```
+pub enum TraceEncoding {
+    /// v0.4 endoding (TracerPayloadV04).
+    V04,
+    /// v0.7 endoding (TracerPayload).
+    V07,
+}
+
+#[derive(Debug, Clone)]
+/// Enum representing a general abstraction for a collection of tracer payloads.
+/// ```
+pub enum TracerPayloadCollection {
+    /// Collection of TracerPayloads.
+    V07(Vec<TracerPayload>),
+    /// Collection of TracerPayloadsV04.
+    V04(Vec<TracerPayloadV04>),
+}
+
+impl TracerPayloadCollection {
+    /// Appends `other` collection of the same type to the current collection.
+    ///
+    /// #Arguments
+    ///
+    /// * `other`: collection of the same type.
+    ///
+    /// # Examples:
+    ///
+    /// ```rust
+    /// use datadog_trace_protobuf::pb::TracerPayload;
+    /// use datadog_trace_utils::tracer_payload::TracerPayloadCollection;
+    /// let mut col1 = TracerPayloadCollection::V07(vec![TracerPayload::default()]);
+    /// let mut col2 = TracerPayloadCollection::V07(vec![TracerPayload::default()]);
+    /// col1.append(&mut col2);
+    /// ```
+    pub fn append(&mut self, other: &mut Self) {
+        match self {
+            TracerPayloadCollection::V07(dest) => {
+                if let TracerPayloadCollection::V07(src) = other {
+                    dest.append(src)
+                }
+            }
+            TracerPayloadCollection::V04(dest) => {
+                if let TracerPayloadCollection::V04(src) = other {
+                    dest.append(src)
+                }
+            }
+        }
+    }
+
+    /// Merges traces that came from the same origin together to reduce the payload size.
+    ///
+    /// # Examples:
+    ///
+    /// ```rust
+    /// use datadog_trace_protobuf::pb::TracerPayload;
+    /// use datadog_trace_utils::tracer_payload::TracerPayloadCollection;
+    /// let mut col1 =
+    ///     TracerPayloadCollection::V07(vec![TracerPayload::default(), TracerPayload::default()]);
+    /// col1.merge();
+    /// ```
+    pub fn merge(&mut self) {
+        if let TracerPayloadCollection::V07(collection) = self {
+            collection.sort_unstable_by(cmp_send_data_payloads);
+            collection.dedup_by(|a, b| {
+                if cmp_send_data_payloads(a, b) == Ordering::Equal {
+                    // Note: dedup_by drops a, and retains b.
+                    b.chunks.append(&mut a.chunks);
+                    return true;
+                }
+                false
+            })
+        }
+    }
+
+    /// Computes the size of the collection.
+    ///
+    /// # Returns
+    ///
+    /// The number of traces contained in the collection.
+    ///
+    /// # Examples:
+    ///
+    /// ```rust
+    /// use datadog_trace_protobuf::pb::TracerPayload;
+    /// use datadog_trace_utils::tracer_payload::TracerPayloadCollection;
+    /// let col1 = TracerPayloadCollection::V07(vec![TracerPayload::default()]);
+    /// col1.size();
+    /// ```
+    pub fn size(&self) -> usize {
+        match self {
+            TracerPayloadCollection::V07(collection) => {
+                collection.iter().map(|s| s.chunks.len()).sum()
+            }
+            TracerPayloadCollection::V04(collection) => collection.len(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::create_test_span;
+    use datadog_trace_protobuf::pb::TraceChunk;
+
+    fn create_dummy_collection_v07() -> TracerPayloadCollection {
+        TracerPayloadCollection::V07(vec![TracerPayload {
+            container_id: "".to_string(),
+            language_name: "".to_string(),
+            language_version: "".to_string(),
+            tracer_version: "".to_string(),
+            runtime_id: "".to_string(),
+            chunks: vec![TraceChunk {
+                priority: 0,
+                origin: "".to_string(),
+                spans: vec![],
+                tags: Default::default(),
+                dropped_trace: false,
+            }],
+            tags: Default::default(),
+            env: "".to_string(),
+            hostname: "".to_string(),
+            app_version: "".to_string(),
+        }])
+    }
+
+    #[test]
+    fn test_append_traces_v07() {
+        let mut trace = create_dummy_collection_v07();
+
+        let empty = TracerPayloadCollection::V07(vec![]);
+
+        trace.append(&mut trace.clone());
+        assert_eq!(2, trace.size());
+
+        trace.append(&mut trace.clone());
+        assert_eq!(4, trace.size());
+
+        trace.append(&mut empty.clone());
+        assert_eq!(4, trace.size());
+    }
+
+    #[test]
+    fn test_append_traces_v04() {
+        let mut trace =
+            TracerPayloadCollection::V04(vec![vec![create_test_span(0, 1, 0, 2, true)]]);
+
+        let empty = TracerPayloadCollection::V04(vec![]);
+
+        trace.append(&mut trace.clone());
+        assert_eq!(2, trace.size());
+
+        trace.append(&mut trace.clone());
+        assert_eq!(4, trace.size());
+
+        trace.append(&mut empty.clone());
+        assert_eq!(4, trace.size());
+    }
+
+    #[test]
+    fn test_merge_traces() {
+        let mut trace = create_dummy_collection_v07();
+
+        trace.append(&mut trace.clone());
+        assert_eq!(2, trace.size());
+
+        trace.merge();
+        assert_eq!(2, trace.size());
+        if let TracerPayloadCollection::V07(collection) = trace {
+            assert_eq!(1, collection.len());
+        } else {
+            panic!("Unexpected type");
+        }
+    }
+}


### PR DESCRIPTION
# What does this PR do?

Add support for sending v0.4 encoded traces to the agent.