### PR TITLE
[Serverless Mini Agent] Add Default Values for peer_tags and is_trace_root when Generating Trace Metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3726,9 +3726,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,6 +1408,8 @@ dependencies = [
  "protoc-bin-vendored",
  "serde",
  "serde_bytes",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/trace-protobuf/Cargo.toml
+++ b/trace-protobuf/Cargo.toml
@@ -19,5 +19,5 @@ protoc-bin-vendored = { version = "3.0.0", optional = true }
 generate-protobuf = ["dep:prost-build", "dep:protoc-bin-vendored"]
 
 [dev-dependencies]
-serde_json = "1.0"
+serde_json = "1.0.117"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/trace-protobuf/Cargo.toml
+++ b/trace-protobuf/Cargo.toml
@@ -10,8 +10,6 @@ license.workspace = true
 prost = "0.11.6"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_bytes = "0.11.9"
-serde_json = "1.0"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
 prost-build = { version = "0.11.9", optional = true  }

--- a/trace-protobuf/Cargo.toml
+++ b/trace-protobuf/Cargo.toml
@@ -10,6 +10,8 @@ license.workspace = true
 prost = "0.11.6"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_bytes = "0.11.9"
+serde_json = "1.0"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 
 [build-dependencies]
 prost-build = { version = "0.11.9", optional = true  }
@@ -17,3 +19,7 @@ protoc-bin-vendored = { version = "3.0.0", optional = true }
 
 [features]
 generate-protobuf = ["dep:prost-build", "dep:protoc-bin-vendored"]
+
+[dev-dependencies]
+serde_json = "1.0"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/trace-protobuf/build.rs
+++ b/trace-protobuf/build.rs
@@ -90,6 +90,8 @@ fn generate_protobuf() {
     config.field_attribute("ClientGroupedStats.type", "#[serde(default)]");
     config.field_attribute("ClientGroupedStats.peer_service", "#[serde(default)]");
     config.field_attribute("ClientGroupedStats.span_kind", "#[serde(default)]");
+    config.field_attribute("ClientGroupedStats.peer_tags", "#[serde(default)]");
+    config.field_attribute("ClientGroupedStats.is_trace_root", "#[serde(default)]");
 
     config.field_attribute(
         "ClientGroupedStats.okSummary",

--- a/trace-protobuf/src/pb.rs
+++ b/trace-protobuf/src/pb.rs
@@ -557,18 +557,14 @@ mod tests {
                     errors: 0,
                     duration: 10000000,
                     ok_summary: vec![0, 0, 0],
-                    error_summary: vec![
-                        0,
-                        0,
-                        0
-                    ],
+                    error_summary: vec![0, 0, 0],
                     synthetics: false,
                     top_level_hits: 1,
                     span_kind: "".to_string(),
                     peer_tags: vec![],
-                    is_trace_root: NotSet.into()
+                    is_trace_root: NotSet.into(),
                 }],
-                agent_time_shift: 0
+                agent_time_shift: 0,
             }],
             lang: "javascript".to_string(),
             tracer_version: "1.0.0".to_string(),
@@ -579,7 +575,7 @@ mod tests {
             container_id: "".to_string(),
             tags: vec![],
             git_commit_sha: "".to_string(),
-            image_tag: "".to_string()
+            image_tag: "".to_string(),
         };
 
         assert_eq!(deserialized_stats_json, client_stats_payload)

--- a/trace-protobuf/src/pb.rs
+++ b/trace-protobuf/src/pb.rs
@@ -490,3 +490,98 @@ impl TraceRootFlag {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::pb::{ClientGroupedStats, ClientStatsBucket, ClientStatsPayload, Trilean::NotSet};
+
+    #[tokio::test]
+    async fn test_deserialize_client_stats_payload() {
+        let stats_json = r#"{
+            "Hostname": "TestHost",
+            "Env": "test",
+            "Version": "1.0.0",
+            "Stats": [
+                {
+                    "Start": 0,
+                    "Duration": 10000000000,
+                    "Stats": [
+                        {
+                            "Name": "test-span",
+                            "Service": "test-service",
+                            "Resource": "test-span",
+                            "Type": "",
+                            "HTTPStatusCode": 0,
+                            "Synthetics": false,
+                            "Hits": 1,
+                            "TopLevelHits": 1,
+                            "Errors": 0,
+                            "Duration": 10000000,
+                            "OkSummary": [
+                                0,
+                                0,
+                                0
+                            ],
+                            "ErrorSummary": [
+                                0,
+                                0,
+                                0
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "Lang": "javascript",
+            "TracerVersion": "1.0.0",
+            "RuntimeID": "00000000-0000-0000-0000-000000000000",
+            "Sequence": 1
+        }"#;
+
+        let deserialized_stats_json: ClientStatsPayload = serde_json::from_str(stats_json).unwrap();
+
+        let client_stats_payload = ClientStatsPayload {
+            hostname: "TestHost".to_string(),
+            env: "test".to_string(),
+            version: "1.0.0".to_string(),
+            stats: vec![ClientStatsBucket {
+                start: 0,
+                duration: 10000000000,
+                stats: vec![ClientGroupedStats {
+                    service: "test-service".to_string(),
+                    name: "test-span".to_string(),
+                    resource: "test-span".to_string(),
+                    http_status_code: 0,
+                    r#type: "".to_string(),
+                    db_type: "".to_string(),
+                    hits: 1,
+                    errors: 0,
+                    duration: 10000000,
+                    ok_summary: vec![0, 0, 0],
+                    error_summary: vec![
+                        0,
+                        0,
+                        0
+                    ],
+                    synthetics: false,
+                    top_level_hits: 1,
+                    span_kind: "".to_string(),
+                    peer_tags: vec![],
+                    is_trace_root: NotSet.into()
+                }],
+                agent_time_shift: 0
+            }],
+            lang: "javascript".to_string(),
+            tracer_version: "1.0.0".to_string(),
+            runtime_id: "00000000-0000-0000-0000-000000000000".to_string(),
+            sequence: 1,
+            agent_aggregation: "".to_string(),
+            service: "".to_string(),
+            container_id: "".to_string(),
+            tags: vec![],
+            git_commit_sha: "".to_string(),
+            image_tag: "".to_string()
+        };
+
+        assert_eq!(deserialized_stats_json, client_stats_payload)
+    }
+}

--- a/trace-protobuf/src/pb.rs
+++ b/trace-protobuf/src/pb.rs
@@ -424,9 +424,11 @@ pub struct ClientGroupedStats {
     /// peer_tags are supplementary tags that further describe a peer entity
     /// E.g., `grpc.target` to describe the name of a gRPC peer, or `db.hostname` to describe the name of peer DB
     #[prost(string, repeated, tag = "16")]
+    #[serde(default)]
     pub peer_tags: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// this field's value is equal to span's ParentID == 0.
     #[prost(enumeration = "Trilean", tag = "17")]
+    #[serde(default)]
     pub is_trace_root: i32,
 }
 /// Trilean is an expanded boolean type that is meant to differentiate between being unset and false.

--- a/trace-utils/src/stats_utils.rs
+++ b/trace-utils/src/stats_utils.rs
@@ -82,8 +82,10 @@ pub async fn send_stats_payload(
 
 #[cfg(test)]
 mod tests {
-    use datadog_trace_protobuf::pb::{ClientGroupedStats, ClientStatsBucket, ClientStatsPayload, Trilean::NotSet};
     use crate::stats_utils;
+    use datadog_trace_protobuf::pb::{
+        ClientGroupedStats, ClientStatsBucket, ClientStatsPayload, Trilean::NotSet,
+    };
     use hyper::Request;
     use serde_json::Value;
 
@@ -161,18 +163,14 @@ mod tests {
                     errors: 0,
                     duration: 10000000,
                     ok_summary: vec![0, 0, 0],
-                    error_summary: vec![
-                        0,
-                        0,
-                        0
-                    ],
+                    error_summary: vec![0, 0, 0],
                     synthetics: false,
                     top_level_hits: 1,
                     span_kind: "".to_string(),
                     peer_tags: vec![],
-                    is_trace_root: NotSet.into()
+                    is_trace_root: NotSet.into(),
                 }],
-                agent_time_shift: 0
+                agent_time_shift: 0,
             }],
             lang: "javascript".to_string(),
             tracer_version: "1.0.0".to_string(),
@@ -183,7 +181,7 @@ mod tests {
             container_id: "".to_string(),
             tags: vec![],
             git_commit_sha: "".to_string(),
-            image_tag: "".to_string()
+            image_tag: "".to_string(),
         };
 
         assert!(


### PR DESCRIPTION
# What does this PR do?

Adds `#[serde(default)]` for `peer_tags` and `is_trace_root` to prevent errors when stats payloads do not include these fields.

# Motivation

https://datadoghq.atlassian.net/browse/SVLS-4933

Deserialization errors when sending trace stats from Azure Functions and Google Cloud Functions.

```
2024-06-17T17:56:38Z   [Information]   [2024-06-17T17:56:37Z ERROR datadog_trace_mini_agent::http_utils] Error deserializing trace stats from request body: Error deserializing stats from request body: missing field `PeerTags`
```

```
2024-06-17T18:58:42Z   [Information]   [2024-06-17T18:58:42Z ERROR datadog_trace_mini_agent::http_utils] Error deserializing trace stats from request body: Error deserializing stats from request body: missing field `IsTraceRoot`
```

# Additional Notes

# How to test the change?

- Build mini agent locally
- Deploy Azure Function or Google Cloud Function with mini agent binary in root path
- Set `DD_MINI_AGENT_PATH`
  - Azure: `/home/site/wwwroot/datadog-serverless-trace-mini-agent`
  - Google: `/workspace/datadog-serverless-trace-mini-agent`
