### PR TITLE
Encode the file path in url authority so we don't crash on whitespaces

### DIFF
--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -226,12 +226,13 @@ fn setup_test_fixtures<'a>(crates: &[&'a ArtifactsBuild]) -> TestFixtures<'a> {
     let artifacts = build_artifacts(crates).unwrap();
 
     let tmpdir = tempfile::TempDir::new().unwrap();
+    let dirpath = tmpdir.path();
     TestFixtures {
-        crash_profile_path: extend_path(tmpdir.path(), "crash"),
-        crash_telemetry_path: extend_path(tmpdir.path(), "crash.telemetry"),
-        stdout_path: extend_path(tmpdir.path(), "out.stdout"),
-        stderr_path: extend_path(tmpdir.path(), "out.stderr"),
-        unix_socket_path: extend_path(tmpdir.path(), "crashtracker.socket"),
+        crash_profile_path: extend_path(dirpath, "crash"),
+        crash_telemetry_path: extend_path(dirpath, "crash.telemetry"),
+        stdout_path: extend_path(dirpath, "out.stdout"),
+        stderr_path: extend_path(dirpath, "out.stderr"),
+        unix_socket_path: extend_path(dirpath, "crashtracker.socket"),
 
         artifacts,
         tmpdir,

--- a/crashtracker/src/telemetry.rs
+++ b/crashtracker/src/telemetry.rs
@@ -6,7 +6,7 @@ use std::fmt::Write;
 use std::time::{self, SystemTime};
 
 use super::{CrashInfo, CrashtrackerConfiguration, CrashtrackerMetadata, StackFrame};
-use anyhow::Ok;
+use anyhow::{Context, Ok};
 use ddtelemetry::{
     build_host,
     data::{self, Application, LogLevel},
@@ -70,7 +70,9 @@ impl TelemetryCrashUploader {
 
             // ignore result because what are we going to do?
             let _ = if endpoint.url.scheme_str() == Some("file") {
-                cfg.set_host_from_url(&format!("file://{}.telemetry", endpoint.url.path()))
+                let path = ddcommon::decode_uri_path_in_authority(&endpoint.url)
+                    .context("file path is not valid")?;
+                cfg.set_host_from_url(&format!("file://{}.telemetry", path.display()))
             } else {
                 cfg.set_endpoint(endpoint.clone())
             };

--- a/ddcommon/src/lib.rs
+++ b/ddcommon/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{borrow::Cow, ops::Deref, str::FromStr};
+use std::{borrow::Cow, ffi::OsString, ops::Deref, path::PathBuf, str::FromStr};
 
 use hyper::{
     header::HeaderValue,
@@ -94,17 +94,7 @@ pub fn parse_uri(uri: &str) -> anyhow::Result<hyper::Uri> {
     } else if let Some(path) = uri.strip_prefix("windows:") {
         encode_uri_path_in_authority("windows", path)
     } else if let Some(path) = uri.strip_prefix("file://") {
-        let mut parts = uri::Parts::default();
-        parts.scheme = uri::Scheme::from_str("file").ok();
-        parts.authority = Some(uri::Authority::from_static("localhost"));
-
-        // TODO: handle edge cases like improperly escaped url strings
-        //
-        // this is eventually user configurable field
-        // anything we can do to ensure invalid input becomes valid - will improve usability
-        parts.path_and_query = uri::PathAndQuery::from_str(path).ok();
-
-        Ok(hyper::Uri::from_parts(parts)?)
+        encode_uri_path_in_authority("file", path)
     } else {
         Ok(hyper::Uri::from_str(uri)?)
     }
@@ -119,6 +109,26 @@ fn encode_uri_path_in_authority(scheme: &str, path: &str) -> anyhow::Result<hype
     parts.authority = uri::Authority::from_str(path.as_str()).ok();
     parts.path_and_query = Some(uri::PathAndQuery::from_static(""));
     Ok(hyper::Uri::from_parts(parts)?)
+}
+
+pub fn decode_uri_path_in_authority(uri: &hyper::Uri) -> anyhow::Result<PathBuf> {
+    let path = hex::decode(
+        uri.authority()
+            .ok_or_else(|| anyhow::anyhow!("missing uri authority"))?
+            .as_str(),
+    )?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStringExt;
+        Ok(PathBuf::from(OsString::from_vec(path)))
+    }
+    #[cfg(not(unix))]
+    {
+        match String::from_utf8(path) {
+            Ok(s) => Ok(PathBuf::from(s.as_str())),
+            _ => Err(anyhow::anyhow!("file uri should be utf-8")),
+        }
+    }
 }
 
 impl Endpoint {

--- a/ddtelemetry/src/config.rs
+++ b/ddtelemetry/src/config.rs
@@ -267,6 +267,8 @@ impl Config {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     #[cfg(unix)]
     use ddcommon::connector::uds;
 
@@ -388,6 +390,10 @@ mod tests {
             ("file:///absolute/path", "/absolute/path"),
             ("file://./relative/path", "./relative/path"),
             ("file://relative/path", "relative/path"),
+            (
+                "file://c://temp//with space\\foo.json",
+                "c://temp//with space\\foo.json",
+            ),
         ];
 
         for (input, expected) in cases {
@@ -405,15 +411,8 @@ mod tests {
                     .to_string()
             );
             assert_eq!(
-                expected,
-                cfg.clone()
-                    .endpoint
-                    .unwrap()
-                    .url
-                    .into_parts()
-                    .path_and_query
-                    .unwrap()
-                    .as_str()
+                Path::new(expected),
+                ddcommon::decode_uri_path_in_authority(&cfg.endpoint.unwrap().url).unwrap(),
             );
         }
     }


### PR DESCRIPTION
# What does this PR do?

Encode the file path in url authority so we don't crash on whitespaces

# Motivation

The telemetry lib would fail because of a panic on URI violation, because we were trying to encode the file path in the url path, which doesn't accept some characters.

This PR encodes the path as hex, like we do for unix socket and windows pipe.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
