### PR TITLE
Skip serialization of field Span.error if equals to 0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,6 +1408,7 @@ dependencies = [
  "protoc-bin-vendored",
  "serde",
  "serde_bytes",
+ "serde_json",
 ]
 
 [[package]]
@@ -3724,9 +3725,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",

--- a/LICENSE-3rdparty.yml
+++ b/LICENSE-3rdparty.yml
@@ -19251,7 +19251,7 @@ third_party_libraries:
 
       END OF TERMS AND CONDITIONS
 - package_name: serde_json
-  package_version: 1.0.115
+  package_version: 1.0.117
   repository: https://github.com/serde-rs/json
   license: MIT OR Apache-2.0
   licenses:

--- a/trace-protobuf/Cargo.toml
+++ b/trace-protobuf/Cargo.toml
@@ -10,6 +10,8 @@ license.workspace = true
 prost = "0.11.6"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_bytes = "0.11.9"
+
+[dev-dependencies]
 serde_json = "1.0.117"
 
 [build-dependencies]

--- a/trace-protobuf/Cargo.toml
+++ b/trace-protobuf/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 prost = "0.11.6"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_bytes = "0.11.9"
+serde_json = "1.0.117"
 
 [build-dependencies]
 prost-build = { version = "0.11.9", optional = true  }

--- a/trace-protobuf/build.rs
+++ b/trace-protobuf/build.rs
@@ -63,6 +63,10 @@ fn generate_protobuf() {
         ".pb.Span.spanLinks",
         "#[serde(skip_serializing_if = \"::prost::alloc::vec::Vec::is_empty\")]",
     );
+    config.field_attribute(
+        ".pb.Span.error",
+        "#[serde(skip_serializing_if = \"is_default\")]",
+    );
 
     config.type_attribute("StatsPayload", "#[derive(Deserialize, Serialize)]");
     config.type_attribute("StatsPayload", "#[serde(rename_all = \"PascalCase\")]");
@@ -139,6 +143,10 @@ where
 {
     let opt = Option::deserialize(deserializer)?;
     Ok(opt.unwrap_or_default())
+}
+
+fn is_default<T: Default + PartialEq>(t: &T) -> bool {
+    t == &T::default()
 }
 
 "

--- a/trace-protobuf/build.rs
+++ b/trace-protobuf/build.rs
@@ -145,7 +145,7 @@ where
     Ok(opt.unwrap_or_default())
 }
 
-fn is_default<T: Default + PartialEq>(t: &T) -> bool {
+pub fn is_default<T: Default + PartialEq>(t: &T) -> bool {
     t == &T::default()
 }
 

--- a/trace-protobuf/src/lib.rs
+++ b/trace-protobuf/src/lib.rs
@@ -3,3 +3,6 @@
 
 #[rustfmt::skip]
 pub mod pb;
+
+#[cfg(test)]
+mod pb_test;

--- a/trace-protobuf/src/pb.rs
+++ b/trace-protobuf/src/pb.rs
@@ -12,6 +12,10 @@ where
     Ok(opt.unwrap_or_default())
 }
 
+fn is_default<T: Default + PartialEq>(t: &T) -> bool {
+    t == &T::default()
+}
+
 #[derive(Deserialize, Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -107,6 +111,7 @@ pub struct Span {
     #[prost(int32, tag = "9")]
     #[serde(default)]
     #[serde(deserialize_with = "deserialize_null_into_default")]
+    #[serde(skip_serializing_if = "is_default")]
     pub error: i32,
     /// meta is a mapping from tag name to tag value for string-valued tags.
     /// @gotags: json:"meta,omitempty" msg:"meta,omitempty"

--- a/trace-protobuf/src/pb.rs
+++ b/trace-protobuf/src/pb.rs
@@ -12,7 +12,7 @@ where
     Ok(opt.unwrap_or_default())
 }
 
-fn is_default<T: Default + PartialEq>(t: &T) -> bool {
+pub fn is_default<T: Default + PartialEq>(t: &T) -> bool {
     t == &T::default()
 }
 

--- a/trace-protobuf/src/pb_test.rs
+++ b/trace-protobuf/src/pb_test.rs
@@ -4,24 +4,25 @@
 #[cfg(test)]
 mod tests {
     use crate::pb::{is_default, Span};
-    use serde_json;
 
     #[test]
     fn test_is_default() {
-        assert_eq!(true, is_default(&false));
-        assert_eq!(false, is_default(&true));
+        assert!(is_default(&false));
+        assert!(!is_default(&true));
 
-        assert_eq!(true, is_default(&0));
-        assert_eq!(false, is_default(&1));
+        assert!(is_default(&0));
+        assert!(!is_default(&1));
 
-        assert_eq!(true, is_default(&""));
-        assert_eq!(false, is_default(&"foo"));
+        assert!(is_default(&""));
+        assert!(!is_default(&"foo"));
     }
 
     #[test]
     fn test_serialize_span() {
-        let mut span = Span::default();
-        span.name = "test".to_string();
+        let mut span = Span {
+            name: "test".to_string(),
+            ..Default::default()
+        };
 
         let json = serde_json::to_string(&span).unwrap();
         let expected = "{\"service\":\"\",\"name\":\"test\",\"resource\":\"\",\"trace_id\":0,\"span_id\":0,\"parent_id\":0,\"start\":0,\"duration\":0,\"meta\":{},\"metrics\":{},\"type\":\"\"}";

--- a/trace-protobuf/src/pb_test.rs
+++ b/trace-protobuf/src/pb_test.rs
@@ -3,8 +3,8 @@
 
 #[cfg(test)]
 mod tests {
-    use serde_json;
     use crate::pb::{is_default, Span};
+    use serde_json;
 
     #[test]
     fn test_is_default() {

--- a/trace-protobuf/src/pb_test.rs
+++ b/trace-protobuf/src/pb_test.rs
@@ -1,0 +1,35 @@
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(test)]
+mod tests {
+    use serde_json;
+    use crate::pb::{is_default, Span};
+
+    #[test]
+    fn test_is_default() {
+        assert_eq!(true, is_default(&false));
+        assert_eq!(false, is_default(&true));
+
+        assert_eq!(true, is_default(&0));
+        assert_eq!(false, is_default(&1));
+
+        assert_eq!(true, is_default(&""));
+        assert_eq!(false, is_default(&"foo"));
+    }
+
+    #[test]
+    fn test_serialize_span() {
+        let mut span = Span::default();
+        span.name = "test".to_string();
+
+        let json = serde_json::to_string(&span).unwrap();
+        let expected = "{\"service\":\"\",\"name\":\"test\",\"resource\":\"\",\"trace_id\":0,\"span_id\":0,\"parent_id\":0,\"start\":0,\"duration\":0,\"meta\":{},\"metrics\":{},\"type\":\"\"}";
+        assert_eq!(expected, json);
+
+        span.error = 42;
+        let json = serde_json::to_string(&span).unwrap();
+        let expected = "{\"service\":\"\",\"name\":\"test\",\"resource\":\"\",\"trace_id\":0,\"span_id\":0,\"parent_id\":0,\"start\":0,\"duration\":0,\"error\":42,\"meta\":{},\"metrics\":{},\"type\":\"\"}";
+        assert_eq!(expected, json);
+    }
+}


### PR DESCRIPTION
# What does this PR do?

It skips the serialization of the field `Span.error` if the value is 0 as it's done by tracers (at least [.net](https://github.com/DataDog/dd-trace-dotnet/blob/f4ba8212dc62f8a61e947086202ba21f2fdd0bb2/tracer/src/Datadog.Trace/Agent/MessagePack/SpanMessagePackFormatter.cs#L199) and [PHP](https://github.com/DataDog/dd-trace-php/blob/master/ext/serializer.c#L1360-L1362))

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
