### PR TITLE
[Serverless Mini Agent] Bump Serverless Mini Agent Version to 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-mini-agent"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/trace-mini-agent/Cargo.toml
+++ b/trace-mini-agent/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "datadog-trace-mini-agent"
 description = "A subset of the trace agent that is shipped alongside tracers in a few serverless use cases (Google Cloud Functions and Azure Functions)"
-version = "0.4.0"
+version = "0.4.2"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
# What does this PR do?

Bumps Serverless Mini Agent Version to 0.4.2.

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Setting correctly for upcoming release of version 0.4.2.

# How to test the change?

- Build mini agent locally
- Deploy Azure Function or Google Cloud Function with mini agent binary in root path
- Set `DD_MINI_AGENT_PATH`
  - Azure: `/home/site/wwwroot/datadog-serverless-trace-mini-agent`
  - Google: `/workspace/datadog-serverless-trace-mini-agent`
