### PR TITLE
DEBUG-2510 Document cbindgen dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ bash build-profiling-ffi.sh /opt/libdatadog
 #### Build Dependencies
 
 - Rust 1.71 or newer with cargo
+- `cbindgen` 0.26
 - `cmake` and `protoc`
 
 ### Running tests


### PR DESCRIPTION
# What does this PR do?

Adds `cbindgen` and its required version to the readme to the requirements section.

# Motivation

Building C headers requires `cbindgen` which is not mentioned in the readme.

Ubuntu package of `cbindgen` is of an old version which does not work, producing cryptic errors.

# Additional Notes

None

# How to test the change?

N/A