### PR TITLE
[PROF-10099] Package libdatadog v10.0.0 for Ruby

### DIFF
--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -11,7 +11,7 @@ require "rubygems/package"
 
 RSpec::Core::RakeTask.new(:spec)
 
-LIB_VERSION_TO_PACKAGE = "9.0.0"
+LIB_VERSION_TO_PACKAGE = "10.0.0"
 unless LIB_VERSION_TO_PACKAGE.start_with?(Libdatadog::LIB_VERSION)
   raise "`LIB_VERSION_TO_PACKAGE` setting in <Rakefile> (#{LIB_VERSION_TO_PACKAGE}) does not match " \
     "`LIB_VERSION` setting in <lib/libdatadog/version.rb> (#{Libdatadog::LIB_VERSION})"
@@ -20,22 +20,22 @@ end
 LIB_GITHUB_RELEASES = [
   {
     file: "libdatadog-aarch64-alpine-linux-musl.tar.gz",
-    sha256: "c2c6c32f612e8c1682131e72bd50492d809bac973f516e56e163e797435eef75",
+    sha256: "61249c5a2a3c4c80e6f54a24251b5035a49123b1664d28cc21645fa8c7271432",
     ruby_platform: "aarch64-linux-musl"
   },
   {
     file: "libdatadog-aarch64-unknown-linux-gnu.tar.gz",
-    sha256: "97c4fc46f92580b8929e8fcc3f51b47226836e29bce0b57ac8d3387a27a81ce1",
+    sha256: "14df33b816e12533b95bad64ae0df049bb1fce6b4dc0fe7df4add6ce3ce531e7",
     ruby_platform: "aarch64-linux"
   },
   {
     file: "libdatadog-x86_64-alpine-linux-musl.tar.gz",
-    sha256: "68e67c5e87616f830289bc85626d2062277bef54694cc6dbb445105c66fe8885",
+    sha256: "7c5dcf51fec39c7fc0cfca47ee1788630e15682f0a5f9580e94518163300f221",
     ruby_platform: "x86_64-linux-musl"
   },
   {
     file: "libdatadog-x86_64-unknown-linux-gnu.tar.gz",
-    sha256: "cd89cbe480db0b828a43afd161ddd83e57319dbe3d412fa4a2d096daae244595",
+    sha256: "ec3a8582f8be34edd3b9b89aed7d0642645b41f8e7c9d5b4d1d6ecdcaa8f31f0",
     ruby_platform: "x86_64-linux"
   }
 ]

--- a/ruby/lib/libdatadog/version.rb
+++ b/ruby/lib/libdatadog/version.rb
@@ -2,7 +2,7 @@
 
 module Libdatadog
   # Current libdatadog version
-  LIB_VERSION = "9.0.0"
+  LIB_VERSION = "10.0.0"
 
   GEM_MAJOR_VERSION = "1"
   GEM_MINOR_VERSION = "0"


### PR DESCRIPTION
# What does this PR do?

This PR includes the changes documented in the "Releasing a new version to rubygems.org" part of the README: https://github.com/datadog/libdatadog/tree/main/ruby#releasing-a-new-version-to-rubygemsorg

(It's also very similar to the v9.0.0 release PR).

# Motivation

Enable Ruby to use libdatadog v10.0.0.

# Additional Notes

N/A

# How to test the change?

I've tested this release locally using the changes in DataDog/dd-trace-rb#3753 .

As a reminder, new libdatadog releases don't get automatically picked up by dd-trace-rb, so the PR that bumps the Ruby profiler will also test this release against all supported Ruby versions.