### PR TITLE
Implement timeouts for both sending traces and telemetry.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,19 @@ jobs:
           fi
           echo "OUTPUT_FOLDER=$WORKSPACE_PATH/artifacts" >> $GITHUB_ENV
 
+      - name: Free Disk Space (Ubuntu only)
+        if: runner.os == 'Linux' && matrix.platform == 'ubuntu-latest'
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: true
+
+
       - name: Cache
         uses: ./.github/actions/cache
         with:
@@ -112,18 +125,6 @@ jobs:
       - id: rust-version
         # On Windows run happens in a PowerShell, so start bash explicitly
         run: bash -c 'echo "version=$(rustc --version)" >> $GITHUB_OUTPUT'
-
-      - name: Free Disk Space (Ubuntu only)
-        if: runner.os == 'Linux' && matrix.platform == 'ubuntu-latest'
-        uses: jlumbroso/free-disk-space@v1.3.1
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: false
-          docker-images: false
-          swap-storage: true
 
       - name: "Generate profiling FFI"
         shell: bash

--- a/bin_tests/src/bin/crashtracker_bin_test.rs
+++ b/bin_tests/src/bin/crashtracker_bin_test.rs
@@ -45,7 +45,7 @@ mod unix {
         } else {
             Some(ddcommon::Endpoint {
                 url: ddcommon::parse_uri(&output_url)?,
-                api_key: None,
+                ..Default::default()
             })
         };
 

--- a/bin_tests/src/bin/crashtracker_bin_test.rs
+++ b/bin_tests/src/bin/crashtracker_bin_test.rs
@@ -19,7 +19,7 @@ mod unix {
         self as crashtracker, CrashtrackerConfiguration, CrashtrackerMetadata,
         CrashtrackerReceiverConfig,
     };
-    use ddcommon::{parse_uri, tag, Endpoint};
+    use ddcommon::{tag, Endpoint};
 
     #[inline(never)]
     unsafe fn deref_ptr(p: *mut u8) {
@@ -42,11 +42,7 @@ mod unix {
         let endpoint = if output_url.is_empty() {
             None
         } else {
-            Some(Endpoint {
-                url: parse_uri(&output_url).unwrap(),
-                timeout_ms: 30_000,
-                ..Default::default()
-            })
+            Some(Endpoint::from_slice(&output_url))
         };
 
         let config = CrashtrackerConfiguration {

--- a/bin_tests/src/bin/crashtracker_bin_test.rs
+++ b/bin_tests/src/bin/crashtracker_bin_test.rs
@@ -43,10 +43,7 @@ mod unix {
         let endpoint = if output_url.is_empty() {
             None
         } else {
-            Some(ddcommon::Endpoint {
-                url: ddcommon::parse_uri(&output_url)?,
-                ..Default::default()
-            })
+            Some(ddcommon::Endpoint::from_slice(&output_url))
         };
 
         let config = CrashtrackerConfiguration {

--- a/crashtracker/src/api.rs
+++ b/crashtracker/src/api.rs
@@ -143,7 +143,7 @@ fn test_crash() -> anyhow::Result<()> {
 
     let endpoint = Some(Endpoint {
         url: parse_uri(&output_url).unwrap(),
-        api_key: None,
+        ..Default::default()
     });
 
     let path_to_receiver_binary =

--- a/crashtracker/src/api.rs
+++ b/crashtracker/src/api.rs
@@ -140,11 +140,7 @@ fn test_crash() -> anyhow::Result<()> {
     let dir = "/tmp/crashreports/";
     let output_url = format!("file://{dir}{time}.txt");
 
-    let endpoint = Some(Endpoint {
-        url: ddcommon::parse_uri(&output_url).unwrap(),
-        timeout_ms: 30_000,
-        ..Default::default()
-    });
+    let endpoint = Some(Endpoint::from_slice(&output_url));
 
     let path_to_receiver_binary =
         "/tmp/libdatadog/bin/libdatadog-crashtracking-receiver".to_string();

--- a/crashtracker/src/api.rs
+++ b/crashtracker/src/api.rs
@@ -140,7 +140,11 @@ fn test_crash() -> anyhow::Result<()> {
     let dir = "/tmp/crashreports/";
     let output_url = format!("file://{dir}{time}.txt");
 
-    let endpoint = Some(Endpoint::from_slice(&output_url));
+    let endpoint = Some(Endpoint {
+        url: ddcommon::parse_uri(&output_url).unwrap(),
+        timeout_ms: 30_000,
+        ..Default::default()
+    });
 
     let path_to_receiver_binary =
         "/tmp/libdatadog/bin/libdatadog-crashtracking-receiver".to_string();
@@ -148,7 +152,6 @@ fn test_crash() -> anyhow::Result<()> {
     let resolve_frames = StacktraceCollection::EnabledWithInprocessSymbols;
     let stderr_filename = Some(format!("{dir}/stderr_{time}.txt"));
     let stdout_filename = Some(format!("{dir}/stdout_{time}.txt"));
-    let timeout = Duration::from_secs(30);
     let wait_for_receiver = true;
     let receiver_config = CrashtrackerReceiverConfig::new(
         vec![],
@@ -162,7 +165,6 @@ fn test_crash() -> anyhow::Result<()> {
         create_alt_stack,
         endpoint,
         resolve_frames,
-        timeout,
         wait_for_receiver,
     )?;
     let metadata = CrashtrackerMetadata::new(

--- a/crashtracker/src/api.rs
+++ b/crashtracker/src/api.rs
@@ -132,7 +132,6 @@ pub fn init_with_unix_socket(
 fn test_crash() -> anyhow::Result<()> {
     use crate::{begin_profiling_op, StacktraceCollection};
     use chrono::Utc;
-    use ddcommon::parse_uri;
     use ddcommon::tag;
     use ddcommon::Endpoint;
     use std::time::Duration;
@@ -141,10 +140,7 @@ fn test_crash() -> anyhow::Result<()> {
     let dir = "/tmp/crashreports/";
     let output_url = format!("file://{dir}{time}.txt");
 
-    let endpoint = Some(Endpoint {
-        url: parse_uri(&output_url).unwrap(),
-        ..Default::default()
-    });
+    let endpoint = Some(Endpoint::from_slice(&output_url));
 
     let path_to_receiver_binary =
         "/tmp/libdatadog/bin/libdatadog-crashtracking-receiver".to_string();

--- a/crashtracker/src/configuration.rs
+++ b/crashtracker/src/configuration.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 use ddcommon::Endpoint;
 use serde::{Deserialize, Serialize};
-use std::time::Duration;
 
 /// Stacktrace collection occurs in the context of a crashing process.
 /// If the stack is sufficiently corruputed, it is possible (but unlikely),
@@ -26,7 +25,6 @@ pub struct CrashtrackerConfiguration {
     pub create_alt_stack: bool,
     pub endpoint: Option<Endpoint>,
     pub resolve_frames: StacktraceCollection,
-    pub timeout: Duration,
     pub wait_for_receiver: bool,
 }
 
@@ -74,7 +72,6 @@ impl CrashtrackerConfiguration {
         create_alt_stack: bool,
         endpoint: Option<Endpoint>,
         resolve_frames: StacktraceCollection,
-        timeout: Duration,
         wait_for_receiver: bool,
     ) -> anyhow::Result<Self> {
         Ok(Self {
@@ -82,7 +79,6 @@ impl CrashtrackerConfiguration {
             create_alt_stack,
             endpoint,
             resolve_frames,
-            timeout,
             wait_for_receiver,
         })
     }

--- a/crashtracker/src/crash_info.rs
+++ b/crashtracker/src/crash_info.rs
@@ -265,7 +265,7 @@ impl CrashInfo {
     fn upload_to_telemetry(&self, config: &CrashtrackerConfiguration) -> anyhow::Result<()> {
         if let Some(metadata) = &self.metadata {
             if let Ok(uploader) = TelemetryCrashUploader::new(metadata, config) {
-                uploader.upload_to_telemetry(self, config.timeout)?;
+                uploader.upload_to_telemetry(self)?;
             }
         }
         Ok(())

--- a/crashtracker/src/telemetry.rs
+++ b/crashtracker/src/telemetry.rs
@@ -210,7 +210,7 @@ mod tests {
                 create_alt_stack: true,
                 endpoint: Some(Endpoint {
                     url: hyper::Uri::from_static("http://localhost:8126/profiling/v1/input"),
-                    api_key: None,
+                    ..Default::default()
                 }),
                 resolve_frames: crate::StacktraceCollection::WithoutSymbols,
                 timeout: time::Duration::from_secs(30),

--- a/crashtracker/src/telemetry.rs
+++ b/crashtracker/src/telemetry.rs
@@ -208,10 +208,9 @@ mod tests {
             &crate::CrashtrackerConfiguration {
                 additional_files: vec![],
                 create_alt_stack: true,
-                endpoint: Some(Endpoint {
-                    url: hyper::Uri::from_static("http://localhost:8126/profiling/v1/input"),
-                    ..Default::default()
-                }),
+                endpoint: Some(Endpoint::from_slice(
+                    "http://localhost:8126/profiling/v1/input",
+                )),
                 resolve_frames: crate::StacktraceCollection::WithoutSymbols,
                 timeout: time::Duration::from_secs(30),
                 wait_for_receiver: true,

--- a/data-pipeline/src/trace_exporter.rs
+++ b/data-pipeline/src/trace_exporter.rs
@@ -316,12 +316,7 @@ impl TraceExporterBuilder {
             .build()?;
 
         Ok(TraceExporter {
-            endpoint: Endpoint::from_slice(
-                self.url
-                    .to_owned()
-                    .unwrap_or("http://127.0.0.1:8126/".to_string())
-                    .as_str(),
-            ),
+            endpoint: Endpoint::from_slice(self.url.as_deref().unwrap_or("http://127.0.0.1:8126")),
             tags: TracerTags {
                 tracer_version: std::mem::take(&mut self.tracer_version),
                 language_version: std::mem::take(&mut self.language_version),

--- a/data-pipeline/src/trace_exporter.rs
+++ b/data-pipeline/src/trace_exporter.rs
@@ -311,21 +311,17 @@ impl TraceExporterBuilder {
     }
 
     pub fn build(mut self) -> anyhow::Result<TraceExporter> {
-        let endpoint = Endpoint {
-            url: hyper::Uri::from_str(
-                self.url
-                    .to_owned()
-                    .unwrap_or(String::from("http://127.0.0.1:8126/"))
-                    .as_str(),
-            )?,
-            ..Default::default()
-        };
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()?;
 
         Ok(TraceExporter {
-            endpoint,
+            endpoint: Endpoint::from_slice(
+                self.url
+                    .to_owned()
+                    .unwrap_or("http://127.0.0.1:8126/".to_string())
+                    .as_str(),
+            ),
             tags: TracerTags {
                 tracer_version: std::mem::take(&mut self.tracer_version),
                 language_version: std::mem::take(&mut self.language_version),

--- a/data-pipeline/src/trace_exporter.rs
+++ b/data-pipeline/src/trace_exporter.rs
@@ -318,7 +318,7 @@ impl TraceExporterBuilder {
                     .unwrap_or(String::from("http://127.0.0.1:8126/"))
                     .as_str(),
             )?,
-            api_key: None,
+            ..Default::default()
         };
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()

--- a/ddcommon-ffi/src/endpoint.rs
+++ b/ddcommon-ffi/src/endpoint.rs
@@ -55,13 +55,17 @@ pub extern "C" fn ddog_endpoint_from_api_key_and_site(
 }
 
 #[no_mangle]
+extern "C" fn ddog_endpoint_set_timeout(endpoint: &mut Endpoint, millis: u64) {
+    endpoint.timeout = millis;
+}
+
+#[no_mangle]
 pub extern "C" fn ddog_endpoint_drop(_: Box<Endpoint>) {}
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::CharSlice;
-
-    use super::ddog_endpoint_from_url;
 
     #[test]
     fn test_ddog_endpoint_from_url() {
@@ -79,5 +83,25 @@ mod tests {
             let actual = ddog_endpoint_from_url(CharSlice::from(input)).is_some();
             assert_eq!(actual, expected);
         }
+    }
+
+    #[test]
+    fn set_timeout() {
+        let url = CharSlice::from("http://127.0.0.1");
+
+        let mut endpoint = ddog_endpoint_from_url(url);
+        assert_eq!(
+            endpoint.as_ref().unwrap().timeout,
+            Endpoint::DEFAULT_TIMEOUT
+        );
+
+        ddog_endpoint_set_timeout(endpoint.as_mut().unwrap(), 2000);
+        assert_eq!(endpoint.unwrap().timeout, 2000);
+
+        let mut endpoint_api_key = ddog_endpoint_from_api_key(CharSlice::from("test-key"));
+        assert_eq!(endpoint_api_key.timeout, Endpoint::DEFAULT_TIMEOUT);
+
+        ddog_endpoint_set_timeout(&mut endpoint_api_key, 2000);
+        assert_eq!(endpoint_api_key.timeout, 2000);
     }
 }

--- a/ddcommon-ffi/src/endpoint.rs
+++ b/ddcommon-ffi/src/endpoint.rs
@@ -12,7 +12,7 @@ use std::str::FromStr;
 pub extern "C" fn ddog_endpoint_from_url(url: crate::CharSlice) -> Option<Box<Endpoint>> {
     parse_uri(url.to_utf8_lossy().as_ref())
         .ok()
-        .map(|url| Box::new(Endpoint { url, api_key: None }))
+        .map(|url| Box::new(Endpoint { url, api_key: None, ..Default::default() }))
 }
 
 // We'll just specify the base site here. If api key provided, different intakes need to use their
@@ -25,6 +25,7 @@ pub extern "C" fn ddog_endpoint_from_api_key(api_key: crate::CharSlice) -> Box<E
     Box::new(Endpoint {
         url: hyper::Uri::from_parts(parts).unwrap(),
         api_key: Some(api_key.to_utf8_lossy().to_string().into()),
+        ..Default::default()
     })
 }
 
@@ -45,6 +46,7 @@ pub extern "C" fn ddog_endpoint_from_api_key_and_site(
     *endpoint = Box::into_raw(Box::new(Endpoint {
         url: hyper::Uri::from_parts(parts).unwrap(),
         api_key: Some(api_key.to_utf8_lossy().to_string().into()),
+        ..Default::default()
     }));
     None
 }

--- a/ddcommon-ffi/src/endpoint.rs
+++ b/ddcommon-ffi/src/endpoint.rs
@@ -10,9 +10,12 @@ use std::str::FromStr;
 #[no_mangle]
 #[must_use]
 pub extern "C" fn ddog_endpoint_from_url(url: crate::CharSlice) -> Option<Box<Endpoint>> {
-    parse_uri(url.to_utf8_lossy().as_ref())
-        .ok()
-        .map(|url| Box::new(Endpoint { url, api_key: None, ..Default::default() }))
+    parse_uri(url.to_utf8_lossy().as_ref()).ok().map(|url| {
+        Box::new(Endpoint {
+            url,
+            ..Default::default()
+        })
+    })
 }
 
 // We'll just specify the base site here. If api key provided, different intakes need to use their

--- a/ddcommon-ffi/src/endpoint.rs
+++ b/ddcommon-ffi/src/endpoint.rs
@@ -10,12 +10,9 @@ use std::str::FromStr;
 #[no_mangle]
 #[must_use]
 pub extern "C" fn ddog_endpoint_from_url(url: crate::CharSlice) -> Option<Box<Endpoint>> {
-    parse_uri(url.to_utf8_lossy().as_ref()).ok().map(|url| {
-        Box::new(Endpoint {
-            url,
-            ..Default::default()
-        })
-    })
+    parse_uri(url.to_utf8_lossy().as_ref())
+        .ok()
+        .map(|url| Box::new(Endpoint::from_url(url)))
 }
 
 // We'll just specify the base site here. If api key provided, different intakes need to use their
@@ -56,7 +53,7 @@ pub extern "C" fn ddog_endpoint_from_api_key_and_site(
 
 #[no_mangle]
 extern "C" fn ddog_endpoint_set_timeout(endpoint: &mut Endpoint, millis: u64) {
-    endpoint.timeout = millis;
+    endpoint.timeout_ms = millis;
 }
 
 #[no_mangle]
@@ -91,17 +88,17 @@ mod tests {
 
         let mut endpoint = ddog_endpoint_from_url(url);
         assert_eq!(
-            endpoint.as_ref().unwrap().timeout,
+            endpoint.as_ref().unwrap().timeout_ms,
             Endpoint::DEFAULT_TIMEOUT
         );
 
         ddog_endpoint_set_timeout(endpoint.as_mut().unwrap(), 2000);
-        assert_eq!(endpoint.unwrap().timeout, 2000);
+        assert_eq!(endpoint.unwrap().timeout_ms, 2000);
 
         let mut endpoint_api_key = ddog_endpoint_from_api_key(CharSlice::from("test-key"));
-        assert_eq!(endpoint_api_key.timeout, Endpoint::DEFAULT_TIMEOUT);
+        assert_eq!(endpoint_api_key.timeout_ms, Endpoint::DEFAULT_TIMEOUT);
 
         ddog_endpoint_set_timeout(&mut endpoint_api_key, 2000);
-        assert_eq!(endpoint_api_key.timeout, 2000);
+        assert_eq!(endpoint_api_key.timeout_ms, 2000);
     }
 }

--- a/ddcommon/src/lib.rs
+++ b/ddcommon/src/lib.rs
@@ -45,7 +45,7 @@ impl Default for Endpoint {
         Endpoint {
             url: hyper::Uri::default(),
             api_key: Option::default(),
-            timeout: 10_000,
+            timeout: Self::DEFAULT_TIMEOUT,
         }
     }
 }
@@ -144,6 +144,9 @@ pub fn decode_uri_path_in_authority(uri: &hyper::Uri) -> anyhow::Result<PathBuf>
 }
 
 impl Endpoint {
+    /// Default value for the timeout field in milliseconds.
+    pub const DEFAULT_TIMEOUT: u64 = 10_000;
+
     /// Return a request builder with the following headers:
     /// - User agent
     /// - Api key

--- a/ddcommon/src/lib.rs
+++ b/ddcommon/src/lib.rs
@@ -32,11 +32,18 @@ pub type HttpClient = hyper::Client<connector::Connector, hyper::Body>;
 pub type HttpResponse = hyper::Response<hyper::Body>;
 pub type HttpRequestBuilder = hyper::http::request::Builder;
 
-#[derive(Default, Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
 pub struct Endpoint {
     #[serde(serialize_with = "serialize_uri", deserialize_with = "deserialize_uri")]
     pub url: hyper::Uri,
     pub api_key: Option<Cow<'static, str>>,
+    pub timeout: u64,
+}
+
+impl Default for Endpoint {
+    fn default() -> Self {
+        Endpoint { url: hyper::Uri::default(), api_key: Option::default(), timeout: 10_000 }
+    }
 }
 
 #[derive(serde::Deserialize, serde::Serialize)]

--- a/ddcommon/src/lib.rs
+++ b/ddcommon/src/lib.rs
@@ -42,7 +42,11 @@ pub struct Endpoint {
 
 impl Default for Endpoint {
     fn default() -> Self {
-        Endpoint { url: hyper::Uri::default(), api_key: Option::default(), timeout: 10_000 }
+        Endpoint {
+            url: hyper::Uri::default(),
+            api_key: Option::default(),
+            timeout: 10_000,
+        }
     }
 }
 

--- a/ddcommon/src/lib.rs
+++ b/ddcommon/src/lib.rs
@@ -37,7 +37,7 @@ pub struct Endpoint {
     #[serde(serialize_with = "serialize_uri", deserialize_with = "deserialize_uri")]
     pub url: hyper::Uri,
     pub api_key: Option<Cow<'static, str>>,
-    pub timeout: u64,
+    pub timeout_ms: u64,
 }
 
 impl Default for Endpoint {
@@ -45,7 +45,7 @@ impl Default for Endpoint {
         Endpoint {
             url: hyper::Uri::default(),
             api_key: Option::default(),
-            timeout: Self::DEFAULT_TIMEOUT,
+            timeout_ms: Self::DEFAULT_TIMEOUT,
         }
     }
 }
@@ -177,5 +177,21 @@ impl Endpoint {
         }
 
         Ok(builder)
+    }
+
+    #[inline]
+    pub fn from_slice(url: &str) -> Endpoint {
+        Endpoint {
+            url: parse_uri(url).unwrap(),
+            ..Default::default()
+        }
+    }
+
+    #[inline]
+    pub fn from_url(url: hyper::Uri) -> Endpoint {
+        Endpoint {
+            url,
+            ..Default::default()
+        }
     }
 }

--- a/ddcommon/src/lib.rs
+++ b/ddcommon/src/lib.rs
@@ -145,7 +145,7 @@ pub fn decode_uri_path_in_authority(uri: &hyper::Uri) -> anyhow::Result<PathBuf>
 
 impl Endpoint {
     /// Default value for the timeout field in milliseconds.
-    pub const DEFAULT_TIMEOUT: u64 = 10_000;
+    pub const DEFAULT_TIMEOUT: u64 = 3_000;
 
     /// Return a request builder with the following headers:
     /// - User agent

--- a/ddtelemetry-ffi/src/lib.rs
+++ b/ddtelemetry-ffi/src/lib.rs
@@ -245,12 +245,12 @@ mod tests {
                 ddog_telemetry_builder_with_endpoint_config_endpoint(
                     &mut builder,
                     &Endpoint {
-                        api_key: None,
                         url: parse_uri(&format!(
                             "file://{}",
                             f.path().as_os_str().to_str().unwrap()
                         ))
                         .unwrap(),
+                        ..Default::default()
                     },
                 ),
                 MaybeError::None
@@ -292,12 +292,12 @@ mod tests {
                 ddog_telemetry_builder_with_endpoint_config_endpoint(
                     &mut builder,
                     &Endpoint {
-                        api_key: None,
                         url: parse_uri(&format!(
                             "file://{}",
                             f.path().as_os_str().to_str().unwrap()
                         ))
                         .unwrap(),
+                        ..Default::default()
                     },
                 ),
                 MaybeError::None

--- a/ddtelemetry-ffi/src/lib.rs
+++ b/ddtelemetry-ffi/src/lib.rs
@@ -107,7 +107,7 @@ pub(crate) use c_setters;
 #[cfg(test)]
 mod tests {
     use crate::{builder::*, worker_handle::*};
-    use ddcommon::{parse_uri, Endpoint};
+    use ddcommon::Endpoint;
     use ddcommon_ffi as ffi;
     use ddtelemetry::{
         data::metrics::{MetricNamespace, MetricType},
@@ -244,14 +244,10 @@ mod tests {
             assert_eq!(
                 ddog_telemetry_builder_with_endpoint_config_endpoint(
                     &mut builder,
-                    &Endpoint {
-                        url: parse_uri(&format!(
-                            "file://{}",
-                            f.path().as_os_str().to_str().unwrap()
-                        ))
-                        .unwrap(),
-                        ..Default::default()
-                    },
+                    &Endpoint::from_slice(&format!(
+                        "file://{}",
+                        f.path().as_os_str().to_str().unwrap()
+                    )),
                 ),
                 MaybeError::None
             );
@@ -291,14 +287,10 @@ mod tests {
             assert_eq!(
                 ddog_telemetry_builder_with_endpoint_config_endpoint(
                     &mut builder,
-                    &Endpoint {
-                        url: parse_uri(&format!(
-                            "file://{}",
-                            f.path().as_os_str().to_str().unwrap()
-                        ))
-                        .unwrap(),
-                        ..Default::default()
-                    },
+                    &Endpoint::from_slice(&format!(
+                        "file://{}",
+                        f.path().as_os_str().to_str().unwrap()
+                    )),
                 ),
                 MaybeError::None
             );

--- a/ddtelemetry/Cargo.toml
+++ b/ddtelemetry/Cargo.toml
@@ -38,3 +38,4 @@ hashbrown = { version = "0.12", features = ["raw"] }
 
 [dev-dependencies]
 tracing-subscriber = "0.3.18"
+tokio = { version = "1.23", features = ["sync", "io-util", "rt-multi-thread"] }

--- a/ddtelemetry/examples/tm-metrics-worker-test.rs
+++ b/ddtelemetry/examples/tm-metrics-worker-test.rs
@@ -35,7 +35,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     builder.config.telemetry_debug_logging_enabled = Some(true);
     builder.config.endpoint = Some(ddcommon::Endpoint {
         url: ddcommon::parse_uri("file://./tm-metrics-worker-test.output").unwrap(),
-        api_key: None,
+        ..Default::default()
     });
     builder.config.telemetry_hearbeat_interval = Some(Duration::from_secs(1));
 

--- a/ddtelemetry/examples/tm-metrics-worker-test.rs
+++ b/ddtelemetry/examples/tm-metrics-worker-test.rs
@@ -33,10 +33,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         "none".into(),
     );
     builder.config.telemetry_debug_logging_enabled = Some(true);
-    builder.config.endpoint = Some(ddcommon::Endpoint {
-        url: ddcommon::parse_uri("file://./tm-metrics-worker-test.output").unwrap(),
-        ..Default::default()
-    });
+    builder.config.endpoint = Some(ddcommon::Endpoint::from_slice(
+        "file://./tm-metrics-worker-test.output",
+    ));
     builder.config.telemetry_hearbeat_interval = Some(Duration::from_secs(1));
 
     let handle = builder.run_metrics_logs()?;

--- a/ddtelemetry/examples/tm-send-sketch.rs
+++ b/ddtelemetry/examples/tm-send-sketch.rs
@@ -116,6 +116,7 @@ async fn async_main() {
             "https://instrumentation-telemetry-intake.datad0g.com/api/v2/apmtelemetry",
         ),
         api_key: Some(Cow::Owned(std::env::var("DD_API_KEY").unwrap())),
+        ..Default::default()
     });
     push_telemetry(&config, &req).await.unwrap();
 }

--- a/ddtelemetry/examples/tm-worker-test.rs
+++ b/ddtelemetry/examples/tm-worker-test.rs
@@ -38,7 +38,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     builder.config.telemetry_debug_logging_enabled = Some(true);
     builder.config.endpoint = Some(ddcommon::Endpoint {
         url: ddcommon::parse_uri("file://./tm-worker-test.output").unwrap(),
-        api_key: None,
+        ..Default::default()
     });
     builder.config.telemetry_hearbeat_interval = Some(Duration::from_secs(1));
 

--- a/ddtelemetry/src/config.rs
+++ b/ddtelemetry/src/config.rs
@@ -228,7 +228,11 @@ impl Config {
             restartable: false,
         };
         if let Ok(url) = parse_uri(&trace_agent_url) {
-            let _res = this.set_endpoint(Endpoint { url, api_key, ..Default::default() });
+            let _res = this.set_endpoint(Endpoint {
+                url,
+                api_key,
+                ..Default::default()
+            });
         }
 
         this

--- a/ddtelemetry/src/config.rs
+++ b/ddtelemetry/src/config.rs
@@ -228,7 +228,7 @@ impl Config {
             restartable: false,
         };
         if let Ok(url) = parse_uri(&trace_agent_url) {
-            let _res = this.set_endpoint(Endpoint { url, api_key });
+            let _res = this.set_endpoint(Endpoint { url, api_key, ..Default::default() });
         }
 
         this
@@ -261,6 +261,7 @@ impl Config {
         self.set_endpoint(Endpoint {
             url: parse_uri(host_url)?,
             api_key,
+            ..Default::default()
         })
     }
 }

--- a/ddtelemetry/src/config.rs
+++ b/ddtelemetry/src/config.rs
@@ -261,11 +261,11 @@ impl Config {
     ///  If the host_url is http/https, any path will be ignored and replaced by the
     /// appropriate telemetry endpoint path
     pub fn set_host_from_url(&mut self, host_url: &str) -> anyhow::Result<()> {
-        let api_key = self.endpoint.take().and_then(|e| e.api_key);
+        let endpoint = self.endpoint.take().unwrap_or_default();
+
         self.set_endpoint(Endpoint {
             url: parse_uri(host_url)?,
-            api_key,
-            ..Default::default()
+            ..endpoint
         })
     }
 }

--- a/ddtelemetry/src/worker/mod.rs
+++ b/ddtelemetry/src/worker/mod.rs
@@ -13,6 +13,7 @@ use crate::{
     worker::builder::ConfigBuilder,
 };
 use ddcommon::tag::Tag;
+use ddcommon::Endpoint;
 
 use std::iter::Sum;
 use std::ops::Add;
@@ -183,9 +184,6 @@ mod serialize {
 }
 
 impl TelemetryWorker {
-    // Default request timeout in milliseconds.
-    const DEFAULT_TIMEOUT: u64 = 10_000;
-
     fn log_err(&self, err: &anyhow::Error) {
         telemetry_worker_log!(self, ERROR, "{}", err);
     }
@@ -678,9 +676,9 @@ impl TelemetryWorker {
             },
             _ = tokio::time::sleep(time::Duration::from_millis(
                     if let Some(endpoint) = self.config.endpoint.as_ref() {
-                        endpoint.timeout
+                        endpoint.timeout_ms
                     } else {
-                        Self::DEFAULT_TIMEOUT
+                        Endpoint::DEFAULT_TIMEOUT
                     })) => {
                 Err(anyhow::anyhow!("Request timed out"))
             },

--- a/examples/ffi/exporter.cpp
+++ b/examples/ffi/exporter.cpp
@@ -140,10 +140,11 @@ int main(int argc, char *argv[]) {
   ddog_CharSlice info_example = DDOG_CHARSLICE_C_BARE(
       "{\"application\": {\"start_time\": \"2024-01-24T11:17:22+0000\"}, \"platform\": {\"kernel\": \"Darwin Kernel 22.5.0\"}}");
 
+  ddog_prof_Exporter_set_timeout(exporter, 30000);
+
   ddog_prof_Exporter_Request_BuildResult build_result = ddog_prof_Exporter_Request_build(
       exporter, encoded_profile->start, encoded_profile->end, files_to_compress_and_export,
-      files_to_export_unmodified, nullptr, nullptr, &internal_metadata_example, &info_example,
-      30000);
+      files_to_export_unmodified, nullptr, nullptr, &internal_metadata_example, &info_example);
   ddog_prof_EncodedProfile_drop(encoded_profile);
 
   if (build_result.tag == DDOG_PROF_EXPORTER_REQUEST_BUILD_RESULT_ERR) {

--- a/examples/ffi/exporter.cpp
+++ b/examples/ffi/exporter.cpp
@@ -140,7 +140,12 @@ int main(int argc, char *argv[]) {
   ddog_CharSlice info_example = DDOG_CHARSLICE_C_BARE(
       "{\"application\": {\"start_time\": \"2024-01-24T11:17:22+0000\"}, \"platform\": {\"kernel\": \"Darwin Kernel 22.5.0\"}}");
 
-  ddog_prof_Exporter_set_timeout(exporter, 30000);
+  auto res = ddog_prof_Exporter_set_timeout(exporter, 30000);
+  if (res.tag == DDOG_PROF_OPTION_ERROR_SOME_ERROR) {
+          print_error("Failed to set the timeout", res.some);
+          ddog_Error_drop(&res.some);
+          return 1;
+  }
 
   ddog_prof_Exporter_Request_BuildResult build_result = ddog_prof_Exporter_Request_build(
       exporter, encoded_profile->start, encoded_profile->end, files_to_compress_and_export,

--- a/profiling-ffi/src/crashtracker/datatypes.rs
+++ b/profiling-ffi/src/crashtracker/datatypes.rs
@@ -7,7 +7,6 @@ use ddcommon::tag::Tag;
 use ddcommon_ffi::slice::{AsBytes, ByteSlice, CharSlice};
 use ddcommon_ffi::{Error, Slice, StringWrapper};
 use std::ops::Not;
-use std::time::Duration;
 
 #[repr(C)]
 pub struct EnvVar<'a> {
@@ -95,14 +94,12 @@ impl<'a> TryFrom<CrashtrackerConfiguration<'a>>
         let create_alt_stack = value.create_alt_stack;
         let endpoint = unsafe { exporter::try_to_endpoint(value.endpoint).ok() };
         let resolve_frames = value.resolve_frames;
-        let timeout = Duration::from_secs(value.timeout_secs);
         let wait_for_receiver = value.wait_for_receiver;
         Self::new(
             additional_files,
             create_alt_stack,
             endpoint,
             resolve_frames,
-            timeout,
             wait_for_receiver,
         )
     }

--- a/profiling-ffi/src/exporter.rs
+++ b/profiling-ffi/src/exporter.rs
@@ -10,7 +10,7 @@ use datadog_profiling::exporter::{ProfileExporter, Request};
 use datadog_profiling::internal::ProfiledEndpointsStats;
 use ddcommon::tag::Tag;
 use ddcommon_ffi::slice::{AsBytes, ByteSlice, CharSlice, Slice};
-use ddcommon_ffi::Error;
+use ddcommon_ffi::{Error, MaybeError};
 use std::borrow::Cow;
 use std::ptr::NonNull;
 use std::str::FromStr;
@@ -192,7 +192,7 @@ fn ddog_prof_exporter_new_impl(
     )
 }
 
-/// Sets the timeout for the exporte's timeout.
+/// Sets the value for the exporter's timeout.
 /// # Arguments
 /// * `exporter` - ProfileExporter instance.
 /// * `timeout_ms` - timeout in milliseconds.
@@ -200,9 +200,12 @@ fn ddog_prof_exporter_new_impl(
 pub unsafe extern "C" fn ddog_prof_Exporter_set_timeout(
     exporter: Option<&mut ProfileExporter>,
     timeout_ms: u64,
-) {
+) -> MaybeError {
     if let Some(ptr) = exporter {
         ptr.set_timeout(timeout_ms);
+        MaybeError::None
+    } else {
+        MaybeError::Some(Error::from("Invalid argument"))
     }
 }
 

--- a/profiling-ffi/src/exporter.rs
+++ b/profiling-ffi/src/exporter.rs
@@ -192,6 +192,20 @@ fn ddog_prof_exporter_new_impl(
     )
 }
 
+/// Sets the timeout for the exporte's timeout.
+/// # Arguments
+/// * `exporter` - ProfileExporter instance.
+/// * `timeout_ms` - timeout in milliseconds.
+#[no_mangle]
+pub unsafe extern "C" fn ddog_prof_Exporter_set_timeout(
+    exporter: Option<&mut ProfileExporter>,
+    timeout_ms: u64,
+) {
+    if let Some(ptr) = exporter {
+        ptr.set_timeout(timeout_ms);
+    }
+}
+
 /// # Safety
 /// The `exporter` may be null, but if non-null the pointer must point to a
 /// valid `ddog_prof_Exporter_Request` object made by the Rust Global
@@ -255,12 +269,10 @@ pub unsafe extern "C" fn ddog_prof_Exporter_Request_build(
     optional_endpoints_stats: Option<&ProfiledEndpointsStats>,
     optional_internal_metadata_json: Option<&CharSlice>,
     optional_info_json: Option<&CharSlice>,
-    timeout_ms: u64,
 ) -> RequestBuildResult {
     match exporter {
         None => RequestBuildResult::Err(anyhow::anyhow!("exporter was null").into()),
         Some(exporter) => {
-            let timeout = std::time::Duration::from_millis(timeout_ms);
             let files_to_compress_and_export = into_vec_files(files_to_compress_and_export);
             let files_to_export_unmodified = into_vec_files(files_to_export_unmodified);
             let tags = optional_additional_tags.map(|tags| tags.iter().cloned().collect());
@@ -285,7 +297,6 @@ pub unsafe extern "C" fn ddog_prof_Exporter_Request_build(
                 optional_endpoints_stats,
                 internal_metadata,
                 info,
-                timeout,
             ) {
                 Ok(request) => {
                     RequestBuildResult::Ok(NonNull::new_unchecked(Box::into_raw(Box::new(request))))
@@ -573,6 +584,9 @@ mod tests {
             nanoseconds: 78,
         };
         let timeout_milliseconds = 90;
+        unsafe {
+            ddog_prof_Exporter_set_timeout(Some(exporter.as_mut()), timeout_milliseconds);
+        }
 
         let build_result = unsafe {
             ddog_prof_Exporter_Request_build(
@@ -585,7 +599,6 @@ mod tests {
                 None,
                 None,
                 None,
-                timeout_milliseconds,
             )
         };
 
@@ -644,6 +657,9 @@ mod tests {
             nanoseconds: 78,
         };
         let timeout_milliseconds = 90;
+        unsafe {
+            ddog_prof_Exporter_set_timeout(Some(exporter.as_mut()), timeout_milliseconds);
+        }
 
         let raw_internal_metadata = CharSlice::from(
             r#"
@@ -666,7 +682,6 @@ mod tests {
                 None,
                 Some(&raw_internal_metadata),
                 None,
-                timeout_milliseconds,
             )
         };
 
@@ -716,6 +731,9 @@ mod tests {
             nanoseconds: 78,
         };
         let timeout_milliseconds = 90;
+        unsafe {
+            ddog_prof_Exporter_set_timeout(Some(exporter.as_mut()), timeout_milliseconds);
+        }
 
         let raw_internal_metadata = CharSlice::from("this is not a valid json string");
 
@@ -730,7 +748,6 @@ mod tests {
                 None,
                 Some(&raw_internal_metadata),
                 None,
-                timeout_milliseconds,
             )
         };
 
@@ -776,6 +793,9 @@ mod tests {
             nanoseconds: 78,
         };
         let timeout_milliseconds = 90;
+        unsafe {
+            ddog_prof_Exporter_set_timeout(Some(exporter.as_mut()), timeout_milliseconds);
+        }
 
         let raw_info = CharSlice::from(
             r#"
@@ -819,7 +839,6 @@ mod tests {
                 None,
                 None,
                 Some(&raw_info),
-                timeout_milliseconds,
             )
         };
 
@@ -890,6 +909,9 @@ mod tests {
             nanoseconds: 78,
         };
         let timeout_milliseconds = 90;
+        unsafe {
+            ddog_prof_Exporter_set_timeout(Some(exporter.as_mut()), timeout_milliseconds);
+        }
 
         let raw_info = CharSlice::from("this is not a valid json string");
 
@@ -904,7 +926,6 @@ mod tests {
                 None,
                 None,
                 Some(&raw_info),
-                timeout_milliseconds,
             )
         };
 
@@ -926,7 +947,6 @@ mod tests {
             seconds: 56,
             nanoseconds: 78,
         };
-        let timeout_milliseconds = 90;
 
         let build_result = unsafe {
             ddog_prof_Exporter_Request_build(
@@ -939,7 +959,6 @@ mod tests {
                 None,
                 None,
                 None,
-                timeout_milliseconds,
             )
         };
 

--- a/profiling/src/exporter/config.rs
+++ b/profiling/src/exporter/config.rs
@@ -28,7 +28,7 @@ pub fn agent(base_url: Uri) -> anyhow::Result<Endpoint> {
     };
     parts.path_and_query = p_q;
     let url = Uri::from_parts(parts)?;
-    Ok(Endpoint { url, api_key: None })
+    Ok(Endpoint { url, ..Default::default() })
 }
 
 /// Creates an Endpoint for talking to the Datadog agent though a unix socket.
@@ -66,6 +66,7 @@ pub fn agentless<AsStrRef: AsRef<str>, IntoCow: Into<Cow<'static, str>>>(
     Ok(Endpoint {
         url: Uri::from_str(intake_url.as_str())?,
         api_key: Some(api_key.into()),
+        ..Default::default()
     })
 }
 
@@ -73,6 +74,6 @@ pub fn file(path: impl AsRef<str>) -> anyhow::Result<Endpoint> {
     let url: String = format!("file://{}", path.as_ref());
     Ok(Endpoint {
         url: Uri::from_str(url.as_str())?,
-        api_key: None,
+        ..Default::default()
     })
 }

--- a/profiling/src/exporter/config.rs
+++ b/profiling/src/exporter/config.rs
@@ -28,7 +28,10 @@ pub fn agent(base_url: Uri) -> anyhow::Result<Endpoint> {
     };
     parts.path_and_query = p_q;
     let url = Uri::from_parts(parts)?;
-    Ok(Endpoint { url, ..Default::default() })
+    Ok(Endpoint {
+        url,
+        ..Default::default()
+    })
 }
 
 /// Creates an Endpoint for talking to the Datadog agent though a unix socket.

--- a/profiling/src/exporter/config.rs
+++ b/profiling/src/exporter/config.rs
@@ -28,10 +28,7 @@ pub fn agent(base_url: Uri) -> anyhow::Result<Endpoint> {
     };
     parts.path_and_query = p_q;
     let url = Uri::from_parts(parts)?;
-    Ok(Endpoint {
-        url,
-        ..Default::default()
-    })
+    Ok(Endpoint::from_url(url))
 }
 
 /// Creates an Endpoint for talking to the Datadog agent though a unix socket.
@@ -75,8 +72,5 @@ pub fn agentless<AsStrRef: AsRef<str>, IntoCow: Into<Cow<'static, str>>>(
 
 pub fn file(path: impl AsRef<str>) -> anyhow::Result<Endpoint> {
     let url: String = format!("file://{}", path.as_ref());
-    Ok(Endpoint {
-        url: Uri::from_str(url.as_str())?,
-        ..Default::default()
-    })
+    Ok(Endpoint::from_slice(&url))
 }

--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -170,7 +170,6 @@ impl ProfileExporter {
         endpoint_counts: Option<&ProfiledEndpointsStats>,
         internal_metadata: Option<serde_json::Value>,
         info: Option<serde_json::Value>,
-        timeout: std::time::Duration,
     ) -> anyhow::Result<Request> {
         let mut form = multipart::Form::default();
 
@@ -288,7 +287,7 @@ impl ProfileExporter {
 
         Ok(
             Request::from(form.set_body_convert::<hyper::Body, multipart::Body>(builder)?)
-                .with_timeout(timeout),
+                .with_timeout(std::time::Duration::from_millis(self.endpoint.timeout_ms)),
         )
     }
 
@@ -300,6 +299,10 @@ impl ProfileExporter {
         self.exporter
             .runtime
             .block_on(request.send(&self.exporter.client, cancel))
+    }
+
+    pub fn set_timeout(&mut self, timeout_ms: u64) {
+        self.endpoint.timeout_ms = timeout_ms;
     }
 }
 

--- a/profiling/tests/form.rs
+++ b/profiling/tests/form.rs
@@ -35,7 +35,7 @@ fn multipart(
     let start = now.sub(chrono::Duration::seconds(60));
     let end = now;
 
-    let timeout: u64 = 10;
+    let timeout: u64 = 10_000;
     exporter.set_timeout(timeout);
 
     let request = exporter

--- a/profiling/tests/form.rs
+++ b/profiling/tests/form.rs
@@ -17,7 +17,7 @@ fn open<P: AsRef<Path>>(path: P) -> Result<Vec<u8>, Box<dyn Error>> {
 }
 
 fn multipart(
-    exporter: &ProfileExporter,
+    exporter: &mut ProfileExporter,
     internal_metadata: Option<serde_json::Value>,
     info: Option<serde_json::Value>,
 ) -> Request {
@@ -35,7 +35,8 @@ fn multipart(
     let start = now.sub(chrono::Duration::seconds(60));
     let end = now;
 
-    let timeout = std::time::Duration::from_secs(10);
+    let timeout: u64 = 10;
+    exporter.set_timeout(timeout);
 
     let request = exporter
         .build(
@@ -47,12 +48,11 @@ fn multipart(
             None,
             internal_metadata,
             info,
-            timeout,
         )
         .expect("request to be built");
 
     let actual_timeout = request.timeout().expect("timeout to exist");
-    assert_eq!(actual_timeout, timeout);
+    assert_eq!(actual_timeout, std::time::Duration::from_millis(timeout));
     request
 }
 
@@ -95,7 +95,7 @@ mod tests {
         let profiling_library_version = "1.2.3";
         let base_url = "http://localhost:8126".parse().expect("url to parse");
         let endpoint = config::agent(base_url).expect("endpoint to construct");
-        let exporter = ProfileExporter::new(
+        let mut exporter = ProfileExporter::new(
             profiling_library_name,
             profiling_library_version,
             "php",
@@ -104,7 +104,7 @@ mod tests {
         )
         .expect("exporter to construct");
 
-        let request = multipart(&exporter, None, None);
+        let request = multipart(&mut exporter, None, None);
 
         assert_eq!(
             request.uri().to_string(),
@@ -144,7 +144,7 @@ mod tests {
         let profiling_library_version = "1.2.3";
         let base_url = "http://localhost:8126".parse().expect("url to parse");
         let endpoint = config::agent(base_url).expect("endpoint to construct");
-        let exporter = ProfileExporter::new(
+        let mut exporter = ProfileExporter::new(
             profiling_library_name,
             profiling_library_version,
             "php",
@@ -158,7 +158,7 @@ mod tests {
             "execution_trace_enabled": "false",
             "extra object": {"key": [1, 2, true]}
         });
-        let request = multipart(&exporter, Some(internal_metadata.clone()), None);
+        let request = multipart(&mut exporter, Some(internal_metadata.clone()), None);
         let parsed_event_json = parsed_event_json(request);
 
         assert_eq!(parsed_event_json["internal"], internal_metadata);
@@ -173,7 +173,7 @@ mod tests {
         let profiling_library_version = "1.2.3";
         let base_url = "http://localhost:8126".parse().expect("url to parse");
         let endpoint = config::agent(base_url).expect("endpoint to construct");
-        let exporter = ProfileExporter::new(
+        let mut exporter = ProfileExporter::new(
             profiling_library_name,
             profiling_library_version,
             "php",
@@ -198,7 +198,7 @@ mod tests {
                 "settings": {}
             }
         });
-        let request = multipart(&exporter, None, Some(info.clone()));
+        let request = multipart(&mut exporter, None, Some(info.clone()));
         let parsed_event_json = parsed_event_json(request);
 
         assert_eq!(parsed_event_json["info"], info);
@@ -213,7 +213,7 @@ mod tests {
         let profiling_library_version = "1.2.3";
         let api_key = "1234567890123456789012";
         let endpoint = config::agentless("datadoghq.com", api_key).expect("endpoint to construct");
-        let exporter = ProfileExporter::new(
+        let mut exporter = ProfileExporter::new(
             profiling_library_name,
             profiling_library_version,
             "php",
@@ -222,7 +222,7 @@ mod tests {
         )
         .expect("exporter to construct");
 
-        let request = multipart(&exporter, None, None);
+        let request = multipart(&mut exporter, None, None);
 
         assert_eq!(
             request.uri().to_string(),

--- a/sidecar-ffi/tests/sidecar.rs
+++ b/sidecar-ffi/tests/sidecar.rs
@@ -85,8 +85,8 @@ fn test_ddog_sidecar_register_app() {
             &mut transport,
             "session_id".into(),
             &Endpoint {
-                api_key: None,
                 url: hyper::Uri::from_static("http://localhost:8082/"),
+                ..Default::default()
             },
             &Endpoint::default(),
             1000,
@@ -130,8 +130,8 @@ fn test_ddog_sidecar_register_app() {
             &mut transport,
             "session_id".into(),
             &Endpoint {
-                api_key: None,
                 url: hyper::Uri::from_static("http://localhost:8083/"),
+                ..Default::default()
             },
             &Endpoint::default(),
             1000,

--- a/sidecar/src/config.rs
+++ b/sidecar/src/config.rs
@@ -178,6 +178,7 @@ pub fn get_product_endpoint(subdomain: &str, endpoint: &Endpoint) -> Endpoint {
         Endpoint {
             url: hyper::Uri::from_parts(parts).unwrap(),
             api_key: Some(api_key.clone()),
+            ..Default::default()
         }
     } else {
         endpoint.clone()

--- a/sidecar/src/config.rs
+++ b/sidecar/src/config.rs
@@ -178,7 +178,7 @@ pub fn get_product_endpoint(subdomain: &str, endpoint: &Endpoint) -> Endpoint {
         Endpoint {
             url: hyper::Uri::from_parts(parts).unwrap(),
             api_key: Some(api_key.clone()),
-            ..Default::default()
+            ..*endpoint
         }
     } else {
         endpoint.clone()

--- a/sidecar/src/dogstatsd.rs
+++ b/sidecar/src/dogstatsd.rs
@@ -185,7 +185,7 @@ mod test {
                 .as_str()
                 .parse::<Uri>()
                 .unwrap(),
-            api_key: None,
+            ..Default::default()
         });
         flusher.send(vec![
             Count("test_count".to_string(), 3, vec![tag!("foo", "bar")]),
@@ -226,20 +226,20 @@ mod test {
 
         let res = create_client(Some(Endpoint {
             url: "localhost:99999".parse::<Uri>().unwrap(),
-            api_key: None,
+            ..Default::default()
         }));
         assert!(res.is_err());
         assert_eq!("invalid port", res.unwrap_err().to_string().as_str());
 
         let res = create_client(Some(Endpoint {
             url: "localhost:80".parse::<Uri>().unwrap(),
-            api_key: None,
+            ..Default::default()
         }));
         assert!(res.is_ok());
 
         let res = create_client(Some(Endpoint {
             url: "http://localhost:80".parse::<Uri>().unwrap(),
-            api_key: None,
+            ..Default::default()
         }));
         assert!(res.is_ok());
     }
@@ -250,14 +250,14 @@ mod test {
     fn test_create_client_unix_domain_socket() {
         let res = create_client(Some(Endpoint {
             url: "unix://localhost:80".parse::<Uri>().unwrap(),
-            api_key: None,
+            ..Default::default()
         }));
         assert!(res.is_err());
         assert_eq!("invalid url", res.unwrap_err().to_string().as_str());
 
         let res = create_client(Some(Endpoint {
             url: socket_path_to_uri("/path/to/a/socket.sock".as_ref()).unwrap(),
-            api_key: None,
+            ..Default::default()
         }));
         assert!(res.is_ok());
     }

--- a/sidecar/src/dogstatsd.rs
+++ b/sidecar/src/dogstatsd.rs
@@ -224,23 +224,14 @@ mod test {
         assert!(res.is_err());
         assert_eq!("invalid host", res.unwrap_err().to_string().as_str());
 
-        let res = create_client(Some(Endpoint {
-            url: "localhost:99999".parse::<Uri>().unwrap(),
-            ..Default::default()
-        }));
+        let res = create_client(Some(Endpoint::from_slice("localhost:99999")));
         assert!(res.is_err());
         assert_eq!("invalid port", res.unwrap_err().to_string().as_str());
 
-        let res = create_client(Some(Endpoint {
-            url: "localhost:80".parse::<Uri>().unwrap(),
-            ..Default::default()
-        }));
+        let res = create_client(Some(Endpoint::from_slice("localhost:80")));
         assert!(res.is_ok());
 
-        let res = create_client(Some(Endpoint {
-            url: "http://localhost:80".parse::<Uri>().unwrap(),
-            ..Default::default()
-        }));
+        let res = create_client(Some(Endpoint::from_slice("http://localhost:80")));
         assert!(res.is_ok());
     }
 
@@ -255,10 +246,9 @@ mod test {
         assert!(res.is_err());
         assert_eq!("invalid url", res.unwrap_err().to_string().as_str());
 
-        let res = create_client(Some(Endpoint {
-            url: socket_path_to_uri("/path/to/a/socket.sock".as_ref()).unwrap(),
-            ..Default::default()
-        }));
+        let res = create_client(Some(Endpoint::from_url(
+            socket_path_to_uri("/path/to/a/socket.sock".as_ref()).unwrap(),
+        )));
         assert!(res.is_ok());
     }
 }

--- a/sidecar/src/service/tracing/trace_flusher.rs
+++ b/sidecar/src/service/tracing/trace_flusher.rs
@@ -338,6 +338,7 @@ mod tests {
         let target_endpoint = Endpoint {
             url: server.url("").to_owned().parse().unwrap(),
             api_key: Some("test-key".into()),
+            ..Default::default()
         };
 
         let send_data_1 = create_send_data(size, &target_endpoint);
@@ -379,6 +380,7 @@ mod tests {
         let target_endpoint = Endpoint {
             url: server.url("").to_owned().parse().unwrap(),
             api_key: Some("test-key".into()),
+            ..Default::default()
         };
         let send_data_1 = create_send_data(size, &target_endpoint);
 
@@ -415,6 +417,7 @@ mod tests {
         let target_endpoint = Endpoint {
             url: server.url("").to_owned().parse().unwrap(),
             api_key: Some("test-key".into()),
+            ..Default::default()
         };
 
         let send_data_1 = create_send_data(size, &target_endpoint);

--- a/sidecar/src/tracer.rs
+++ b/sidecar/src/tracer.rs
@@ -22,7 +22,7 @@ impl Config {
         };
         self.endpoint = Some(Endpoint {
             url: uri,
-            api_key: endpoint.api_key,
+            ..endpoint
         });
         Ok(())
     }

--- a/trace-mini-agent/src/config.rs
+++ b/trace-mini-agent/src/config.rs
@@ -76,10 +76,12 @@ impl Config {
             trace_intake: Endpoint {
                 url: hyper::Uri::from_str(&trace_intake_url).unwrap(),
                 api_key: Some(api_key.clone()),
+                ..Default::default()
             },
             trace_stats_intake: Endpoint {
                 url: hyper::Uri::from_str(&trace_stats_intake_url).unwrap(),
                 api_key: Some(api_key),
+                ..Default::default()
             },
             obfuscation_config,
             mini_agent_version,

--- a/trace-mini-agent/src/trace_processor.rs
+++ b/trace-mini-agent/src/trace_processor.rs
@@ -163,10 +163,12 @@ mod tests {
             trace_intake: Endpoint {
                 url: hyper::Uri::from_static("https://trace.agent.notdog.com/traces"),
                 api_key: Some("dummy_api_key".into()),
+                ..Default::default()
             },
             trace_stats_intake: Endpoint {
                 url: hyper::Uri::from_static("https://trace.agent.notdog.com/stats"),
                 api_key: Some("dummy_api_key".into()),
+                ..Default::default()
             },
             dd_site: "datadoghq.com".to_string(),
             env_type: trace_utils::EnvironmentType::CloudFunction,

--- a/trace-utils/src/send_data/mod.rs
+++ b/trace-utils/src/send_data/mod.rs
@@ -896,8 +896,16 @@ mod tests {
         let res = data.send().await;
 
         assert!(res.last_result.is_err());
-        assert_eq!(res.errors_timeout, 0);
-        assert_eq!(res.errors_network, 1);
+        match std::env::consts::OS {
+            "windows" => {
+                assert_eq!(res.errors_timeout, 1);
+                assert_eq!(res.errors_network, 0);
+            }
+            _ => {
+                assert_eq!(res.errors_timeout, 0);
+                assert_eq!(res.errors_network, 1);
+            }
+        }
         assert_eq!(res.errors_status_code, 0);
         assert_eq!(res.requests_count, 5);
         assert_eq!(res.errors_status_code, 0);

--- a/trace-utils/src/send_data/mod.rs
+++ b/trace-utils/src/send_data/mod.rs
@@ -1118,10 +1118,7 @@ mod tests {
             })
             .await;
 
-        let target_endpoint = Endpoint {
-            url: server.url("").to_owned().parse().unwrap(),
-            ..Default::default()
-        };
+        let target_endpoint = Endpoint::from_slice(server.url("").as_str());
 
         let size = 512;
 

--- a/trace-utils/src/send_data/mod.rs
+++ b/trace-utils/src/send_data/mod.rs
@@ -213,7 +213,7 @@ impl SendData {
         };
 
         match tokio::time::timeout(
-            Duration::from_millis(self.target.timeout),
+            Duration::from_millis(self.target.timeout_ms),
             Client::builder()
                 .build(connector::Connector::default())
                 .request(req),
@@ -563,7 +563,7 @@ mod tests {
             &Endpoint {
                 api_key: Some(std::borrow::Cow::Borrowed("TEST-KEY")),
                 url: "/foo/bar?baz".parse::<hyper::Uri>().unwrap(),
-                timeout: MILLIS_PER_SECOND,
+                timeout_ms: MILLIS_PER_SECOND,
             },
         );
 
@@ -587,7 +587,7 @@ mod tests {
             &Endpoint {
                 api_key: None,
                 url: "/foo/bar?baz".parse::<hyper::Uri>().unwrap(),
-                timeout: MILLIS_PER_SECOND,
+                timeout_ms: MILLIS_PER_SECOND,
             },
         );
 
@@ -624,7 +624,7 @@ mod tests {
             &Endpoint {
                 api_key: Some(std::borrow::Cow::Borrowed("TEST-KEY")),
                 url: server.url("/").parse::<hyper::Uri>().unwrap(),
-                timeout: MILLIS_PER_SECOND,
+                timeout_ms: MILLIS_PER_SECOND,
             },
         );
 
@@ -667,7 +667,7 @@ mod tests {
             &Endpoint {
                 api_key: Some(std::borrow::Cow::Borrowed("TEST-KEY")),
                 url: server.url("/").parse::<hyper::Uri>().unwrap(),
-                timeout: MILLIS_PER_SECOND,
+                timeout_ms: MILLIS_PER_SECOND,
             },
         );
 
@@ -721,7 +721,7 @@ mod tests {
             &Endpoint {
                 api_key: None,
                 url: server.url("/").parse::<hyper::Uri>().unwrap(),
-                timeout: MILLIS_PER_SECOND,
+                timeout_ms: MILLIS_PER_SECOND,
             },
         );
 
@@ -775,7 +775,7 @@ mod tests {
             &Endpoint {
                 api_key: None,
                 url: server.url("/").parse::<hyper::Uri>().unwrap(),
-                timeout: MILLIS_PER_SECOND,
+                timeout_ms: MILLIS_PER_SECOND,
             },
         );
 
@@ -818,7 +818,7 @@ mod tests {
             &Endpoint {
                 api_key: None,
                 url: server.url("/").parse::<hyper::Uri>().unwrap(),
-                timeout: MILLIS_PER_SECOND,
+                timeout_ms: MILLIS_PER_SECOND,
             },
         );
 
@@ -859,7 +859,7 @@ mod tests {
             &Endpoint {
                 api_key: None,
                 url: server.url("/").parse::<hyper::Uri>().unwrap(),
-                timeout: MILLIS_PER_SECOND,
+                timeout_ms: MILLIS_PER_SECOND,
             },
         );
 
@@ -889,7 +889,7 @@ mod tests {
             &Endpoint {
                 api_key: None,
                 url: "http://127.0.0.1:4321/".parse::<hyper::Uri>().unwrap(),
-                timeout: MILLIS_PER_SECOND,
+                timeout_ms: MILLIS_PER_SECOND,
             },
         );
 
@@ -898,6 +898,9 @@ mod tests {
         assert!(res.last_result.is_err());
         match std::env::consts::OS {
             "windows" => {
+                // On windows the TCP/IP stack returns a timeout error (at hyper level) rather
+                // than a connection refused error despite not having a listening socket on the
+                // port.
                 assert_eq!(res.errors_timeout, 1);
                 assert_eq!(res.errors_network, 0);
             }
@@ -949,7 +952,7 @@ mod tests {
             &Endpoint {
                 api_key: None,
                 url: server.url("/").parse::<hyper::Uri>().unwrap(),
-                timeout: 200,
+                timeout_ms: 200,
             },
         );
 
@@ -990,7 +993,7 @@ mod tests {
             &Endpoint {
                 api_key: None,
                 url: server.url("/").parse::<hyper::Uri>().unwrap(),
-                timeout: 200,
+                timeout_ms: 200,
             },
         );
 

--- a/trace-utils/src/send_data/mod.rs
+++ b/trace-utils/src/send_data/mod.rs
@@ -471,7 +471,7 @@ mod tests {
     use httpmock::MockServer;
     use std::collections::HashMap;
 
-    const MILLIS_PER_SECOND: u64 = 1_000;
+    const ONE_SECOND: u64 = 1_000;
     const HEADER_TAGS: TracerHeaderTags = TracerHeaderTags {
         lang: "test-lang",
         lang_version: "2.0",
@@ -563,7 +563,7 @@ mod tests {
             &Endpoint {
                 api_key: Some(std::borrow::Cow::Borrowed("TEST-KEY")),
                 url: "/foo/bar?baz".parse::<hyper::Uri>().unwrap(),
-                timeout_ms: MILLIS_PER_SECOND,
+                timeout_ms: ONE_SECOND,
             },
         );
 
@@ -587,7 +587,7 @@ mod tests {
             &Endpoint {
                 api_key: None,
                 url: "/foo/bar?baz".parse::<hyper::Uri>().unwrap(),
-                timeout_ms: MILLIS_PER_SECOND,
+                timeout_ms: ONE_SECOND,
             },
         );
 
@@ -624,7 +624,7 @@ mod tests {
             &Endpoint {
                 api_key: Some(std::borrow::Cow::Borrowed("TEST-KEY")),
                 url: server.url("/").parse::<hyper::Uri>().unwrap(),
-                timeout_ms: MILLIS_PER_SECOND,
+                timeout_ms: ONE_SECOND,
             },
         );
 
@@ -667,7 +667,7 @@ mod tests {
             &Endpoint {
                 api_key: Some(std::borrow::Cow::Borrowed("TEST-KEY")),
                 url: server.url("/").parse::<hyper::Uri>().unwrap(),
-                timeout_ms: MILLIS_PER_SECOND,
+                timeout_ms: ONE_SECOND,
             },
         );
 
@@ -721,7 +721,7 @@ mod tests {
             &Endpoint {
                 api_key: None,
                 url: server.url("/").parse::<hyper::Uri>().unwrap(),
-                timeout_ms: MILLIS_PER_SECOND,
+                timeout_ms: ONE_SECOND,
             },
         );
 
@@ -775,7 +775,7 @@ mod tests {
             &Endpoint {
                 api_key: None,
                 url: server.url("/").parse::<hyper::Uri>().unwrap(),
-                timeout_ms: MILLIS_PER_SECOND,
+                timeout_ms: ONE_SECOND,
             },
         );
 
@@ -818,7 +818,7 @@ mod tests {
             &Endpoint {
                 api_key: None,
                 url: server.url("/").parse::<hyper::Uri>().unwrap(),
-                timeout_ms: MILLIS_PER_SECOND,
+                timeout_ms: ONE_SECOND,
             },
         );
 
@@ -859,7 +859,7 @@ mod tests {
             &Endpoint {
                 api_key: None,
                 url: server.url("/").parse::<hyper::Uri>().unwrap(),
-                timeout_ms: MILLIS_PER_SECOND,
+                timeout_ms: ONE_SECOND,
             },
         );
 
@@ -889,7 +889,7 @@ mod tests {
             &Endpoint {
                 api_key: None,
                 url: "http://127.0.0.1:4321/".parse::<hyper::Uri>().unwrap(),
-                timeout_ms: MILLIS_PER_SECOND,
+                timeout_ms: ONE_SECOND,
             },
         );
 

--- a/trace-utils/src/test_utils/datadog_test_agent.rs
+++ b/trace-utils/src/test_utils/datadog_test_agent.rs
@@ -122,10 +122,7 @@ impl DatadogTestAgentContainer {
 ///         .get_uri_for_endpoint("test-endpoint", Some("snapshot-token"))
 ///         .await;
 ///
-///     let endpoint = Endpoint {
-///         url: uri,
-///         api_key: None,
-///     };
+///     let endpoint = Endpoint::from_url(uri);
 ///
 ///     let trace = vec![];
 ///

--- a/trace-utils/src/test_utils/mod.rs
+++ b/trace-utils/src/test_utils/mod.rs
@@ -183,6 +183,7 @@ pub async fn poll_for_mock_hit(
 /// let target_endpoint = Endpoint {
 ///     url: "http://localhost:8080".to_owned().parse().unwrap(),
 ///     api_key: Some("test-key".into()),
+///     ..Default::default()
 /// };
 ///
 /// let send_data = create_send_data(size, &target_endpoint);

--- a/trace-utils/tests/test_send_data.rs
+++ b/trace-utils/tests/test_send_data.rs
@@ -29,12 +29,11 @@ mod tracing_integration_tests {
             client_computed_stats: false,
         };
 
-        let endpoint = Endpoint {
-            url: test_agent
+        let endpoint = Endpoint::from_url(
+            test_agent
                 .get_uri_for_endpoint("v0.4/traces", Some("compare_v04_trace_snapshot_test"))
                 .await,
-            api_key: None,
-        };
+        );
 
         let mut span_1 = create_test_span(1234, 12342, 12341, 1, false);
         span_1.metrics.insert("_dd_metric1".to_string(), 1.0);


### PR DESCRIPTION
# What does this PR do?

This PR adds a new timeout field to the `Endpoint` struct in order to set a timeout for outgoing connections used for sending telemetry and traces.

# Motivation

Prevent situations where holding too many connections could lead to memory pressure or resource exhaustion in the system by dropping them after a period of inactivity.
