### PR TITLE
Enable all benchmarks

### DIFF
--- a/alloc/Cargo.toml
+++ b/alloc/Cargo.toml
@@ -25,3 +25,6 @@ features = [
 [dev-dependencies]
 allocator-api2 = { version = "0.2", default-features = false, features = ["alloc"] }
 bolero = "0.10.1"
+
+[lib]
+bench = false

--- a/benchmark/run_benchmarks_ci.sh
+++ b/benchmark/run_benchmarks_ci.sh
@@ -21,12 +21,8 @@ OUTPUT_DIR="${1:-}"
 pushd "${PROJECT_DIR}" > /dev/null
 
 # Run benchmarks
-# TODO https://datadoghq.atlassian.net/browse/APMSP-1228
-# Right now we are only running a single benchmark to test the CI setup, and there is only
-# support for the Criterion SamplingMode::Flat in the new benchmarking framework. This will be
-# worked on going forward.
 message "Running benchmarks"
-cargo bench -p datadog-trace-obfuscation --bench trace_obfuscation -- sql/obfuscate_sql_string
+cargo bench --workspace -- --sample-size=200
 message "Finished running benchmarks"
 
 # Copy the benchmark results to the output directory

--- a/bin_tests/Cargo.toml
+++ b/bin_tests/Cargo.toml
@@ -20,8 +20,21 @@ serde_json = { version = "1.0" }
 hyper = { version = "0.14", default-features = false }
 strum = { version = "0.26.2", features = ["derive"] }
 
+[lib]
+bench = false
+
 [[bin]]
 name = "crashtracker_bin_test"
+bench = false
 
 [[bin]]
 name = "test_the_tests"
+bench = false
+
+[[bin]]
+name = "crashtracker_receiver"
+bench = false
+
+[[bin]]
+name = "crashtracker_unix_socket_receiver"
+bench = false

--- a/build-common/Cargo.toml
+++ b/build-common/Cargo.toml
@@ -16,3 +16,6 @@ cbindgen = []
 cbindgen = {version = "0.26"}
 serde = "1.0"
 serde_json = "1.0"
+
+[lib]
+bench = false

--- a/crashtracker/Cargo.toml
+++ b/crashtracker/Cargo.toml
@@ -9,6 +9,7 @@ license.workspace = true
 
 [lib]
 crate-type = ["lib"]
+bench = false
 
 [target.'cfg(unix)'.dependencies]
 # Should be kept in sync with the libdatadog symbolizer crate (also using blasesym)

--- a/data-pipeline-ffi/Cargo.toml
+++ b/data-pipeline-ffi/Cargo.toml
@@ -12,6 +12,7 @@ license.workspace = true
 
 [lib]
 crate-type = ["lib", "staticlib", "cdylib"]
+bench = false
 
 [features]
 default = ["cbindgen"]

--- a/data-pipeline/Cargo.toml
+++ b/data-pipeline/Cargo.toml
@@ -21,3 +21,6 @@ ddcommon = { path = "../ddcommon" }
 datadog-trace-protobuf = { path = "../trace-protobuf" }
 datadog-trace-utils = { path = "../trace-utils" }
 datadog-trace-normalization = { path = "../trace-normalization" }
+
+[lib]
+bench = false

--- a/ddcommon-ffi/Cargo.toml
+++ b/ddcommon-ffi/Cargo.toml
@@ -8,6 +8,9 @@ version.workspace = true
 rust-version.workspace = true
 license.workspace = true
 
+[lib]
+bench =false
+
 [features]
 default = ["cbindgen"]
 cbindgen = ["build_common/cbindgen"]

--- a/ddcommon/Cargo.toml
+++ b/ddcommon/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 
 [lib]
 crate-type = ["lib"]
+bench =false
 
 [dependencies]
 anyhow = "1.0"

--- a/ddsketch/Cargo.toml
+++ b/ddsketch/Cargo.toml
@@ -17,3 +17,6 @@ protoc-bin-vendored = { version = "3.0.0", optional = true }
 
 [features]
 generate-protobuf = ["dep:prost-build", "dep:protoc-bin-vendored"]
+
+[lib]
+bench = false

--- a/ddtelemetry-ffi/Cargo.toml
+++ b/ddtelemetry-ffi/Cargo.toml
@@ -10,6 +10,7 @@ license.workspace = true
 
 [lib]
 crate-type = ["lib", "staticlib", "cdylib"]
+bench = false
 
 [features]
 default = ["cbindgen", "expanded_builder_macros"]

--- a/ddtelemetry/Cargo.toml
+++ b/ddtelemetry/Cargo.toml
@@ -6,6 +6,9 @@ version.workspace = true
 rust-version.workspace = true
 license.workspace = true
 
+[lib]
+bench = false
+
 [features]
 default = []
 tracing = ["tracing/std"]

--- a/ipc/Cargo.toml
+++ b/ipc/Cargo.toml
@@ -52,6 +52,9 @@ winapi = { version = "0.3.9", features = ["handleapi", "memoryapi", "winbase", "
 windows-sys = { version = "0.48.0", features = ["Win32_System", "Win32_System_WindowsProgramming", "Win32_Foundation"] }
 tokio = { version = "1.23", features = ["sync", "io-util", "signal", "net"] }
 
+[lib]
+bench = false
+
 [[bench]]
 harness = false
 name = "ipc"

--- a/ipc/macros/Cargo.toml
+++ b/ipc/macros/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.0.1"
 
 [lib]
 proc-macro = true
+bench = false
 
 [dependencies]
 syn = "^2"

--- a/ipc/tarpc/plugins/Cargo.toml
+++ b/ipc/tarpc/plugins/Cargo.toml
@@ -26,6 +26,7 @@ syn = { version = "1.0", features = ["full"] }
 
 [lib]
 proc-macro = true
+bench = false
 
 [dev-dependencies]
 assert-type-eq = "0.1.0"

--- a/ipc/tarpc/tarpc/Cargo.toml
+++ b/ipc/tarpc/tarpc/Cargo.toml
@@ -16,6 +16,9 @@ categories = ["asynchronous", "network-programming"]
 readme = "README.md"
 description = "An RPC framework for Rust with a focus on ease of use."
 
+[lib]
+bench = false
+
 [features]
 default = []
 

--- a/profiling-ffi/Cargo.toml
+++ b/profiling-ffi/Cargo.toml
@@ -12,6 +12,7 @@ license.workspace = true
 # LTO is ignored if "lib" is added as crate type
 # cf. https://github.com/rust-lang/rust/issues/51009
 crate-type = ["staticlib", "cdylib"]
+bench = false
 
 [features]
 default = []

--- a/profiling-replayer/Cargo.toml
+++ b/profiling-replayer/Cargo.toml
@@ -13,3 +13,7 @@ clap = { version = "4.3.21", features = ["cargo", "color", "derive"] }
 datadog-profiling = { path = "../profiling"}
 prost = "0.12"
 sysinfo = {version = "0.29.8", default-features = false}
+
+[[bin]]
+name = "datadog-profiling-replayer"
+bench = false

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -7,9 +7,11 @@ edition.workspace = true
 version.workspace = true
 rust-version.workspace = true
 license.workspace = true
+autobenches = false
 
 [lib]
 crate-type = ["lib"]
+bench = false
 
 [[bench]]
 name = "main"

--- a/serverless/Cargo.toml
+++ b/serverless/Cargo.toml
@@ -9,3 +9,7 @@ env_logger = "0.10.0"
 datadog-trace-mini-agent = { path = "../trace-mini-agent" }
 datadog-trace-protobuf = { path = "../trace-protobuf" }
 datadog-trace-utils = { path = "../trace-utils" }
+
+[[bin]]
+name = "datadog-serverless-trace-mini-agent"
+bench = false

--- a/sidecar-ffi/Cargo.toml
+++ b/sidecar-ffi/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 
 [lib]
 crate-type = ["lib", "staticlib", "cdylib"]
+bench = false
 
 [dependencies]
 ddtelemetry = { path = "../ddtelemetry" }

--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -4,6 +4,9 @@ license = "Apache 2.0"
 name = "datadog-sidecar"
 version = "0.0.1"
 
+[lib]
+bench = false
+
 [features]
 default = ["tracing"]
 tracing = ["tracing/std", "tracing-log", "tracing-subscriber"]

--- a/sidecar/macros/Cargo.toml
+++ b/sidecar/macros/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.0.1"
 
 [lib]
 proc-macro = true
+bench = false
 
 [dependencies]
 syn = { version = "^2", features = ["full"] }

--- a/spawn_worker/Cargo.toml
+++ b/spawn_worker/Cargo.toml
@@ -3,6 +3,9 @@ edition = "2021"
 name = "spawn_worker"
 version = "0.0.1"
 
+[lib]
+bench = false
+
 [dependencies]
 anyhow = { version = "1.0" }
 io-lifetimes = { version = "1.0" }

--- a/symbolizer-ffi/Cargo.toml
+++ b/symbolizer-ffi/Cargo.toml
@@ -12,6 +12,7 @@ build_common = { path = "../build-common" }
 
 [lib]
 crate-type = ["lib"]
+bench = false
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 # Should be kept in sync with the libdatadog crashtracker crate (also using blasesym)

--- a/tests/spawn_from_lib/Cargo.toml
+++ b/tests/spawn_from_lib/Cargo.toml
@@ -6,6 +6,7 @@ version = "0.0.1"
 [lib]
 # needs to by dylib for the trampoline tests to work correctly
 crate-type = ["rlib", "dylib"]
+bench = false
 
 [features]
 # hack to avoid compilation and testing by default

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -10,9 +10,13 @@ license.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+bench = false
+
 [dependencies]
 regex = "1"
 lazy_static = "1.4"
 
 [[bin]]
 name = "dedup_headers"
+bench = false

--- a/tools/cc_utils/Cargo.toml
+++ b/tools/cc_utils/Cargo.toml
@@ -8,3 +8,7 @@ version = "0.1.0"
 [dependencies]
 anyhow = {version = "1.0"}
 cc = {version = "1.0"}
+
+[lib]
+bench = false
+

--- a/tools/docker/Dockerfile.build
+++ b/tools/docker/Dockerfile.build
@@ -109,7 +109,30 @@ COPY "data-pipeline/Cargo.toml" "data-pipeline/"
 COPY "data-pipeline-ffi/Cargo.toml" "data-pipeline-ffi/"
 COPY "bin_tests/Cargo.toml"  "bin_tests/"
 RUN find -name "Cargo.toml" | sed -e s#Cargo.toml#src/lib.rs#g | xargs -n 1 sh -c 'mkdir -p $(dirname $1); touch $1; echo $1' create_stubs
-RUN echo trace-normalization/benches/normalization_utils.rs profiling/benches/main.rs profiling/benches/interning_strings.rs trace-obfuscation/benches/trace_obfuscation.rs tools/src/bin/dedup_headers.rs tools/sidecar_mockgen/src/bin/sidecar_mockgen.rs ddtelemetry/examples/tm-worker-test.rs ipc/benches/ipc.rs ipc/tarpc/tarpc/examples/compression.rs ipc/tarpc/tarpc/examples/custom_transport.rs ipc/tarpc/tarpc/examples/pubsub.rs ipc/tarpc/tarpc/examples/readme.rs ipc/tarpc/tarpc/examples/tracing.rs ipc/tarpc/tarpc/tests/compile_fail.rs ipc/tarpc/tarpc/tests/dataservice.rs ipc/tarpc/tarpc/tests/service_functional.rs bin_tests/src/bin/crashtracker_bin_test.rs bin_tests/src/bin/test_the_tests.rs | xargs -n 1 sh -c 'mkdir -p $(dirname $1); touch $1; echo $1' create_stubs
+RUN echo \
+    bin_tests/src/bin/crashtracker_bin_test.rs \
+    bin_tests/src/bin/crashtracker_receiver.rs \
+    bin_tests/src/bin/crashtracker_unix_socket_receiver.rs \
+    bin_tests/src/bin/test_the_tests.rs \
+    ddtelemetry/examples/tm-worker-test.rs \
+    ipc/benches/ipc.rs \
+    ipc/tarpc/tarpc/examples/compression.rs \
+    ipc/tarpc/tarpc/examples/custom_transport.rs \
+    ipc/tarpc/tarpc/examples/pubsub.rs \
+    ipc/tarpc/tarpc/examples/readme.rs \
+    ipc/tarpc/tarpc/examples/tracing.rs \
+    ipc/tarpc/tarpc/tests/compile_fail.rs \
+    ipc/tarpc/tarpc/tests/dataservice.rs \
+    ipc/tarpc/tarpc/tests/service_functional.rs \
+    profiling-replayer/src/main.rs \
+    profiling/benches/interning_strings.rs \
+    profiling/benches/main.rs \
+    serverless/src/main.rs \
+    tools/sidecar_mockgen/src/bin/sidecar_mockgen.rs \
+    tools/src/bin/dedup_headers.rs \
+    trace-normalization/benches/normalization_utils.rs \
+    trace-obfuscation/benches/trace_obfuscation.rs \
+    | xargs -n 1 sh -c 'mkdir -p $(dirname $1); touch $1; echo $1' create_stubs
 
 # cache dependencies
 RUN cargo fetch --locked

--- a/tools/sidecar_mockgen/Cargo.toml
+++ b/tools/sidecar_mockgen/Cargo.toml
@@ -3,8 +3,12 @@ edition = "2021"
 name = "sidecar_mockgen"
 version = "0.1.0"
 
+[lib]
+bench = false
+
 [dependencies]
 object = {version = "0.31.0"}
 
 [[bin]]
 name = "sidecar_mockgen"
+bench = false

--- a/trace-mini-agent/Cargo.toml
+++ b/trace-mini-agent/Cargo.toml
@@ -3,6 +3,10 @@ name = "datadog-trace-mini-agent"
 description = "A subset of the trace agent that is shipped alongside tracers in a few serverless use cases (Google Cloud Functions and Azure Functions)"
 version = "0.4.2"
 edition = "2021"
+autobenches = false
+
+[lib]
+bench = false
 
 [dependencies]
 anyhow = "1.0"

--- a/trace-normalization/Cargo.toml
+++ b/trace-normalization/Cargo.toml
@@ -7,6 +7,9 @@ version.workspace = true
 rust-version.workspace = true
 license.workspace = true
 
+[lib]
+bench = false
+
 [dependencies]
 anyhow = "1.0"
 datadog-trace-protobuf = { path = "../trace-protobuf" }

--- a/trace-obfuscation/Cargo.toml
+++ b/trace-obfuscation/Cargo.toml
@@ -24,6 +24,9 @@ duplicate = "0.4.1"
 criterion = { version = "0.5", features = [ "csv_output"] }
 datadog-trace-utils = { path = "../trace-utils", features = ["test-utils"] }
 
+[lib]
+bench = false
+
 [[bench]]
 name = "trace_obfuscation"
 harness = false

--- a/trace-obfuscation/benches/benchmarks/sql_obfuscation_bench.rs
+++ b/trace-obfuscation/benches/benchmarks/sql_obfuscation_bench.rs
@@ -1,22 +1,18 @@
 // Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use criterion::{black_box, criterion_group, Criterion, SamplingMode};
+use criterion::{black_box, criterion_group, Criterion};
 use datadog_trace_obfuscation::sql::obfuscate_sql_string;
 
 fn sql_obfuscation(c: &mut Criterion) {
     let mut group = c.benchmark_group("sql");
-    // TODO https://datadoghq.atlassian.net/browse/APMSP-1228
-    // Enable more sample modes for Criterion benchmarks
-    group
-        .sampling_mode(SamplingMode::Flat)
-        .bench_function("obfuscate_sql_string", |b| {
-            b.iter(|| {
-                for (input, _) in CASES {
-                    black_box(obfuscate_sql_string(input));
-                }
-            })
-        });
+    group.bench_function("obfuscate_sql_string", |b| {
+        b.iter(|| {
+            for (input, _) in CASES {
+                black_box(obfuscate_sql_string(input));
+            }
+        })
+    });
 }
 
 criterion_group!(benches, sql_obfuscation);

--- a/trace-protobuf/Cargo.toml
+++ b/trace-protobuf/Cargo.toml
@@ -6,6 +6,9 @@ version.workspace = true
 rust-version.workspace = true
 license.workspace = true
 
+[lib]
+bench = false
+
 [dependencies]
 prost = "0.11.6"
 serde = { version = "1.0.145", features = ["derive"] }

--- a/trace-utils/Cargo.toml
+++ b/trace-utils/Cargo.toml
@@ -6,6 +6,9 @@ version.workspace = true
 rust-version.workspace = true
 license.workspace = true
 
+[lib]
+bench = false
+
 [dependencies]
 anyhow = "1.0"
 hyper = { version = "0.14", features = ["client", "server"] }


### PR DESCRIPTION
# What does this PR do?

This PR makes all Criterion benchmarks run on the benchmarking platform.

# Motivation

It should be easy to add new benchmarks and we should run them to catch regressions early.

# How to test the change?

It's run on this PR

[APMSP-1228]

[APMSP-1228]: https://datadoghq.atlassian.net/browse/APMSP-1228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ