### PR TITLE
feat: move these to debug logs

### DIFF
--- a/trace-mini-agent/src/http_utils.rs
+++ b/trace-mini-agent/src/http_utils.rs
@@ -6,7 +6,7 @@ use hyper::{
     http::{self, HeaderMap},
     Body, Response, StatusCode,
 };
-use log::{error, debug};
+use log::{debug, error};
 use serde_json::json;
 
 /// Does two things:

--- a/trace-mini-agent/src/http_utils.rs
+++ b/trace-mini-agent/src/http_utils.rs
@@ -24,7 +24,7 @@ pub fn log_and_create_http_response(
     status: StatusCode,
 ) -> http::Result<Response<Body>> {
     if status.is_success() {
-        info!("{message}");
+        debug!("{message}");
     } else {
         error!("{message}");
     }

--- a/trace-mini-agent/src/http_utils.rs
+++ b/trace-mini-agent/src/http_utils.rs
@@ -6,11 +6,11 @@ use hyper::{
     http::{self, HeaderMap},
     Body, Response, StatusCode,
 };
-use log::{error, info};
+use log::{error, debug};
 use serde_json::json;
 
 /// Does two things:
-/// 1. Logs the given message. A success status code (within 200-299) will cause an info log to be
+/// 1. Logs the given message. A success status code (within 200-299) will cause a debug log to be
 ///    written,
 /// otherwise error will be written.
 /// 2. Returns the given message in the body of JSON response with the given status code.


### PR DESCRIPTION
# What does this PR do?
Info seems just a bit noisy to me, as we get the output from every single trace request served:
<img width="977" alt="image" src="https://github.com/DataDog/libdatadog/assets/1598537/25bba359-ecfb-4d00-ab1f-5022d48fc898">

IMHO this is more suited to debug, but happy to revert if necessary.

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
