### PR TITLE
Make bench file not need by pecl package

### DIFF
--- a/trace-normalization/Cargo.toml
+++ b/trace-normalization/Cargo.toml
@@ -22,3 +22,4 @@ criterion = "0.5"
 [[bench]]
 name = "normalization_utils"
 harness = false
+path = "benches/normalization_utils.rs"


### PR DESCRIPTION
Fixes failures like this in dd-trace-php: https://app.circleci.com/pipelines/github/DataDog/dd-trace-php/16600/workflows/31d2931c-8a5b-449c-bc12-d911585b2ddb/jobs/4698215