### PR TITLE
Tel v2 schema for app-started payload requires 'configuration'

### DIFF
--- a/ddtelemetry/src/data/payloads.rs
+++ b/ddtelemetry/src/data/payloads.rs
@@ -39,7 +39,6 @@ pub enum ConfigurationOrigin {
 
 #[derive(Serialize, Debug)]
 pub struct AppStarted {
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     pub configuration: Vec<Configuration>,
 }
 


### PR DESCRIPTION
# What does this PR do?

Fixes app-started telemetry messages that don't include the "configuration" key. This key is required by the schema.

# Motivation

Failing system tests: https://github.com/DataDog/system-tests/pull/2785

# Additional Notes

System tests started failing once https://github.com/DataDog/dd-trace-php/pull/2757 was merged and telemetry messages were actually sent.
