### PR TITLE
[PROF-10208] Package libdatadog v11.0.0 for Ruby

### DIFF
--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -20,22 +20,22 @@ end
 LIB_GITHUB_RELEASES = [
   {
     file: "libdatadog-aarch64-alpine-linux-musl.tar.gz",
-    sha256: "61249c5a2a3c4c80e6f54a24251b5035a49123b1664d28cc21645fa8c7271432",
+    sha256: "81017bdc4634163151272539e98700e5e0fb076d4aa88a004087c4a01be0cfc3",
     ruby_platform: "aarch64-linux-musl"
   },
   {
     file: "libdatadog-aarch64-unknown-linux-gnu.tar.gz",
-    sha256: "14df33b816e12533b95bad64ae0df049bb1fce6b4dc0fe7df4add6ce3ce531e7",
+    sha256: "9b06e0dced2cfa72279a1f50bf12bb485eaa54d54b6d09764cc297d79a7ce0da",
     ruby_platform: "aarch64-linux"
   },
   {
     file: "libdatadog-x86_64-alpine-linux-musl.tar.gz",
-    sha256: "7c5dcf51fec39c7fc0cfca47ee1788630e15682f0a5f9580e94518163300f221",
+    sha256: "96ed601629feb33ce3b1acf6ffd0c30eacb04c4353c8a52388eccd6b4027c2f1",
     ruby_platform: "x86_64-linux-musl"
   },
   {
     file: "libdatadog-x86_64-unknown-linux-gnu.tar.gz",
-    sha256: "ec3a8582f8be34edd3b9b89aed7d0642645b41f8e7c9d5b4d1d6ecdcaa8f31f0",
+    sha256: "cac9b7c4c0f791d8618426bac81f14c0be40bfeecb2d01a98dcae67ba217eca5",
     ruby_platform: "x86_64-linux"
   }
 ]


### PR DESCRIPTION
 # What does this PR do?

This PR includes the changes documented in the "Releasing a new version to rubygems.org" part of the README:
https://github.com/datadog/libdatadog/tree/main/ruby#releasing-a-new-version-to-rubygemsorg

The v11 version bump PR (#529) had already bumped the version itself, so I just needed to add the hashes.

 # Motivation

Enable Ruby to use libdatadog v11.0.0.

 # Additional Notes

N/A

 # How to test the change?

I've tested this release locally using the changes in https://github.com/DataDog/dd-trace-rb/pull/3799 .

As a reminder, new libdatadog releases don't get automatically picked up by dd-trace-rb, so the PR that bumps the Ruby profiler will also test this release against all supported Ruby versions.
