### PR TITLE
[Serverless Mini Agent] Add _dd.mini_agent_version tag to all spans for Azure Functions, Google Cloud Functions, and Azure Spring Apps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-mini-agent"
-version = "0.5.0"
+version = "11.0.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/serverless/src/main.rs
+++ b/serverless/src/main.rs
@@ -3,7 +3,7 @@
 
 use env_logger::{Builder, Env, Target};
 use log::{error, info};
-use std::sync::Arc;
+use std::{env, sync::Arc};
 
 use datadog_trace_mini_agent::{
     config, env_verifier, mini_agent, stats_flusher, stats_processor, trace_flusher,
@@ -15,6 +15,9 @@ pub fn main() {
     Builder::from_env(env).target(Target::Stdout).init();
 
     info!("Starting serverless trace mini agent");
+
+    let mini_agent_version = env!("CARGO_PKG_VERSION").to_string();
+    env::set_var("DD_MINI_AGENT_VERSION", mini_agent_version);
 
     let env_verifier = Arc::new(env_verifier::ServerlessEnvVerifier::default());
 

--- a/trace-mini-agent/Cargo.toml
+++ b/trace-mini-agent/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
 name = "datadog-trace-mini-agent"
 description = "A subset of the trace agent that is shipped alongside tracers in a few serverless use cases (Google Cloud Functions and Azure Functions)"
-version = "0.5.0"
-edition = "2021"
+edition.workspace = true
+version.workspace = true
+rust-version.workspace = true
+license.workspace = true
 autobenches = false
 
 [lib]

--- a/trace-mini-agent/src/config.rs
+++ b/trace-mini-agent/src/config.rs
@@ -19,7 +19,6 @@ pub struct Config {
     pub env_type: trace_utils::EnvironmentType,
     pub function_name: Option<String>,
     pub max_request_content_length: usize,
-    pub mini_agent_version: String,
     pub obfuscation_config: obfuscation_config::ObfuscationConfig,
     pub os: String,
     /// how often to flush stats, in seconds
@@ -62,8 +61,6 @@ impl Config {
             )
         })?;
 
-        let mini_agent_version: String = env!("CARGO_PKG_VERSION").to_string();
-
         Ok(Config {
             function_name: Some(function_name),
             env_type,
@@ -84,7 +81,6 @@ impl Config {
                 ..Default::default()
             },
             obfuscation_config,
-            mini_agent_version,
         })
     }
 }

--- a/trace-mini-agent/src/env_verifier.rs
+++ b/trace-mini-agent/src/env_verifier.rs
@@ -117,6 +117,7 @@ impl ServerlessEnvVerifier {
             gcp_region: Some(get_region_from_gcp_region_string(
                 gcp_metadata.instance.region,
             )),
+            version: trace_utils::MiniAgentMetadata::default().version,
         }
     }
 }
@@ -466,6 +467,7 @@ mod tests {
             trace_utils::MiniAgentMetadata {
                 gcp_project_id: Some("unknown".to_string()),
                 gcp_region: Some("unknown".to_string()),
+                version: None
             }
         );
     }

--- a/trace-mini-agent/src/trace_processor.rs
+++ b/trace-mini-agent/src/trace_processor.rs
@@ -47,10 +47,7 @@ impl TraceChunkProcessor for ChunkProcessor {
         );
         for span in chunk.spans.iter_mut() {
             trace_utils::enrich_span_with_mini_agent_metadata(span, &self.mini_agent_metadata);
-            trace_utils::enrich_span_with_azure_metadata(
-                span,
-                self.config.mini_agent_version.as_str(),
-            );
+            trace_utils::enrich_span_with_azure_metadata(span);
             obfuscate_span(span, &self.config.obfuscation_config);
         }
     }
@@ -174,7 +171,6 @@ mod tests {
             env_type: trace_utils::EnvironmentType::CloudFunction,
             os: "linux".to_string(),
             obfuscation_config: ObfuscationConfig::new().unwrap(),
-            mini_agent_version: "0.1.0".to_string(),
         }
     }
 

--- a/trace-utils/src/trace_utils.rs
+++ b/trace-utils/src/trace_utils.rs
@@ -10,6 +10,7 @@ use rmpv::decode::read_value;
 use rmpv::{Integer, Value};
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
+use std::env;
 
 pub use crate::send_data::send_data_result::SendDataResult;
 pub use crate::send_data::SendData;
@@ -453,10 +454,21 @@ pub enum EnvironmentType {
     LambdaFunction,
 }
 
-#[derive(Clone, Default, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MiniAgentMetadata {
     pub gcp_project_id: Option<String>,
     pub gcp_region: Option<String>,
+    pub version: Option<String>,
+}
+
+impl Default for MiniAgentMetadata {
+    fn default() -> Self {
+        MiniAgentMetadata {
+            gcp_project_id: Default::default(),
+            gcp_region: Default::default(),
+            version: env::var("DD_MINI_AGENT_VERSION").ok(),
+        }
+    }
 }
 
 pub fn enrich_span_with_mini_agent_metadata(
@@ -471,9 +483,13 @@ pub fn enrich_span_with_mini_agent_metadata(
         span.meta
             .insert("location".to_string(), gcp_region.to_string());
     }
+    if let Some(mini_agent_version) = &mini_agent_metadata.version {
+        span.meta
+            .insert("_dd.mini_agent_version".to_string(), mini_agent_version.to_string());
+    }
 }
 
-pub fn enrich_span_with_azure_metadata(span: &mut pb::Span, mini_agent_version: &str) {
+pub fn enrich_span_with_azure_metadata(span: &mut pb::Span) {
     if let Some(aas_metadata) = azure_app_services::get_function_metadata() {
         let aas_tags = [
             ("aas.resource.id", aas_metadata.get_resource_id()),
@@ -486,7 +502,6 @@ pub fn enrich_span_with_azure_metadata(span: &mut pb::Span, mini_agent_version: 
                 aas_metadata.get_instance_name(),
             ),
             ("aas.subscription.id", aas_metadata.get_subscription_id()),
-            ("aas.environment.mini_agent_version", mini_agent_version),
             ("aas.environment.os", aas_metadata.get_operating_system()),
             ("aas.environment.runtime", aas_metadata.get_runtime()),
             (

--- a/trace-utils/src/trace_utils.rs
+++ b/trace-utils/src/trace_utils.rs
@@ -484,8 +484,10 @@ pub fn enrich_span_with_mini_agent_metadata(
             .insert("location".to_string(), gcp_region.to_string());
     }
     if let Some(mini_agent_version) = &mini_agent_metadata.version {
-        span.meta
-            .insert("_dd.mini_agent_version".to_string(), mini_agent_version.to_string());
+        span.meta.insert(
+            "_dd.mini_agent_version".to_string(),
+            mini_agent_version.to_string(),
+        );
     }
 }
 


### PR DESCRIPTION
# What does this PR do?

Adds `_dd.mini_agent_version` span tag to all spans from Azure Functions, Google Cloud Functions, and Azure Spring Apps.

# Motivation

https://datadoghq.atlassian.net/browse/SVLS-5167

# Additional Notes

Previously there was an `aas.environment.mini_agent_version` span tag added for Azure Functions. This tag is being replaced for a span tag that will be applied in all relevant environments: Azure Functions, Google Cloud Functions, and Azure Spring Apps.

Set `DD_MINI_AGENT_VERSION` environment variable to the package version of `datadog-serverless-trace-mini-agent`. Then reference this environment variable in the packages that are run from `datadog-serverless-trace-mini-agent`.

Set the version of `datadog-trace-mini-agent` to match the version of libdatadog so the Serverless Mini Agent version is only managed in a single package moving forward.

# How to test the change?

**Azure Spring Apps**

- Build mini agent locally
- Build an Azure Spring App with persistent storage
- ssh into the Azure Spring App instance and upload the Datadog Java Tracer and Serverless Mini Agent
- Add `-javaagent:/persistent/dd-java-agent.jar` to the JVM options
- Set `DD_TRACE_TRACER_METRICS_ENABLED` to `true`
- Start the Serverless Mini Agent

**Azure Functions / Google Cloud Functions**

- Build mini agent locally
- Deploy Azure Function or Google Cloud Function with mini agent binary in root path
- Set `DD_MINI_AGENT_PATH`
  - Azure: `/home/site/wwwroot/datadog-serverless-trace-mini-agent`
  - Google: `/workspace/datadog-serverless-trace-mini-agent`

