### PR TITLE
[crashtracker] Use common Endpoint to further decouple from profiler

### DIFF
--- a/ddcommon-ffi/src/endpoint.rs
+++ b/ddcommon-ffi/src/endpoint.rs
@@ -15,6 +15,13 @@ pub extern "C" fn ddog_endpoint_from_url(url: crate::CharSlice) -> Option<Box<En
         .map(|url| Box::new(Endpoint::from_url(url)))
 }
 
+#[no_mangle]
+#[must_use]
+pub extern "C" fn ddog_endpoint_from_filename(filename: crate::CharSlice) -> Option<Box<Endpoint>> {
+    let url = format!("file://{}", filename.to_utf8_lossy());
+    Some(Box::new(Endpoint::from_slice(&url)))
+}
+
 // We'll just specify the base site here. If api key provided, different intakes need to use their
 // own subdomains.
 #[no_mangle]

--- a/examples/ffi/crashtracking.c
+++ b/examples/ffi/crashtracking.c
@@ -49,11 +49,15 @@ int main(int argc, char **argv) {
       .optional_stdout_filename = DDOG_CHARSLICE_C("/tmp/crashreports/stdout.txt"),
   };
 
+  struct ddog_Endpoint *endpoint =
+      ddog_endpoint_from_filename(DDOG_CHARSLICE_C("/tmp/crashreports/crashreport.json"));
+  // Alternatively:
+  //  struct ddog_Endpoint * endpoint =
+  //      ddog_endpoint_from_url(DDOG_CHARSLICE_C("http://localhost:8126"));
+
   ddog_prof_CrashtrackerConfiguration config = {
       .create_alt_stack = false,
-      .endpoint = ddog_Endpoint_file(DDOG_CHARSLICE_C("/tmp/crashreports/crashreport.json")),
-      // Alternatively:
-      //.endpoint = ddog_prof_Endpoint_agent(DDOG_CHARSLICE_C("http://localhost:8126")),
+      .endpoint = endpoint,
       .resolve_frames = DDOG_PROF_STACKTRACE_COLLECTION_ENABLED_WITH_INPROCESS_SYMBOLS,
   };
 
@@ -65,6 +69,8 @@ int main(int argc, char **argv) {
   };
 
   handle_result(ddog_prof_Crashtracker_init_with_receiver(config, receiver_config, metadata));
+  ddog_endpoint_drop(endpoint);
+
   handle_result(
       ddog_prof_Crashtracker_begin_profiling_op(DDOG_PROF_PROFILING_OP_TYPES_SERIALIZING));
   handle_uintptr_t_result(ddog_prof_Crashtracker_insert_span_id(0, 42));

--- a/profiling-ffi/cbindgen.toml
+++ b/profiling-ffi/cbindgen.toml
@@ -23,6 +23,7 @@ renaming_overrides_prefixing = true
 "ByteSlice" = "ddog_ByteSlice"
 "CancellationToken" = "ddog_CancellationToken"
 "CharSlice" = "ddog_CharSlice"
+"Endpoint" = "ddog_Endpoint"
 "Error" = "ddog_Error"
 "HttpStatus" = "ddog_HttpStatus"
 "Slice_CChar" = "ddog_Slice_CChar"

--- a/profiling-ffi/src/crashtracker/collector/datatypes.rs
+++ b/profiling-ffi/src/crashtracker/collector/datatypes.rs
@@ -1,7 +1,6 @@
 // Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::exporter::{self, ProfilingEndpoint};
 use crate::option_from_char_slice;
 pub use datadog_crashtracker::{ProfilingOpTypes, StacktraceCollection};
 use ddcommon_ffi::slice::{AsBytes, CharSlice};
@@ -67,7 +66,7 @@ pub struct CrashtrackerConfiguration<'a> {
     ///
     /// If ProfilingEndpoint is left to a zero value (enum value for Agent + empty charslice),
     /// the crashtracker will infer the agent host from env variables.
-    pub endpoint: ProfilingEndpoint<'a>,
+    pub endpoint: Option<&'a ddcommon::Endpoint>,
     pub resolve_frames: StacktraceCollection,
     pub timeout_secs: u64,
     pub wait_for_receiver: bool,
@@ -86,7 +85,7 @@ impl<'a> TryFrom<CrashtrackerConfiguration<'a>>
             vec
         };
         let create_alt_stack = value.create_alt_stack;
-        let endpoint = unsafe { exporter::try_to_endpoint(value.endpoint).ok() };
+        let endpoint = value.endpoint.cloned();
         let resolve_frames = value.resolve_frames;
         let wait_for_receiver = value.wait_for_receiver;
         Self::new(


### PR DESCRIPTION
# What does this PR do?

Uses the `ddcommon::Endpoint` rather than the `profiling-ffi::exporter::Endpoint`.

# Motivation

We're trying to decouple the crashtracker and the profiler, this removes one of the final remaining links.

# Additional Notes

This is a breaking change for users of the API. 
Eventually, the `profiling-ffi` endpoint type itself should probably be unified with this. 

# How to test the change?

Compile and run the modified example file.

[PROF-10245]

[PROF-10245]: https://datadoghq.atlassian.net/browse/PROF-10245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ