### PR TITLE
Fixes to make clippy version 1.80 happy

### DIFF
--- a/crashtracker/src/receiver.rs
+++ b/crashtracker/src/receiver.rs
@@ -232,6 +232,7 @@ enum CrashReportStatus {
 /// Listens to `stream`, reading it line by line, until
 /// 1. A crash-report is received, in which case it is processed for upload
 /// 2. `stdin` closes without a crash report (i.e. if the parent terminated normally)
+///
 /// In the case where the parent failed to transfer a full crash-report
 /// (for instance if it crashed while calculating the crash-report), we return
 /// a PartialCrashReport.

--- a/ddcommon/src/tag.rs
+++ b/ddcommon/src/tag.rs
@@ -14,6 +14,7 @@ pub struct Tag {
     ///  - "language:native"
     ///  - "src_library:libdatadog"
     ///  - "type:timeout"
+    ///
     /// So being able to save allocations is nice.
     value: Cow<'static, str>,
 }

--- a/ddsketch/src/lib.rs
+++ b/ddsketch/src/lib.rs
@@ -21,8 +21,7 @@ pub mod pb;
 ///
 /// This implementation only supports a part of the standard (which is also only the parts dd
 /// backend supports :shrug:)
-/// - max length contiguous bin store, with lower bin
-/// collapse behavior.
+/// - max length contiguous bin store, with lower bin collapse behavior.
 /// - Positive or zero values
 ///
 /// The default sketch has a 1% relative accuracy, and only accepts positive points

--- a/ipc/Cargo.toml
+++ b/ipc/Cargo.toml
@@ -59,3 +59,6 @@ bench = false
 harness = false
 name = "ipc"
 path = "benches/ipc.rs"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(polyfill_glibc_memfd)'] }

--- a/ipc/src/platform/mem_handle.rs
+++ b/ipc/src/platform/mem_handle.rs
@@ -15,6 +15,7 @@ pub struct ShmHandle {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct AnonHandle {
     pub(crate) size: usize,
 }

--- a/ipc/tarpc/tarpc/src/client.rs
+++ b/ipc/tarpc/tarpc/src/client.rs
@@ -133,7 +133,7 @@ impl<Req, Resp> Channel<Req, Resp> {
             );
             ctx.trace_context.new_child()
         });
-        span.record("rpc.trace_id", &tracing::field::display(ctx.trace_id()));
+        span.record("rpc.trace_id", tracing::field::display(ctx.trace_id()));
         let (response_completion, mut response) = oneshot::channel();
         let request_id =
             u64::try_from(self.next_request_id.fetch_add(1, Ordering::Relaxed)).unwrap();

--- a/ipc/tarpc/tarpc/src/serde_transport.rs
+++ b/ipc/tarpc/tarpc/src/serde_transport.rs
@@ -631,10 +631,11 @@ mod tests {
         );
     }
 
-    #[cfg(tcp)]
+    #[cfg(feature = "tcp")]
     #[tokio::test]
     async fn tcp() -> io::Result<()> {
         use super::tcp;
+        use futures::{SinkExt, StreamExt};
 
         let mut listener = tcp::listen("0.0.0.0:0", SymmetricalJson::<String>::default).await?;
         let addr = listener.local_addr();

--- a/profiling/src/collections/string_table/mod.rs
+++ b/profiling/src/collections/string_table/mod.rs
@@ -236,11 +236,12 @@ mod tests {
     /// This is a fuzz test for the allocation optimized `StringTable`.
     /// It checks both safety (lack of crashes / sanitizer failures),
     /// as well as functional correctness (the table should behave like an
-    /// ordered set).  
+    /// ordered set).
     /// Limitations:
     ///   - The crate used here to generate Strings internally has a default range for the length of
     ///     a string, (0..=64) We should experiment with longer strings to see what happens. https://github.com/camshaft/bolero/blob/f401669697ffcbe7f34cbfd09fd57b93d5df734c/lib/bolero-generator/src/alloc/mod.rs#L17
     ///   - Since iterating is destructive, can only check the string values once.
+    ///
     /// `cargo +nightly bolero test collections::string_table::tests::fuzz_string_table -T 1min`
     #[test]
     fn fuzz_string_table() {

--- a/profiling/src/collections/string_table/wordpress_test_data.rs
+++ b/profiling/src/collections/string_table/wordpress_test_data.rs
@@ -5,6 +5,7 @@
 /// profiler version generated it. It was made from setting up a WordPress
 /// demo app of some kind. It's extracted from this file (relative to root):
 ///  * `profiling/tests/wordpress.pprof.lz4`
+///
 /// For various tests such as using MIRI, it's too slow to decompress, open,
 /// parse, and extract the strings on-demand.
 pub const WORDPRESS_STRINGS: [&str; 1059] = [

--- a/profiling/src/internal/profile/mod.rs
+++ b/profiling/src/internal/profile/mod.rs
@@ -142,6 +142,7 @@ impl Profile {
     ///  - "" (the empty string)
     ///  - "local root span id"
     ///  - "trace endpoint"
+    ///
     /// All other fields are default.
     #[inline]
     pub fn new(

--- a/profiling/src/pprof/sliced_proto.rs
+++ b/profiling/src/pprof/sliced_proto.rs
@@ -40,6 +40,7 @@
 //! 1. repeatedly emitting a sliced message with a "required" field,
 //! 2. repeatedly emitting a sliced message using a "repeated" field,
 //! 3. Emitting once the message with the repeated field containing all values.
+//!
 //! In other words, we get the same bytes from "required" as "repeated", but
 //! with fewer allocations (since we don't need a `Vec` for the elements).
 //!

--- a/sidecar-ffi/Cargo.toml
+++ b/sidecar-ffi/Cargo.toml
@@ -28,5 +28,5 @@ tempfile = { version = "3.3" }
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
     "cfg(coverage_nightly)",
-    'cfg(feature, values("prefer_dynamic")',
+    'cfg(feature, values("prefer_dynamic"))',
 ] }

--- a/sidecar-ffi/Cargo.toml
+++ b/sidecar-ffi/Cargo.toml
@@ -24,3 +24,6 @@ libc = "0.2"
 [dev-dependencies]
 hyper = { version = "0.14", default-features = false }
 tempfile = {version = "3.3"}
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg =["cfg(coverage_nightly)"] }

--- a/sidecar-ffi/Cargo.toml
+++ b/sidecar-ffi/Cargo.toml
@@ -23,7 +23,10 @@ libc = "0.2"
 
 [dev-dependencies]
 hyper = { version = "0.14", default-features = false }
-tempfile = {version = "3.3"}
+tempfile = { version = "3.3" }
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg =["cfg(coverage_nightly)"] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+    "cfg(coverage_nightly)",
+    'cfg(feature, values("prefer_dynamic")',
+] }

--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -44,7 +44,13 @@ rmp-serde = "1.1.1"
 spawn_worker = { path = "../spawn_worker" }
 zwohash = "0.1.2"
 sys-info = { version = "0.9.0" }
-tokio = { version = "1.35.1", features = ["fs", "sync", "io-util", "signal", "rt-multi-thread"] }
+tokio = { version = "1.35.1", features = [
+    "fs",
+    "sync",
+    "io-util",
+    "signal",
+    "rt-multi-thread",
+] }
 tokio-util = { version = "0.7", features = ["codec"] }
 
 prctl = "1.0.0"
@@ -71,7 +77,7 @@ features = [
     "Win32_Foundation",
     "Wdk_Storage_FileSystem",
     "Win32_System_IO",
-    "Win32_System_WindowsProgramming"
+    "Win32_System_WindowsProgramming",
 ]
 version = "0.51.0"
 
@@ -96,4 +102,7 @@ httpmock = "0.7.0"
 datadog-trace-utils = { path = "../trace-utils", features = ["test-utils"] }
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_taskdump)', 'cfg(feature, values("logging"))'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(tokio_taskdump,windows_seh_wrapper)',
+    'cfg(feature, values("logging"))',
+] }

--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -95,3 +95,5 @@ tempfile = { version = "3.3" }
 httpmock = "0.7.0"
 datadog-trace-utils = { path = "../trace-utils", features = ["test-utils"] }
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_taskdump)', 'cfg(feature, values("logging"))'] }

--- a/sidecar/src/service/tracing/trace_flusher.rs
+++ b/sidecar/src/service/tracing/trace_flusher.rs
@@ -146,6 +146,7 @@ impl TraceFlusher {
     ///
     /// * A `Result` which is `Ok` if the flusher task successfully joins, or `Err` if the flusher
     ///   task panics.
+    ///
     /// If the flusher task is not running, it returns `Ok`.
     pub(crate) async fn join(&self) -> anyhow::Result<(), JoinError> {
         let flusher = {

--- a/spawn_worker/Cargo.toml
+++ b/spawn_worker/Cargo.toml
@@ -39,3 +39,7 @@ tempfile = { version = "3.3" }
 
 [target.'cfg(not(windows))'.dev-dependencies]
 rlimit = {version = "0.9"}
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage,coverage_nightly)'] }
+

--- a/tests/spawn_from_lib/tests/spawn.rs
+++ b/tests/spawn_from_lib/tests/spawn.rs
@@ -3,10 +3,10 @@
 // #![cfg(feature = "prefer-dynamic")]
 // use test_spawn_from_lib::spawn_self;
 
-#[cfg(feature = "prefer_dynamic")]
+#[cfg(feature = "prefer-dynamic")]
 use std::io::{Read, Seek};
 
-#[cfg(feature = "prefer_dynamic")]
+#[cfg(feature = "prefer-dynamic")]
 fn rewind_and_read(file: &mut std::fs::File) -> anyhow::Result<String> {
     file.rewind()?;
     let mut buf = String::new();
@@ -19,7 +19,7 @@ fn rewind_and_read(file: &mut std::fs::File) -> anyhow::Result<String> {
 /// prefer-dynamic -- --ignored
 #[test]
 #[ignore = "requires -C prefer-dynamic"]
-#[cfg(feature = "prefer_dynamic")]
+#[cfg(feature = "prefer-dynamic")]
 fn test_spawning_trampoline_worker() {
     let mut stdout = tempfile::tempfile().unwrap();
     let mut stderr = tempfile::tempfile().unwrap();

--- a/trace-mini-agent/src/http_utils.rs
+++ b/trace-mini-agent/src/http_utils.rs
@@ -11,8 +11,7 @@ use serde_json::json;
 
 /// Does two things:
 /// 1. Logs the given message. A success status code (within 200-299) will cause an info log to be
-///    written,
-/// otherwise error will be written.
+///    written, otherwise error will be written.
 /// 2. Returns the given message in the body of JSON response with the given status code.
 ///
 /// Response body format:

--- a/trace-normalization/src/normalizer.rs
+++ b/trace-normalization/src/normalizer.rs
@@ -73,9 +73,8 @@ pub fn normalize_trace(trace: &mut [pb::Span]) -> anyhow::Result<()> {
 
 /// normalize_chunk takes a trace chunk and
 /// * populates origin field if it wasn't populated
-/// * populates priority field if it wasn't populated
-/// the root span is used to populate these fields, and it's index in TraceChunk spans vec must be
-/// passed.
+/// * populates priority field if it wasn't populated the root span is used to populate these
+///   fields, and it's index in TraceChunk spans vec must be passed.
 pub fn normalize_chunk(chunk: &mut pb::TraceChunk, root_span_index: usize) -> anyhow::Result<()> {
     // check if priority is not populated
     let root_span = match chunk.spans.get(root_span_index) {


### PR DESCRIPTION
# What does this PR do?

Most of the changes are one of the following
1. Indentation for lists in docs -> fixed by adding a new line and/or spaces
3. [Automatic checking of cfgs at compile-time](https://blog.rust-lang.org/2024/05/06/check-cfg.html) -> fixed by adding `check-cfg` under `[lints.rust.unexpected_cfgs]` in `Cargo.toml`
4. `allow(dead_code)`

# Motivation

Unblock CI for pending PRs

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
