### PR TITLE
[Serverless Mini Agent] Bump Serverless Mini Agent Version to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1464,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-serverless-trace-mini-agent"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "datadog-trace-mini-agent",
  "datadog-trace-protobuf",

--- a/serverless/Cargo.toml
+++ b/serverless/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datadog-serverless-trace-mini-agent"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
# What does this PR do?

Bumps Serverless Mini Agent Version to 0.6.0.

# Motivation

Upcoming release of version 0.6.0.

# Additional Notes

# How to test the change?

- Build mini agent locally
- Azure Functions
  * Deploy Azure Function or Google Cloud Function with mini agent binary in root path
  * Set `DD_MINI_AGENT_PATH`
    - Azure: `/home/site/wwwroot/datadog-serverless-trace-mini-agent`
    - Google: `/workspace/datadog-serverless-trace-mini-agent`
- Spring Apps
  * Build an Azure Spring App with persistent storage
  * ssh into the Azure Spring App instance and upload the Datadog Java Tracer and Serverless Mini Agent
  * Add -javaagent:/persistent/dd-java-agent.jar to the JVM options
  * Set DD_TRACE_TRACER_METRICS_ENABLED to true
  * Start the Serverless Mini Agent
