### PR TITLE
[SVLS-5049] It is okay to have a stats payload without stats

### DIFF
--- a/trace-mini-agent/src/stats_processor.rs
+++ b/trace-mini-agent/src/stats_processor.rs
@@ -62,12 +62,14 @@ impl StatsProcessor for ServerlessStatsProcessor {
                 }
             };
 
-        let start = SystemTime::now();
-        let timestamp = start
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_nanos();
-        stats.stats[0].start = timestamp as u64;
+        if !stats.stats.is_empty() {
+            let start = SystemTime::now();
+            let timestamp = start
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos();
+            stats.stats[0].start = timestamp as u64;
+        }
 
         // send trace payload to our trace flusher
         match tx.send(stats).await {

--- a/trace-utils/src/stats_utils.rs
+++ b/trace-utils/src/stats_utils.rs
@@ -283,6 +283,10 @@ mod tests {
             client_stats_payload_without_inner_stats,
         ]));
 
-        assert!(res.is_ok(), "Expected Ok result, but got Err: {}", res.unwrap_err());
+        assert!(
+            res.is_ok(),
+            "Expected Ok result, but got Err: {}",
+            res.unwrap_err()
+        );
     }
 }

--- a/trace-utils/src/stats_utils.rs
+++ b/trace-utils/src/stats_utils.rs
@@ -21,8 +21,7 @@ pub async fn get_stats_from_request_body(body: Body) -> anyhow::Result<pb::Clien
     };
 
     if client_stats_payload.stats.is_empty() {
-        debug!("Empty trace stats payload received");
-        anyhow::bail!("No stats in stats payload");
+        debug!("Empty trace stats payload received, but this is okay");
     }
     Ok(client_stats_payload)
 }
@@ -185,5 +184,105 @@ mod tests {
             res.unwrap_err()
         );
         assert_eq!(res.unwrap(), client_stats_payload)
+    }
+
+    #[tokio::test]
+    async fn test_get_stats_from_request_body_without_stats() {
+        let stats_json = r#"{
+            "Hostname": "TestHost",
+            "Env": "test",
+            "Version": "1.0.0",
+            "Lang": "javascript",
+            "TracerVersion": "1.0.0",
+            "RuntimeID": "00000000-0000-0000-0000-000000000000",
+            "Sequence": 1
+        }"#;
+
+        let v: Value = match serde_json::from_str(stats_json) {
+            Ok(value) => value,
+            Err(err) => {
+                panic!("Failed to parse stats JSON: {}", err);
+            }
+        };
+
+        let bytes = rmp_serde::to_vec(&v).unwrap();
+        let request = Request::builder()
+            .body(hyper::body::Body::from(bytes))
+            .unwrap();
+
+        let res = stats_utils::get_stats_from_request_body(request.into_body()).await;
+
+        let client_stats_payload = ClientStatsPayload {
+            hostname: "TestHost".to_string(),
+            env: "test".to_string(),
+            version: "1.0.0".to_string(),
+            stats: vec![],
+            lang: "javascript".to_string(),
+            tracer_version: "1.0.0".to_string(),
+            runtime_id: "00000000-0000-0000-0000-000000000000".to_string(),
+            sequence: 1,
+            agent_aggregation: "".to_string(),
+            service: "".to_string(),
+            container_id: "".to_string(),
+            tags: vec![],
+            git_commit_sha: "".to_string(),
+            image_tag: "".to_string(),
+        };
+
+        assert!(
+            res.is_ok(),
+            "Expected Ok result, but got Err: {}",
+            res.unwrap_err()
+        );
+        assert_eq!(res.unwrap(), client_stats_payload)
+    }
+
+    #[tokio::test]
+    async fn test_serialize_client_stats_payload_without_stats() {
+        let client_stats_payload_without_stats = ClientStatsPayload {
+            hostname: "TestHost".to_string(),
+            env: "test".to_string(),
+            version: "1.0.0".to_string(),
+            stats: vec![],
+            lang: "javascript".to_string(),
+            tracer_version: "1.0.0".to_string(),
+            runtime_id: "00000000-0000-0000-0000-000000000000".to_string(),
+            sequence: 1,
+            agent_aggregation: "".to_string(),
+            service: "".to_string(),
+            container_id: "".to_string(),
+            tags: vec![],
+            git_commit_sha: "".to_string(),
+            image_tag: "".to_string(),
+        };
+
+        let client_stats_payload_without_inner_stats = ClientStatsPayload {
+            hostname: "TestHost".to_string(),
+            env: "test".to_string(),
+            version: "1.0.0".to_string(),
+            stats: vec![ClientStatsBucket {
+                start: 0,
+                duration: 10000000000,
+                stats: vec![],
+                agent_time_shift: 0,
+            }],
+            lang: "javascript".to_string(),
+            tracer_version: "1.0.0".to_string(),
+            runtime_id: "00000000-0000-0000-0000-000000000000".to_string(),
+            sequence: 1,
+            agent_aggregation: "".to_string(),
+            service: "".to_string(),
+            container_id: "".to_string(),
+            tags: vec![],
+            git_commit_sha: "".to_string(),
+            image_tag: "".to_string(),
+        };
+
+        let res = stats_utils::serialize_stats_payload(stats_utils::construct_stats_payload(vec![
+            client_stats_payload_without_stats,
+            client_stats_payload_without_inner_stats,
+        ]));
+
+        assert!(res.is_ok(), "Expected Ok result, but got Err: {}", res.unwrap_err());
     }
 }


### PR DESCRIPTION
# What does this PR do?

Prevents seemingly unnecessary errors if a Serverless stats payload happens to not have any stats.

The payload definition in the go protobuf code seems to indicate that stats are allowed to be empty. And [that code](https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/api/api.go#L525-L535) (`firstService` closure) is defensive about this possibility. Furthermore our `datadog.trace_agent.receiver.stats_buckets` metric has a minimum value of 0 so this apparently does happen and is handled as such by our systems.

# Motivation

The serverless agent is generating a bunch of noise when it receives these kinds of "empty" stats payloads from the node tracer.

# How to test the change?

Added a unit test to confirm that we are able to create stats payloads with these empty stats objects (and empty stats of stats... our naming is a bit hard to follow). Also checking that this does in fact work with an azure function and that we correctly don't have errors there.
