### PR TITLE
Fix error check in trampoline.c

### DIFF
--- a/spawn_worker/src/trampoline.c
+++ b/spawn_worker/src/trampoline.c
@@ -74,6 +74,9 @@ int main(int argc, char *argv[]) {
       return 10;
     }
 
+    // clear any previous errors
+    (void)dlerror();
+
     void (*fn)() = dlsym(handle, symbol_name);
     char *error = NULL;
 


### PR DESCRIPTION
The appsec helper library has a call to dlopen() during constructors that may fail. Without clearing it, a call to dlerror() after a successful call to dlsym() will return the previous error message.

man 3 dlsym() says:

> The correct way to distinguish an error from a symbol whose value is NULL is to
> call  dlerror(3)  to clear any old error conditions, then call dlsym(), and then call dlerror(3) again, saving its
> return value into a variable, and check whether this saved value is not NULL.