### PR TITLE
[NO-TICKET] Validate that all public symbols are prefixed in Ruby releases

### DIFF
--- a/ruby/spec/gem_packaging.rb
+++ b/ruby/spec/gem_packaging.rb
@@ -34,4 +34,18 @@ RSpec.describe "gem release process (after packaging)" do
       end
     end
   end
+
+  it "prefixes all public symbols in .so files" do
+    so_files = Dir.glob("vendor/libdatadog-#{Libdatadog::LIB_VERSION}/**/*.so")
+    expect(so_files.size).to be 4
+
+    so_files.each do |so_file|
+      raw_symbols = `nm -D --defined-only #{so_file}`
+
+      symbols = raw_symbols.split("\n").map { |it| it.split(" ").last }.sort
+      expect(symbols.size).to be > 20 # Quick sanity check
+
+      expect(symbols).to all(start_with("ddog_").or(start_with("blaze_")))
+    end
+  end
 end


### PR DESCRIPTION
# What does this PR do?

This PR adds a check during packaging of Ruby releases that all symbols exported in the libdatadog shared library are correctly prefixed.

# Motivation

This allows us to catch any new unprefixed symbols, and thus we're able to rely on libdatadog not exporting symbols that would clash with other libraries that may be loaded in the same Ruby VM.

# Additional Notes

N/A

# How to test the change?

You can observe the new check running with `docker-compose run push_to_rubygems`.

This is safe to call as it'll stop asking for credentials before actually publishing anything to rubygems.

