### PR TITLE
[Serverless Mini Agent] bump version to 0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-serverless-trace-mini-agent"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "datadog-trace-mini-agent",
  "datadog-trace-protobuf",

--- a/serverless/Cargo.toml
+++ b/serverless/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datadog-serverless-trace-mini-agent"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
# What does this PR do?

Bumps serverless mini agent version up.

# Motivation

Releasing this new version

# Additional Notes

Here are the [changes since v0.6.0](https://github.com/DataDog/libdatadog/compare/sls-v0.6.0...aleksandr.pasechnik/sls-v0.6.1-pre-release?expand=1)

# How to test the change?

In addition to unit tests, this code was deployed to a test Azure Function.