### PR TITLE
Stabilize criterion benchmark results

### DIFF
--- a/benchmark/run_benchmarks_ci.sh
+++ b/benchmark/run_benchmarks_ci.sh
@@ -22,7 +22,7 @@ pushd "${PROJECT_DIR}" > /dev/null
 
 # Run benchmarks
 message "Running benchmarks"
-cargo bench --workspace -- --sample-size=200
+cargo bench --workspace -- --warm-up-time 1 --measurement-time 5 --sample-size=200
 message "Finished running benchmarks"
 
 # Copy the benchmark results to the output directory

--- a/trace-obfuscation/benches/benchmarks/replace_trace_tags_bench.rs
+++ b/trace-obfuscation/benches/benchmarks/replace_trace_tags_bench.rs
@@ -48,11 +48,13 @@ fn criterion_benchmark(c: &mut Criterion) {
         span_links: vec![],
     };
 
-    let mut trace = [span_1];
+    let trace = [span_1];
     group.bench_function("replace_trace_tags", |b| {
-        b.iter(|| {
-            replacer::replace_trace_tags(black_box(&mut trace), black_box(rules));
-        })
+        b.iter_batched_ref(
+            || trace.to_owned(),
+            |t| replacer::replace_trace_tags(black_box(t), black_box(rules)),
+            criterion::BatchSize::LargeInput,
+        )
     });
 }
 


### PR DESCRIPTION
# What does this PR do?

This PR tries to stabilize the criterion micro benchmarks results. The reason why the benchmark result comment is so full of changes is that the batching and how the benchmarks are run has changed compared to `main`.

# Motivation

There is soo much noise in the results that they trigger false positives on almost every PR.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

I have run the the benchmarks repeatedly on a separate PR #577 (that has no code changes), and only occasionally will there be a change in a benchmark result.
