### PR TITLE
Support x-datadog-test-session-token for parallel tests with the test agent

### DIFF
--- a/ddcommon-ffi/src/endpoint.rs
+++ b/ddcommon-ffi/src/endpoint.rs
@@ -5,6 +5,7 @@ use crate::slice::AsBytes;
 use crate::Error;
 use ddcommon::{parse_uri, Endpoint};
 use hyper::http::uri::{Authority, Parts};
+use std::borrow::Cow;
 use std::str::FromStr;
 
 #[no_mangle]
@@ -61,6 +62,15 @@ pub extern "C" fn ddog_endpoint_from_api_key_and_site(
 #[no_mangle]
 extern "C" fn ddog_endpoint_set_timeout(endpoint: &mut Endpoint, millis: u64) {
     endpoint.timeout_ms = millis;
+}
+
+#[no_mangle]
+extern "C" fn ddog_endpoint_set_test_token(endpoint: &mut Endpoint, token: crate::CharSlice) {
+    endpoint.test_token = if token.is_empty() {
+        None
+    } else {
+        Some(Cow::Owned(token.to_utf8_lossy().to_string()))
+    };
 }
 
 #[no_mangle]

--- a/ddcommon-ffi/src/slice.rs
+++ b/ddcommon-ffi/src/slice.rs
@@ -54,27 +54,27 @@ pub fn is_aligned_and_not_null<T>(ptr: *const T) -> bool {
 }
 
 pub trait AsBytes<'a> {
-    fn as_bytes(&'a self) -> &'a [u8];
+    fn as_bytes(&self) -> &'a [u8];
 
     #[inline]
-    fn try_to_utf8(&'a self) -> Result<&'a str, Utf8Error> {
+    fn try_to_utf8(&self) -> Result<&'a str, Utf8Error> {
         std::str::from_utf8(self.as_bytes())
     }
 
     #[inline]
-    fn to_utf8_lossy(&'a self) -> Cow<'a, str> {
+    fn to_utf8_lossy(&self) -> Cow<'a, str> {
         String::from_utf8_lossy(self.as_bytes())
     }
 }
 
 impl<'a> AsBytes<'a> for Slice<'a, u8> {
-    fn as_bytes(&'a self) -> &'a [u8] {
+    fn as_bytes(&self) -> &'a [u8] {
         self.as_slice()
     }
 }
 
 impl<'a> AsBytes<'a> for Slice<'a, i8> {
-    fn as_bytes(&'a self) -> &'a [u8] {
+    fn as_bytes(&self) -> &'a [u8] {
         unsafe { slice::from_raw_parts(self.ptr.cast(), self.len) }
     }
 }

--- a/sidecar-ffi/src/lib.rs
+++ b/sidecar-ffi/src/lib.rs
@@ -694,6 +694,23 @@ pub unsafe extern "C" fn ddog_sidecar_dogstatsd_set(
     MaybeError::None
 }
 
+/// Sets x-datadog-test-session-token on all requests for the given session.
+#[no_mangle]
+#[allow(clippy::missing_safety_doc)]
+pub unsafe extern "C" fn ddog_sidecar_set_test_session_token(
+    transport: &mut Box<SidecarTransport>,
+    session_id: ffi::CharSlice,
+    token: ffi::CharSlice,
+) -> MaybeError {
+    try_c!(blocking::set_test_session_token(
+        transport,
+        session_id.to_utf8_lossy().into_owned(),
+        token.to_utf8_lossy().into_owned(),
+    ));
+
+    MaybeError::None
+}
+
 /// This function creates a new transport using the provided callback function when the current
 /// transport is closed.
 ///

--- a/sidecar/src/agent_remote_config.rs
+++ b/sidecar/src/agent_remote_config.rs
@@ -24,6 +24,7 @@ fn path_for_endpoint(endpoint: &Endpoint) -> CString {
     // We need a stable hash so that the outcome is independent of the process
     let mut hasher = ZwoHasher::default();
     endpoint.url.authority().unwrap().hash(&mut hasher);
+    endpoint.test_token.hash(&mut hasher);
     CString::new(format!(
         "/ddcfg-{}-{}", // short enough because 31 character macos limitation
         primary_sidecar_identifier(),

--- a/sidecar/src/config.rs
+++ b/sidecar/src/config.rs
@@ -245,6 +245,7 @@ pub fn get_product_endpoint(subdomain: &str, endpoint: &Endpoint) -> Endpoint {
         Endpoint {
             url: hyper::Uri::from_parts(parts).unwrap(),
             api_key: Some(api_key.clone()),
+            test_token: endpoint.test_token.clone(),
             ..*endpoint
         }
     } else {

--- a/sidecar/src/dogstatsd.rs
+++ b/sidecar/src/dogstatsd.rs
@@ -37,12 +37,12 @@ pub enum DogStatsDAction {
 
 #[derive(Default)]
 pub struct Flusher {
-    endpoint: Option<Endpoint>,
+    pub endpoint: Option<Endpoint>,
     client: Option<StatsdClient>,
 }
 
 impl Flusher {
-    pub fn set_endpoint(&mut self, endpoint: Endpoint) {
+    pub fn set_endpoint(&mut self, endpoint: Endpoint) -> anyhow::Result<()> {
         self.client = None;
         self.endpoint = match endpoint.api_key {
             Some(_) => {
@@ -53,7 +53,8 @@ impl Flusher {
                 debug!("Updating DogStatsD endpoint to {}", endpoint.url);
                 Some(endpoint)
             }
-        }
+        };
+        Ok(())
     }
 
     pub fn send(&mut self, actions: Vec<DogStatsDAction>) {
@@ -178,7 +179,7 @@ mod test {
         let _ = socket.set_read_timeout(Some(Duration::from_millis(500)));
 
         let mut flusher = Flusher::default();
-        flusher.set_endpoint(Endpoint::from_slice(
+        _ = flusher.set_endpoint(Endpoint::from_slice(
             socket.local_addr().unwrap().to_string().as_str(),
         ));
         flusher.send(vec![

--- a/sidecar/src/service/blocking.rs
+++ b/sidecar/src/service/blocking.rs
@@ -283,6 +283,23 @@ pub fn send_dogstatsd_actions(
     })
 }
 
+/// Sets x-datadog-test-session-token on all requests for the given session.
+///
+/// # Arguments
+///
+/// * `session_id` - The ID of the session.
+/// * `token` - The session token.
+/// # Returns
+///
+/// An `io::Result<()>` indicating the result of the operation.
+pub fn set_test_session_token(
+    transport: &mut SidecarTransport,
+    session_id: String,
+    token: String,
+) -> io::Result<()> {
+    transport.send(SidecarInterfaceRequest::SetTestSessionToken { session_id, token })
+}
+
 /// Dumps the current state of the service.
 ///
 /// # Arguments

--- a/sidecar/src/service/session_info.rs
+++ b/sidecar/src/service/session_info.rs
@@ -7,7 +7,6 @@ use std::{
 };
 
 use futures::future;
-
 use tracing::{enabled, info, Level};
 
 use crate::log::{MultiEnvFilterGuard, MultiWriterGuard};
@@ -125,9 +124,9 @@ impl SessionInfo {
         cfg
     }
 
-    pub(crate) fn modify_telemetry_config<F>(&self, mut f: F)
+    pub(crate) fn modify_telemetry_config<F>(&self, f: F)
     where
-        F: FnMut(&mut ddtelemetry::config::Config),
+        F: FnOnce(&mut ddtelemetry::config::Config),
     {
         if let Some(cfg) = &mut *self.get_telemetry_config() {
             f(cfg)
@@ -138,9 +137,9 @@ impl SessionInfo {
         self.tracer_config.lock().unwrap()
     }
 
-    pub(crate) fn modify_trace_config<F>(&self, mut f: F)
+    pub(crate) fn modify_trace_config<F>(&self, f: F)
     where
-        F: FnMut(&mut tracer::Config),
+        F: FnOnce(&mut tracer::Config),
     {
         f(&mut self.get_trace_config());
     }
@@ -149,9 +148,9 @@ impl SessionInfo {
         self.dogstatsd.lock().unwrap()
     }
 
-    pub(crate) fn configure_dogstatsd<F>(&self, mut f: F)
+    pub(crate) fn configure_dogstatsd<F>(&self, f: F)
     where
-        F: FnMut(&mut dogstatsd::Flusher),
+        F: FnOnce(&mut dogstatsd::Flusher),
     {
         f(&mut self.get_dogstatsd());
     }

--- a/sidecar/src/service/sidecar_interface.rs
+++ b/sidecar/src/service/sidecar_interface.rs
@@ -109,6 +109,14 @@ pub trait SidecarInterface {
     /// Flushes any outstanding traces queued for sending.
     async fn flush_traces();
 
+    /// Sets x-datadog-test-session-token on all requests for the given session.
+    ///
+    /// # Arguments
+    ///
+    /// * `session_id` - The ID of the session.
+    /// * `token` - The session token.
+    async fn set_test_session_token(session_id: String, token: String);
+
     /// Sends a ping to the service.
     async fn ping();
 

--- a/trace-utils/src/send_data/mod.rs
+++ b/trace-utils/src/send_data/mod.rs
@@ -129,11 +129,14 @@ impl SendData {
         tracer_header_tags: TracerHeaderTags,
         target: &Endpoint,
     ) -> SendData {
-        let headers = if let Some(api_key) = &target.api_key {
+        let mut headers = if let Some(api_key) = &target.api_key {
             HashMap::from([(DD_API_KEY, api_key.as_ref().to_string())])
         } else {
             tracer_header_tags.into()
         };
+        if let Some(token) = &target.test_token {
+            headers.insert("x-datadog-test-session-token", token.to_string());
+        }
 
         SendData {
             tracer_payloads: tracer_payload,
@@ -564,6 +567,7 @@ mod tests {
                 api_key: Some(std::borrow::Cow::Borrowed("TEST-KEY")),
                 url: "/foo/bar?baz".parse::<hyper::Uri>().unwrap(),
                 timeout_ms: ONE_SECOND,
+                ..Endpoint::default()
             },
         );
 
@@ -588,6 +592,7 @@ mod tests {
                 api_key: None,
                 url: "/foo/bar?baz".parse::<hyper::Uri>().unwrap(),
                 timeout_ms: ONE_SECOND,
+                ..Endpoint::default()
             },
         );
 
@@ -625,6 +630,7 @@ mod tests {
                 api_key: Some(std::borrow::Cow::Borrowed("TEST-KEY")),
                 url: server.url("/").parse::<hyper::Uri>().unwrap(),
                 timeout_ms: ONE_SECOND,
+                ..Endpoint::default()
             },
         );
 
@@ -668,6 +674,7 @@ mod tests {
                 api_key: Some(std::borrow::Cow::Borrowed("TEST-KEY")),
                 url: server.url("/").parse::<hyper::Uri>().unwrap(),
                 timeout_ms: ONE_SECOND,
+                ..Endpoint::default()
             },
         );
 
@@ -722,6 +729,7 @@ mod tests {
                 api_key: None,
                 url: server.url("/").parse::<hyper::Uri>().unwrap(),
                 timeout_ms: ONE_SECOND,
+                ..Endpoint::default()
             },
         );
 
@@ -776,6 +784,7 @@ mod tests {
                 api_key: None,
                 url: server.url("/").parse::<hyper::Uri>().unwrap(),
                 timeout_ms: ONE_SECOND,
+                ..Endpoint::default()
             },
         );
 
@@ -819,6 +828,7 @@ mod tests {
                 api_key: None,
                 url: server.url("/").parse::<hyper::Uri>().unwrap(),
                 timeout_ms: ONE_SECOND,
+                ..Endpoint::default()
             },
         );
 
@@ -860,6 +870,7 @@ mod tests {
                 api_key: None,
                 url: server.url("/").parse::<hyper::Uri>().unwrap(),
                 timeout_ms: ONE_SECOND,
+                ..Endpoint::default()
             },
         );
 
@@ -890,6 +901,7 @@ mod tests {
                 api_key: None,
                 url: "http://127.0.0.1:4321/".parse::<hyper::Uri>().unwrap(),
                 timeout_ms: ONE_SECOND,
+                ..Endpoint::default()
             },
         );
 
@@ -953,6 +965,7 @@ mod tests {
                 api_key: None,
                 url: server.url("/").parse::<hyper::Uri>().unwrap(),
                 timeout_ms: 200,
+                ..Endpoint::default()
             },
         );
 
@@ -994,6 +1007,7 @@ mod tests {
                 api_key: None,
                 url: server.url("/").parse::<hyper::Uri>().unwrap(),
                 timeout_ms: 200,
+                ..Endpoint::default()
             },
         );
 

--- a/trace-utils/src/trace_utils.rs
+++ b/trace-utils/src/trace_utils.rs
@@ -312,9 +312,12 @@ pub fn coalesce_send_data(mut data: Vec<SendData>) -> Vec<SendData> {
             .url
             .to_string()
             .cmp(&b.get_target().url.to_string())
+            .then(a.get_target().test_token.cmp(&b.get_target().test_token))
     });
     data.dedup_by(|a, b| {
-        if a.get_target().url == b.get_target().url {
+        if a.get_target().url == b.get_target().url
+            && a.get_target().test_token == b.get_target().test_token
+        {
             // Size is only an approximation. In practice it won't vary much, but be safe here.
             // We also don't care about the exact maximum size, like two 25 MB or one 50 MB request
             // has similar results. The primary goal here is avoiding many small requests.


### PR DESCRIPTION
I've decided to put it into Endpoint, as it has to be used at basically any place Endpoint is used.