### PR TITLE
[crashtracker] Build static binary

### DIFF
--- a/crashtracker/Cargo.toml
+++ b/crashtracker/Cargo.toml
@@ -11,6 +11,11 @@ license.workspace = true
 crate-type = ["lib"]
 bench = false
 
+[[bin]]
+name = "crashtracker-receiver"
+path = "src/bin/crashtracker_receiver.rs"
+bench = false
+
 [features]
 default = ["collector", "receiver"]
 # Enables the in-process collection of crash-info

--- a/crashtracker/src/bin/crashtracker_receiver.rs
+++ b/crashtracker/src/bin/crashtracker_receiver.rs
@@ -1,0 +1,10 @@
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(not(unix))]
+fn main() {}
+
+#[cfg(unix)]
+fn main() -> anyhow::Result<()> {
+    datadog_crashtracker::receiver_entry_point_stdin()
+}


### PR DESCRIPTION
# What does this PR do?

Builds a static binary for the crashtracker

# Motivation

Request from Node.

# Additional Notes

The binary is statically linked, and hence much larger than the dynamically linked C binary we currently generate.  If possible, using that one will save binary size.

# How to test the change?

Describe here in detail how the change can be validated.
