### PR TITLE
Use append() for writing telemetry lock to file

### DIFF
--- a/tools/docker/Dockerfile.build
+++ b/tools/docker/Dockerfile.build
@@ -60,7 +60,7 @@ ENV PATH="/root/.cargo/bin:$PATH"
 ARG CARGO_BUILD_INCREMENTAL
 ARG CARGO_NET_RETRY
 ENV CARGO_NET_RETRY="${CARGO_NET_RETRY}"
-RUN cargo install cbindgen && cargo install bindgen-cli --locked && rm -rf /root/.cargo/registry /root/.cargo/git
+RUN cargo install cbindgen --version "^0.26" && cargo install bindgen-cli --locked && rm -rf /root/.cargo/registry /root/.cargo/git
 
 FROM alpine_aws_cli as alpine_builder
 COPY --from=alpine_cbindgen /root/.cargo/bin/cbindgen /usr/local/bin/cbindgen


### PR DESCRIPTION
Otherwise we see spurious race conditions where the file is opened twice and one thread is overwriting to the start of the file.

And lock cbindgen version for CI.