### PR TITLE
improve crashtracker config deserialization

### DIFF
--- a/crashtracker/src/crash_info/metadata.rs
+++ b/crashtracker/src/crash_info/metadata.rs
@@ -3,7 +3,7 @@
 use ddcommon::tag::Tag;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 pub struct CrashtrackerMetadata {
     pub library_name: String,
     pub library_version: String,

--- a/crashtracker/src/shared/configuration.rs
+++ b/crashtracker/src/shared/configuration.rs
@@ -12,7 +12,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StacktraceCollection {
     /// Stacktrace collection occurs in the
-    #[default] Disabled,
+    #[default]
+    Disabled,
     WithoutSymbols,
     EnabledWithInprocessSymbols,
     EnabledWithSymbolsInReceiver,

--- a/crashtracker/src/shared/configuration.rs
+++ b/crashtracker/src/shared/configuration.rs
@@ -9,16 +9,17 @@ use serde::{Deserialize, Serialize};
 /// We recommend fully enabling stacktrace collection, but having an environment
 /// variable to allow downgrading the collector.
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StacktraceCollection {
     /// Stacktrace collection occurs in the
-    Disabled,
+    #[default] Disabled,
     WithoutSymbols,
     EnabledWithInprocessSymbols,
     EnabledWithSymbolsInReceiver,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
 pub struct CrashtrackerConfiguration {
     // Paths to any additional files to track, if any
     pub additional_files: Vec<String>,
@@ -28,7 +29,8 @@ pub struct CrashtrackerConfiguration {
     pub wait_for_receiver: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
 pub struct CrashtrackerReceiverConfig {
     pub args: Vec<String>,
     pub env: Vec<(String, String)>,

--- a/ddcommon/src/lib.rs
+++ b/ddcommon/src/lib.rs
@@ -66,7 +66,7 @@ struct SerializedUri<'a> {
 #[serde(untagged)]
 enum StringOrSerializedUri<'a> {
     String(String),
-    SerializedUri(SerializedUri<'a>)
+    SerializedUri(SerializedUri<'a>),
 }
 
 fn serialize_uri<S>(uri: &hyper::Uri, serializer: S) -> Result<S::Ok, S::Error>


### PR DESCRIPTION
# What does this PR do?

Improve crashtracker config deserialization:

- A string can now be passed as an endpoint URL when deserializing instead of having to know about Hyper.
- Fields with a default value are no longer required.

# Motivation

When using NAPI-RS, JavaScript types are converted directly to Rust types through serialization/deserialization. This meant that a lot of unneeded options were required to be passed, and the URL had to be passed with the internal structure as well.

# Additional Notes

# How to test the change?

Good question 😅 I'm not familiar with tests in libdatadog, and I don't know if serialization/deserialization is even tested at all right now.
