### PR TITLE
Only run one proptest case when using miri

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CARGO_TERM_COLOR: always
+      PROPTEST_CASES: 1
     steps:
     - uses: actions/checkout@v4
     - name: Set up Rust


### PR DESCRIPTION
# What does this PR do?

This PR tells `proptest` to only run one test case when we are running the tests under `miri`.

# Motivation

Running `miri` is slow.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Watch the running time for `miri`.
