### PR TITLE
Fix log file and disable LSAN usage in sidecar

### DIFF
--- a/sidecar/src/entry.rs
+++ b/sidecar/src/entry.rs
@@ -148,6 +148,7 @@ pub fn daemonize(listener: IpcServer, cfg: Config) -> anyhow::Result<()> {
     for (env, val) in cfg.to_env().into_iter() {
         spawn_cfg.append_env(env, val);
     }
+    spawn_cfg.append_env("LSAN_OPTIONS", "detect_leaks=0");
 
     match cfg.log_method {
         config::LogMethod::File(ref path) => {

--- a/spawn_worker/src/unix/spawn.rs
+++ b/spawn_worker/src/unix/spawn.rs
@@ -634,8 +634,8 @@ impl SpawnWorker {
                 }
                 unsafe {
                     libc::close(skip_close_fd);
+                    libc::_exit(0);
                 }
-                std::process::exit(0);
             }
         }
 


### PR DESCRIPTION
- Sidecar will leak some global structures, using LSAN there would either require an extensive suppressions list. For now we just opt to disable it. This avoids false positives in our testing we have to manually detect and ignore.
- Using an invalid log file should simply avoid sending it to the sidecar completely instead of failing there again, preventing two log messages for the same issue.
- Use _exit(0) instead of regular exit(0) when daemonizing to avoid sideeffects from atexit() handlers inherited from forking.