### PR TITLE
[ruby] Prepare gem release for version 12

### DIFF
--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -11,7 +11,7 @@ require "rubygems/package"
 
 RSpec::Core::RakeTask.new(:spec)
 
-LIB_VERSION_TO_PACKAGE = "11.0.0"
+LIB_VERSION_TO_PACKAGE = "12.0.0"
 unless LIB_VERSION_TO_PACKAGE.start_with?(Libdatadog::LIB_VERSION)
   raise "`LIB_VERSION_TO_PACKAGE` setting in <Rakefile> (#{LIB_VERSION_TO_PACKAGE}) does not match " \
     "`LIB_VERSION` setting in <lib/libdatadog/version.rb> (#{Libdatadog::LIB_VERSION})"
@@ -20,22 +20,22 @@ end
 LIB_GITHUB_RELEASES = [
   {
     file: "libdatadog-aarch64-alpine-linux-musl.tar.gz",
-    sha256: "81017bdc4634163151272539e98700e5e0fb076d4aa88a004087c4a01be0cfc3",
+    sha256: "8e7b429fcd7476cd800c041d8196e908b3a85ce6817e852f18f57a200c89e22a",
     ruby_platform: "aarch64-linux-musl"
   },
   {
     file: "libdatadog-aarch64-unknown-linux-gnu.tar.gz",
-    sha256: "9b06e0dced2cfa72279a1f50bf12bb485eaa54d54b6d09764cc297d79a7ce0da",
+    sha256: "a78da9ed45cb301dc9aa43e6ca16df789c9dd845417f0ac4feee895f4df63ad4",
     ruby_platform: "aarch64-linux"
   },
   {
     file: "libdatadog-x86_64-alpine-linux-musl.tar.gz",
-    sha256: "96ed601629feb33ce3b1acf6ffd0c30eacb04c4353c8a52388eccd6b4027c2f1",
+    sha256: "67d518a17147ea29383c4a6d72805a542dca1cb94f9233b322b510254b93ac0f",
     ruby_platform: "x86_64-linux-musl"
   },
   {
     file: "libdatadog-x86_64-unknown-linux-gnu.tar.gz",
-    sha256: "cac9b7c4c0f791d8618426bac81f14c0be40bfeecb2d01a98dcae67ba217eca5",
+    sha256: "d4fd8bc13042d6c3c78cc5526b969d1279b26021858a470e25d25599bffd4f5f",
     ruby_platform: "x86_64-linux"
   }
 ]

--- a/ruby/lib/libdatadog/version.rb
+++ b/ruby/lib/libdatadog/version.rb
@@ -2,11 +2,11 @@
 
 module Libdatadog
   # Current libdatadog version
-  LIB_VERSION = '12.0.0'
+  LIB_VERSION = "12.0.0"
 
-  GEM_MAJOR_VERSION = '1'
-  GEM_MINOR_VERSION = '0'
-  GEM_PRERELEASE_VERSION = '' # remember to include dot prefix, if needed!
+  GEM_MAJOR_VERSION = "1"
+  GEM_MINOR_VERSION = "0"
+  GEM_PRERELEASE_VERSION = "" # remember to include dot prefix, if needed!
   private_constant :GEM_MAJOR_VERSION, :GEM_MINOR_VERSION, :GEM_PRERELEASE_VERSION
 
   # The gem version scheme is lib_version.gem_major.gem_minor[.prerelease].

--- a/ruby/lib/libdatadog/version.rb
+++ b/ruby/lib/libdatadog/version.rb
@@ -2,11 +2,11 @@
 
 module Libdatadog
   # Current libdatadog version
-  LIB_VERSION = "11.0.0"
+  LIB_VERSION = '12.0.0'
 
-  GEM_MAJOR_VERSION = "1"
-  GEM_MINOR_VERSION = "0"
-  GEM_PRERELEASE_VERSION = "" # remember to include dot prefix, if needed!
+  GEM_MAJOR_VERSION = '1'
+  GEM_MINOR_VERSION = '0'
+  GEM_PRERELEASE_VERSION = '' # remember to include dot prefix, if needed!
   private_constant :GEM_MAJOR_VERSION, :GEM_MINOR_VERSION, :GEM_PRERELEASE_VERSION
 
   # The gem version scheme is lib_version.gem_major.gem_minor[.prerelease].


### PR DESCRIPTION
# What does this PR do?

The ruby gem for libdatadog was still only setup for version 11. This PR prepares the release for version 12.

# Motivation

Keep things up to date.

# Additional Notes

N/A

# How to test the change?

We'll trigger the gem release process once this gets merged and will soon push a PR in dd-trace-rb to make it use the new gem.
