### PR TITLE
Consider ifunc symbols also defined

### DIFF
--- a/remote-config/src/fetch/test_server.rs
+++ b/remote-config/src/fetch/test_server.rs
@@ -53,10 +53,9 @@ impl RemoteConfigServer {
                         let this = this.clone();
                         async move {
                             let body_bytes = hyper::body::to_bytes(req.into_body()).await.unwrap();
-                            let request: ClientGetConfigsRequest = serde_json::from_str(
-                                &String::from_utf8(body_bytes.to_vec()).unwrap(),
-                            )
-                            .unwrap();
+                            let request: ClientGetConfigsRequest =
+                                serde_json::from_str(core::str::from_utf8(&body_bytes).unwrap())
+                                    .unwrap();
                             let response =
                                 if let Some(response) = this.next_response.lock().unwrap().take() {
                                     response

--- a/tools/sidecar_mockgen/src/lib.rs
+++ b/tools/sidecar_mockgen/src/lib.rs
@@ -1,7 +1,7 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use object::{File, Object, ObjectSymbol, SymbolKind};
+use object::{File, Object, ObjectSymbol, Symbol, SymbolFlags, SymbolKind};
 use std::collections::HashSet;
 use std::fmt::Write;
 use std::path::Path;
@@ -42,9 +42,20 @@ pub fn generate_mock_symbols(binary: &Path, objects: &[&Path]) -> Result<String,
         }
     }
 
+    fn sym_is_definition(sym: &Symbol) -> bool {
+        if sym.is_definition() {
+            return true;
+        }
+        match sym.flags() {
+            // 10 == STT_GNU_IFUNC for ELF files
+            SymbolFlags::Elf { st_info, .. } => st_info & 0xf == 10,
+            _ => false,
+        }
+    }
+
     let mut generated = String::new();
     for sym in so_file.symbols().chain(so_file.dynamic_symbols()) {
-        if sym.is_definition() {
+        if sym_is_definition(&sym) {
             if let Ok(name) = sym.name() {
                 if missing_symbols.remove(name) {
                     // strip leading underscore


### PR DESCRIPTION
Looks like php may be built with certain optimizations causing some symbols to be resolved as ifunc. The object crate is not recognizing these as definition, but for our purposes, it is one.

Fixes part of Datadog/dd-trace-php#2831.