### PR TITLE
improve assert failure message for send_data retry tests and increase tolerance for time measurements

### DIFF
--- a/trace-utils/src/send_data/retry_strategy.rs
+++ b/trace-utils/src/send_data/retry_strategy.rs
@@ -135,7 +135,8 @@ mod tests {
                 && elapsed
                     <= retry_strategy.delay_ms
                         + Duration::from_millis(RETRY_STRATEGY_TIME_TOLERANCE_MS),
-            "Elapsed time was not within expected range"
+            "Elapsed time of {} ms was not within expected range",
+            elapsed.as_millis().to_string()
         );
 
         let start = Instant::now();
@@ -147,7 +148,8 @@ mod tests {
                 && elapsed
                     <= retry_strategy.delay_ms
                         + Duration::from_millis(RETRY_STRATEGY_TIME_TOLERANCE_MS),
-            "Elapsed time was not within expected range"
+            "Elapsed time of {} ms was not within expected range",
+            elapsed.as_millis().to_string()
         );
     }
 
@@ -170,7 +172,8 @@ mod tests {
                 && elapsed
                     <= retry_strategy.delay_ms
                         + Duration::from_millis(RETRY_STRATEGY_TIME_TOLERANCE_MS),
-            "Elapsed time was not within expected range"
+            "Elapsed time of {} ms was not within expected range",
+            elapsed.as_millis().to_string()
         );
 
         let start = Instant::now();
@@ -185,7 +188,8 @@ mod tests {
                     <= retry_strategy.delay_ms
                         + (retry_strategy.delay_ms * 2)
                         + Duration::from_millis(RETRY_STRATEGY_TIME_TOLERANCE_MS),
-            "Elapsed time was not within expected range"
+            "Elapsed time of {} ms was not within expected range",
+            elapsed.as_millis().to_string()
         );
     }
 
@@ -208,7 +212,8 @@ mod tests {
                 && elapsed
                     <= retry_strategy.delay_ms
                         + Duration::from_millis(RETRY_STRATEGY_TIME_TOLERANCE_MS),
-            "Elapsed time was not within expected range"
+            "Elapsed time of {} ms was not within expected range",
+            elapsed.as_millis().to_string()
         );
 
         let start = Instant::now();
@@ -221,7 +226,8 @@ mod tests {
                 && elapsed
                     <= retry_strategy.delay_ms * 4
                         + Duration::from_millis(RETRY_STRATEGY_TIME_TOLERANCE_MS),
-            "Elapsed time was not within expected range"
+            "Elapsed time of {} ms was not within expected range",
+            elapsed.as_millis().to_string()
         );
     }
 
@@ -246,7 +252,8 @@ mod tests {
                     <= retry_strategy.delay_ms
                         + retry_strategy.jitter.unwrap()
                         + Duration::from_millis(RETRY_STRATEGY_TIME_TOLERANCE_MS),
-            "Elapsed time was not within expected range"
+            "Elapsed time of {} ms was not within expected range",
+            elapsed.as_millis().to_string()
         );
     }
 

--- a/trace-utils/src/send_data/retry_strategy.rs
+++ b/trace-utils/src/send_data/retry_strategy.rs
@@ -114,7 +114,7 @@ mod tests {
     use super::*;
     use tokio::time::Instant;
 
-    const RETRY_STRATEGY_TIME_TOLERANCE_MS: u64 = 25;
+    const RETRY_STRATEGY_TIME_TOLERANCE_MS: u64 = 01;
 
     #[cfg_attr(miri, ignore)]
     #[tokio::test]

--- a/trace-utils/src/send_data/retry_strategy.rs
+++ b/trace-utils/src/send_data/retry_strategy.rs
@@ -114,7 +114,10 @@ mod tests {
     use super::*;
     use tokio::time::Instant;
 
-    const RETRY_STRATEGY_TIME_TOLERANCE_MS: u64 = 01;
+    // This tolerance is on the higher side to account for github's runners not having consistent
+    // performance. It shouldn't impact the quality of the tests since the most important aspect
+    // of the retry logic is we wait a minimum amount of time.
+    const RETRY_STRATEGY_TIME_TOLERANCE_MS: u64 = 100;
 
     #[cfg_attr(miri, ignore)]
     #[tokio::test]

--- a/trace-utils/src/send_data/retry_strategy.rs
+++ b/trace-utils/src/send_data/retry_strategy.rs
@@ -136,7 +136,7 @@ mod tests {
                     <= retry_strategy.delay_ms
                         + Duration::from_millis(RETRY_STRATEGY_TIME_TOLERANCE_MS),
             "Elapsed time of {} ms was not within expected range",
-            elapsed.as_millis().to_string()
+            elapsed.as_millis()
         );
 
         let start = Instant::now();
@@ -149,7 +149,7 @@ mod tests {
                     <= retry_strategy.delay_ms
                         + Duration::from_millis(RETRY_STRATEGY_TIME_TOLERANCE_MS),
             "Elapsed time of {} ms was not within expected range",
-            elapsed.as_millis().to_string()
+            elapsed.as_millis()
         );
     }
 
@@ -173,7 +173,7 @@ mod tests {
                     <= retry_strategy.delay_ms
                         + Duration::from_millis(RETRY_STRATEGY_TIME_TOLERANCE_MS),
             "Elapsed time of {} ms was not within expected range",
-            elapsed.as_millis().to_string()
+            elapsed.as_millis()
         );
 
         let start = Instant::now();
@@ -189,7 +189,7 @@ mod tests {
                         + (retry_strategy.delay_ms * 2)
                         + Duration::from_millis(RETRY_STRATEGY_TIME_TOLERANCE_MS),
             "Elapsed time of {} ms was not within expected range",
-            elapsed.as_millis().to_string()
+            elapsed.as_millis()
         );
     }
 
@@ -213,7 +213,7 @@ mod tests {
                     <= retry_strategy.delay_ms
                         + Duration::from_millis(RETRY_STRATEGY_TIME_TOLERANCE_MS),
             "Elapsed time of {} ms was not within expected range",
-            elapsed.as_millis().to_string()
+            elapsed.as_millis()
         );
 
         let start = Instant::now();
@@ -227,7 +227,7 @@ mod tests {
                     <= retry_strategy.delay_ms * 4
                         + Duration::from_millis(RETRY_STRATEGY_TIME_TOLERANCE_MS),
             "Elapsed time of {} ms was not within expected range",
-            elapsed.as_millis().to_string()
+            elapsed.as_millis()
         );
     }
 
@@ -253,7 +253,7 @@ mod tests {
                         + retry_strategy.jitter.unwrap()
                         + Duration::from_millis(RETRY_STRATEGY_TIME_TOLERANCE_MS),
             "Elapsed time of {} ms was not within expected range",
-            elapsed.as_millis().to_string()
+            elapsed.as_millis()
         );
     }
 


### PR DESCRIPTION
# What does this PR do?
It has been observed that some of the send_data retry strategy logic can be flaky on the macOS github actions runners. This PR adds more time to the retry observation tolerances for these tests. Also, a bit more info was added to the relevant test assertions when a failure does occur. 

# Motivation
@bwoebi 

