### PR TITLE
Fix missing symbol `ddog_crasht_demangle`

### DIFF
--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 
 [features]
 default = []
-crashtracker = ["datadog-profiling-ffi?/crashtracker-receiver", "datadog-profiling-ffi?/crashtracker-collector"]
+crashtracker = ["datadog-profiling-ffi?/crashtracker-receiver", "datadog-profiling-ffi?/crashtracker-collector", "datadog-profiling-ffi?/demangler"]
 profiling = ["dep:datadog-profiling-ffi"]
 telemetry = ["profiling", "datadog-profiling-ffi?/ddtelemetry-ffi"]
 data-pipeline = ["telemetry", "datadog-profiling-ffi?/data-pipeline-ffi"]

--- a/examples/ffi/crashinfo.cpp
+++ b/examples/ffi/crashinfo.cpp
@@ -15,7 +15,8 @@ extern "C" {
 #include <vector>
 
 static ddog_CharSlice to_slice_c_char(const char *s) { return {.ptr = s, .len = strlen(s)}; }
-static ddog_CharSlice to_slice_string(std::string &s) {
+static ddog_CharSlice to_slice_c_char(const char *s, std::size_t size) { return {.ptr = s, .len = size}; }
+static ddog_CharSlice to_slice_string(std::string const &s) {
   return {.ptr = s.data(), .len = s.length()};
 }
 
@@ -39,19 +40,28 @@ void check_result(ddog_crasht_Result result, const char *msg) {
 void add_stacktrace(std::unique_ptr<ddog_crasht_CrashInfo, Deleter> &crashinfo) {
 
   // Collect things into vectors so they stay alive till the function exits
-  std::vector<std::string> filenames;
-  std::vector<std::string> function_names;
-  for (uintptr_t i = 0; i < 20; ++i) {
-    filenames.push_back("/path/to/code/file_" + std::to_string(i));
-    function_names.push_back("func_" + std::to_string(i));
+  constexpr std::size_t nb_elements = 20;
+  std::vector<std::pair<std::string, std::string>> functions_and_filenames{nb_elements};
+  for (uintptr_t i = 0; i < nb_elements; ++i) {
+    functions_and_filenames.push_back({"func_" + std::to_string(i), "/path/to/code/file_" + std::to_string(i)});
   }
 
-  std::vector<ddog_crasht_StackFrameNames> names;
-  for (uintptr_t i = 0; i < 20; ++i) {
+  std::vector<ddog_crasht_StackFrameNames> names{nb_elements};
+  for (auto i = 0; i < nb_elements; i++) {
+    auto const& [function_name, filename] = functions_and_filenames[i];
+
+    auto function_name_slice = to_slice_string(function_name);
+    auto res = ddog_crasht_demangle(function_name_slice, DDOG_CRASHT_DEMANGLE_OPTIONS_COMPLETE);
+    if (res.tag == DDOG_CRASHT_STRING_WRAPPER_RESULT_OK)
+    {
+      auto string_result = res.ok.message;
+      function_name_slice = to_slice_c_char((const char*)string_result.ptr, string_result.len);
+    }
+
     names.push_back({.colno = ddog_Option_U32_some(i),
-                     .filename = to_slice_string(filenames[i]),
+                     .filename = to_slice_string(filename),
                      .lineno = ddog_Option_U32_some(2 * i + 3),
-                     .name = to_slice_string(function_names[i])});
+                     .name = function_name_slice});
   }
 
   std::vector<ddog_crasht_StackFrame> trace;

--- a/examples/ffi/crashtracking.c
+++ b/examples/ffi/crashtracking.c
@@ -75,7 +75,6 @@ int main(int argc, char **argv) {
   handle_uintptr_t_result(ddog_crasht_insert_span_id(0, 42));
   handle_uintptr_t_result(ddog_crasht_insert_trace_id(1, 1));
 
-  ddog_crasht_demangle(DDOG_CHARSLICE_C("nopp"), DDOG_CRASHT_DEMANGLE_OPTIONS_COMPLETE);
 #ifdef EXPLICIT_RAISE_SEGV
   // Test raising SEGV explicitly, to ensure chaining works
   // properly in this case

--- a/examples/ffi/crashtracking.c
+++ b/examples/ffi/crashtracking.c
@@ -75,6 +75,7 @@ int main(int argc, char **argv) {
   handle_uintptr_t_result(ddog_crasht_insert_span_id(0, 42));
   handle_uintptr_t_result(ddog_crasht_insert_trace_id(1, 1));
 
+  ddog_crasht_demangle(DDOG_CHARSLICE_C("nopp"), DDOG_CRASHT_DEMANGLE_OPTIONS_COMPLETE);
 #ifdef EXPLICIT_RAISE_SEGV
   // Test raising SEGV explicitly, to ensure chaining works
   // properly in this case

--- a/profiling-ffi/Cargo.toml
+++ b/profiling-ffi/Cargo.toml
@@ -25,6 +25,7 @@ crashtracker-ffi = ["dep:datadog-crashtracker-ffi"]
 crashtracker-collector = ["crashtracker-ffi", "datadog-crashtracker-ffi/collector"]
 # Enables the use of this library to receiver crash-info from a suitable collector
 crashtracker-receiver = ["crashtracker-ffi", "datadog-crashtracker-ffi/receiver"]
+demangler = ["crashtracker-ffi", "datadog-crashtracker-ffi/demangler"]
 
 [build-dependencies]
 build_common = { path = "../build-common" }


### PR DESCRIPTION
# What does this PR do?

Ensure `ddog_crasht_demangle` is exported. Currently, it's not compiling/linking at all.

# Motivation

Since https://github.com/DataDog/libdatadog/pull/551, `ddog_crasht_demangle` is not exported anymore (not in v11 nor v12).

# Additional Notes


# How to test the change?
Added a call to `ddog_crasht_demangle` in the example.
+
Downloaded the artifacts and checked that the symbol is part of the library

```
╭─greg@DESKTOP-DQNLFF9 ~/repos/libdatadog/tmp  ‹gleocadie/add-crashtracking-feature-for-windows›
╰─➤  nm lib/libdatadog_profiling.so | grep ddog_crasht_demangle
00000000004f8710 T ddog_crasht_demangle
```

## Next step
Add a test to check the exported functions.  