### PR TITLE
Upgrade to Rust 1.76.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,7 +31,7 @@ jobs:
       fail-fast: false
       matrix:
         # Ignore nightly for now, it fails too often
-        rust_version: ["1.71.1", "stable"]
+        rust_version: ["1.76.0", "stable"]
         platform: [windows-latest, ubuntu-latest]
     steps:
       - name: Checkout sources
@@ -46,7 +46,7 @@ jobs:
         shell: bash
         run: |
           # shellcheck disable=SC2046
-          cargo clippy --workspace --all-targets --all-features -- -D warnings $([ ${{ matrix.rust_version }} = 1.71.1 ] && echo -Aunknown-lints -Aclippy::cast_ref_to_mut)
+          cargo clippy --workspace --all-targets --all-features -- -D warnings $([ ${{ matrix.rust_version }} = 1.76.0 ] && echo -Aunknown-lints -Ainvalid_reference_casting)
   licensecheck:
     runs-on: ubuntu-latest
     name: "Presence of licence headers"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 on: [push]
 env: 
   CARGO_TERM_COLOR: always
-  RUST_VERSION: 1.71.1
+  RUST_VERSION: 1.76.0
 
 jobs:
   test:

--- a/.github/workflows/verify-proto-files.yml
+++ b/.github/workflows/verify-proto-files.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   DATADOG_AGENT_TAG: "7.55.0-rc.3"
-  rust_version: "1.71.1"
+  rust_version: "1.76.0"
 
 jobs:
   verify-proto-files:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ resolver = "2"
 # serverless packages wanted to maintain their own version numbers. Some of
 # their depenencies also remain under their own versioning.
 [workspace.package]
-rust-version = "1.71.1"
+rust-version = "1.76.0"
 edition = "2021"
 version = "12.0.0"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ bash build-profiling-ffi.sh /opt/libdatadog
 
 #### Build Dependencies
 
-- Rust 1.71 or newer with cargo
+- Rust 1.76.0 or newer with cargo
 - `cbindgen` 0.26
 - `cmake` and `protoc`
 
@@ -77,6 +77,6 @@ Tracing integration tests require docker to be installed and running. If you don
 cargo nextest run -E '!test(tracing_integration_tests::)'
 ```
 
-Please note that the locked version is to make sure that it can be built using rust `1.71.1`, and if you are using a newer rust version, then it's enough to limit the version to `0.9.*`.
+Please note that the locked version is to make sure that it can be built using rust `1.76.0`, and if you are using a newer rust version, then it's enough to limit the version to `0.9.*`.
 
 [nt]: https://nexte.st/

--- a/crashtracker-ffi/src/collector/spans.rs
+++ b/crashtracker-ffi/src/collector/spans.rs
@@ -52,7 +52,7 @@ pub unsafe extern "C" fn ddog_crasht_clear_trace_ids() -> Result {
 ///
 /// Note: 128 bit ints in FFI were not stabilized until Rust 1.77
 /// https://blog.rust-lang.org/2024/03/30/i128-layout-update.html
-/// We're currently locked into 1.71, have to do an ugly workaround involving 2 64 bit ints
+/// We're currently locked into 1.76.0, have to do an ugly workaround involving 2 64 bit ints
 /// until we can upgrade.
 ///
 /// # Safety
@@ -80,7 +80,7 @@ pub unsafe extern "C" fn ddog_crasht_insert_trace_id(id_high: u64, id_low: u64) 
 ///
 /// Note: 128 bit ints in FFI were not stabilized until Rust 1.77
 /// https://blog.rust-lang.org/2024/03/30/i128-layout-update.html
-/// We're currently locked into 1.71, have to do an ugly workaround involving 2 64 bit ints
+/// We're currently locked into 1.76.0, have to do an ugly workaround involving 2 64 bit ints
 /// until we can upgrade.
 
 ///
@@ -110,7 +110,7 @@ pub unsafe extern "C" fn ddog_crasht_insert_span_id(id_high: u64, id_low: u64) -
 ///
 /// Note: 128 bit ints in FFI were not stabilized until Rust 1.77
 /// https://blog.rust-lang.org/2024/03/30/i128-layout-update.html
-/// We're currently locked into 1.71, have to do an ugly workaround involving 2 64 bit ints
+/// We're currently locked into 1.76.0, have to do an ugly workaround involving 2 64 bit ints
 /// until we can upgrade.
 ///
 /// # Safety
@@ -143,7 +143,7 @@ pub unsafe extern "C" fn ddog_crasht_remove_span_id(
 ///
 /// Note: 128 bit ints in FFI were not stabilized until Rust 1.77
 /// https://blog.rust-lang.org/2024/03/30/i128-layout-update.html
-/// We're currently locked into 1.71, have to do an ugly workaround involving 2 64 bit ints
+/// We're currently locked into 1.76.0, have to do an ugly workaround involving 2 64 bit ints
 /// until we can upgrade.
 ///
 /// # Safety

--- a/tools/docker/Dockerfile.build
+++ b/tools/docker/Dockerfile.build
@@ -1,4 +1,4 @@
-ARG ALPINE_BASE_IMAGE="alpine:3.18"
+ARG ALPINE_BASE_IMAGE="alpine:3.19.3"
 ARG CARGO_BUILD_INCREMENTAL="true"
 ARG CARGO_NET_RETRY="2"
 ARG BUILDER_IMAGE=debian_builder
@@ -44,13 +44,7 @@ SHELL ["/bin/bash", "-c"]
 #RUN rustup-init -y --no-modify-path --default-toolchain stable
 
 FROM alpine_base as alpine_aws_cli
-RUN apk add --no-cache \
-    python3 \
-    py3-pip \
-    groff \
-  && pip3 install --upgrade pip \
-  && pip3 install --no-cache-dir \
-    awscli \
+RUN apk add --no-cache aws-cli \
   && rm -rf /var/cache/apk/*
 
 RUN aws --version   # Just to make sure its installed alright


### PR DESCRIPTION
# What does this PR do?

Upgrade minimum Rust version to 1.76.0.

# Motivation

Necessary for changes in https://github.com/DataDog/libdatadog/pull/606.

# Additional Notes

Other PRs related to Rust version upgrade:

* https://github.com/DataDog/benchmarking-platform/pull/96
* https://github.com/DataDog/libddprof-build/pull/49

# How to test the change?
