### PR TITLE
[Profiling/Build] Add crashtracking feature for windows (event it's not ready yet)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,6 +161,7 @@ jobs:
         shell: bash
         run: |
           set -e
+          rm -rf examples/ffi/build_dll
           mkdir examples/ffi/build_dll
           cd examples/ffi/build_dll
           cmake -S .. -DDatadog_ROOT=$LIBDD_OUTPUT_FOLDER -DVCRUNTIME_LINK_TYPE=DLL
@@ -171,6 +172,7 @@ jobs:
         shell: bash
         run: |
           set -e
+          rm -rf examples/ffi/build_static
           mkdir examples/ffi/build_static
           cd examples/ffi/build_static
           cmake -S .. -DDatadog_ROOT=$LIBDD_OUTPUT_FOLDER -DVCRUNTIME_LINK_TYPE=STATIC
@@ -181,6 +183,7 @@ jobs:
         if: matrix.platform != 'windows-latest'
         run: |
           set -e
+          rm -rf examples/ffi/build
           mkdir examples/ffi/build
           cd examples/ffi/build
           # Add BUILD_SYMBOLIZER variable only for Linux platforms

--- a/windows/build-artifacts.ps1
+++ b/windows/build-artifacts.ps1
@@ -22,10 +22,10 @@ Write-Host "Building project into $($output_dir)" -ForegroundColor Magenta
 
 # build inside the crate to use the config.toml file
 pushd profiling-ffi
-Invoke-Call -ScriptBlock { cargo build --features datadog-profiling-ffi/ddtelemetry-ffi --target i686-pc-windows-msvc --release --target-dir $output_dir }
-Invoke-Call -ScriptBlock { cargo build --features datadog-profiling-ffi/ddtelemetry-ffi --target i686-pc-windows-msvc --target-dir $output_dir }
-Invoke-Call -ScriptBlock { cargo build --features datadog-profiling-ffi/ddtelemetry-ffi --target x86_64-pc-windows-msvc --release --target-dir $output_dir }
-Invoke-Call -ScriptBlock { cargo build --features datadog-profiling-ffi/ddtelemetry-ffi --target x86_64-pc-windows-msvc --target-dir $output_dir }
+Invoke-Call -ScriptBlock { cargo build --features datadog-profiling-ffi/ddtelemetry-ffi,datadog-profiling-ffi/crashtracker-receiver,datadog-profiling-ffi/crashtracker-collector,datadog-profiling-ffi/demangler --target i686-pc-windows-msvc --release --target-dir $output_dir }
+Invoke-Call -ScriptBlock { cargo build --features datadog-profiling-ffi/ddtelemetry-ffi,datadog-profiling-ffi/crashtracker-receiver,datadog-profiling-ffi/crashtracker-collector,datadog-profiling-ffi/demangler --target i686-pc-windows-msvc --target-dir $output_dir }
+Invoke-Call -ScriptBlock { cargo build --features datadog-profiling-ffi/ddtelemetry-ffi,datadog-profiling-ffi/crashtracker-receiver,datadog-profiling-ffi/crashtracker-collector,datadog-profiling-ffi/demangler --target x86_64-pc-windows-msvc --release --target-dir $output_dir }
+Invoke-Call -ScriptBlock { cargo build --features datadog-profiling-ffi/ddtelemetry-ffi,datadog-profiling-ffi/crashtracker-receiver,datadog-profiling-ffi/crashtracker-collector,datadog-profiling-ffi/demangler --target x86_64-pc-windows-msvc --target-dir $output_dir }
 popd
 
 Write-Host "Building tools" -ForegroundColor Magenta
@@ -38,6 +38,7 @@ Invoke-Call -ScriptBlock { cbindgen --crate ddcommon-ffi --config ddcommon-ffi/c
 Invoke-Call -ScriptBlock { cbindgen --crate datadog-profiling-ffi --config profiling-ffi/cbindgen.toml --output $output_dir\profiling.h }
 Invoke-Call -ScriptBlock { cbindgen --crate ddtelemetry-ffi --config ddtelemetry-ffi/cbindgen.toml --output $output_dir\telemetry.h }
 Invoke-Call -ScriptBlock { cbindgen --crate data-pipeline-ffi --config data-pipeline-ffi/cbindgen.toml --output $output_dir"\data-pipeline.h" }
-Invoke-Call -ScriptBlock { .\target\release\dedup_headers $output_dir"\common.h"  $output_dir"\profiling.h" $output_dir"\telemetry.h" $output_dir"\data-pipeline.h" }
+Invoke-Call -ScriptBlock { cbindgen --crate datadog-crashtracker-ffi --config crashtracker-ffi/cbindgen.toml --output $output_dir"\crashtracker.h" }
+Invoke-Call -ScriptBlock { .\target\release\dedup_headers $output_dir"\common.h"  $output_dir"\profiling.h" $output_dir"\telemetry.h" $output_dir"\data-pipeline.h" $output_dir"\crashtracker.h"}
 
 Write-Host "Build finished"  -ForegroundColor Magenta

--- a/windows/libdatadog.csproj
+++ b/windows/libdatadog.csproj
@@ -33,6 +33,8 @@
       PackagePath="include\native\datadog\profiling.h" />
     <None Include="$(LibDatadogBinariesOutputDir)\telemetry.h" Pack="true"
       PackagePath="include\native\datadog\telemetry.h" />
+    <None Include="$(LibDatadogBinariesOutputDir)\crashtracker.h" Pack="true"
+      PackagePath="include\native\datadog\crashtracker.h" />
 
     <None Include="$(LibDatadogBinariesOutputDir)\x86_64-pc-windows-msvc\debug\datadog_profiling_ffi.lib"
       Pack="true" PackagePath="build\native\lib\x64\debug\datadog_profiling_ffi.lib" />


### PR DESCRIPTION
# What does this PR do?

Since https://github.com/DataDog/libdatadog/pull/551, crashtracker has its own header `crashtracker.h`. This header is not part of the nuget package and prevent compilation on windows.

# Motivation

Make sure we can compile in Visual Studio.

# Additional Notes

Waiting for https://github.com/DataDog/libdatadog/pull/611

Anything else we should know when reviewing?

# How to test the change?

Downloaded the nuget package (from the gitlab job) and checked that :
- `crashtracker.h` is present
- `ddog_crasht_demangle` symbol is present

