### PR TITLE
[Serverless Mini Agent] Use DogStatsD in Serverless

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,8 +1585,11 @@ dependencies = [
  "datadog-trace-mini-agent",
  "datadog-trace-protobuf",
  "datadog-trace-utils",
+ "dogstatsd",
  "env_logger",
  "log",
+ "tokio",
+ "tokio-util 0.7.11",
 ]
 
 [[package]]
@@ -3106,7 +3109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c2a198fb6b0eada2a8df47933734e6d35d350665a33a3593d7164fa52c75c19"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/serverless/Cargo.toml
+++ b/serverless/Cargo.toml
@@ -9,6 +9,9 @@ env_logger = "0.10.0"
 datadog-trace-mini-agent = { path = "../trace-mini-agent" }
 datadog-trace-protobuf = { path = "../trace-protobuf" }
 datadog-trace-utils = { path = "../trace-utils" }
+dogstatsd = { path = "../dogstatsd" }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"]}
+tokio-util = { version = "0.7", default-features = false }
 
 [[bin]]
 name = "datadog-serverless-trace-mini-agent"

--- a/trace-mini-agent/src/config.rs
+++ b/trace-mini-agent/src/config.rs
@@ -16,6 +16,7 @@ use datadog_trace_utils::trace_utils;
 #[derive(Debug)]
 pub struct Config {
     pub dd_site: String,
+    pub dd_dogstatsd_port: u16,
     pub env_type: trace_utils::EnvironmentType,
     pub function_name: Option<String>,
     pub max_request_content_length: usize,
@@ -41,6 +42,10 @@ impl Config {
             anyhow::anyhow!("Unable to identify environment. Shutting down Mini Agent.")
         })?;
 
+        let dd_dogstatsd_port: u16 = env::var("DD_DOGSTATSD_PORT")
+            .ok()
+            .and_then(|port| port.parse::<u16>().ok())
+            .unwrap_or(8125);
         let dd_site = env::var("DD_SITE").unwrap_or_else(|_| "datadoghq.com".to_string());
 
         // construct the trace & trace stats intake urls based on DD_SITE env var (to flush traces &
@@ -69,6 +74,7 @@ impl Config {
             trace_flush_interval: 3,
             stats_flush_interval: 3,
             verify_env_timeout: 100,
+            dd_dogstatsd_port,
             dd_site,
             trace_intake: Endpoint {
                 url: hyper::Uri::from_str(&trace_intake_url).unwrap(),
@@ -206,5 +212,33 @@ mod tests {
         env::remove_var("DD_API_KEY");
         env::remove_var("DD_APM_DD_URL");
         env::remove_var("K_SERVICE");
+    }
+
+    #[test]
+    #[serial]
+    fn test_default_dogstatsd_port() {
+        env::set_var("ASCSVCRT_SPRING__APPLICATION__NAME", "test-spring-app");
+        env::set_var("DD_API_KEY", "_not_a_real_key_");
+        let config_res = config::Config::new();
+        assert!(config_res.is_ok());
+        let config = config_res.unwrap();
+        assert_eq!(config.dd_dogstatsd_port, 8125);
+        env::remove_var("DD_DOGSTATSD_PORT");
+        env::remove_var("ASCSVCRT_SPRING__APPLICATION__NAME");
+    }
+
+    #[test]
+    #[serial]
+    fn test_custom_dogstatsd_port() {
+        env::set_var("DD_DOGSTATSD_PORT", "18125");
+        env::set_var("DD_API_KEY", "_not_a_real_key_");
+        env::set_var("ASCSVCRT_SPRING__APPLICATION__NAME", "test-spring-app");
+        let config_res = config::Config::new();
+        println!("{:?}", config_res);
+        assert!(config_res.is_ok());
+        let config = config_res.unwrap();
+        assert_eq!(config.dd_dogstatsd_port, 18125);
+        env::remove_var("DD_DOGSTATSD_PORT");
+        env::remove_var("ASCSVCRT_SPRING__APPLICATION__NAME");
     }
 }

--- a/trace-mini-agent/src/config.rs
+++ b/trace-mini-agent/src/config.rs
@@ -13,6 +13,8 @@ use datadog_trace_utils::config_utils::{
 };
 use datadog_trace_utils::trace_utils;
 
+const DEFAULT_DOGSTATSD_PORT: u16 = 8125;
+
 #[derive(Debug)]
 pub struct Config {
     pub dd_site: String,
@@ -45,7 +47,7 @@ impl Config {
         let dd_dogstatsd_port: u16 = env::var("DD_DOGSTATSD_PORT")
             .ok()
             .and_then(|port| port.parse::<u16>().ok())
-            .unwrap_or(8125);
+            .unwrap_or(DEFAULT_DOGSTATSD_PORT);
         let dd_site = env::var("DD_SITE").unwrap_or_else(|_| "datadoghq.com".to_string());
 
         // construct the trace & trace stats intake urls based on DD_SITE env var (to flush traces &

--- a/trace-mini-agent/src/config.rs
+++ b/trace-mini-agent/src/config.rs
@@ -217,28 +217,29 @@ mod tests {
     #[test]
     #[serial]
     fn test_default_dogstatsd_port() {
-        env::set_var("ASCSVCRT_SPRING__APPLICATION__NAME", "test-spring-app");
         env::set_var("DD_API_KEY", "_not_a_real_key_");
+        env::set_var("ASCSVCRT_SPRING__APPLICATION__NAME", "test-spring-app");
         let config_res = config::Config::new();
         assert!(config_res.is_ok());
         let config = config_res.unwrap();
         assert_eq!(config.dd_dogstatsd_port, 8125);
-        env::remove_var("DD_DOGSTATSD_PORT");
+        env::remove_var("DD_API_KEY");
         env::remove_var("ASCSVCRT_SPRING__APPLICATION__NAME");
     }
 
     #[test]
     #[serial]
     fn test_custom_dogstatsd_port() {
-        env::set_var("DD_DOGSTATSD_PORT", "18125");
         env::set_var("DD_API_KEY", "_not_a_real_key_");
         env::set_var("ASCSVCRT_SPRING__APPLICATION__NAME", "test-spring-app");
+        env::set_var("DD_DOGSTATSD_PORT", "18125");
         let config_res = config::Config::new();
         println!("{:?}", config_res);
         assert!(config_res.is_ok());
         let config = config_res.unwrap();
         assert_eq!(config.dd_dogstatsd_port, 18125);
-        env::remove_var("DD_DOGSTATSD_PORT");
+        env::remove_var("DD_API_KEY");
         env::remove_var("ASCSVCRT_SPRING__APPLICATION__NAME");
+        env::remove_var("DD_DOGSTATSD_PORT");
     }
 }

--- a/trace-mini-agent/src/mini_agent.rs
+++ b/trace-mini-agent/src/mini_agent.rs
@@ -34,7 +34,6 @@ pub struct MiniAgent {
 }
 
 impl MiniAgent {
-    #[tokio::main]
     pub async fn start_mini_agent(&self) -> Result<(), Box<dyn std::error::Error>> {
         let now = Instant::now();
 
@@ -168,7 +167,7 @@ impl MiniAgent {
                     ),
                 }
             }
-            (_, INFO_ENDPOINT_PATH) => match Self::info_handler() {
+            (_, INFO_ENDPOINT_PATH) => match Self::info_handler(config.dd_dogstatsd_port) {
                 Ok(res) => Ok(res),
                 Err(err) => log_and_create_http_response(
                     &format!("Info endpoint error: {err}"),
@@ -183,7 +182,7 @@ impl MiniAgent {
         }
     }
 
-    fn info_handler() -> http::Result<Response<Body>> {
+    fn info_handler(dd_dogstatsd_port: u16) -> http::Result<Response<Body>> {
         let response_json = json!(
             {
                 "endpoints": [
@@ -193,7 +192,7 @@ impl MiniAgent {
                 ],
                 "client_drop_p0s": true,
                 "config": {
-                    "statsd_port": MINI_AGENT_PORT
+                    "statsd_port": dd_dogstatsd_port
                 }
             }
         );

--- a/trace-mini-agent/src/trace_processor.rs
+++ b/trace-mini-agent/src/trace_processor.rs
@@ -168,6 +168,7 @@ mod tests {
                 ..Default::default()
             },
             dd_site: "datadoghq.com".to_string(),
+            dd_dogstatsd_port: 8125,
             env_type: trace_utils::EnvironmentType::CloudFunction,
             os: "linux".to_string(),
             obfuscation_config: ObfuscationConfig::new().unwrap(),


### PR DESCRIPTION
# What does this PR do?

Starts a DogStatsD server when running the Serverless Mini Agent.

# Motivation

Allow runtime metrics and custom metrics to be sent from Azure Spring Apps and Azure Functions.

- https://datadoghq.atlassian.net/browse/SVLS-5177
- https://datadoghq.atlassian.net/browse/SVLS-5521

# Additional Notes

- Updated `main` method of Serverless to be asynchronous.
- Allow custom DogStatsD port with `DD_DOGSTATSD_PORT`
- Allow DogStatsD to be disabled with `DD_USE_DOGSTATSD`

# How to test the change?

* Build mini agent and deploy to Azure Spring App and Azure Function
* Confirm runtime metrics are sent successfully to Datadog