### PR TITLE
Fix CI failure: update `libdatadog_profiling.so` `SONAME`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,13 +183,12 @@ jobs:
         if: matrix.platform != 'windows-latest'
         run: |
           set -e
-          rm -rf examples/ffi/build
           mkdir examples/ffi/build
           cd examples/ffi/build
           # Add BUILD_SYMBOLIZER variable only for Linux platforms
           if [[ "${{ matrix.platform }}" == "ubuntu-latest" ]]; then
             cmake -S .. -DDatadog_ROOT=$LIBDD_OUTPUT_FOLDER -DBUILD_SYMBOLIZER=true
-            cmake --build  .
+            cmake --build .
             ./symbolizer
           else
             cmake -S .. -DDatadog_ROOT=$LIBDD_OUTPUT_FOLDER

--- a/builder/build/arch/apple.rs
+++ b/builder/build/arch/apple.rs
@@ -35,3 +35,5 @@ pub fn strip_libraries(lib_path: &str) {
 
     strip.wait().expect("Failed to strip library");
 }
+
+pub fn fix_soname(_lib_path: &str) {}

--- a/builder/build/arch/linux.rs
+++ b/builder/build/arch/linux.rs
@@ -56,3 +56,12 @@ pub fn strip_libraries(lib_path: &str) {
 
     debug.wait().expect("Failed to set debuglink");
 }
+
+pub fn fix_soname(lib_path: &str) {
+    Command::new("patchelf")
+        .arg("--set-soname")
+        .arg(PROF_DYNAMIC_LIB)
+        .arg(lib_path.to_owned() + "/" + PROF_DYNAMIC_LIB)
+        .spawn()
+        .expect("failed to change the soname");
+}

--- a/builder/build/arch/musl.rs
+++ b/builder/build/arch/musl.rs
@@ -56,3 +56,12 @@ pub fn strip_libraries(lib_path: &str) {
 
     debug.wait().expect("Failed to set debuglink");
 }
+
+pub fn fix_soname(lib_path: &str) {
+    Command::new("patchelf")
+        .arg("--set-soname")
+        .arg(PROF_DYNAMIC_LIB)
+        .arg(lib_path)
+        .spawn()
+        .expect("failed to change the soname");
+}

--- a/builder/build/arch/windows.rs
+++ b/builder/build/arch/windows.rs
@@ -11,3 +11,4 @@ pub const BUILD_CRASHTRACKER: bool = false;
 
 pub fn fix_rpath(_lib_path: &str) {}
 pub fn strip_libraries(_lib_path: &str) {}
+pub fn fix_soname(_lib_path: &str) {}

--- a/builder/build/profiling.rs
+++ b/builder/build/profiling.rs
@@ -61,6 +61,8 @@ impl Profiling {
             .collect();
         fs::copy(from_static, to_static).expect("unable to copy static lib");
 
+        arch::fix_soname(&self.target_lib);
+
         // Generate debug information
         arch::strip_libraries(&self.target_lib);
         Ok(())


### PR DESCRIPTION
# What does this PR do?

Update the `SONAME` in the `libdatadog_profiling.so` file.

# Motivation

Fix CI.

Cargo produces the `libdatadog_profiling_ffi.so` then late renames it into `libdatadog_profiling.so`. But the `SONAME` in `libdatadog_profiling.so` is `libdatadog_profiling_ffi.so` (same as the original).
So when building the symbolizer (for example) and linking against `libdatadog_profiling.so`, the linker will register `libdatadog_profiling_ffi.so` as `NEEDED`

![image](https://github.com/user-attachments/assets/ed32a728-4ddb-477e-9290-d0f78f3c0949)

But it's not its name anymore, so we have to patch `libdatadog_profiling.so` to change its `SONAME` into `libdatadog_profiling.so`.

