### PR TITLE
[Gitlab] Fix build in Gitlab

### DIFF
--- a/build-profiling-ffi.sh
+++ b/build-profiling-ffi.sh
@@ -136,9 +136,9 @@ cp -v LICENSE LICENSE-3rdparty.yml NOTICE "$destdir/"
 
 
 datadog_profiling_ffi="datadog-profiling-ffi"
-FEATURES="--features crashtracker-collector,crashtracker-receiver,cbindgen,datadog-profiling-ffi/ddtelemetry-ffi"
+FEATURES="--features crashtracker-collector,crashtracker-receiver,cbindgen,datadog-profiling-ffi/ddtelemetry-ffi,datadog-profiling-ffi/demangler"
 if [[ "$symbolizer" -eq 1 ]]; then
-    FEATURES="--features crashtracker-collector,crashtracker-receiver,cbindgen,datadog-profiling-ffi/ddtelemetry-ffi,cbindgen,datadog-profiling-ffi/ddtelemetry-ffi,symbolizer"
+    FEATURES="--features crashtracker-collector,crashtracker-receiver,cbindgen,datadog-profiling-ffi/ddtelemetry-ffi,cbindgen,datadog-profiling-ffi/ddtelemetry-ffi,datadog-profiling-ffi/demangler,symbolizer"
 fi
 
 if [[ ! -z ${ARG_FEATURES} ]]; then


### PR DESCRIPTION
# What does this PR do?

Enable the demangler feature when building artifacts on Gitlab.

# Motivation

Since https://github.com/DataDog/libdatadog/pull/551, `ddog_crasht_demangle` is not include in the sofile. A fix was provided for github which uses the new builder. But in GitLab we still rely on the `build-profiling.sh` shell script.

# Additional Notes

🤷‍♂️ 

# How to test the change?

download the artifact from gitlab and check the presence of `ddog_crasht_demangle`
