### PR TITLE
Fix SONAME for artifact produced in Gitlab

### DIFF
--- a/build-profiling-ffi.sh
+++ b/build-profiling-ffi.sh
@@ -169,6 +169,10 @@ if [[ "$fix_macos_rpath" -eq 1 ]]; then
     install_name_tool -id @rpath/${shared_library_name} "$destdir/lib/${shared_library_name}"
 fi
 
+if command -v patchelf > /dev/null && [[ "$target" != "x86_64-pc-windows-msvc" ]]; then
+    patchelf --set-soname ${shared_library_name}  "$destdir/lib/${shared_library_rename}"
+fi
+
 # objcopy might not be available on macOS
 if command -v objcopy > /dev/null && [[ "$target" != "x86_64-pc-windows-msvc" ]]; then
     # Remove .llvmbc section which is not useful for clients


### PR DESCRIPTION
# What does this PR do?

Fix `SONAME` for artifacts produced in Gitlab.

# Motivation

Since in GitLab we do not use the new builder, we have to update the `build-profiling.sh` shell script in order to port this [change](https://github.com/DataDog/libdatadog/pull/624).

# Additional Notes
🤷 

# How to test the change?

Download the artifact from Gitlab and run `readelf -d libdatadog_profiling.so`
![image](https://github.com/user-attachments/assets/c71061e9-fa16-49e1-8339-ef7dd2a3d63a)

