### PR TITLE
[Serverless Mini Agent] Install Protoc for Serverless Release

### DIFF
--- a/.github/workflows/publish-serverless-agent.yml
+++ b/.github/workflows/publish-serverless-agent.yml
@@ -11,9 +11,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Install Protoc Binary
+        shell: bash
+        run: chmod +x ./scripts/install-protoc.sh && ./scripts/install-protoc.sh $HOME
       - name: Install musl dependencies
         run: rustup target add x86_64-unknown-linux-musl && sudo apt-get install musl-tools
       - name: Build project
+        shell: bash
         run: cargo build --release -p datadog-serverless-trace-mini-agent --target x86_64-unknown-linux-musl
       - name: Upload artifacts for release step
         uses: actions/upload-artifact@v3
@@ -26,7 +30,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Install Protoc Binary
+        shell: bash
+        run: chmod +x ./scripts/install-protoc.sh && ./scripts/install-protoc.sh $HOME
       - name: Build project
+        shell: bash
         run: cargo build --release -p datadog-serverless-trace-mini-agent
       - name: Upload artifacts for release step
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
# What does this PR do?

Installs protoc for Serverless Release.

# Motivation

Follows changes in https://github.com/DataDog/libdatadog/pull/606 to install protoc.

# Additional Notes

Needed for upcoming release of 0.7.0.

# How to test the change?

See https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/2977497119/Serverless+Mini+Agent#Testing
