### PR TITLE
feat: Support DD_HTTP_PROXY and DD_HTTPS_PROXY

### DIFF
--- a/dogstatsd/src/datadog.rs
+++ b/dogstatsd/src/datadog.rs
@@ -34,13 +34,36 @@ pub enum ShipError {
     Json(#[from] serde_json::Error),
 }
 
+fn build_http_client(http_proxy: Option<String>, https_proxy: Option<String>) -> Result<reqwest::Client, reqwest::Error> {
+    let client = reqwest::Client::builder();
+    if let Some(proxy_uri) = http_proxy {
+        let proxy = reqwest::Proxy::http(proxy_uri)?;
+        client.proxy(proxy).build()
+    } else if let Some(proxy_uri) = https_proxy {
+        let proxy = reqwest::Proxy::https(proxy_uri)?;
+        client.proxy(proxy).build()
+    } else {
+        client.build()
+    }
+}
+
 impl DdApi {
     #[must_use]
-    pub fn new(api_key: String, site: String) -> Self {
+    pub fn new(api_key: String, site: String, http_proxy: Option<String>, https_proxy: Option<String>) -> Self {
+        let client = match build_http_client(http_proxy, https_proxy) {
+            Ok(client) => client,
+            Err(e) => {
+                error!(
+                    "Unable to parse proxy configuration: {}, no proxy will be used",
+                    e
+                );
+                reqwest::Client::new()
+            }
+        };
         DdApi {
             api_key,
             fqdn_site: site,
-            client: reqwest::Client::new(),
+            client
         }
     }
 

--- a/dogstatsd/src/datadog.rs
+++ b/dogstatsd/src/datadog.rs
@@ -34,7 +34,10 @@ pub enum ShipError {
     Json(#[from] serde_json::Error),
 }
 
-fn build_http_client(http_proxy: Option<String>, https_proxy: Option<String>) -> Result<reqwest::Client, reqwest::Error> {
+fn build_http_client(
+    http_proxy: Option<String>,
+    https_proxy: Option<String>,
+) -> Result<reqwest::Client, reqwest::Error> {
     let client = reqwest::Client::builder();
     if let Some(proxy_uri) = http_proxy {
         let proxy = reqwest::Proxy::http(proxy_uri)?;
@@ -49,7 +52,12 @@ fn build_http_client(http_proxy: Option<String>, https_proxy: Option<String>) ->
 
 impl DdApi {
     #[must_use]
-    pub fn new(api_key: String, site: String, http_proxy: Option<String>, https_proxy: Option<String>) -> Self {
+    pub fn new(
+        api_key: String,
+        site: String,
+        http_proxy: Option<String>,
+        https_proxy: Option<String>,
+    ) -> Self {
         let client = match build_http_client(http_proxy, https_proxy) {
             Ok(client) => client,
             Err(e) => {
@@ -63,7 +71,7 @@ impl DdApi {
         DdApi {
             api_key,
             fqdn_site: site,
-            client
+            client,
         }
     }
 

--- a/dogstatsd/src/flusher.rs
+++ b/dogstatsd/src/flusher.rs
@@ -18,7 +18,13 @@ pub fn build_fqdn_metrics(site: String) -> String {
 
 #[allow(clippy::await_holding_lock)]
 impl Flusher {
-    pub fn new(api_key: String, aggregator: Arc<Mutex<Aggregator>>, site: String, http_proxy: Option<String>, https_proxy: Option<String>) -> Self {
+    pub fn new(
+        api_key: String,
+        aggregator: Arc<Mutex<Aggregator>>,
+        site: String,
+        http_proxy: Option<String>,
+        https_proxy: Option<String>,
+    ) -> Self {
         let dd_api = datadog::DdApi::new(api_key, site, http_proxy, https_proxy);
         Flusher { dd_api, aggregator }
     }

--- a/dogstatsd/src/flusher.rs
+++ b/dogstatsd/src/flusher.rs
@@ -18,8 +18,8 @@ pub fn build_fqdn_metrics(site: String) -> String {
 
 #[allow(clippy::await_holding_lock)]
 impl Flusher {
-    pub fn new(api_key: String, aggregator: Arc<Mutex<Aggregator>>, site: String) -> Self {
-        let dd_api = datadog::DdApi::new(api_key, site);
+    pub fn new(api_key: String, aggregator: Arc<Mutex<Aggregator>>, site: String, http_proxy: Option<String>, https_proxy: Option<String>) -> Self {
+        let dd_api = datadog::DdApi::new(api_key, site, http_proxy, https_proxy);
         Flusher { dd_api, aggregator }
     }
 

--- a/dogstatsd/tests/integration_test.rs
+++ b/dogstatsd/tests/integration_test.rs
@@ -39,6 +39,8 @@ async fn dogstatsd_server_ships_series() {
         "mock-api-key".to_string(),
         Arc::clone(&metrics_aggr),
         mock_server.url(),
+        None,
+        None
     );
 
     let server_address = "127.0.0.1:18125";

--- a/dogstatsd/tests/integration_test.rs
+++ b/dogstatsd/tests/integration_test.rs
@@ -40,7 +40,7 @@ async fn dogstatsd_server_ships_series() {
         Arc::clone(&metrics_aggr),
         mock_server.url(),
         None,
-        None
+        None,
     );
 
     let server_address = "127.0.0.1:18125";

--- a/serverless/src/main.rs
+++ b/serverless/src/main.rs
@@ -30,6 +30,8 @@ pub async fn main() {
     Builder::from_env(env).target(Target::Stdout).init();
 
     let dd_api_key: Option<String> = env::var("DD_API_KEY").ok();
+    let dd_http_proxy: Option<String> = env::var("DD_HTTP_PROXY").ok();
+    let dd_https_proxy: Option<String> = env::var("DD_HTTPS_PROXY").ok();
     let dd_dogstatsd_port: u16 = env::var("DD_DOGSTATSD_PORT")
         .ok()
         .and_then(|port| port.parse::<u16>().ok())
@@ -78,7 +80,14 @@ pub async fn main() {
 
     let mut metrics_flusher = if dd_use_dogstatsd {
         debug!("Starting dogstatsd");
-        let (_, metrics_flusher) = start_dogstatsd(dd_dogstatsd_port, dd_api_key, dd_site).await;
+        let (_, metrics_flusher) = start_dogstatsd(
+            dd_dogstatsd_port,
+            dd_api_key,
+            dd_site,
+            dd_http_proxy,
+            dd_https_proxy,
+        )
+        .await;
         info!("dogstatsd-udp: starting to listen on port {dd_dogstatsd_port}");
         metrics_flusher
     } else {
@@ -103,6 +112,8 @@ async fn start_dogstatsd(
     port: u16,
     dd_api_key: Option<String>,
     dd_site: String,
+    dd_http_proxy: Option<String>,
+    dd_https_proxy: Option<String>,
 ) -> (CancellationToken, Option<Flusher>) {
     let metrics_aggr = Arc::new(Mutex::new(
         MetricsAggregator::new(Vec::new(), CONTEXTS).expect("Failed to create metrics aggregator"),
@@ -130,6 +141,8 @@ async fn start_dogstatsd(
                 dd_api_key,
                 Arc::clone(&metrics_aggr),
                 build_fqdn_metrics(dd_site),
+                dd_http_proxy,
+                dd_https_proxy,
             );
             Some(metrics_flusher)
         }


### PR DESCRIPTION
# What does this PR do?
We had implemented this in the [Lambda Extension](https://github.com/DataDog/datadog-lambda-extension/pull/381/files/ef7ec6cdeac9fc8b066de42be4498175d567fbfb), but it didn't land in time.

# Motivation
Customer is asking for it and we'll need it for anyone using a VPC without privatelink.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
