### PR TITLE
[Serverless Mini Agent] Bump datadog-serverless-trace-mini-agent version to 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-serverless-trace-mini-agent"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "datadog-trace-mini-agent",
  "datadog-trace-protobuf",

--- a/serverless/Cargo.toml
+++ b/serverless/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datadog-serverless-trace-mini-agent"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
# What does this PR do?

Bumps Serverless Mini Agent Version to 0.7.1.

# Motivation

Upcoming release of version 0.7.1.

# Additional Notes

# How to test the change?

See https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/2977497119/Serverless+Mini+Agent#Testing