### PR TITLE
Remove Cargo.toml default-members since builder has no default feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,41 +36,6 @@ members = [
   "tinybytes",
 ]
 
-default-members = [
-  "alloc",
-  "crashtracker",
-  "crashtracker-ffi",
-  "profiling",
-  "profiling-ffi",
-  "profiling-replayer",
-  "ddcommon",
-  "ddcommon-ffi",
-  "ddtelemetry",
-  "ddtelemetry-ffi",
-  "dynamic-configuration",
-  "dogstatsd",
-  "tools",
-  "ipc",
-  "ipc/macros",
-  "remote-config",
-  "sidecar",
-  "sidecar/macros",
-  "sidecar-ffi",
-  "tools/cc_utils",
-  "tools/sidecar_mockgen",
-  "trace-normalization",
-  "trace-obfuscation",
-  "trace-utils",
-  "spawn_worker",
-  "tests/spawn_from_lib",
-  "serverless",
-  "bin_tests",
-  "data-pipeline",
-  "data-pipeline-ffi",
-  "ddsketch",
-  "tinybytes",
-]
-
 # https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2
 resolver = "2"
 


### PR DESCRIPTION
# What does this PR do?

Removes the `default-members` section of the `Cargo.toml` that was added to avoid the `builder` doing work, but now that `builder` doesn't have a default feature it probably doesn't add that much overhead.

# Motivation

It's easy to miss adding a new crate in both places and then the crate is not included in `workspace` level commands.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
