### PR TITLE
Implement deadlock watchdog for sidecar

### DIFF
--- a/sidecar/src/watchdog.rs
+++ b/sidecar/src/watchdog.rs
@@ -1,19 +1,19 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
+use futures::{
+    future::{BoxFuture, Shared},
+    FutureExt,
+};
 use std::{
     sync::{
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicU32, AtomicUsize, Ordering},
         Arc,
     },
     time::Duration,
 };
 
-use futures::{
-    future::{BoxFuture, Shared},
-    FutureExt,
-};
-
 use tokio::{select, sync::mpsc::Receiver};
+use tracing::error;
 
 pub struct Watchdog {
     interval: tokio::time::Interval,
@@ -36,7 +36,7 @@ impl WatchdogHandle {
 impl Watchdog {
     pub fn from_receiver(shutdown_receiver: Receiver<()>) -> Self {
         Watchdog {
-            interval: tokio::time::interval(Duration::from_secs(60)),
+            interval: tokio::time::interval(Duration::from_secs(5)),
             max_memory_usage_bytes: 1024 * 1024 * 1024, // 1 GB
             shutdown_receiver,
         }
@@ -46,12 +46,44 @@ impl Watchdog {
         let mem_usage_bytes = Arc::new(AtomicUsize::new(0));
         let handle_mem_usage_bytes = mem_usage_bytes.clone();
 
+        let still_alive = Arc::new(AtomicU32::new(0));
+        let still_alive_thread = still_alive.clone();
+
+        let interval = self.interval.period();
+        std::thread::spawn(move || {
+            let mut repeats = false;
+            let mut last = 0;
+            loop {
+                std::thread::sleep(interval);
+                let current = still_alive_thread.load(Ordering::Relaxed);
+                if last != current {
+                    if current == u32::MAX {
+                        return;
+                    }
+                    last = current;
+                    repeats = false;
+                } else {
+                    if repeats {
+                        std::thread::spawn(move || {
+                            error!("Watchdog timeout: Sidecar stuck for at least {} seconds. Sending SIGABRT, possibly dumping core.", interval.as_secs());
+                        });
+                        // wait 1 seconds to give log a chance to flush - then kill the process
+                        std::thread::sleep(Duration::from_secs(1));
+                        unsafe { libc::abort() };
+                    }
+                    repeats = true;
+                }
+            }
+        });
+
         let join_handle = tokio::spawn(async move {
             mem_usage_bytes.store(0, Ordering::Relaxed);
 
             loop {
                 select! {
                     _ = self.interval.tick() => {
+                        still_alive.fetch_add(1, Ordering::Relaxed);
+
                         let current_mem_usage_bytes = memory_stats::memory_stats()
                         .map(|s| s.physical_mem)
                         .unwrap_or(0);
@@ -69,6 +101,7 @@ impl Watchdog {
 
                     },
                     _ = self.shutdown_receiver.recv() => {
+                        still_alive.store(u32::MAX, Ordering::Relaxed);
                         return
                     },
                 }


### PR DESCRIPTION
If the sidecar hangs, it can cause every process trying to write to it to be much slower.

Better kill it once in doubt.