### PR TITLE
[APMSP-1391] Wait for spawned children

### DIFF
--- a/builder/build/arch/linux.rs
+++ b/builder/build/arch/linux.rs
@@ -58,10 +58,12 @@ pub fn strip_libraries(lib_path: &str) {
 }
 
 pub fn fix_soname(lib_path: &str) {
-    Command::new("patchelf")
+    let mut patch_soname = Command::new("patchelf")
         .arg("--set-soname")
         .arg(PROF_DYNAMIC_LIB)
         .arg(lib_path.to_owned() + "/" + PROF_DYNAMIC_LIB)
         .spawn()
-        .expect("failed to change the soname");
+        .expect("failed to span patchelf");
+
+    patch_soname.wait().expect("failed to change the soname");
 }

--- a/builder/build/arch/musl.rs
+++ b/builder/build/arch/musl.rs
@@ -58,10 +58,12 @@ pub fn strip_libraries(lib_path: &str) {
 }
 
 pub fn fix_soname(lib_path: &str) {
-    Command::new("patchelf")
+    let mut patch_soname = Command::new("patchelf")
         .arg("--set-soname")
         .arg(PROF_DYNAMIC_LIB)
         .arg(lib_path)
         .spawn()
-        .expect("failed to change the soname");
+        .expect("failed to spawn patchelf");
+
+    patch_soname.wait().expect("failed to change the soname");
 }


### PR DESCRIPTION
# What does this PR do?

Actively waiting for spawned children in the builder in order to avoid concurrency problems.

# Motivation

Letting child process on their own could lead to issues if the parent process finish before them or another subsequent command is added that operates on the same resources. 