### PR TITLE
[Crashtracking] Add PDB info to crash info

### DIFF
--- a/crashtracker-ffi/src/crash_info/datatypes.rs
+++ b/crashtracker-ffi/src/crash_info/datatypes.rs
@@ -69,12 +69,14 @@ pub enum NormalizedAddressTypes {
     // Make None 0 so that default construction gives none
     None = 0,
     Elf,
+    Pdb,
 }
 
 #[repr(C)]
 pub struct NormalizedAddress<'a> {
     file_offset: u64,
     build_id: ByteSlice<'a>,
+    age: u64,
     path: CharSlice<'a>,
     typ: NormalizedAddressTypes,
 }
@@ -111,15 +113,28 @@ impl<'a> TryFrom<&NormalizedAddress<'a>> for datadog_crashtracker::NormalizedAdd
     type Error = anyhow::Error;
 
     fn try_from(value: &NormalizedAddress<'a>) -> Result<Self, Self::Error> {
+        let to_opt_bytes = |v: ByteSlice| {
+            if v.is_empty() {
+                None
+            } else {
+                Some(Vec::from(v.as_bytes()))
+            }
+        };
         match &value.typ {
             NormalizedAddressTypes::Elf => {
-                let build_id = if value.build_id.is_empty() {
-                    None
-                } else {
-                    Some(Vec::from(value.build_id.as_bytes()))
-                };
+                let build_id = to_opt_bytes(value.build_id);
                 let path = value.path.try_to_utf8()?.into();
                 let meta = datadog_crashtracker::NormalizedAddressMeta::Elf { build_id, path };
+                Ok(Self {
+                    file_offset: value.file_offset,
+                    meta,
+                })
+            }
+            NormalizedAddressTypes::Pdb => {
+                let guid = to_opt_bytes(value.build_id);
+                let path = value.path.try_to_utf8()?.into();
+                let age = value.age;
+                let meta = datadog_crashtracker::NormalizedAddressMeta::Pdb { path, guid, age };
                 Ok(Self {
                     file_offset: value.file_offset,
                     meta,

--- a/crashtracker/src/crash_info/stacktrace.rs
+++ b/crashtracker/src/crash_info/stacktrace.rs
@@ -50,6 +50,11 @@ pub enum NormalizedAddressMeta {
         path: PathBuf,
         build_id: Option<Vec<u8>>,
     },
+    Pdb {
+        path: PathBuf,
+        guid: Option<Vec<u8>>,
+        age: u64,
+    },
     Unknown,
     Unexpected(String),
 }


### PR DESCRIPTION
# What does this PR do?

Add Pdb enum to the `Normalized` data structure.

# Motivation

Crashtracker will be soon available on Windows. In order to provide useful information for remote symbolication, we add Pdb enum + needed information (guid and age). We reuse the `build_id` field for the guid.

# How to test the change?

Same as crashtracking on linux + manual tests.

