### PR TITLE
Support for remote config in the appsec helper

### DIFF
--- a/ipc/src/platform/unix/mem_handle.rs
+++ b/ipc/src/platform/unix/mem_handle.rs
@@ -10,7 +10,7 @@ use nix::fcntl::OFlag;
 use nix::sys::mman::{mmap, munmap, shm_open, shm_unlink, MapFlags, ProtFlags};
 use nix::sys::stat::Mode;
 use nix::unistd::ftruncate;
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 use std::fs::File;
 use std::io;
 use std::num::NonZeroUsize;
@@ -92,8 +92,8 @@ impl NamedShmHandle {
         Self::new(fd, Some(path), size)
     }
 
-    pub fn open(path: &CString) -> io::Result<NamedShmHandle> {
-        let fd = shm_open(path.as_bytes(), OFlag::O_RDWR, Mode::empty())?;
+    pub fn open(path: &CStr) -> io::Result<NamedShmHandle> {
+        let fd = shm_open(path, OFlag::O_RDWR, Mode::empty())?;
         let file: File = unsafe { OwnedFd::from_raw_fd(fd) }.into();
         let size = file.metadata()?.size() as usize;
         Self::new(file.into_raw_fd(), None, size)

--- a/ipc/src/platform/unix/mem_handle_macos.rs
+++ b/ipc/src/platform/unix/mem_handle_macos.rs
@@ -10,7 +10,7 @@ use nix::fcntl::OFlag;
 use nix::sys::mman::{mmap, munmap, shm_open, shm_unlink, MapFlags, ProtFlags};
 use nix::sys::stat::Mode;
 use nix::unistd::ftruncate;
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 use std::io;
 use std::num::NonZeroUsize;
 use std::os::unix::prelude::{AsRawFd, FromRawFd, RawFd};
@@ -87,9 +87,9 @@ impl ShmHandle {
         })
     }
 }
-fn path_slice(path: &CString) -> &[u8] {
-    assert_eq!(path.as_bytes()[0], b'/');
-    &path.as_bytes()[1..]
+fn path_slice(path: &CStr) -> &[u8] {
+    assert_eq!(path.to_bytes()[0], b'/');
+    &path.to_bytes()[1..]
 }
 
 impl NamedShmHandle {
@@ -109,7 +109,7 @@ impl NamedShmHandle {
         Self::new(fd, Some(path), size)
     }
 
-    pub fn open(path: &CString) -> io::Result<NamedShmHandle> {
+    pub fn open(path: &CStr) -> io::Result<NamedShmHandle> {
         let fd = shm_open(path_slice(path), OFlag::O_RDWR, Mode::empty())?;
         Self::new(fd, None, 0)
     }

--- a/ipc/src/platform/windows/mem_handle.rs
+++ b/ipc/src/platform/windows/mem_handle.rs
@@ -4,7 +4,7 @@
 use crate::platform::{
     FileBackedHandle, MappedMem, MemoryHandle, NamedShmHandle, PlatformHandle, ShmHandle, ShmPath,
 };
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 use std::io::Error;
 use std::mem::MaybeUninit;
 use std::os::windows::io::{AsRawHandle, FromRawHandle, RawHandle};
@@ -109,13 +109,13 @@ impl ShmHandle {
 }
 
 impl NamedShmHandle {
-    fn format_name(path: &CString) -> CString {
+    fn format_name(path: &CStr) -> CString {
         // Global\ namespace is reserved for Session ID 0.
         // We cannot rely on our PHP process having permissions to have access to Session 0.
         // This requires us to have one sidecar per Session ID. That's good enough though.
         CString::new(format!(
             "Local\\{}",
-            String::from_utf8_lossy(&path.as_bytes()[1..])
+            String::from_utf8_lossy(&path.to_bytes()[1..])
         ))
         .unwrap() // strip leading slash
     }
@@ -129,14 +129,14 @@ impl NamedShmHandle {
         )
     }
 
-    pub fn open(path: &CString) -> io::Result<NamedShmHandle> {
+    pub fn open(path: &CStr) -> io::Result<NamedShmHandle> {
         let name = Self::format_name(path);
         let handle = unsafe { OpenFileMappingA(FILE_MAP_WRITE, 0, name.as_ptr() as LPCSTR) };
         if handle.is_null() {
             return Err(Error::last_os_error());
         }
         // We need to map the handle to query its size, hence starting out with NOT_COMMITTED
-        Self::new(handle as RawHandle, path.clone(), NOT_COMMITTED)
+        Self::new(handle as RawHandle, path.to_owned(), NOT_COMMITTED)
     }
 
     fn new(handle: RawHandle, name: CString, size: usize) -> io::Result<NamedShmHandle> {

--- a/remote-config/src/fetch/fetcher.rs
+++ b/remote-config/src/fetch/fetcher.rs
@@ -51,7 +51,7 @@ pub trait FileStorage {
 }
 
 /// Fundamental configuration of the RC client, which always must be set.
-#[derive(Clone, Hash, Eq, PartialEq)]
+#[derive(Clone, Hash, Eq, PartialEq, Debug)]
 pub struct ConfigInvariants {
     pub language: String,
     pub tracer_version: String,

--- a/remote-config/src/parse.rs
+++ b/remote-config/src/parse.rs
@@ -9,6 +9,7 @@ use datadog_live_debugger::LiveDebuggingData;
 pub enum RemoteConfigData {
     DynamicConfig(DynamicConfigFile),
     LiveDebugger(LiveDebuggingData),
+    Ignored(RemoteConfigProduct),
 }
 
 impl RemoteConfigData {
@@ -24,6 +25,7 @@ impl RemoteConfigData {
                 let parsed = datadog_live_debugger::parse_json(&String::from_utf8_lossy(data))?;
                 RemoteConfigData::LiveDebugger(parsed)
             }
+            _ => RemoteConfigData::Ignored(product),
         })
     }
 }
@@ -33,6 +35,7 @@ impl From<&RemoteConfigData> for RemoteConfigProduct {
         match value {
             RemoteConfigData::DynamicConfig(_) => RemoteConfigProduct::ApmTracing,
             RemoteConfigData::LiveDebugger(_) => RemoteConfigProduct::LiveDebugger,
+            RemoteConfigData::Ignored(product) => *product,
         }
     }
 }

--- a/remote-config/src/path.rs
+++ b/remote-config/src/path.rs
@@ -17,6 +17,10 @@ pub enum RemoteConfigSource {
 #[derive(Debug, Copy, Clone, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub enum RemoteConfigProduct {
     ApmTracing,
+    AsmData,
+    Asm,
+    AsmDD,
+    AsmFeatures,
     LiveDebugger,
 }
 
@@ -25,6 +29,10 @@ impl Display for RemoteConfigProduct {
         let str = match self {
             RemoteConfigProduct::ApmTracing => "APM_TRACING",
             RemoteConfigProduct::LiveDebugger => "LIVE_DEBUGGING",
+            RemoteConfigProduct::Asm => "ASM",
+            RemoteConfigProduct::AsmDD => "ASM_DD",
+            RemoteConfigProduct::AsmData => "ASM_DATA",
+            RemoteConfigProduct::AsmFeatures => "ASM_FEATURES",
         };
         write!(f, "{}", str)
     }
@@ -68,6 +76,10 @@ impl RemoteConfigPath {
             product: match parts[parts.len() - 3] {
                 "APM_TRACING" => RemoteConfigProduct::ApmTracing,
                 "LIVE_DEBUGGING" => RemoteConfigProduct::LiveDebugger,
+                "ASM" => RemoteConfigProduct::Asm,
+                "ASM_DD" => RemoteConfigProduct::AsmDD,
+                "ASM_DATA" => RemoteConfigProduct::AsmData,
+                "ASM_FEATURES" => RemoteConfigProduct::AsmFeatures,
                 product => anyhow::bail!("Unknown product {}", product),
             },
             config_id: parts[parts.len() - 2],

--- a/sidecar-ffi/src/lib.rs
+++ b/sidecar-ffi/src/lib.rs
@@ -18,7 +18,7 @@ use datadog_sidecar::service::{
     blocking::{self, SidecarTransport},
     InstanceId, QueueId, RuntimeMetadata, SerializedTracerHeaderTags, SessionConfig, SidecarAction,
 };
-use datadog_sidecar::shm_remote_config::RemoteConfigReader;
+use datadog_sidecar::shm_remote_config::{path_for_remote_config, RemoteConfigReader};
 use ddcommon::tag::Tag;
 use ddcommon::Endpoint;
 use ddcommon_ffi as ffi;
@@ -31,7 +31,7 @@ use ddtelemetry_ffi::try_c;
 use dogstatsd_client::DogStatsDActionOwned;
 use ffi::slice::AsBytes;
 use libc::c_char;
-use std::ffi::c_void;
+use std::ffi::{c_void, CStr, CString};
 use std::fs::File;
 #[cfg(unix)]
 use std::os::unix::prelude::FromRawFd;
@@ -228,6 +228,29 @@ pub unsafe extern "C" fn ddog_remote_config_reader_for_endpoint<'a>(
             app_version: app_version.to_utf8_lossy().into(),
         }),
     ))
+}
+
+/// # Safety
+/// Argument should point to a valid C string.
+#[no_mangle]
+pub unsafe extern "C" fn ddog_remote_config_reader_for_path(
+    path: *const c_char,
+) -> Box<RemoteConfigReader> {
+    Box::new(RemoteConfigReader::from_path(CStr::from_ptr(path)))
+}
+
+#[no_mangle]
+extern "C" fn ddog_remote_config_path(
+    id: *const ConfigInvariants,
+    target: *const Arc<Target>,
+) -> *mut c_char {
+    let id = unsafe { &*id };
+    let target = unsafe { &*target };
+    path_for_remote_config(id, target).into_raw()
+}
+#[no_mangle]
+unsafe extern "C" fn ddog_remote_config_path_free(path: *mut c_char) {
+    drop(CString::from_raw(path));
 }
 
 #[no_mangle]

--- a/sidecar/src/one_way_shared_memory.rs
+++ b/sidecar/src/one_way_shared_memory.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use datadog_ipc::platform::{FileBackedHandle, MappedMem, NamedShmHandle, ShmHandle};
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 use std::io;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Mutex;
@@ -101,7 +101,7 @@ where
     }
 }
 
-pub fn open_named_shm(path: &CString) -> io::Result<MappedMem<NamedShmHandle>> {
+pub fn open_named_shm(path: &CStr) -> io::Result<MappedMem<NamedShmHandle>> {
     NamedShmHandle::open(path)?.map()
 }
 


### PR DESCRIPTION
Adds some ASM constants, some functions to work with RC shared memory paths (rather than only ConfigInvariants and Targets, which are more difficult to pass around), and an in-memory notification mechanism.

In support of https://github.com/DataDog/dd-trace-php/pull/2864