### PR TITLE
[Serverless Mini Agent] Add Zipping of Serverless Binaries with Proper Github Permissions

### DIFF
--- a/.github/workflows/publish-serverless-agent.yml
+++ b/.github/workflows/publish-serverless-agent.yml
@@ -45,6 +45,8 @@ jobs:
     name: Zip and Release
     needs: [build-windows, build-linux-musl]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -59,8 +61,12 @@ jobs:
             chmod +x "$file"
             upx "$file" --lzma
           done
-      - name: Upload binaries
-        uses: actions/upload-artifact@v4
+      - name: Zip binaries
+        run: zip -r datadog-serverless-agent.zip ./*
+        working-directory: target/release/binaries
+      - name: Release
+        uses: softprops/action-gh-release@v1
         with:
-          name: datadog-serverless-agent
-          path: target/release/binaries/*/*
+          draft: true
+          generate_release_notes: true
+          files: target/release/binaries/datadog-serverless-agent.zip


### PR DESCRIPTION
# What does this PR do?

Zip Serverless binaries and create a Github release with the proper permissions.

# Motivation

Revert changes made in the below PR to only upload the binaries to Github. By adding the proper Github job permissions we can create a Github release and automatically attach the binaries to the release.

https://github.com/DataDog/libdatadog/pull/634

# Additional Notes

# How to test the change?

Pushed a test tag and confirmed that the generated binaries in the zip file worked successfully.
