### PR TITLE
test: ignore dogstatsd tests under miri

### DIFF
--- a/dogstatsd/src/aggregator.rs
+++ b/dogstatsd/src/aggregator.rs
@@ -124,13 +124,12 @@ impl Aggregator {
             .unwrap_or_default();
         let mut sketch_payload = SketchPayload::new();
 
-        self.map
+        sketch_payload.sketches = self.map
             .iter()
             .filter_map(|entry| match entry.value {
                 MetricValue::Distribution(_) => build_sketch(now, entry, &self.tags),
                 _ => None,
-            })
-            .for_each(|sketch| sketch_payload.sketches.push(sketch));
+            }).collect();
         sketch_payload
     }
 
@@ -345,6 +344,7 @@ pub mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn insertion() {
         let mut aggregator = Aggregator::new(EMPTY_TAGS, 2).unwrap();
 
@@ -359,6 +359,7 @@ pub mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn distribution_insertion() {
         let mut aggregator = Aggregator::new(EMPTY_TAGS, 2).unwrap();
 
@@ -373,6 +374,7 @@ pub mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn overflow() {
         let mut aggregator = Aggregator::new(EMPTY_TAGS, 2).unwrap();
 
@@ -402,6 +404,7 @@ pub mod tests {
 
     #[test]
     #[allow(clippy::float_cmp)]
+    #[cfg_attr(miri, ignore)]
     fn clear() {
         let mut aggregator = Aggregator::new(EMPTY_TAGS, 2).unwrap();
 
@@ -433,6 +436,7 @@ pub mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn to_series() {
         let mut aggregator = Aggregator::new(EMPTY_TAGS, 2).unwrap();
 
@@ -454,6 +458,7 @@ pub mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn distributions_to_protobuf() {
         let mut aggregator = Aggregator::new(EMPTY_TAGS, 2).unwrap();
 
@@ -471,6 +476,7 @@ pub mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn consume_distributions_ignore_single_metrics() {
         let mut aggregator = Aggregator::new(EMPTY_TAGS, 1_000).unwrap();
         assert_eq!(aggregator.distributions_to_protobuf().sketches.len(), 0);
@@ -487,6 +493,7 @@ pub mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn consume_distributions_batch_entries() {
         let max_batch = 5;
         let tot = 12;
@@ -511,6 +518,7 @@ pub mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn consume_distributions_batch_bytes() {
         let expected_distribution_per_batch = 2;
         let total_number_of_distributions = 5;
@@ -555,6 +563,7 @@ pub mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn consume_distribution_one_element_bigger_than_max_size() {
         let max_bytes = 1;
         let tot = 5;
@@ -589,6 +598,7 @@ pub mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn consume_series_ignore_distribution() {
         let mut aggregator = Aggregator::new(EMPTY_TAGS, 1_000).unwrap();
 
@@ -613,6 +623,7 @@ pub mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn consume_series_batch_entries() {
         let max_batch = 5;
         let tot = 13;
@@ -638,6 +649,7 @@ pub mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn consume_metrics_batch_bytes() {
         let expected_metrics_per_batch = 2;
         let total_number_of_metrics = 5;
@@ -675,6 +687,7 @@ pub mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn consume_series_one_element_bigger_than_max_size() {
         let max_bytes = 1;
         let tot = 5;
@@ -701,6 +714,7 @@ pub mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn distribution_serialized_deserialized() {
         let mut aggregator = Aggregator::new(EMPTY_TAGS, 1_000).unwrap();
 

--- a/dogstatsd/src/aggregator.rs
+++ b/dogstatsd/src/aggregator.rs
@@ -124,12 +124,14 @@ impl Aggregator {
             .unwrap_or_default();
         let mut sketch_payload = SketchPayload::new();
 
-        sketch_payload.sketches = self.map
+        sketch_payload.sketches = self
+            .map
             .iter()
             .filter_map(|entry| match entry.value {
                 MetricValue::Distribution(_) => build_sketch(now, entry, &self.tags),
                 _ => None,
-            }).collect();
+            })
+            .collect();
         sketch_payload
     }
 

--- a/dogstatsd/src/dogstatsd.rs
+++ b/dogstatsd/src/dogstatsd.rs
@@ -116,6 +116,7 @@ mod tests {
     use std::sync::{Arc, Mutex};
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn test_dogstatsd_multi_distribution() {
         let locked_aggregator = setup_dogstatsd(
             "single_machine_performance.rouster.api.series_v2.payload_size_bytes:269942|d
@@ -150,6 +151,7 @@ single_machine_performance.rouster.metrics_max_timestamp_latency:1376.90870216|d
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn test_dogstatsd_multi_metric() {
         let locked_aggregator = setup_dogstatsd(
             "metric3:3|c|#tag3:val3,tag4:val4\nmetric1:1|c\nmetric2:2|c|#tag2:val2\n",
@@ -169,6 +171,7 @@ single_machine_performance.rouster.metrics_max_timestamp_latency:1376.90870216|d
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn test_dogstatsd_single_metric() {
         let locked_aggregator = setup_dogstatsd("metric123:99123|c").await;
         let aggregator = locked_aggregator.lock().expect("lock poisoned");

--- a/dogstatsd/src/metric.rs
+++ b/dogstatsd/src/metric.rs
@@ -258,6 +258,7 @@ mod tests {
         // For any valid name, tags et al the parse routine is able to parse an
         // encoded metric line.
         #[test]
+        #[cfg_attr(miri, ignore)]
         fn parse_valid_inputs(
             name in metric_name(),
             values in metric_values(),
@@ -319,6 +320,7 @@ mod tests {
         }
 
         #[test]
+        #[cfg_attr(miri, ignore)]
         fn parse_missing_name_and_value(
             mtype in metric_type(),
             tagset in metric_tagset()
@@ -334,6 +336,7 @@ mod tests {
         }
 
         #[test]
+        #[cfg_attr(miri, ignore)]
         fn parse_invalid_name_and_value_format(
             name in metric_name(),
             values in metric_values(),
@@ -357,6 +360,7 @@ mod tests {
         }
 
         #[test]
+        #[cfg_attr(miri, ignore)]
         fn parse_unsupported_metric_type(
             name in metric_name(),
             values in metric_values(),
@@ -381,6 +385,7 @@ mod tests {
         // For any valid name, tags et al the parse routine is able to parse an
         // encoded metric line.
         #[test]
+        #[cfg_attr(miri, ignore)]
         fn id_consistent(name in metric_name(),
                          mut tags in metric_tags()) {
             let mut tagset1 = String::new();
@@ -412,6 +417,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn parse_too_many_tags() {
         // 33
         assert_eq!(parse("foo:1|g|#a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3").unwrap_err(),
@@ -428,6 +434,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn invalid_dogstatsd_no_panic() {
         assert!(parse("somerandomstring|c+a;slda").is_err());
     }


### PR DESCRIPTION
# What does this PR do?
Disables miri for dogstatsd.
Also uses `collect` instead of `for_each` + `push` which Levi thinks could avoid `memcpy`s.

# Motivation

dogstatsd tests were really slow under miri in CI, like 20,000 times slower (higher than normal for miri).

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
