### PR TITLE
[PROF-10656] Add faulting_address to crashtracker reports

### DIFF
--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -105,6 +105,7 @@ fn test_crash_tracking_bin(
         serde_json::json!({
           "signum": 11,
           "signame": "SIGSEGV",
+          "crash_address": "0x0000000000000000",
         }),
         crash_payload["siginfo"]
     );
@@ -146,7 +147,8 @@ fn assert_telemetry_message(crash_telemetry: &[u8]) {
             "profiler_collecting_sample:1",
             "profiler_inactive:0",
             "profiler_serializing:0",
-            "signame:SIGSEGV"
+            "signame:SIGSEGV",
+            "crash_address:0x0000000000000000",
         ]),
         tags
     );

--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -104,7 +104,7 @@ fn test_crash_tracking_bin(
     assert_eq!(
         serde_json::json!({
           "signum": 11,
-          "signame": "SIGSEGV"
+          "signame": "SIGSEGV",
         }),
         crash_payload["siginfo"]
     );

--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -105,7 +105,7 @@ fn test_crash_tracking_bin(
         serde_json::json!({
           "signum": 11,
           "signame": "SIGSEGV",
-          "crash_address": 0,
+          "faulting_address": 0,
         }),
         crash_payload["siginfo"]
     );
@@ -148,7 +148,7 @@ fn assert_telemetry_message(crash_telemetry: &[u8]) {
             "profiler_inactive:0",
             "profiler_serializing:0",
             "signame:SIGSEGV",
-            "crash_address:0x0000000000000000",
+            "faulting_address:0x0000000000000000",
         ]),
         tags
     );

--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -105,7 +105,7 @@ fn test_crash_tracking_bin(
         serde_json::json!({
           "signum": 11,
           "signame": "SIGSEGV",
-          "crash_address": "0x0000000000000000",
+          "crash_address": 0,
         }),
         crash_payload["siginfo"]
     );

--- a/crashtracker-ffi/src/crash_info/datatypes.rs
+++ b/crashtracker-ffi/src/crash_info/datatypes.rs
@@ -237,11 +237,11 @@ impl<'a> TryFrom<SigInfo<'a>> for datadog_crashtracker::SigInfo {
     fn try_from(value: SigInfo<'a>) -> Result<Self, Self::Error> {
         let signum = value.signum;
         let signame = option_from_char_slice(value.signame)?;
-        let crash_address = None; // TODO: Expose this to FFI
+        let faulting_address = None; // TODO: Expose this to FFI
         Ok(Self {
             signum,
             signame,
-            crash_address,
+            faulting_address,
         })
     }
 }

--- a/crashtracker-ffi/src/crash_info/datatypes.rs
+++ b/crashtracker-ffi/src/crash_info/datatypes.rs
@@ -229,7 +229,6 @@ impl<'a> TryFrom<&StackFrame<'a>> for datadog_crashtracker::StackFrame {
 pub struct SigInfo<'a> {
     pub signum: u64,
     pub signame: CharSlice<'a>,
-    pub crash_address: CharSlice<'a>,
 }
 
 impl<'a> TryFrom<SigInfo<'a>> for datadog_crashtracker::SigInfo {
@@ -238,7 +237,7 @@ impl<'a> TryFrom<SigInfo<'a>> for datadog_crashtracker::SigInfo {
     fn try_from(value: SigInfo<'a>) -> Result<Self, Self::Error> {
         let signum = value.signum;
         let signame = option_from_char_slice(value.signame)?;
-        let crash_address = option_from_char_slice(value.crash_address)?;
+        let crash_address = None; // TODO: Expose this to FFI
         Ok(Self {
             signum,
             signame,

--- a/crashtracker-ffi/src/crash_info/datatypes.rs
+++ b/crashtracker-ffi/src/crash_info/datatypes.rs
@@ -229,6 +229,7 @@ impl<'a> TryFrom<&StackFrame<'a>> for datadog_crashtracker::StackFrame {
 pub struct SigInfo<'a> {
     pub signum: u64,
     pub signame: CharSlice<'a>,
+    pub crash_address: CharSlice<'a>,
 }
 
 impl<'a> TryFrom<SigInfo<'a>> for datadog_crashtracker::SigInfo {
@@ -237,7 +238,12 @@ impl<'a> TryFrom<SigInfo<'a>> for datadog_crashtracker::SigInfo {
     fn try_from(value: SigInfo<'a>) -> Result<Self, Self::Error> {
         let signum = value.signum;
         let signame = option_from_char_slice(value.signame)?;
-        Ok(Self { signum, signame })
+        let crash_address = option_from_char_slice(value.crash_address)?;
+        Ok(Self {
+            signum,
+            signame,
+            crash_address,
+        })
     }
 }
 

--- a/crashtracker/src/collector/crash_handler.rs
+++ b/crashtracker/src/collector/crash_handler.rs
@@ -255,14 +255,14 @@ extern "C" fn handle_posix_sigaction(signum: i32, sig_info: *mut siginfo_t, ucon
     // Handle the signal.  Note this has a guard to ensure that we only generate
     // one crash report per process.
 
-    let crash_address: Option<usize> =
+    let faulting_address: Option<usize> =
         if !sig_info.is_null() && (signum == libc::SIGSEGV || signum == libc::SIGBUS) {
             unsafe { Some((*sig_info).si_addr() as usize) }
         } else {
             None
         };
 
-    let _ = handle_posix_signal_impl(signum, crash_address);
+    let _ = handle_posix_signal_impl(signum, faulting_address);
 
     // Once we've handled the signal, chain to any previous handlers.
     // SAFETY: This was created by [register_crash_handlers].  There is a tiny
@@ -311,7 +311,7 @@ extern "C" fn handle_posix_sigaction(signum: i32, sig_info: *mut siginfo_t, ucon
     };
 }
 
-fn handle_posix_signal_impl(signum: i32, crash_address: Option<usize>) -> anyhow::Result<()> {
+fn handle_posix_signal_impl(signum: i32, faulting_address: Option<usize>) -> anyhow::Result<()> {
     static NUM_TIMES_CALLED: AtomicU64 = AtomicU64::new(0);
     if NUM_TIMES_CALLED.fetch_add(1, SeqCst) > 0 {
         // In the case where some lower-level signal handler recovered the error
@@ -344,7 +344,7 @@ fn handle_posix_signal_impl(signum: i32, crash_address: Option<usize>) -> anyhow
                 config_str,
                 metadata_string,
                 signum,
-                crash_address,
+                faulting_address,
             );
             let _ = pipe.flush();
             if config.wait_for_receiver {
@@ -377,7 +377,7 @@ fn handle_posix_signal_impl(signum: i32, crash_address: Option<usize>) -> anyhow
                 config_str,
                 metadata_string,
                 signum,
-                crash_address,
+                faulting_address,
             );
             let _ = unix_stream.flush();
             unix_stream

--- a/crashtracker/src/collector/emitters.rs
+++ b/crashtracker/src/collector/emitters.rs
@@ -178,16 +178,13 @@ fn emit_siginfo(
     };
 
     writeln!(w, "{DD_CRASHTRACK_BEGIN_SIGINFO}")?;
-    match faulting_address {
-        Some(addr) => {
-            writeln!(
-                w,
-                "{{\"signum\": {signum}, \"signame\": \"{signame}\", \"faulting_address\": {addr}}}"
-            )?;
-        }
-        None => {
-            writeln!(w, "{{\"signum\": {signum}, \"signame\": \"{signame}\"}}")?;
-        }
+    if let Some(addr) = faulting_address {
+        writeln!(
+            w,
+            "{{\"signum\": {signum}, \"signame\": \"{signame}\", \"faulting_address\": {addr}}}"
+        )?;
+    } else {
+        writeln!(w, "{{\"signum\": {signum}, \"signame\": \"{signame}\"}}")?;
     };
     writeln!(w, "{DD_CRASHTRACK_END_SIGINFO}")?;
     Ok(())

--- a/crashtracker/src/collector/emitters.rs
+++ b/crashtracker/src/collector/emitters.rs
@@ -177,16 +177,18 @@ fn emit_siginfo(
         "UNKNOWN"
     };
 
-    let crash_address_str = match crash_address {
-        Some(addr) => format!("{:#018x}", addr), // // Fixed width with 0x prefix
-        None => "None".to_string(),
-    };
-
     writeln!(w, "{DD_CRASHTRACK_BEGIN_SIGINFO}")?;
-    writeln!(
-        w,
-        "{{\"signum\": {signum}, \"signame\": \"{signame}\", \"crash_address\": \"{crash_address_str}\"}}"
-    )?;
+    match crash_address {
+        Some(addr) => {
+            writeln!(
+                w,
+                "{{\"signum\": {signum}, \"signame\": \"{signame}\", \"crash_address\": {addr}}}"
+            )?;
+        }
+        None => {
+            writeln!(w, "{{\"signum\": {signum}, \"signame\": \"{signame}\"}}")?;
+        }
+    };
     writeln!(w, "{DD_CRASHTRACK_END_SIGINFO}")?;
     Ok(())
 }

--- a/crashtracker/src/collector/emitters.rs
+++ b/crashtracker/src/collector/emitters.rs
@@ -101,11 +101,11 @@ pub(crate) fn emit_crashreport(
     config_str: &str,
     metadata_string: &str,
     signum: i32,
-    crash_address: Option<usize>,
+    faulting_address: Option<usize>,
 ) -> anyhow::Result<()> {
     emit_metadata(pipe, metadata_string)?;
     emit_config(pipe, config_str)?;
-    emit_siginfo(pipe, signum, crash_address)?;
+    emit_siginfo(pipe, signum, faulting_address)?;
     emit_procinfo(pipe)?;
     pipe.flush()?;
     emit_counters(pipe)?;
@@ -167,7 +167,7 @@ fn emit_proc_self_maps(w: &mut impl Write) -> anyhow::Result<()> {
 fn emit_siginfo(
     w: &mut impl Write,
     signum: i32,
-    crash_address: Option<usize>,
+    faulting_address: Option<usize>,
 ) -> anyhow::Result<()> {
     let signame = if signum == libc::SIGSEGV {
         "SIGSEGV"
@@ -178,11 +178,11 @@ fn emit_siginfo(
     };
 
     writeln!(w, "{DD_CRASHTRACK_BEGIN_SIGINFO}")?;
-    match crash_address {
+    match faulting_address {
         Some(addr) => {
             writeln!(
                 w,
-                "{{\"signum\": {signum}, \"signame\": \"{signame}\", \"crash_address\": {addr}}}"
+                "{{\"signum\": {signum}, \"signame\": \"{signame}\", \"faulting_address\": {addr}}}"
             )?;
         }
         None => {

--- a/crashtracker/src/crash_info/mod.rs
+++ b/crashtracker/src/crash_info/mod.rs
@@ -25,7 +25,7 @@ pub struct SigInfo {
     pub signame: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    pub crash_address: Option<usize>,
+    pub faulting_address: Option<usize>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crashtracker/src/crash_info/mod.rs
+++ b/crashtracker/src/crash_info/mod.rs
@@ -25,7 +25,7 @@ pub struct SigInfo {
     pub signame: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
-    pub crash_address: Option<String>,
+    pub crash_address: Option<usize>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crashtracker/src/crash_info/mod.rs
+++ b/crashtracker/src/crash_info/mod.rs
@@ -23,6 +23,9 @@ pub struct SigInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub signame: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub crash_address: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crashtracker/src/crash_info/telemetry.rs
+++ b/crashtracker/src/crash_info/telemetry.rs
@@ -191,8 +191,8 @@ fn extract_crash_info_tags(crash_info: &CrashInfo) -> anyhow::Result<String> {
         if let Some(signame) = &siginfo.signame {
             write!(&mut tags, ",signame:{}", signame)?;
         }
-        if let Some(crash_address) = &siginfo.crash_address {
-            write!(&mut tags, ",crash_address:{:#018x}", crash_address)?;
+        if let Some(faulting_address) = &siginfo.faulting_address {
+            write!(&mut tags, ",faulting_address:{:#018x}", faulting_address)?;
         }
     }
     for (counter, value) in &crash_info.counters {
@@ -279,7 +279,7 @@ mod tests {
             siginfo: Some(SigInfo {
                 signum: 11,
                 signame: Some("SIGSEGV".to_owned()),
-                crash_address: Some(0x1234),
+                faulting_address: Some(0x1234),
             }),
             proc_info: None,
             stacktrace: vec![],
@@ -313,7 +313,7 @@ mod tests {
                 "signame:SIGSEGV",
                 "collecting_sample:1",
                 "not_profiling:0",
-                "crash_address:0x0000000000001234",
+                "faulting_address:0x0000000000001234",
             ]),
             tags
         );

--- a/crashtracker/src/crash_info/telemetry.rs
+++ b/crashtracker/src/crash_info/telemetry.rs
@@ -191,6 +191,9 @@ fn extract_crash_info_tags(crash_info: &CrashInfo) -> anyhow::Result<String> {
         if let Some(signame) = &siginfo.signame {
             write!(&mut tags, ",signame:{}", signame)?;
         }
+        if let Some(crash_address) = &siginfo.crash_address {
+            write!(&mut tags, ",crash_address:{}", crash_address)?;
+        }
     }
     for (counter, value) in &crash_info.counters {
         write!(&mut tags, ",{}:{}", counter, value)?;
@@ -276,6 +279,7 @@ mod tests {
             siginfo: Some(SigInfo {
                 signum: 11,
                 signame: Some("SIGSEGV".to_owned()),
+                crash_address: Some("0x0000000000001234".to_owned()),
             }),
             proc_info: None,
             stacktrace: vec![],

--- a/crashtracker/src/crash_info/telemetry.rs
+++ b/crashtracker/src/crash_info/telemetry.rs
@@ -312,7 +312,8 @@ mod tests {
                 "signum:11",
                 "signame:SIGSEGV",
                 "collecting_sample:1",
-                "not_profiling:0"
+                "not_profiling:0",
+                "crash_address:0x0000000000001234",
             ]),
             tags
         );

--- a/crashtracker/src/crash_info/telemetry.rs
+++ b/crashtracker/src/crash_info/telemetry.rs
@@ -192,7 +192,7 @@ fn extract_crash_info_tags(crash_info: &CrashInfo) -> anyhow::Result<String> {
             write!(&mut tags, ",signame:{}", signame)?;
         }
         if let Some(crash_address) = &siginfo.crash_address {
-            write!(&mut tags, ",crash_address:{}", crash_address)?;
+            write!(&mut tags, ",crash_address:{:#018x}", crash_address)?;
         }
     }
     for (counter, value) in &crash_info.counters {
@@ -279,7 +279,7 @@ mod tests {
             siginfo: Some(SigInfo {
                 signum: 11,
                 signame: Some("SIGSEGV".to_owned()),
-                crash_address: Some("0x0000000000001234".to_owned()),
+                crash_address: Some(0x1234),
             }),
             proc_info: None,
             stacktrace: vec![],


### PR DESCRIPTION
# What does this PR do?

While investigating a customer crash, I found that I dearly missed having the address that caused a segfault.

E.g. given this code:

```c
  char *potato = 0x1234;
  fprintf(stderr, "Value of potato is %c\n", *potato);
```

...I want to know that the crash was triggered when 0x1234 was dereferenced, as this information may be key in debugging the issue.

We already get this information in our signal handler, so this PR just adds the needed piping to report it to datadog.

# Motivation:

Improve debugging of crashes reported by crashtracker.

# Additional Notes:

I added the `faulting_address` as a tag, similar to `siginfo` and `signame`. We may want to send it as some other thing; no strong opinions there.

# How to test the change?

I was able to test this with the Ruby profiler. I've been trying to update the tests but there's still some failing and I'm kinda struggling with that. Hopefully someone with a bit more rust-fu than me can help out there.

Here's a submitted crash report with a `crashing_address` tag (renamed since this test): https://app.datadoghq.com/dashboard/uwt-n4k-y9a?fromUser=true&refresh_mode=sliding&tpl_var_org_id%5B0%5D=197728&tpl_var_runtime%5B0%5D=ruby&from_ts=1727956296556&to_ts=1727959896556&live=true
