### PR TITLE
Fix the trace payload size hint

### DIFF
--- a/sidecar/src/service/sidecar_server.rs
+++ b/sidecar/src/service/sidecar_server.rs
@@ -265,17 +265,17 @@ impl SidecarServer {
             }
         };
 
-        let size = data.len();
-
-        match tracer_payload::TracerPayloadParams::new(
+        let mut size = 0;
+        let mut processor = tracer_payload::DefaultTraceChunkProcessor;
+        let mut payload_params = tracer_payload::TracerPayloadParams::new(
             data,
             &headers,
-            &mut tracer_payload::DefaultTraceChunkProcessor,
+            &mut processor,
             target.api_key.is_some(),
             TraceEncoding::V04,
-        )
-        .try_into()
-        {
+        );
+        payload_params.measure_size(&mut size);
+        match payload_params.try_into() {
             Ok(payload) => {
                 let data = SendData::new(size, payload, headers, target, None);
                 self.trace_flusher.enqueue(data);

--- a/trace-utils/src/msgpack_decoder/v04/decoder/mod.rs
+++ b/trace-utils/src/msgpack_decoder/v04/decoder/mod.rs
@@ -47,49 +47,56 @@ use tinybytes::{Bytes, BytesString};
 /// };
 /// let encoded_data = to_vec_named(&vec![vec![span]]).unwrap();
 /// let encoded_data_as_tinybytes = tinybytes::Bytes::from(encoded_data);
-/// let decoded_traces = from_slice(encoded_data_as_tinybytes).expect("Decoding failed");
+/// let (decoded_traces, _) = from_slice(encoded_data_as_tinybytes).expect("Decoding failed");
 ///
 /// assert_eq!(1, decoded_traces.len());
 /// assert_eq!(1, decoded_traces[0].len());
 /// let decoded_span = &decoded_traces[0][0];
 /// assert_eq!("test-span", decoded_span.name.as_str());
 /// ```
-pub fn from_slice(mut data: tinybytes::Bytes) -> Result<Vec<Vec<Span>>, DecodeError> {
+pub fn from_slice(mut data: tinybytes::Bytes) -> Result<(Vec<Vec<Span>>, usize), DecodeError> {
     let trace_count =
         rmp::decode::read_array_len(unsafe { data.as_mut_slice() }).map_err(|_| {
             DecodeError::InvalidFormat("Unable to read array len for trace count".to_owned())
         })?;
 
-    (0..trace_count).try_fold(
-        Vec::with_capacity(
-            trace_count
-                .try_into()
-                .expect("Unable to cast trace_count to usize"),
-        ),
-        |mut traces, _| {
-            let span_count =
-                rmp::decode::read_array_len(unsafe { data.as_mut_slice() }).map_err(|_| {
-                    DecodeError::InvalidFormat("Unable to read array len for span count".to_owned())
-                })?;
+    let start_len = data.len();
 
-            let trace = (0..span_count).try_fold(
-                Vec::with_capacity(
-                    span_count
-                        .try_into()
-                        .expect("Unable to cast span_count to usize"),
-                ),
-                |mut trace, _| {
-                    let span = decode_span(&mut data)?;
-                    trace.push(span);
-                    Ok(trace)
-                },
-            )?;
+    Ok((
+        (0..trace_count).try_fold(
+            Vec::with_capacity(
+                trace_count
+                    .try_into()
+                    .expect("Unable to cast trace_count to usize"),
+            ),
+            |mut traces, _| {
+                let span_count = rmp::decode::read_array_len(unsafe { data.as_mut_slice() })
+                    .map_err(|_| {
+                        DecodeError::InvalidFormat(
+                            "Unable to read array len for span count".to_owned(),
+                        )
+                    })?;
 
-            traces.push(trace);
+                let trace = (0..span_count).try_fold(
+                    Vec::with_capacity(
+                        span_count
+                            .try_into()
+                            .expect("Unable to cast span_count to usize"),
+                    ),
+                    |mut trace, _| {
+                        let span = decode_span(&mut data)?;
+                        trace.push(span);
+                        Ok(trace)
+                    },
+                )?;
 
-            Ok(traces)
-        },
-    )
+                traces.push(trace);
+
+                Ok(traces)
+            },
+        )?,
+        start_len - data.len(),
+    ))
 }
 
 #[inline]
@@ -270,7 +277,7 @@ mod tests {
             ..Default::default()
         };
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
-        let decoded_traces =
+        let (decoded_traces, _) =
             from_slice(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
 
         assert_eq!(1, decoded_traces.len());
@@ -290,7 +297,7 @@ mod tests {
         span["meta_struct"] = json!(expected_meta_struct.clone());
 
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
-        let decoded_traces =
+        let (decoded_traces, _) =
             from_slice(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
 
         assert_eq!(1, decoded_traces.len());
@@ -314,7 +321,7 @@ mod tests {
         span["meta_struct"] = json!(expected_meta_struct.clone());
 
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
-        let decoded_traces =
+        let (decoded_traces, _) =
             from_slice(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
 
         assert_eq!(1, decoded_traces.len());
@@ -340,7 +347,7 @@ mod tests {
         span["meta"] = json!(expected_meta.clone());
 
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
-        let decoded_traces =
+        let (decoded_traces, _) =
             from_slice(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
 
         assert_eq!(1, decoded_traces.len());
@@ -370,7 +377,7 @@ mod tests {
         span["meta"] = json!(expected_meta.clone());
 
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
-        let decoded_traces =
+        let (decoded_traces, _) =
             from_slice(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
 
         assert_eq!(1, decoded_traces.len());
@@ -392,7 +399,7 @@ mod tests {
         let mut span = create_test_json_span(1, 2, 0, 0);
         span["metrics"] = json!(expected_metrics.clone());
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
-        let decoded_traces =
+        let (decoded_traces, _) =
             from_slice(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
 
         assert_eq!(1, decoded_traces.len());
@@ -416,7 +423,7 @@ mod tests {
         let mut span = create_test_json_span(1, 2, 0, 0);
         span["metrics"] = json!(expected_metrics.clone());
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
-        let decoded_traces =
+        let (decoded_traces, _) =
             from_slice(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
 
         assert_eq!(1, decoded_traces.len());
@@ -449,7 +456,7 @@ mod tests {
         span["span_links"] = json!([expected_span_link]);
 
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
-        let decoded_traces =
+        let (decoded_traces, _) =
             from_slice(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
 
         assert_eq!(1, decoded_traces.len());


### PR DESCRIPTION
The incoming buffer may be much larger than the actual contained data. The decoder knows where the payload starts and ends, but the sidecar send_trace_v04 method does not.

This ensures proper trace coalescing, leading to less individual http requests.