### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
- "gimli 0.28.1",
+ "gimli 0.31.1",
 ]
 
 [[package]]
@@ -18,15 +18,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "ahash"
-version = "0.7.8"
+name = "adler2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
@@ -390,17 +385,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,17 +464,17 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.71"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
- "object 0.32.2",
+ "miniz_oxide 0.8.0",
+ "object 0.36.5",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -612,7 +596,7 @@ dependencies = [
  "cpp_demangle",
  "gimli 0.30.0",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.7.2",
  "rustc-demangle",
 ]
 
@@ -623,7 +607,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f09c03df5c33f265a7ae6de11a81c9ebb69c4ca632afa45e9fcf7a96c1d8cca0"
 dependencies = [
  "blazesym",
- "memoffset 0.9.1",
+ "memoffset",
 ]
 
 [[package]]
@@ -764,7 +748,7 @@ dependencies = [
  "pin-project-lite",
  "rustls 0.22.4",
  "rustls-native-certs 0.7.0",
- "rustls-pemfile 2.1.2",
+ "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_derive",
@@ -773,7 +757,7 @@ dependencies = [
  "serde_urlencoded",
  "thiserror",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util",
  "tower-service",
  "url",
  "winapi 0.3.9",
@@ -882,21 +866,21 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbindgen"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da6bc11b07529f16944307272d5bd9b22530bc7d05751717c9d416586cedab49"
+checksum = "3fce8dd7fcfcbf3a0a87d8f515194b49d6135acab73e18bd380d1d93bb1a15eb"
 dependencies = [
- "clap 3.2.25",
+ "clap",
  "heck 0.4.1",
- "indexmap 1.9.3",
+ "indexmap 2.2.6",
  "log",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "syn 1.0.109",
+ "syn 2.0.70",
  "tempfile",
- "toml 0.5.11",
+ "toml",
 ]
 
 [[package]]
@@ -993,21 +977,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
-dependencies = [
- "atty",
- "bitflags 1.3.2",
- "clap_lex 0.2.4",
- "indexmap 1.9.3",
- "strsim",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
-name = "clap"
 version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
@@ -1024,7 +993,7 @@ checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.6.0",
+ "clap_lex",
  "strsim",
 ]
 
@@ -1038,15 +1007,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.70",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -1189,7 +1149,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap 4.4.18",
+ "clap",
  "criterion-plot",
  "csv",
  "is-terminal",
@@ -1385,7 +1345,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util",
  "uuid",
 ]
 
@@ -1480,7 +1440,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "memfd",
- "nix 0.26.4",
+ "nix 0.27.1",
  "page_size",
  "pin-project",
  "pretty_assertions",
@@ -1492,7 +1452,7 @@ dependencies = [
  "tinybytes",
  "tokio",
  "tokio-serde",
- "tokio-util 0.6.10",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "winapi 0.3.9",
@@ -1540,7 +1500,7 @@ dependencies = [
  "percent-encoding",
  "serde_json",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util",
  "uuid",
 ]
 
@@ -1578,7 +1538,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1600,7 +1560,7 @@ dependencies = [
  "symbolic-common",
  "symbolic-demangle",
  "symbolizer-ffi",
- "tokio-util 0.7.11",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1608,7 +1568,7 @@ name = "datadog-profiling-replayer"
 version = "13.1.0"
 dependencies = [
  "anyhow",
- "clap 4.4.18",
+ "clap",
  "datadog-profiling",
  "prost 0.12.4",
  "sysinfo",
@@ -1632,7 +1592,7 @@ name = "datadog-remote-config"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "base64 0.21.7",
+ "base64 0.22.1",
  "datadog-dynamic-configuration",
  "datadog-live-debugger",
  "datadog-trace-protobuf",
@@ -1648,7 +1608,7 @@ dependencies = [
  "sha2",
  "time",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util",
  "tracing",
  "uuid",
 ]
@@ -1664,7 +1624,7 @@ dependencies = [
  "env_logger",
  "log",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util",
 ]
 
 [[package]]
@@ -1673,7 +1633,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "arrayref",
- "base64 0.21.7",
+ "base64 0.22.1",
  "bincode",
  "bytes",
  "cadence",
@@ -1693,7 +1653,7 @@ dependencies = [
  "ddtelemetry",
  "dogstatsd-client",
  "futures",
- "hashbrown 0.12.3",
+ "hashbrown 0.14.3",
  "http 0.2.12",
  "httpmock",
  "hyper 0.14.28",
@@ -1703,7 +1663,7 @@ dependencies = [
  "manual_future",
  "memory-stats",
  "microseh",
- "nix 0.26.4",
+ "nix 0.27.1",
  "pin-project",
  "prctl",
  "priority-queue",
@@ -1721,13 +1681,13 @@ dependencies = [
  "tempfile",
  "tinybytes",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util",
  "tracing",
  "tracing-log",
  "tracing-subscriber",
  "uuid",
  "winapi 0.3.9",
- "windows 0.51.1",
+ "windows",
  "windows-sys 0.52.0",
  "zwohash",
 ]
@@ -1879,7 +1839,7 @@ dependencies = [
  "pin-project",
  "regex",
  "rustls 0.23.9",
- "rustls-native-certs 0.6.3",
+ "rustls-native-certs 0.7.0",
  "serde",
  "static_assertions",
  "tokio",
@@ -1921,7 +1881,7 @@ dependencies = [
  "datadog-ddsketch",
  "ddcommon",
  "futures",
- "hashbrown 0.12.3",
+ "hashbrown 0.14.3",
  "http 0.2.12",
  "hyper 0.14.28",
  "io-lifetimes",
@@ -1932,7 +1892,7 @@ dependencies = [
  "serde_json",
  "sys-info",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -2067,7 +2027,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util",
  "tracing",
  "ustr",
 ]
@@ -2278,7 +2238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.7.2",
 ]
 
 [[package]]
@@ -2476,12 +2436,6 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
-
-[[package]]
-name = "gimli"
 version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e1d97fbe9722ba9bbd0c97051c2956e726562b61f86a25a4360398a40edfc9"
@@ -2490,6 +2444,12 @@ dependencies = [
  "indexmap 2.2.6",
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glibc_version"
@@ -2533,7 +2493,7 @@ dependencies = [
  "indexmap 2.2.6",
  "slab",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util",
  "tracing",
 ]
 
@@ -2552,7 +2512,7 @@ dependencies = [
  "indexmap 2.2.6",
  "slab",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util",
  "tracing",
 ]
 
@@ -2581,9 +2541,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash 0.7.8",
-]
 
 [[package]]
 name = "hashbrown"
@@ -2591,7 +2548,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "allocator-api2",
 ]
 
@@ -2643,15 +2600,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -3052,7 +3000,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -3069,7 +3017,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -3200,74 +3148,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
-name = "lexical-core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
-dependencies = [
- "lexical-parse-float",
- "lexical-parse-integer",
- "lexical-util",
- "lexical-write-float",
- "lexical-write-integer",
-]
-
-[[package]]
-name = "lexical-parse-float"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
-dependencies = [
- "lexical-parse-integer",
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-parse-integer"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
-dependencies = [
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-util"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
-dependencies = [
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-write-float"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862"
-dependencies = [
- "lexical-util",
- "lexical-write-integer",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-write-integer"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446"
-dependencies = [
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libloading"
@@ -3385,24 +3269,6 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -3461,6 +3327,15 @@ checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
  "simd-adler32",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+dependencies = [
+ "adler2",
 ]
 
 [[package]]
@@ -3526,31 +3401,6 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset 0.6.5",
-]
-
-[[package]]
-name = "nix"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset 0.7.1",
- "pin-utils",
-]
-
-[[package]]
-name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
@@ -3558,6 +3408,7 @@ dependencies = [
  "bitflags 2.5.0",
  "cfg-if",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -3642,7 +3493,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
@@ -3659,9 +3510,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
@@ -3763,12 +3614,6 @@ dependencies = [
  "serde",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "overload"
@@ -3972,7 +3817,7 @@ checksum = "645493cf344456ef24219d02a768cf1fb92ddf8c92161679ae3d91b91a637be3"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "pin-project-lite",
  "rustix 0.38.32",
  "tracing",
@@ -4054,12 +3899,13 @@ dependencies = [
 
 [[package]]
 name = "priority-queue"
-version = "1.4.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bda9164fe05bc9225752d54aae413343c36f684380005398a6a8fde95fe785"
+checksum = "714c75db297bc88a63783ffc6ab9f830698a6705aa0201416931759ef4c8183d"
 dependencies = [
  "autocfg",
- "indexmap 1.9.3",
+ "equivalent",
+ "indexmap 2.2.6",
 ]
 
 [[package]]
@@ -4539,7 +4385,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.22.4",
- "rustls-pemfile 2.1.2",
+ "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4629,9 +4475,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
@@ -4722,36 +4568,15 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile 1.0.4",
- "schannel",
- "security-framework",
-]
-
-[[package]]
-name = "rustls-native-certs"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.1.2",
+ "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -5092,13 +4917,12 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "simd-json"
-version = "0.13.9"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0b84c23a1066e1d650ebc99aa8fb9f8ed0ab96fd36e2e836173c92fc9fb29bc"
+checksum = "bfa5500f67df6466a45c6f83d1aada89fe0f7e9b17afec424ea06feee0906549"
 dependencies = [
  "getrandom",
  "halfbrown",
- "lexical-core",
  "ref-cast",
  "serde",
  "serde_json",
@@ -5169,11 +4993,11 @@ dependencies = [
  "io-lifetimes",
  "kernel32-sys",
  "memfd",
- "nix 0.24.3",
+ "nix 0.27.1",
  "rlimit",
  "tempfile",
  "winapi 0.2.8",
- "windows 0.48.0",
+ "windows",
 ]
 
 [[package]]
@@ -5390,7 +5214,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-serde",
- "tokio-util 0.7.11",
+ "tokio-util",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -5497,15 +5321,9 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.11",
+ "tokio-util",
  "url",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
@@ -5740,20 +5558,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
@@ -5766,15 +5570,6 @@ dependencies = [
  "pin-project-lite",
  "slab",
  "tokio",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -5906,7 +5701,7 @@ dependencies = [
  "rand",
  "slab",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6017,7 +5812,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "termcolor",
- "toml 0.8.12",
+ "toml",
 ]
 
 [[package]]
@@ -6108,7 +5903,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e904a2279a4a36d2356425bb20be271029cc650c335bc82af8bfae30085a3d0"
 dependencies = [
- "ahash 0.8.11",
+ "ahash",
  "byteorder",
  "lazy_static",
  "parking_lot",
@@ -6144,9 +5939,9 @@ checksum = "5a84c137d37ab0142f0f2ddfe332651fdbf252e7b7dbb4e67b6c1f1b2e925101"
 
 [[package]]
 name = "value-trait"
-version = "0.8.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad8db98c1e677797df21ba03fca7d3bf9bec3ca38db930954e4fe6e1ea27eb4"
+checksum = "bcaa56177466248ba59d693a048c0959ddb67f1151b963f904306312548cf392"
 dependencies = [
  "float-cmp",
  "halfbrown",
@@ -6349,15 +6144,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
-dependencies = [
- "windows-targets 0.48.5",
-]
 
 [[package]]
 name = "windows"

--- a/build-common/Cargo.toml
+++ b/build-common/Cargo.toml
@@ -13,7 +13,7 @@ default = []
 cbindgen = []
 
 [dependencies]
-cbindgen = {version = "0.26"}
+cbindgen = {version = "0.27"}
 serde = "1.0"
 serde_json = "1.0"
 

--- a/crashtracker/Cargo.toml
+++ b/crashtracker/Cargo.toml
@@ -29,7 +29,7 @@ blazesym = "0.2.0-rc.0"
 
 [dependencies]
 anyhow = "1.0"
-backtrace = "0.3.69"
+backtrace = "0.3.74"
 chrono = {version = "0.4", default-features = false, features = ["std", "clock", "serde"]}
 ddcommon = {path = "../ddcommon"}
 hyper = {version = "0.14", features = ["client"], default-features = false}

--- a/ddcommon/Cargo.toml
+++ b/ddcommon/Cargo.toml
@@ -31,7 +31,7 @@ log = { version = "0.4" }
 pin-project = "1"
 regex = "1.5"
 rustls = { version = "0.23", default-features = false }
-rustls-native-certs = { version = "0.6" }
+rustls-native-certs = { version = "0.7" }
 tokio = { version = "1.23", features = ["rt", "macros"] }
 tokio-rustls = { version = "0.26", default-features = false }
 serde = { version = "1.0", features = ["derive"] }

--- a/ddcommon/src/connector/mod.rs
+++ b/ddcommon/src/connector/mod.rs
@@ -114,8 +114,6 @@ fn load_root_certs() -> anyhow::Result<rustls::RootCertStore> {
     let mut roots = rustls::RootCertStore::empty();
 
     for cert in rustls_native_certs::load_native_certs()? {
-        let cert = CertificateDer::from(cert.0);
-
         //TODO: log when invalid cert is loaded
         roots.add(cert).ok();
     }

--- a/ddtelemetry/Cargo.toml
+++ b/ddtelemetry/Cargo.toml
@@ -34,7 +34,7 @@ tokio-util = { version = "0.7", features = ["codec"] }
 io-lifetimes = { version = "1.0" }
 tracing = { version = "0.1", default-features = false }
 uuid = { version = "1.3", features = ["v4"] }
-hashbrown = { version = "0.12", features = ["raw"] }
+hashbrown = { version = "0.14", features = ["raw"] }
 
 [dev-dependencies]
 tracing-subscriber = "0.3.18"

--- a/ipc/Cargo.toml
+++ b/ipc/Cargo.toml
@@ -15,7 +15,7 @@ pin-project = { version = "1" }
 memfd = { version = "0.6" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 tokio-serde = { version = "0.8", features = ["bincode"] }
-tokio-util = { version = "0.6.9", features = ["codec"] }
+tokio-util = { version = "0.7.11", features = ["codec"] }
 libc = { version = "0.2" }
 tinybytes = { path = "../tinybytes", optional = true }
 
@@ -42,7 +42,7 @@ tracing-subscriber = { version = "0.3.11" }
 spawn_worker = { path = "../spawn_worker" }
 
 [target.'cfg(not(windows))'.dependencies]
-nix = { version = "0.26.2", features = ["socket", "mman"] }
+nix = { version = "0.27.1", features = ["mman", "socket", "poll"] }
 sendfd = { version = "0.4", features = ["tokio"] }
 tokio = { version = "1.23", features = ["sync", "io-util", "signal"] }
 

--- a/ipc/src/platform/mem_handle.rs
+++ b/ipc/src/platform/mem_handle.rs
@@ -4,8 +4,6 @@
 use crate::handles::{HandlesTransport, TransferHandles};
 use crate::platform::{mmap_handle, munmap_handle, OwnedFileHandle, PlatformHandle};
 use serde::{Deserialize, Serialize};
-#[cfg(all(unix, not(target_os = "macos")))]
-use std::os::unix::prelude::AsRawFd;
 use std::{ffi::CString, io};
 #[cfg(feature = "tiny-bytes")]
 use tinybytes::UnderlyingBytes;
@@ -90,7 +88,7 @@ where
             self.set_mapping_size(size)?;
         }
         nix::unistd::ftruncate(
-            self.get_shm().handle.as_raw_fd(),
+            self.get_shm().handle.as_owned_fd()?,
             self.get_shm().size as libc::off_t,
         )?;
         Ok(())

--- a/ipc/src/platform/unix/channel.rs
+++ b/ipc/src/platform/unix/channel.rs
@@ -56,7 +56,7 @@ impl Channel {
     }
 
     pub fn probe_readable(&self) -> bool {
-        let raw_fd = self.inner.as_raw_fd();
+        let raw_fd = self.inner.as_owned_fd().unwrap();
         let mut fds = FdSet::new();
         fds.insert(raw_fd);
         nix::sys::select::select(None, Some(&mut fds), None, None, Some(&mut TimeVal::zero()))

--- a/ipc/src/platform/unix/mem_handle_macos.rs
+++ b/ipc/src/platform/unix/mem_handle_macos.rs
@@ -13,6 +13,7 @@ use nix::unistd::ftruncate;
 use std::ffi::{CStr, CString};
 use std::io;
 use std::num::NonZeroUsize;
+use std::os::fd::OwnedFd;
 use std::os::unix::prelude::{AsRawFd, FromRawFd, RawFd};
 use std::sync::atomic::{AtomicI32, AtomicUsize, Ordering};
 
@@ -21,7 +22,7 @@ const NOT_COMMITTED: usize = 1 << (usize::BITS - 1);
 
 pub(crate) fn mmap_handle<T: FileBackedHandle>(mut handle: T) -> io::Result<MappedMem<T>> {
     let shm = handle.get_shm_mut();
-    let fd: RawFd = shm.handle.as_raw_fd();
+    let fd = shm.handle.as_owned_fd()?;
     if shm.size & NOT_COMMITTED != 0 {
         shm.size &= !NOT_COMMITTED;
         let page_size = NonZeroUsize::try_from(page_size::get()).unwrap();
@@ -31,7 +32,7 @@ pub(crate) fn mmap_handle<T: FileBackedHandle>(mut handle: T) -> io::Result<Mapp
                 page_size,
                 ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
                 MapFlags::MAP_SHARED,
-                fd,
+                Some(fd),
                 (MAPPING_MAX_SIZE - usize::from(page_size)) as off_t,
             )?;
             if shm.size == 0 {
@@ -50,7 +51,7 @@ pub(crate) fn mmap_handle<T: FileBackedHandle>(mut handle: T) -> io::Result<Mapp
                 NonZeroUsize::new(shm.size).unwrap(),
                 ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
                 MapFlags::MAP_SHARED,
-                fd,
+                Some(fd),
                 0,
             )?
         },
@@ -78,11 +79,10 @@ impl ShmHandle {
             OFlag::O_CREAT | OFlag::O_RDWR,
             Mode::empty(),
         )?;
-        ftruncate(fd, MAPPING_MAX_SIZE as off_t)?;
+        ftruncate(&fd, MAPPING_MAX_SIZE as off_t)?;
         _ = shm_unlink(path.as_bytes());
-        let handle = unsafe { PlatformHandle::from_raw_fd(fd) };
         Ok(ShmHandle {
-            handle,
+            handle: fd.into(),
             size: size | NOT_COMMITTED,
         })
     }
@@ -99,7 +99,7 @@ impl NamedShmHandle {
 
     pub fn create_mode(path: CString, size: usize, mode: Mode) -> io::Result<NamedShmHandle> {
         let fd = shm_open(path_slice(&path), OFlag::O_CREAT | OFlag::O_RDWR, mode)?;
-        let truncate = ftruncate(fd, MAPPING_MAX_SIZE as off_t);
+        let truncate = ftruncate(&fd, MAPPING_MAX_SIZE as off_t);
         if let Err(error) = truncate {
             // ignore if already exists
             if error != Errno::EINVAL {
@@ -114,10 +114,10 @@ impl NamedShmHandle {
         Self::new(fd, None, 0)
     }
 
-    fn new(fd: RawFd, path: Option<CString>, size: usize) -> io::Result<NamedShmHandle> {
+    fn new(fd: OwnedFd, path: Option<CString>, size: usize) -> io::Result<NamedShmHandle> {
         Ok(NamedShmHandle {
             inner: ShmHandle {
-                handle: unsafe { PlatformHandle::from_raw_fd(fd) },
+                handle: fd.into(),
                 size: size | NOT_COMMITTED,
             },
             path: path.map(|path| ShmPath { name: path }),
@@ -149,7 +149,7 @@ impl<T: FileBackedHandle + From<MappedMem<T>>> MappedMem<T> {
                 page_size,
                 ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
                 MapFlags::MAP_SHARED,
-                handle.get_shm().handle.fd,
+                Some(handle.get_shm().handle.as_owned_fd().unwrap()),
                 (MAPPING_MAX_SIZE - usize::from(page_size)) as off_t,
             )
             .unwrap();

--- a/ipc/src/platform/unix/sockets.rs
+++ b/ipc/src/platform/unix/sockets.rs
@@ -14,7 +14,7 @@ mod linux {
         io,
         os::unix::{
             net::{UnixListener, UnixStream},
-            prelude::{AsRawFd, FromRawFd, OsStrExt},
+            prelude::{AsRawFd, OsStrExt},
         },
         path::Path,
     };
@@ -24,15 +24,13 @@ mod linux {
         bind, connect, listen, socket, AddressFamily, SockFlag, SockType, UnixAddr,
     };
 
-    fn socket_stream() -> io::Result<OwnedFd> {
-        let fd = socket(
+    fn socket_stream() -> nix::Result<OwnedFd> {
+        socket(
             AddressFamily::Unix,
             SockType::Stream,
             SockFlag::SOCK_CLOEXEC,
             None,
-        )?;
-
-        Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+        )
     }
 
     pub fn connect_abstract<P: AsRef<Path>>(path: P) -> io::Result<UnixStream> {
@@ -46,7 +44,7 @@ mod linux {
         let sock = socket_stream()?;
         let addr = UnixAddr::new_abstract(path.as_ref().as_os_str().as_bytes())?;
         bind(sock.as_raw_fd(), &addr)?;
-        listen(sock.as_raw_fd(), 128)?;
+        listen(&sock, 128)?;
         Ok(sock.into())
     }
 }

--- a/remote-config/Cargo.toml
+++ b/remote-config/Cargo.toml
@@ -15,7 +15,7 @@ datadog-trace-protobuf = { path = "../trace-protobuf" }
 datadog-live-debugger = { path = "../live-debugger" }
 hyper = { version = "0.14", features = ["client"], default-features = false }
 http = "0.2"
-base64 = "0.21.0"
+base64 = "0.22.1"
 sha2 = "0.10"
 uuid = { version = "1.7.0", features = ["v4"] }
 futures-util = "0.3"

--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -16,7 +16,7 @@ tokio-console = ["tokio/full", "tokio/tracing", "console-subscriber"]
 anyhow = { version = "1.0" }
 arrayref = "0.3.7"
 bytes = "1.4"
-priority-queue = "1.3.2"
+priority-queue = "2.1.1"
 ddcommon = { path = "../ddcommon" }
 datadog-sidecar-macros = { path = "macros" }
 
@@ -47,7 +47,7 @@ serde_with = "3.6.0"
 bincode = { version = "1.3.3" }
 serde_json = "1.0"
 rmp-serde = "1.1.1"
-base64 = "0.21.0"
+base64 = "0.22.1"
 spawn_worker = { path = "../spawn_worker" }
 zwohash = "0.1.2"
 sha2 = "0.10"
@@ -73,7 +73,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 chrono = "0.4.31"
 console-subscriber = { version = "0.1", optional = true }
 uuid = { version = "1.3", features = ["v4"] }
-hashbrown = { version = "0.12", features = ["raw"] }
+hashbrown = { version = "0.14", features = ["raw"] }
 libc = { version = "0.2" }
 
 # watchdog and self telemetry
@@ -90,10 +90,10 @@ features = [
 version = "0.51.0"
 
 [target.'cfg(not(target_arch = "x86"))'.dependencies]
-simd-json = "0.13.8"
+simd-json = "0.14.1"
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.26.2", features = ["socket", "mman"] }
+nix = { version = "0.27.1", features = ["socket", "mman"] }
 sendfd = { version = "0.4", features = ["tokio"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/spawn_worker/Cargo.toml
+++ b/spawn_worker/Cargo.toml
@@ -23,7 +23,7 @@ features = [
   "Win32_System_Diagnostics_Debug",
   "Win32_System_Kernel",
 ]
-version = "0.48"
+version = "0.51.1"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "=0.2.8" }
@@ -31,7 +31,7 @@ kernel32-sys = "0.2.2"
 
 [target.'cfg(not(windows))'.dependencies]
 memfd = { version = "0.6" }
-nix = { version = "0.24" }
+nix = { version = "0.27.1", features = ["dir", "process"] }
 tempfile = { version = "3.3" }
 
 [target.'cfg(windows)'.dev-dependencies]

--- a/spawn_worker/src/win32.rs
+++ b/spawn_worker/src/win32.rs
@@ -1,7 +1,6 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Context;
 use kernel32::{CreateFileA, WaitForSingleObject};
 use std::ffi::{c_void, OsStr, OsString};
 use std::fs::{File, OpenOptions};
@@ -108,7 +107,8 @@ impl From<&File> for Stdio {
                     0,
                     true,
                     DUPLICATE_SAME_ACCESS,
-                );
+                )
+                .unwrap();
                 ret.0 as RawHandle
             })
         })
@@ -308,7 +308,7 @@ impl SpawnWorker {
         inherited_handles.push(stderr);
 
         let mut size: usize = 0;
-        unsafe {
+        let _ = unsafe {
             InitializeProcThreadAttributeList(
                 LPPROC_THREAD_ATTRIBUTE_LIST(null_mut()),
                 1,
@@ -319,7 +319,7 @@ impl SpawnWorker {
         let mut attribute_list_vec: Vec<u8> = Vec::with_capacity(size);
         let attribute_list =
             LPPROC_THREAD_ATTRIBUTE_LIST(attribute_list_vec.as_mut_ptr() as *mut c_void);
-        unsafe { InitializeProcThreadAttributeList(attribute_list, 1, 0, &mut size) };
+        unsafe { InitializeProcThreadAttributeList(attribute_list, 1, 0, &mut size).unwrap() };
         unsafe {
             UpdateProcThreadAttribute(
                 attribute_list,
@@ -330,7 +330,8 @@ impl SpawnWorker {
                 None,
                 None,
             )
-        };
+        }
+        .unwrap();
 
         let mut pi = Self::zeroed_process_information();
         let mut si = STARTUPINFOEXW {
@@ -371,7 +372,7 @@ impl SpawnWorker {
         program.extend(path.as_os_str().encode_wide());
         program.push(0);
 
-        if unsafe {
+        unsafe {
             CreateProcessW(
                 PCWSTR(program.as_ptr()),
                 PWSTR(cmd.as_mut_ptr()),
@@ -389,14 +390,14 @@ impl SpawnWorker {
                 &mut pi,
             )
         }
-        .0 == 0
-        {
-            return Err(io::Error::last_os_error()).context(format!(
+        .map_err(|e| {
+            let e: anyhow::Error = e.into();
+            e.context(format!(
                 "Tried to spawn {} with args {}",
                 path.display(),
                 args.join(", ")
-            ));
-        }
+            ))
+        })?;
 
         unsafe {
             Ok(Child {
@@ -420,11 +421,8 @@ fn get_module_file_name(h: HMODULE) -> anyhow::Result<String> {
     loop {
         let read: usize = unsafe { GetModuleFileNameW(h, &mut buf) } as usize;
         if read == 0 {
-            return Err(unsafe { GetLastError() }
-                .ok()
-                .err()
-                .map(|e| e.into())
-                .unwrap_or_else(|| anyhow::anyhow!("unknown error getting module name")));
+            unsafe { GetLastError() }?;
+            anyhow::bail!("unknown error getting module name");
         }
 
         if read == buf.len() {
@@ -443,8 +441,7 @@ pub fn get_trampoline_target_data(f: *const u8) -> anyhow::Result<String> {
             GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
             PCSTR::from_raw(f),
             &mut h as *mut HMODULE,
-        )
-        .ok()?
+        )?
     };
 
     get_module_file_name(h)
@@ -460,12 +457,10 @@ impl Child {
         unsafe {
             let res = WaitForSingleObject(self.handle.as_raw_handle(), INFINITE);
             let mut status = 0;
-            if res != WAIT_OBJECT_0
-                || GetExitCodeProcess(HANDLE(self.handle.as_raw_handle() as isize), &mut status).0
-                    == 0
-            {
+            if res != WAIT_OBJECT_0 {
                 return Err(io::Error::last_os_error());
             }
+            GetExitCodeProcess(HANDLE(self.handle.as_raw_handle() as isize), &mut status)?;
             Ok(ExitStatus::from_raw(status))
         }
     }


### PR DESCRIPTION
Primarily reduces duplicate dependencies with different versions to reduce binary size slightly.

Fixes Datadog/dd-trace-php#2878.