### PR TITLE
Make coverage success optional in CI

### DIFF
--- a/.github/workflows/all-checks.yml
+++ b/.github/workflows/all-checks.yml
@@ -16,3 +16,4 @@ jobs:
                 delay: '3'
                 retries: '30'
                 polling_interval: '1'
+                checks_exclude: 'coverage'


### PR DESCRIPTION
# What does this PR do?

Allows merging of a PR even if Coverage fails

# Motivation

Strange behavior with code coverage and library paths in CI leads to failures that are not related to the PRs.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
