### PR TITLE
Allow sending tags via RC

### DIFF
--- a/ddcommon/src/tag.rs
+++ b/ddcommon/src/tag.rs
@@ -7,7 +7,7 @@ use std::fmt::{Debug, Display, Formatter};
 
 pub use static_assertions::{const_assert, const_assert_ne};
 
-#[derive(Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Tag {
     /// Many tags are made from literal strings, such as:

--- a/remote-config/examples/remote_config_fetch.rs
+++ b/remote-config/examples/remote_config_fetch.rs
@@ -6,6 +6,7 @@ use datadog_remote_config::file_change_tracker::{Change, FilePath};
 use datadog_remote_config::file_storage::ParsedFileStorage;
 use datadog_remote_config::RemoteConfigProduct::ApmTracing;
 use datadog_remote_config::{RemoteConfigData, Target};
+use ddcommon::tag::Tag;
 use ddcommon::Endpoint;
 use std::time::Duration;
 use tokio::time::sleep;
@@ -31,6 +32,7 @@ async fn main() {
             service: SERVICE.to_string(),
             env: ENV.to_string(),
             app_version: VERSION.to_string(),
+            tags: vec![Tag::new("test", "value").unwrap()],
         },
         RUNTIME_ID.to_string(),
         ConfigInvariants {

--- a/remote-config/src/fetch/fetcher.rs
+++ b/remote-config/src/fetch/fetcher.rs
@@ -238,6 +238,7 @@ impl<S: FileStorage> ConfigFetcher<S> {
             service,
             env,
             app_version,
+            tags,
         } = (*target).clone();
 
         let mut cached_target_files = vec![];
@@ -287,7 +288,7 @@ impl<S: FileStorage> ConfigFetcher<S> {
                     extra_services: vec![],
                     env,
                     app_version,
-                    tags: vec![],
+                    tags: tags.iter().map(|t| t.to_string()).collect(),
                 }),
                 is_agent: false,
                 client_agent: None,
@@ -546,6 +547,7 @@ pub mod tests {
             service: "service".to_string(),
             env: "env".to_string(),
             app_version: "1.3.5".to_string(),
+            tags: vec![],
         });
     }
 

--- a/remote-config/src/fetch/shared.rs
+++ b/remote-config/src/fetch/shared.rs
@@ -375,6 +375,7 @@ pub mod tests {
             service: "other".to_string(),
             env: "env".to_string(),
             app_version: "7.8.9".to_string(),
+            tags: vec![],
         });
     }
 

--- a/remote-config/src/lib.rs
+++ b/remote-config/src/lib.rs
@@ -8,6 +8,7 @@ mod parse;
 mod path;
 mod targets;
 
+use ddcommon::tag::Tag;
 pub use parse::*;
 pub use path::*;
 use serde::{Deserialize, Serialize};
@@ -17,6 +18,7 @@ pub struct Target {
     pub service: String,
     pub env: String,
     pub app_version: String,
+    pub tags: Vec<Tag>,
 }
 
 #[repr(C)]

--- a/sidecar-ffi/src/lib.rs
+++ b/sidecar-ffi/src/lib.rs
@@ -204,6 +204,7 @@ pub unsafe extern "C" fn ddog_remote_config_reader_for_endpoint<'a>(
     service_name: ffi::CharSlice,
     env_name: ffi::CharSlice,
     app_version: ffi::CharSlice,
+    tags: &ddcommon_ffi::Vec<Tag>,
     remote_config_products: *const RemoteConfigProduct,
     remote_config_products_count: usize,
     remote_config_capabilities: *const RemoteConfigCapabilities,
@@ -226,6 +227,7 @@ pub unsafe extern "C" fn ddog_remote_config_reader_for_endpoint<'a>(
             service: service_name.to_utf8_lossy().into(),
             env: env_name.to_utf8_lossy().into(),
             app_version: app_version.to_utf8_lossy().into(),
+            tags: tags.as_slice().to_vec(),
         }),
     ))
 }

--- a/sidecar/src/service/remote_configs.rs
+++ b/sidecar/src/service/remote_configs.rs
@@ -3,6 +3,7 @@
 
 use crate::shm_remote_config::{ShmRemoteConfigs, ShmRemoteConfigsGuard};
 use datadog_remote_config::fetch::{ConfigInvariants, MultiTargetStats, NotifyTarget};
+use ddcommon::tag::Tag;
 use std::collections::hash_map::Entry;
 use std::fmt::Debug;
 use std::sync::{Arc, Mutex};
@@ -104,6 +105,7 @@ impl RemoteConfigs {
         env: String,
         service: String,
         app_version: String,
+        tags: Vec<Tag>,
     ) -> RemoteConfigsGuard {
         match self.0.lock().unwrap().entry(invariants) {
             Entry::Occupied(e) => e.into_mut(),
@@ -119,7 +121,7 @@ impl RemoteConfigs {
                 ))
             }
         }
-        .add_runtime(runtime_id, notify_target, env, service, app_version)
+        .add_runtime(runtime_id, notify_target, env, service, app_version, tags)
     }
 
     pub fn shutdown(&self) {

--- a/sidecar/src/service/sidecar_server.rs
+++ b/sidecar/src/service/sidecar_server.rs
@@ -896,6 +896,7 @@ impl SidecarInterface for SidecarServer {
                 env_name.clone(),
                 service_name,
                 app_version.clone(),
+                global_tags.clone(),
             ),
         );
         app.set_metadata(env_name, app_version, global_tags);

--- a/sidecar/src/shm_remote_config.rs
+++ b/sidecar/src/shm_remote_config.rs
@@ -15,6 +15,7 @@ use datadog_remote_config::fetch::{
     MultiTargetStats, NotifyTarget, RefcountedFile,
 };
 use datadog_remote_config::{RemoteConfigPath, RemoteConfigProduct, RemoteConfigValue, Target};
+use ddcommon::tag::Tag;
 use priority_queue::PriorityQueue;
 use sha2::{Digest, Sha224};
 use std::cmp::Reverse;
@@ -329,11 +330,13 @@ impl<N: NotifyTarget + 'static> ShmRemoteConfigs<N> {
         env: String,
         service: String,
         app_version: String,
+        tags: Vec<Tag>,
     ) -> ShmRemoteConfigsGuard<N> {
         let target = Arc::new(Target {
             service,
             env,
             app_version,
+            tags,
         });
         self.0
             .add_runtime(runtime_id.clone(), notify_target, &target);
@@ -603,6 +606,7 @@ mod tests {
             service: "service".to_string(),
             env: "env".to_string(),
             app_version: "1.3.5".to_string(),
+            tags: vec![],
         });
     }
 
@@ -670,6 +674,7 @@ mod tests {
             DUMMY_TARGET.env.to_string(),
             DUMMY_TARGET.service.to_string(),
             DUMMY_TARGET.app_version.to_string(),
+            DUMMY_TARGET.tags.clone(),
         );
 
         receiver.recv().await;


### PR DESCRIPTION
As pointed out by DataDog/system-tests#3212, we need to send git metadata to the RC client.

This allows sending it.