### PR TITLE
[Serverless Mini Agent] Add Span Tags for Azure Spring Apps

### DIFF
--- a/trace-mini-agent/src/config.rs
+++ b/trace-mini-agent/src/config.rs
@@ -20,7 +20,7 @@ pub struct Config {
     pub dd_site: String,
     pub dd_dogstatsd_port: u16,
     pub env_type: trace_utils::EnvironmentType,
-    pub function_name: Option<String>,
+    pub app_name: Option<String>,
     pub max_request_content_length: usize,
     pub obfuscation_config: obfuscation_config::ObfuscationConfig,
     pub os: String,
@@ -40,7 +40,7 @@ impl Config {
             .map_err(|_| anyhow::anyhow!("DD_API_KEY environment variable is not set"))?
             .into();
 
-        let (function_name, env_type) = read_cloud_env().ok_or_else(|| {
+        let (app_name, env_type) = read_cloud_env().ok_or_else(|| {
             anyhow::anyhow!("Unable to identify environment. Shutting down Mini Agent.")
         })?;
 
@@ -69,7 +69,7 @@ impl Config {
         })?;
 
         Ok(Config {
-            function_name: Some(function_name),
+            app_name: Some(app_name),
             env_type,
             os: env::consts::OS.to_string(),
             max_request_content_length: 10 * 1024 * 1024, // 10MB in Bytes

--- a/trace-mini-agent/src/env_verifier.rs
+++ b/trace-mini-agent/src/env_verifier.rs
@@ -5,6 +5,7 @@ use async_trait::async_trait;
 use hyper::{Body, Client, Method, Request, Response};
 use log::{debug, error};
 use serde::{Deserialize, Serialize};
+use std::env;
 use std::fs;
 use std::path::Path;
 use std::process;
@@ -113,6 +114,9 @@ impl ServerlessEnvVerifier {
             }
         };
         trace_utils::MiniAgentMetadata {
+            azure_spring_app_hostname: trace_utils::MiniAgentMetadata::default()
+                .azure_spring_app_hostname,
+            azure_spring_app_name: trace_utils::MiniAgentMetadata::default().azure_spring_app_name,
             gcp_project_id: Some(gcp_metadata.project.project_id),
             gcp_region: Some(get_region_from_gcp_region_string(
                 gcp_metadata.instance.region,
@@ -140,9 +144,13 @@ impl EnvVerifier for ServerlessEnvVerifier {
                     .verify_gcp_environment_or_exit(verify_env_timeout)
                     .await;
             }
-            trace_utils::EnvironmentType::AzureSpringApp => {
-                trace_utils::MiniAgentMetadata::default()
-            }
+            trace_utils::EnvironmentType::AzureSpringApp => trace_utils::MiniAgentMetadata {
+                azure_spring_app_hostname: env::var("HOSTNAME").ok(),
+                azure_spring_app_name: env::var("ASCSVCRT_SPRING__APPLICATION__NAME").ok(),
+                gcp_project_id: trace_utils::MiniAgentMetadata::default().gcp_project_id,
+                gcp_region: trace_utils::MiniAgentMetadata::default().gcp_region,
+                version: trace_utils::MiniAgentMetadata::default().version,
+            },
             trace_utils::EnvironmentType::LambdaFunction => {
                 trace_utils::MiniAgentMetadata::default()
             }
@@ -468,6 +476,8 @@ mod tests {
         assert_eq!(
             res,
             trace_utils::MiniAgentMetadata {
+                azure_spring_app_hostname: Some("unknown".to_string()),
+                azure_spring_app_name: Some("unknown".to_string()),
                 gcp_project_id: Some("unknown".to_string()),
                 gcp_region: Some("unknown".to_string()),
                 version: None

--- a/trace-mini-agent/src/env_verifier.rs
+++ b/trace-mini-agent/src/env_verifier.rs
@@ -476,8 +476,8 @@ mod tests {
         assert_eq!(
             res,
             trace_utils::MiniAgentMetadata {
-                azure_spring_app_hostname: Some("unknown".to_string()),
-                azure_spring_app_name: Some("unknown".to_string()),
+                azure_spring_app_hostname: None,
+                azure_spring_app_name: None,
                 gcp_project_id: Some("unknown".to_string()),
                 gcp_region: Some("unknown".to_string()),
                 version: None

--- a/trace-mini-agent/src/trace_processor.rs
+++ b/trace-mini-agent/src/trace_processor.rs
@@ -41,12 +41,12 @@ impl TraceChunkProcessor for ChunkProcessor {
     fn process(&mut self, chunk: &mut pb::TraceChunk, root_span_index: usize) {
         trace_utils::set_serverless_root_span_tags(
             &mut chunk.spans[root_span_index],
-            self.config.function_name.clone(),
+            self.config.app_name.clone(),
             &self.config.env_type,
         );
         for span in chunk.spans.iter_mut() {
             trace_utils::enrich_span_with_mini_agent_metadata(span, &self.mini_agent_metadata);
-            trace_utils::enrich_span_with_azure_metadata(span);
+            trace_utils::enrich_span_with_azure_function_metadata(span);
             obfuscate_span(span, &self.config.obfuscation_config);
         }
     }
@@ -150,7 +150,7 @@ mod tests {
 
     fn create_test_config() -> Config {
         Config {
-            function_name: Some("dummy_function_name".to_string()),
+            app_name: Some("dummy_function_name".to_string()),
             max_request_content_length: 10 * 1024 * 1024,
             trace_flush_interval: 3,
             stats_flush_interval: 3,

--- a/trace-utils/src/trace_utils.rs
+++ b/trace-utils/src/trace_utils.rs
@@ -435,7 +435,7 @@ fn set_top_level_span(span: &mut pb::Span, is_top_level: bool) {
 
 pub fn set_serverless_root_span_tags(
     span: &mut pb::Span,
-    function_name: Option<String>,
+    app_name: Option<String>,
     env_type: &EnvironmentType,
 ) {
     span.r#type = "serverless".to_string();
@@ -450,8 +450,15 @@ pub fn set_serverless_root_span_tags(
     span.meta
         .insert("origin".to_string(), origin_tag.to_string());
 
-    if let Some(function_name) = function_name {
-        span.meta.insert("functionname".to_string(), function_name);
+    if let Some(function_name) = app_name {
+        match env_type {
+            EnvironmentType::CloudFunction
+            | EnvironmentType::AzureFunction
+            | EnvironmentType::LambdaFunction => {
+                span.meta.insert("functionname".to_string(), function_name);
+            }
+            _ => {}
+        }
     }
 }
 
@@ -471,6 +478,8 @@ pub enum EnvironmentType {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MiniAgentMetadata {
+    pub azure_spring_app_hostname: Option<String>,
+    pub azure_spring_app_name: Option<String>,
     pub gcp_project_id: Option<String>,
     pub gcp_region: Option<String>,
     pub version: Option<String>,
@@ -479,6 +488,8 @@ pub struct MiniAgentMetadata {
 impl Default for MiniAgentMetadata {
     fn default() -> Self {
         MiniAgentMetadata {
+            azure_spring_app_hostname: Default::default(),
+            azure_spring_app_name: Default::default(),
             gcp_project_id: Default::default(),
             gcp_region: Default::default(),
             version: env::var("DD_MINI_AGENT_VERSION").ok(),
@@ -490,6 +501,18 @@ pub fn enrich_span_with_mini_agent_metadata(
     span: &mut pb::Span,
     mini_agent_metadata: &MiniAgentMetadata,
 ) {
+    if let Some(azure_spring_app_hostname) = &mini_agent_metadata.azure_spring_app_hostname {
+        span.meta.insert(
+            "azurespringapp.hostname".to_string(),
+            azure_spring_app_hostname.to_string(),
+        );
+    }
+    if let Some(azure_spring_app_name) = &mini_agent_metadata.azure_spring_app_name {
+        span.meta.insert(
+            "azurespringapp.name".to_string(),
+            azure_spring_app_name.to_string(),
+        );
+    }
     if let Some(gcp_project_id) = &mini_agent_metadata.gcp_project_id {
         span.meta
             .insert("project_id".to_string(), gcp_project_id.to_string());
@@ -506,7 +529,7 @@ pub fn enrich_span_with_mini_agent_metadata(
     }
 }
 
-pub fn enrich_span_with_azure_metadata(span: &mut pb::Span) {
+pub fn enrich_span_with_azure_function_metadata(span: &mut pb::Span) {
     if let Some(aas_metadata) = azure_app_services::get_function_metadata() {
         let aas_tags = [
             ("aas.resource.id", aas_metadata.get_resource_id()),


### PR DESCRIPTION
# What does this PR do?

Adds `azurespringapp.name` and `azurespringapp.hostname` span tags to spans from Azure Spring apps.

# Motivation

Add span tags for Azure Spring apps to facilitate billing.

https://datadoghq.atlassian.net/browse/SVLS-5643

# Additional Notes

Remove `functionname` span tag for Azure Spring apps.

# How to test the change?

See https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/2977497119/Serverless+Mini+Agent#Testing
