### PR TITLE
feat: Prefer DD_PROXY_HTTPS over HTTPS_PROXY

### DIFF
--- a/dogstatsd/src/datadog.rs
+++ b/dogstatsd/src/datadog.rs
@@ -8,7 +8,7 @@ use protobuf::Message;
 use reqwest;
 use serde::{Serialize, Serializer};
 use serde_json;
-use tracing::debug;
+use tracing::{debug, error};
 
 /// Interface for the `DogStatsD` metrics intake API.
 #[derive(Debug)]
@@ -20,11 +20,18 @@ pub struct DdApi {
 
 impl DdApi {
     #[must_use]
-    pub fn new(api_key: String, site: String) -> Self {
+    pub fn new(api_key: String, site: String, https_proxy: Option<String>) -> Self {
+        let client = match Self::build_client(https_proxy) {
+            Ok(client) => client,
+            Err(e) => {
+                error!("Unable to parse proxy URL, no proxy will be use");
+                reqwest::Client::new()
+            }
+        };
         DdApi {
             api_key,
             fqdn_site: site,
-            client: reqwest::Client::new(),
+            client,
         }
     }
 
@@ -95,6 +102,14 @@ impl DdApi {
                 debug!("500: Failed to push to API: {:?}", e);
             }
         };
+    }
+
+    fn build_client(https_proxy: Option<String>) -> Result<reqwest::Client, reqwest::Error> {
+        let mut builder = reqwest::Client::builder();
+        if let Some(proxy) = https_proxy {
+            builder = builder.proxy(reqwest::Proxy::https(&proxy)?);
+        }
+        builder.build()
     }
 }
 

--- a/dogstatsd/src/datadog.rs
+++ b/dogstatsd/src/datadog.rs
@@ -24,7 +24,7 @@ impl DdApi {
         let client = match Self::build_client(https_proxy) {
             Ok(client) => client,
             Err(e) => {
-                error!("Unable to parse proxy URL, no proxy will be use");
+                error!("Unable to parse proxy URL, no proxy will be used. {:?}", e);
                 reqwest::Client::new()
             }
         };
@@ -107,7 +107,7 @@ impl DdApi {
     fn build_client(https_proxy: Option<String>) -> Result<reqwest::Client, reqwest::Error> {
         let mut builder = reqwest::Client::builder();
         if let Some(proxy) = https_proxy {
-            builder = builder.proxy(reqwest::Proxy::https(&proxy)?);
+            builder = builder.proxy(reqwest::Proxy::https(proxy)?);
         }
         builder.build()
     }

--- a/dogstatsd/src/flusher.rs
+++ b/dogstatsd/src/flusher.rs
@@ -18,8 +18,13 @@ pub fn build_fqdn_metrics(site: String) -> String {
 
 #[allow(clippy::await_holding_lock)]
 impl Flusher {
-    pub fn new(api_key: String, aggregator: Arc<Mutex<Aggregator>>, site: String) -> Self {
-        let dd_api = datadog::DdApi::new(api_key, site);
+    pub fn new(
+        api_key: String,
+        aggregator: Arc<Mutex<Aggregator>>,
+        site: String,
+        https_proxy: Option<String>,
+    ) -> Self {
+        let dd_api = datadog::DdApi::new(api_key, site, https_proxy);
         Flusher { dd_api, aggregator }
     }
 

--- a/dogstatsd/tests/integration_test.rs
+++ b/dogstatsd/tests/integration_test.rs
@@ -41,6 +41,7 @@ async fn dogstatsd_server_ships_series() {
         "mock-api-key".to_string(),
         Arc::clone(&metrics_aggr),
         mock_server.url(),
+        None,
     );
 
     let server_address = "127.0.0.1:18125";

--- a/trace-mini-agent/src/config.rs
+++ b/trace-mini-agent/src/config.rs
@@ -90,7 +90,9 @@ impl Config {
                 ..Default::default()
             },
             obfuscation_config,
-            proxy_url: env::var("HTTPS_PROXY").ok(),
+            proxy_url: env::var("DD_PROXY_HTTPS")
+                .or_else(|_| env::var("HTTPS_PROXY"))
+                .ok(),
         })
     }
 }


### PR DESCRIPTION
# What does this PR do?
In my earlier PR I made two mistakes:
1. With bleary newborn-parent eyes I didn't realize it was DD_PROXY_HTTPS, I had inverted it.
2. I had hoped that I could simply use the linux native HTTPS_PROXY env var, but our customer is correct and we'll need support for both.

These env vars are enforced _in priority order_ as per the [docs](https://docs.datadoghq.com/agent/configuration/proxy/?tab=linux):
1. DD_PROXY_HTTPS
2. HTTPS_PROXY
3. yaml config file (not used here)

This PR adds support for this for both dogstatsd and the trace mini agent.

I've verified both configs are still valid and work.
Traces:
<img width="1930" alt="traces" src="https://github.com/user-attachments/assets/27cb923f-f5e8-453c-90ae-008aabb82529">

Metrics:
<img width="1976" alt="metrics" src="https://github.com/user-attachments/assets/3f7d1750-c41d-4467-957a-94d3e905b966">

(and logs, but that's not part of libdatadog)

# Motivation
finishing what I started
