### PR TITLE
[PROF-10603] Package libdatadog v13.1.0 for Ruby

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -15,6 +15,13 @@ Otherwise, this is possibly not the droid you were looking for.
 Run `bundle exec rake` to run the tests and the style autofixer.
 You can also run `bundle exec pry` for an interactive prompt that will allow you to experiment.
 
+### Testing packaging locally
+
+You can use `bundle exec rake package` to generate packages locally without publishing them.
+
+TIP: If the test that checks for permissions ("gem release process ... sets the right permissions on the gem files"), you
+may need to run `umask 0022 && bundle exec rake package` so that the generated packages have the correct permissions.
+
 ## Releasing a new version to rubygems.org
 
 Note: No Ruby needed to run this! It all runs inside docker :)

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -11,7 +11,7 @@ require "rubygems/package"
 
 RSpec::Core::RakeTask.new(:spec)
 
-LIB_VERSION_TO_PACKAGE = "12.0.0"
+LIB_VERSION_TO_PACKAGE = "13.1.0"
 unless LIB_VERSION_TO_PACKAGE.start_with?(Libdatadog::LIB_VERSION)
   raise "`LIB_VERSION_TO_PACKAGE` setting in <Rakefile> (#{LIB_VERSION_TO_PACKAGE}) does not match " \
     "`LIB_VERSION` setting in <lib/libdatadog/version.rb> (#{Libdatadog::LIB_VERSION})"
@@ -20,22 +20,22 @@ end
 LIB_GITHUB_RELEASES = [
   {
     file: "libdatadog-aarch64-alpine-linux-musl.tar.gz",
-    sha256: "8e7b429fcd7476cd800c041d8196e908b3a85ce6817e852f18f57a200c89e22a",
+    sha256: "9cddbc9ece4c2fe9a1f0ab5a7cfed218d617c5154f318e0bce9a6102b265c989",
     ruby_platform: "aarch64-linux-musl"
   },
   {
     file: "libdatadog-aarch64-unknown-linux-gnu.tar.gz",
-    sha256: "a78da9ed45cb301dc9aa43e6ca16df789c9dd845417f0ac4feee895f4df63ad4",
+    sha256: "db17a5873d82ef772f969582949b272dcd04044a0cd08b196d3820172a19814d",
     ruby_platform: "aarch64-linux"
   },
   {
     file: "libdatadog-x86_64-alpine-linux-musl.tar.gz",
-    sha256: "67d518a17147ea29383c4a6d72805a542dca1cb94f9233b322b510254b93ac0f",
+    sha256: "46d0e6445fa1b0fbe8d079e6fa997fa10a4fef4084fe10f4b5886c92effc7be8",
     ruby_platform: "x86_64-linux-musl"
   },
   {
     file: "libdatadog-x86_64-unknown-linux-gnu.tar.gz",
-    sha256: "d4fd8bc13042d6c3c78cc5526b969d1279b26021858a470e25d25599bffd4f5f",
+    sha256: "adaf79470fd0b06ce6d63ae8f231e555fa12b70d5bf82565a96a25f59ea8071d",
     ruby_platform: "x86_64-linux"
   }
 ]

--- a/ruby/lib/libdatadog/version.rb
+++ b/ruby/lib/libdatadog/version.rb
@@ -2,7 +2,7 @@
 
 module Libdatadog
   # Current libdatadog version
-  LIB_VERSION = "12.0.0"
+  LIB_VERSION = "13.1.0"
 
   GEM_MAJOR_VERSION = "1"
   GEM_MINOR_VERSION = "0"


### PR DESCRIPTION
**What does this PR do?**

This PR includes the changes documented in the "Releasing a new version to rubygems.org" part of the README:
https://github.com/datadog/libdatadog/tree/main/ruby#releasing-a-new-version-to-rubygemsorg

**Motivation:**

Enable Ruby to use libdatadog v13.1.0.

**Additional Notes:**

We ended up not releasing 13.0 for Ruby. I don't see any reason to backfill so I've skipped ahead.

**How to test the change?**

I've tested this release locally using the changes in https://github.com/datadog/dd-trace-rb/pull/3997 .

As a reminder, new libdatadog releases don't get automatically picked up by dd-trace-rb, so the PR that bumps the Ruby profiler will also test this release against all supported Ruby versions.
