### PR TITLE
[PROF-10680] Use ELF virtual address instead of file offset

### DIFF
--- a/crashtracker/src/crash_info/stacktrace.rs
+++ b/crashtracker/src/crash_info/stacktrace.rs
@@ -68,9 +68,11 @@ pub struct NormalizedAddress {
 #[cfg(unix)]
 mod unix {
     use super::*;
+    use anyhow::anyhow;
     use blazesym::{
+        helper::ElfResolver,
         normalize::{Normalizer, UserMeta},
-        symbolize::{Input, Source, Sym, Symbolized, Symbolizer},
+        symbolize::{Input, Source, Sym, Symbolized, Symbolizer, TranslateFileOffset},
         Pid,
     };
 
@@ -109,8 +111,16 @@ mod unix {
                 let normed = normalizer.normalize_user_addrs(pid, &[ip])?;
                 anyhow::ensure!(normed.outputs.len() == 1);
                 let (file_offset, meta_idx) = normed.outputs[0];
-                let meta = (&normed.meta[meta_idx]).into();
-                self.normalized_ip = Some(NormalizedAddress { file_offset, meta });
+                let meta = &normed.meta[meta_idx];
+                let elf = meta.elf().ok_or(anyhow::anyhow!("Not elf"))?;
+                let resolver = ElfResolver::open(&elf.path)?;
+                let virt_address = resolver
+                    .file_offset_to_virt_offset(file_offset)?
+                    .ok_or(anyhow!("No matching segment found"))?;
+                self.normalized_ip = Some(NormalizedAddress {
+                    file_offset: virt_address,
+                    meta: meta.into(),
+                });
             }
             Ok(())
         }


### PR DESCRIPTION
# What does this PR do?

Use ELF virtual address instead of file offset for normarlized addresses.

# Motivation

When computing normalized address, use elf virtual addresses instead of file offsets because file offset alone is not enough to perform symbolization with split debug information.

# Additional Notes

`file_offset` should probably be renamed, this will be addressed in a later PR.
