### PR TITLE
Enable code coverage.

### DIFF
--- a/.github/workflows/all-checks.yml
+++ b/.github/workflows/all-checks.yml
@@ -16,4 +16,3 @@ jobs:
                 delay: '3'
                 retries: '30'
                 polling_interval: '1'
-                checks_exclude: 'coverage'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-llvm-cov@0.6.9,nextest@0.9.68
+          tool: cargo-llvm-cov@0.6.13,nextest@0.9.81
       - name: Generate code coverage (including doc tests)
         run: |
           cargo llvm-cov --all-features --workspace --no-report nextest


### PR DESCRIPTION
# What does this PR do?

Code coverage started to malfunction due to some compatibility issue between current Rust  and llvm-cov/nextest versions. This PR bumps llvm-cov and nextest to bring back code coverage.
