### PR TITLE
[NO-TICKET] First step of migration from hyper 0.x to 1.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,7 +515,6 @@ dependencies = [
  "datadog-crashtracker",
  "datadog-profiling",
  "ddcommon",
- "hyper 0.14.28",
  "once_cell",
  "serde_json",
  "strum",
@@ -2043,7 +2042,6 @@ dependencies = [
  "datadog-trace-protobuf",
  "ddcommon",
  "http 0.2.12",
- "hyper 0.14.28",
  "serde",
  "tracing",
 ]

--- a/bin_tests/Cargo.toml
+++ b/bin_tests/Cargo.toml
@@ -17,7 +17,6 @@ datadog-crashtracker = { path = "../crashtracker" }
 ddcommon = { path = "../ddcommon" }
 tempfile = "3.3"
 serde_json = { version = "1.0" }
-hyper = { version = "0.14", features = ["backports", "deprecated"], default-features = false }
 strum = { version = "0.26.2", features = ["derive"] }
 
 [lib]

--- a/bin_tests/Cargo.toml
+++ b/bin_tests/Cargo.toml
@@ -15,9 +15,9 @@ current_platform = "0.2.0"
 datadog-profiling = { path = "../profiling" }
 datadog-crashtracker = { path = "../crashtracker" }
 ddcommon = { path = "../ddcommon" }
-tempfile = "3.3" 
+tempfile = "3.3"
 serde_json = { version = "1.0" }
-hyper = { version = "0.14", default-features = false }
+hyper = { version = "0.14", features = ["backports", "deprecated"], default-features = false }
 strum = { version = "0.26.2", features = ["derive"] }
 
 [lib]

--- a/crashtracker-ffi/Cargo.toml
+++ b/crashtracker-ffi/Cargo.toml
@@ -28,6 +28,6 @@ anyhow = "1.0"
 datadog-crashtracker = { path = "../crashtracker" }
 ddcommon = { path = "../ddcommon" }
 ddcommon-ffi = { path = "../ddcommon-ffi", default-features = false }
-hyper = {version = "0.14", default-features = false}
+hyper = {version = "0.14", features = ["backports", "deprecated"], default-features = false}
 symbolic-demangle = { version = "12.8.0", default-features = false, features = ["rust", "cpp", "msvc"], optional = true }
 symbolic-common = { version = "12.8.0", default-features = false, optional = true }

--- a/crashtracker/Cargo.toml
+++ b/crashtracker/Cargo.toml
@@ -32,7 +32,7 @@ anyhow = "1.0"
 backtrace = "0.3.74"
 chrono = {version = "0.4", default-features = false, features = ["std", "clock", "serde"]}
 ddcommon = {path = "../ddcommon"}
-hyper = {version = "0.14", features = ["client"], default-features = false}
+hyper = {version = "0.14", features = ["client", "backports", "deprecated"], default-features = false}
 libc = "0.2"
 nix = { version = "0.27.1", features = ["signal"] }
 os_info = "3.7.0"

--- a/data-pipeline/Cargo.toml
+++ b/data-pipeline/Cargo.toml
@@ -13,7 +13,7 @@ autobenches = false
 anyhow = { version = "1.0" }
 arc-swap = "1.7.1"
 futures = { version = "0.3", default-features = false }
-hyper = {version = "0.14", features = ["client"], default-features = false}
+hyper = {version = "0.14", features = ["client", "backports", "deprecated"], default-features = false}
 log = "0.4"
 rmp-serde = "1.1.1"
 serde = "1.0.209"

--- a/data-pipeline/Cargo.toml
+++ b/data-pipeline/Cargo.toml
@@ -13,7 +13,7 @@ autobenches = false
 anyhow = { version = "1.0" }
 arc-swap = "1.7.1"
 futures = { version = "0.3", default-features = false }
-hyper = {version = "0.14", features = ["client", "backports", "deprecated"], default-features = false}
+hyper = {version = "0.14", features = ["client", "server", "runtime", "backports", "deprecated"], default-features = false}
 log = "0.4"
 rmp-serde = "1.1.1"
 serde = "1.0.209"

--- a/data-pipeline/src/agent_info/fetcher.rs
+++ b/data-pipeline/src/agent_info/fetcher.rs
@@ -7,6 +7,7 @@ use super::{schema::AgentInfo, AgentInfoArc};
 use anyhow::{anyhow, Result};
 use arc_swap::ArcSwapOption;
 use ddcommon::{connector::Connector, Endpoint};
+use hyper::body::HttpBody;
 use hyper::{self, body::Buf, header::HeaderName};
 use log::{error, info};
 use std::sync::Arc;
@@ -46,7 +47,7 @@ async fn fetch_info_with_state(
         return Ok(FetchInfoStatus::SameState);
     }
     let state_hash = new_state_hash.to_string();
-    let body_bytes = hyper::body::aggregate(res.into_body()).await?;
+    let body_bytes = res.into_body().collect().await?.aggregate();
     let info = Box::new(AgentInfo {
         state_hash,
         info: serde_json::from_reader(body_bytes.reader())?,

--- a/data-pipeline/src/trace_exporter.rs
+++ b/data-pipeline/src/trace_exporter.rs
@@ -18,6 +18,7 @@ use ddcommon::tag::Tag;
 use ddcommon::{connector, tag, Endpoint};
 use dogstatsd_client::{new_flusher, Client, DogStatsDAction};
 use either::Either;
+use hyper::body::HttpBody;
 use hyper::http::uri::PathAndQuery;
 use hyper::{Body, Method, Uri};
 use log::{error, info};
@@ -473,7 +474,7 @@ impl TraceExporter {
                     Ok(response) => {
                         let response_status = response.status();
                         if !response_status.is_success() {
-                            let body_bytes = hyper::body::to_bytes(response.into_body()).await?;
+                            let body_bytes = response.into_body().collect().await?.to_bytes();
                             let response_body =
                                 String::from_utf8(body_bytes.to_vec()).unwrap_or_default();
                             let resp_tag_res = &Tag::new("response_code", response_status.as_str());
@@ -496,7 +497,7 @@ impl TraceExporter {
                             }
                             anyhow::bail!("Agent did not accept traces: {response_body}");
                         }
-                        match hyper::body::to_bytes(response.into_body()).await {
+                        match response.into_body().collect().await {
                             Ok(body) => {
                                 self.emit_metric(
                                     HealthMetric::Count(
@@ -505,7 +506,7 @@ impl TraceExporter {
                                     ),
                                     None,
                                 );
-                                Ok(String::from_utf8_lossy(&body).to_string())
+                                Ok(String::from_utf8_lossy(&body.to_bytes()).to_string())
                             }
                             Err(err) => {
                                 self.emit_metric(
@@ -636,8 +637,8 @@ impl TraceExporter {
                 let send_data = SendData::new(size, tracer_payload, header_tags, &endpoint, None);
                 self.runtime.block_on(async {
                     match send_data.send().await.last_result {
-                        Ok(response) => match hyper::body::to_bytes(response.into_body()).await {
-                            Ok(body) => Ok(String::from_utf8_lossy(&body).to_string()),
+                        Ok(response) => match response.into_body().collect().await {
+                            Ok(body) => Ok(String::from_utf8_lossy(&body.to_bytes()).to_string()),
                             Err(err) => {
                                 error!("Error reading agent response body: {err}");
                                 self.emit_metric(

--- a/ddcommon-ffi/Cargo.toml
+++ b/ddcommon-ffi/Cargo.toml
@@ -23,7 +23,7 @@ anyhow = "1.0"
 chrono = { version = "0.4.38", features = ["std"] }
 crossbeam-queue = "0.3.11"
 ddcommon = { path = "../ddcommon" }
-hyper = {version = "0.14", default-features = false}
+hyper = {version = "0.14", features = ["backports", "deprecated"], default-features = false}
 serde = "1.0"
 
 [dev-dependencies]

--- a/ddcommon/Cargo.toml
+++ b/ddcommon/Cargo.toml
@@ -24,6 +24,8 @@ hyper = { version = "0.14", features = [
     "client",
     "tcp",
     "stream",
+    "backports",
+    "deprecated"
 ], default-features = false }
 hyper-util = "0.1.3"
 lazy_static = "1.4"

--- a/ddtelemetry/Cargo.toml
+++ b/ddtelemetry/Cargo.toml
@@ -20,7 +20,7 @@ datadog-ddsketch = { path = "../ddsketch" }
 base64 = "0.22"
 futures = { version = "0.3", default-features = false }
 http = "0.2"
-hyper = { version = "0.14", features = ["client"], default-features = false }
+hyper = { version = "0.14", features = ["client", "backports", "deprecated"], default-features = false }
 lazy_static = "1.4"
 pin-project = "1"
 

--- a/ddtelemetry/src/worker/http_client.rs
+++ b/ddtelemetry/src/worker/http_client.rs
@@ -3,6 +3,7 @@
 
 use ddcommon::HttpRequestBuilder;
 use http::{Request, Response};
+use hyper::body::HttpBody;
 use hyper::Body;
 use std::{
     fs::OpenOptions,
@@ -79,10 +80,10 @@ pub struct MockClient {
 }
 
 impl HttpClient for MockClient {
-    fn request(&self, mut req: Request<hyper::Body>) -> ResponseFuture {
+    fn request(&self, req: Request<hyper::Body>) -> ResponseFuture {
         let s = self.clone();
         Box::pin(async move {
-            let mut body = hyper::body::to_bytes(req.body_mut()).await?.to_vec();
+            let mut body = req.collect().await?.to_bytes().to_vec();
             body.push(b'\n');
 
             {

--- a/dogstatsd-client/Cargo.toml
+++ b/dogstatsd-client/Cargo.toml
@@ -18,5 +18,5 @@ cadence = "1.3.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 tracing = { version = "0.1", default-features = false }
 anyhow = { version = "1.0" }
-hyper = { version = "0.14", features = ["client"], default-features = false }
+hyper = { version = "0.14", features = ["client", "backports", "deprecated"], default-features = false }
 http = "0.2"

--- a/dogstatsd-client/Cargo.toml
+++ b/dogstatsd-client/Cargo.toml
@@ -18,5 +18,4 @@ cadence = "1.3.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 tracing = { version = "0.1", default-features = false }
 anyhow = { version = "1.0" }
-hyper = { version = "0.14", features = ["client", "backports", "deprecated"], default-features = false }
 http = "0.2"

--- a/live-debugger/Cargo.toml
+++ b/live-debugger/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.0.1"
 anyhow = "1.0"
 ddcommon = { path = "../ddcommon" }
 lazy_static = "1.4"
-hyper = { version = "0.14", features = ["client"] }
+hyper = { version = "0.14", features = ["client", "backports", "deprecated"] }
 regex = "1.9.3"
 json = "0.12.4"
 percent-encoding = "2.1"

--- a/live-debugger/src/sender.rs
+++ b/live-debugger/src/sender.rs
@@ -6,7 +6,7 @@ use constcat::concat;
 use ddcommon::connector::Connector;
 use ddcommon::tag::Tag;
 use ddcommon::Endpoint;
-use hyper::body::{Bytes, Sender};
+use hyper::body::{Bytes, HttpBody, Sender};
 use hyper::client::ResponseFuture;
 use hyper::http::uri::PathAndQuery;
 use hyper::{Body, Client, Method, Response, Uri};
@@ -231,7 +231,7 @@ impl PayloadSender {
                 Ok(response) => {
                     let status = response.status().as_u16();
                     if status >= 400 {
-                        let body_bytes = hyper::body::to_bytes(response.into_body()).await?;
+                        let body_bytes = response.into_body().collect().await?.to_bytes();
                         let response_body =
                             String::from_utf8(body_bytes.to_vec()).unwrap_or_default();
                         anyhow::bail!(

--- a/profiling-ffi/Cargo.toml
+++ b/profiling-ffi/Cargo.toml
@@ -32,9 +32,9 @@ build_common = { path = "../build-common" }
 
 [dependencies]
 anyhow = "1.0"
-datadog-crashtracker-ffi = { path = "../crashtracker-ffi", default-features = false, optional = true} 
+datadog-crashtracker-ffi = { path = "../crashtracker-ffi", default-features = false, optional = true}
 datadog-profiling = { path = "../profiling" }
-hyper = { version = "0.14", default-features = false }
+hyper = { version = "0.14", features = ["backports", "deprecated"], default-features = false }
 ddcommon = { path = "../ddcommon"}
 ddcommon-ffi = { path = "../ddcommon-ffi", default-features = false }
 ddtelemetry-ffi = { path = "../ddtelemetry-ffi", default-features = false, optional = true, features = ["expanded_builder_macros"] }

--- a/profiling-ffi/src/exporter.rs
+++ b/profiling-ffi/src/exporter.rs
@@ -481,6 +481,7 @@ mod tests {
     use super::*;
     use ddcommon::tag;
     use ddcommon_ffi::Slice;
+    use hyper::body::HttpBody;
     use serde_json::json;
 
     fn profiling_library_name() -> CharSlice<'static> {
@@ -512,7 +513,9 @@ mod tests {
         // in the profiling tests, please update there too :)
         let body = request.body();
         let body_bytes: String = String::from_utf8_lossy(
-            &futures::executor::block_on(hyper::body::to_bytes(body)).unwrap(),
+            &futures::executor::block_on(body.collect())
+                .unwrap()
+                .to_bytes(),
         )
         .to_string();
         let event_json = body_bytes

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -31,7 +31,7 @@ futures-util = {version = "0.3.0", default-features = false}
 hashbrown = { version = "0.14", default-features = false, features = ["allocator-api2"] }
 http = "0.2"
 http-body = "0.4"
-hyper = {version = "0.14", features = ["client"], default-features = false}
+hyper = {version = "0.14", features = ["client", "backports", "deprecated"], default-features = false}
 hyper-multipart-rfc7578 = "0.7.0"
 indexmap = "2.2"
 libc = "0.2"

--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -181,37 +181,34 @@ impl ProfileExporter {
             tags_profiler.push(',');
         }
 
-        match azure_app_services::get_metadata() {
-            Some(aas_metadata) => {
-                let aas_tags = [
-                    ("aas.resource.id", aas_metadata.get_resource_id()),
-                    (
-                        "aas.environment.extension_version",
-                        aas_metadata.get_extension_version(),
-                    ),
-                    (
-                        "aas.environment.instance_id",
-                        aas_metadata.get_instance_id(),
-                    ),
-                    (
-                        "aas.environment.instance_name",
-                        aas_metadata.get_instance_name(),
-                    ),
-                    ("aas.environment.os", aas_metadata.get_operating_system()),
-                    ("aas.resource.group", aas_metadata.get_resource_group()),
-                    ("aas.site.name", aas_metadata.get_site_name()),
-                    ("aas.site.kind", aas_metadata.get_site_kind()),
-                    ("aas.site.type", aas_metadata.get_site_type()),
-                    ("aas.subscription.id", aas_metadata.get_subscription_id()),
-                ];
-                aas_tags.into_iter().for_each(|(name, value)| {
-                    if let Ok(tag) = Tag::new(name, value) {
-                        tags_profiler.push_str(tag.as_ref());
-                        tags_profiler.push(',');
-                    }
-                });
-            }
-            None => (),
+        if let Some(aas_metadata) = azure_app_services::get_metadata() {
+            let aas_tags = [
+                ("aas.resource.id", aas_metadata.get_resource_id()),
+                (
+                    "aas.environment.extension_version",
+                    aas_metadata.get_extension_version(),
+                ),
+                (
+                    "aas.environment.instance_id",
+                    aas_metadata.get_instance_id(),
+                ),
+                (
+                    "aas.environment.instance_name",
+                    aas_metadata.get_instance_name(),
+                ),
+                ("aas.environment.os", aas_metadata.get_operating_system()),
+                ("aas.resource.group", aas_metadata.get_resource_group()),
+                ("aas.site.name", aas_metadata.get_site_name()),
+                ("aas.site.kind", aas_metadata.get_site_kind()),
+                ("aas.site.type", aas_metadata.get_site_type()),
+                ("aas.subscription.id", aas_metadata.get_subscription_id()),
+            ];
+            aas_tags.into_iter().for_each(|(name, value)| {
+                if let Ok(tag) = Tag::new(name, value) {
+                    tags_profiler.push_str(tag.as_ref());
+                    tags_profiler.push(',');
+                }
+            });
         }
 
         tags_profiler.pop(); // clean up the trailing comma

--- a/profiling/tests/form.rs
+++ b/profiling/tests/form.rs
@@ -61,6 +61,7 @@ mod tests {
     use crate::multipart;
     use datadog_profiling::exporter::*;
     use ddcommon::tag;
+    use hyper::body::HttpBody;
     use serde_json::json;
 
     fn default_tags() -> Vec<Tag> {
@@ -74,7 +75,9 @@ mod tests {
         // in the profiling-ffi tests, please update there too :)
         let body = request.body();
         let body_bytes: String = String::from_utf8_lossy(
-            &futures::executor::block_on(hyper::body::to_bytes(body)).unwrap(),
+            &futures::executor::block_on(body.collect())
+                .unwrap()
+                .to_bytes(),
         )
         .to_string();
         let event_json = body_bytes

--- a/remote-config/Cargo.toml
+++ b/remote-config/Cargo.toml
@@ -13,7 +13,7 @@ ddcommon = { path = "../ddcommon" }
 datadog-dynamic-configuration = { path = "../dynamic-configuration" }
 datadog-trace-protobuf = { path = "../trace-protobuf" }
 datadog-live-debugger = { path = "../live-debugger" }
-hyper = { version = "0.14", features = ["client"], default-features = false }
+hyper = { version = "0.14", features = ["client", "backports", "deprecated"], default-features = false }
 http = "0.2"
 base64 = "0.22.1"
 sha2 = "0.10"
@@ -28,7 +28,7 @@ serde = "1.0"
 serde_json = { version = "1.0", features = ["raw_value"] }
 
 [dev-dependencies]
-hyper = { version = "0.14", features = ["client", "server"], default-features = false }
+hyper = { version = "0.14", features = ["client", "server", "backports", "deprecated"], default-features = false }
 lazy_static = "1.4.0"
 futures = "0.3"
 

--- a/remote-config/src/fetch/fetcher.rs
+++ b/remote-config/src/fetch/fetcher.rs
@@ -13,6 +13,7 @@ use datadog_trace_protobuf::remoteconfig::{
 };
 use ddcommon::{connector, Endpoint};
 use http::uri::Scheme;
+use hyper::body::HttpBody;
 use hyper::http::uri::PathAndQuery;
 use hyper::{Client, StatusCode};
 use serde::{Deserialize, Serialize};
@@ -320,7 +321,7 @@ impl<S: FileStorage> ConfigFetcher<S> {
         .map_err(|e| anyhow::Error::msg(e).context(format!("Url: {:?}", self.state.endpoint)))?
         .map_err(|e| anyhow::Error::msg(e).context(format!("Url: {:?}", self.state.endpoint)))?;
         let status = response.status();
-        let body_bytes = hyper::body::to_bytes(response.into_body()).await?;
+        let body_bytes = response.into_body().collect().await?.to_bytes();
         if status != StatusCode::OK {
             // Not active
             if status == StatusCode::NOT_FOUND {

--- a/remote-config/src/fetch/test_server.rs
+++ b/remote-config/src/fetch/test_server.rs
@@ -10,6 +10,7 @@ use datadog_trace_protobuf::remoteconfig::{
 };
 use ddcommon::Endpoint;
 use http::{Request, Response};
+use hyper::body::HttpBody;
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Server};
 use serde_json::value::to_raw_value;
@@ -52,7 +53,7 @@ impl RemoteConfigServer {
                     Ok::<_, Infallible>(service_fn(move |req: Request<Body>| {
                         let this = this.clone();
                         async move {
-                            let body_bytes = hyper::body::to_bytes(req.into_body()).await.unwrap();
+                            let body_bytes = req.into_body().collect().await.unwrap().to_bytes();
                             let request: ClientGetConfigsRequest =
                                 serde_json::from_str(core::str::from_utf8(&body_bytes).unwrap())
                                     .unwrap();

--- a/sidecar-ffi/Cargo.toml
+++ b/sidecar-ffi/Cargo.toml
@@ -25,7 +25,7 @@ libc = "0.2"
 dogstatsd-client = { path = "../dogstatsd-client" }
 
 [dev-dependencies]
-hyper = { version = "0.14", default-features = false }
+hyper = { version = "0.14", features = ["backports", "deprecated"], default-features = false }
 tempfile = { version = "3.3" }
 
 [lints.rust]

--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -33,7 +33,7 @@ tinybytes = { path = "../tinybytes" }
 futures = { version = "0.3", default-features = false }
 manual_future = "0.1.1"
 http = "0.2"
-hyper = { version = "0.14", features = ["client"], default-features = false }
+hyper = { version = "0.14", features = ["client", "backports", "deprecated"], default-features = false }
 lazy_static = "1.4"
 pin-project = "1"
 

--- a/trace-mini-agent/Cargo.toml
+++ b/trace-mini-agent/Cargo.toml
@@ -12,7 +12,7 @@ bench = false
 
 [dependencies]
 anyhow = "1.0"
-hyper = { version = "0.14", default-features = false, features = ["server"] }
+hyper = { version = "0.14", default-features = false, features = ["server", "backports", "deprecated"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"]}
 async-trait = "0.1.64"
 log = "0.4"

--- a/trace-mini-agent/src/env_verifier.rs
+++ b/trace-mini-agent/src/env_verifier.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
+use hyper::body::HttpBody;
 use hyper::{Body, Client, Method, Request, Response};
 use log::{debug, error};
 use serde::{Deserialize, Serialize};
@@ -233,7 +234,7 @@ async fn ensure_gcp_function_environment(
 }
 
 async fn get_gcp_metadata_from_body(body: hyper::Body) -> anyhow::Result<GCPMetadata> {
-    let bytes = hyper::body::to_bytes(body).await?;
+    let bytes = body.collect().await?.to_bytes();
     let body_str = String::from_utf8(bytes.to_vec())?;
     let gcp_metadata: GCPMetadata = serde_json::from_str(&body_str)?;
     Ok(gcp_metadata)

--- a/trace-mini-agent/src/http_utils.rs
+++ b/trace-mini-agent/src/http_utils.rs
@@ -99,6 +99,7 @@ pub fn verify_request_content_length(
 
 #[cfg(test)]
 mod tests {
+    use hyper::body::HttpBody;
     use hyper::header;
     use hyper::Body;
     use hyper::HeaderMap;
@@ -115,7 +116,7 @@ mod tests {
 
     async fn get_response_body_as_string(response: Response<Body>) -> String {
         let body = response.into_body();
-        let bytes = hyper::body::to_bytes(body).await.unwrap();
+        let bytes = body.collect().await.unwrap().to_bytes();
         String::from_utf8(bytes.into_iter().collect()).unwrap()
     }
 

--- a/trace-utils/Cargo.toml
+++ b/trace-utils/Cargo.toml
@@ -16,7 +16,7 @@ path = "benches/main.rs"
 
 [dependencies]
 anyhow = "1.0"
-hyper = { version = "0.14", features = ["client", "server"] }
+hyper = { version = "0.14", features = ["client", "server", "backports", "deprecated"] }
 hyper-proxy = { version = "0.9.1", default-features = false, features = ["rustls"], optional = true }
 hyper-rustls = {version = "0.27", default-features = false, features = ["native-tokio", "http1", "tls12"]}
 serde = { version = "1.0.145", features = ["derive"] }

--- a/trace-utils/src/send_data/send_data_result.rs
+++ b/trace-utils/src/send_data/send_data_result.rs
@@ -3,6 +3,7 @@
 
 use crate::send_data::RequestResult;
 use anyhow::anyhow;
+use hyper::body::HttpBody;
 use hyper::{Body, Response};
 use std::collections::HashMap;
 
@@ -73,9 +74,9 @@ impl SendDataResult {
                 self.chunks_dropped += chunks;
                 self.requests_count += u64::from(attempts);
 
-                let body_bytes = hyper::body::to_bytes(response.into_body()).await;
-                let response_body =
-                    String::from_utf8(body_bytes.unwrap_or_default().to_vec()).unwrap_or_default();
+                let body = response.into_body().collect().await;
+                let response_body = String::from_utf8(body.unwrap_or_default().to_bytes().to_vec())
+                    .unwrap_or_default();
                 self.last_result = Err(anyhow::format_err!(
                     "{} - Server did not accept traces: {}",
                     status_code,

--- a/trace-utils/src/test_utils/datadog_test_agent.rs
+++ b/trace-utils/src/test_utils/datadog_test_agent.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use cargo_metadata::MetadataCommand;
-use hyper::body::to_bytes;
+use hyper::body::HttpBody;
 use hyper::{Client, Uri};
 use testcontainers::core::AccessMode;
 use testcontainers::{
@@ -217,7 +217,12 @@ impl DatadogTestAgent {
             .await;
         let res = client.get(uri).await.expect("Request failed");
         let status_code = res.status();
-        let body_bytes = to_bytes(res.into_body()).await.expect("Read failed");
+        let body_bytes = res
+            .into_body()
+            .collect()
+            .await
+            .expect("Read failed")
+            .to_bytes();
         let body_string = String::from_utf8(body_bytes.to_vec()).expect("Conversion failed");
 
         assert_eq!(


### PR DESCRIPTION
# What does this PR do?

This PR takes the first step to migrate libdatadog from using version 0.x of the hyper http library crate to version 1.x.

Specifically, it enables the recommended "backports" and "deprecated" features [from the upgrade guide](https://hyper.rs/guides/1/upgrading/), which give us warnings and a bridge to start adopting the new APIs from 1.x.

I then did a pass and fixed every deprecation and warning I could find.

# Motivation

I've started seeing issues with keeping packages up-to-date because newer versions require hyper 1.x, and the hyper 0.x-based ecosystem is getting increasingly unmaintained/abandoned.

# Additional Notes

During this week's weekly meeting, I took an action item to identify what teams needed to be involved in this migration for which packages. These are:

* @DataDog/libdatadog-profiling:
	* `crashtracker`, `crashtracker-ffi`, `profiling`, `profiling-ffi`
* @DataDog/libdatadog-apm 
	* `data-pipeline`
* @DataDog/libdatadog-core 
	* `ddcommon`, `ddcommon-ffi`, `live-debugger`
* @DataDog/libdatadog-telemetry 
	* `ddtelemetry`
* @DataDog/libdatadog-php @DataDog/remote-config @DataDog/libdatadog-apm 
	* `remote-config` 
* @DataDog/libdatadog-php @DataDog/libdatadog-apm 
	* `sidecar`, `sidecar-ffi`
* @DataDog/serverless 
	* `trace-mini-agent`
* @DataDog/serverless @DataDog/libdatadog-apm 
	* `trace-utils`

We'll need to move all these packages to hyper 1.x (but not for this PR! :).

# How to test the change?

Hopefully our existing test coverage is enough for us to be able to validate that everything is working nicely with these small API changes.