### PR TITLE
Lock down nightly version for reproducible builds

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,7 +24,7 @@ jobs:
           swap-storage: true
       - uses: actions/checkout@v4
       - name: Install Rust
-        run: rustup install nightly && rustup default nightly
+        run: rustup install nightly-2024-10-21 && rustup default nightly-2024-10-21
       - name: Install Protoc Binary
         shell: bash
         run: chmod +x ./scripts/install-protoc.sh && ./scripts/install-protoc.sh $HOME

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -16,8 +16,8 @@ jobs:
       run: |
         set -e
         rustup set profile minimal
-        rustup toolchain install nightly
-        rustup default nightly
+        rustup toolchain install nightly-2024-10-21
+        rustup default nightly-2024-10-21
     - uses: taiki-e/install-action@v2
       with:
         tool: cargo-bolero

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,8 +21,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Cache
         uses: ./.github/actions/cache
-      - name: Install latest nightly toolchain and rustfmt
-        run: rustup update nightly && rustup default nightly && rustup component add rustfmt
+      - name: Install nightly-2024-10-21 toolchain and rustfmt
+        run: rustup install nightly-2024-10-21 && rustup default nightly-2024-10-21 && rustup component add rustfmt
       - run: cargo fmt --all -- --check
   clippy:
     name: "clippy #${{ matrix.platform }} ${{ matrix.rust_version }}"
@@ -30,8 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Ignore nightly for now, it fails too often
-        rust_version: ["1.76.0", "stable"]
+        rust_version: ["1.76.0", "stable", "nightly-2024-10-21"]
         platform: [windows-latest, ubuntu-latest]
     steps:
       - name: Checkout sources
@@ -49,7 +48,7 @@ jobs:
         shell: bash
         run: |
           # shellcheck disable=SC2046
-          cargo clippy --workspace --all-targets --all-features -- -D warnings $([ ${{ matrix.rust_version }} = 1.76.0 ] && echo -Aunknown-lints -Ainvalid_reference_casting -Aclippy::redundant-closure-call)
+          cargo clippy --workspace --all-targets --all-features -- -D warnings $([ ${{ matrix.rust_version }} = 1.76.0 ] || [ ${{ matrix.rust_version }} = stable ] && echo -Aunknown-lints -Ainvalid_reference_casting -Aclippy::redundant-closure-call)
   licensecheck:
     runs-on: ubuntu-latest
     name: "Presence of licence headers"

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -14,14 +14,14 @@ jobs:
       run: |
         set -e
         rustup set profile minimal
-        rustup toolchain install nightly --component miri 
-        rustup default nightly
+        rustup toolchain install nightly-2024-10-21 --component miri 
+        rustup default nightly-2024-10-21
     - name: Install Protoc Binary
       shell: bash
       run: chmod +x ./scripts/install-protoc.sh && ./scripts/install-protoc.sh $HOME
     - uses: taiki-e/install-action@v2
       with: 
-        tool: nextest@0.9.68
+        tool: nextest@0.9.81
     - run: MIRIFLAGS="-Zmiri-disable-isolation" cargo miri nextest run
     # We need to disable isolation because 
     # "unsupported operation: `clock_gettime` with `REALTIME` clocks not available when isolation is enabled" 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install cargo nextest
         uses: taiki-e/install-action@v2
         with: 
-          tool: nextest@0.9.72
+          tool: nextest@0.9.81
       - name: "Remove nextest CI report"
         shell: bash
         run: rm -rf target/nextest/ci/junit.xml
@@ -127,9 +127,6 @@ jobs:
         with:
           rust_version: ${{ matrix.rust_version }}
           build_profile: "release"
-
-      - name: Install nightly toolchain
-        run: rustup install nightly
 
       - name: Install Rust ${{ matrix.rust_version }}
         if: matrix.rust_version != ''

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ cargo nextest run
 The simplest way to install [cargo-nextest][nt] is to use `cargo install` like this.
 
 ```bash
-cargo install --locked 'cargo-nextest@0.9.67'
+cargo install --locked 'cargo-nextest@0.9.81'
 ```
 
 #### Skipping tracing integration tests

--- a/bin_tests/src/bin/test_the_tests.rs
+++ b/bin_tests/src/bin/test_the_tests.rs
@@ -3,5 +3,4 @@
 
 /// This is an empty binary used to test the machinery of building bins
 /// in cargo test works
-
 fn main() {}

--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -168,6 +168,7 @@ fn crash_tracking_empty_endpoint_stdin() {
 }
 
 #[cfg(unix)]
+#[allow(clippy::zombie_processes)]
 fn crash_tracking_empty_endpoint_inner(receiver_type: ReceiverType) {
     use std::os::unix::net::UnixListener;
 

--- a/builder/build/arch/apple.rs
+++ b/builder/build/arch/apple.rs
@@ -12,6 +12,7 @@ pub const PROF_STATIC_LIB_FFI: &str = "libdatadog_profiling_ffi.a";
 pub const REMOVE_RPATH: bool = true;
 pub const BUILD_CRASHTRACKER: bool = true;
 
+#[allow(clippy::zombie_processes)]
 pub fn fix_rpath(lib_path: &str) {
     if REMOVE_RPATH {
         let lib_name = lib_path.split('/').last().unwrap();

--- a/builder/build/arch/linux.rs
+++ b/builder/build/arch/linux.rs
@@ -11,6 +11,7 @@ pub const PROF_STATIC_LIB_FFI: &str = "libdatadog_profiling_ffi.a";
 pub const REMOVE_RPATH: bool = false;
 pub const BUILD_CRASHTRACKER: bool = true;
 
+#[allow(clippy::zombie_processes)]
 pub fn fix_rpath(lib_path: &str) {
     if REMOVE_RPATH {
         Command::new("patchelf")

--- a/crashtracker-ffi/src/collector/spans.rs
+++ b/crashtracker-ffi/src/collector/spans.rs
@@ -82,7 +82,6 @@ pub unsafe extern "C" fn ddog_crasht_insert_trace_id(id_high: u64, id_low: u64) 
 /// https://blog.rust-lang.org/2024/03/30/i128-layout-update.html
 /// We're currently locked into 1.76.0, have to do an ugly workaround involving 2 64 bit ints
 /// until we can upgrade.
-
 ///
 /// # Safety
 /// No safety concerns.

--- a/data-pipeline/src/health_metrics.rs
+++ b/data-pipeline/src/health_metrics.rs
@@ -1,7 +1,7 @@
 // Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-/// health_metrics holds data to emit info about the health of the data-pipeline
+//! health_metrics holds data to emit info about the health of the data-pipeline
 
 pub(crate) const STAT_SEND_TRACES: &str = "datadog.libdatadog.send.traces";
 pub(crate) const STAT_SEND_TRACES_ERRORS: &str = "datadog.libdatadog.send.traces.errors";

--- a/ddcommon-ffi/src/slice.rs
+++ b/ddcommon-ffi/src/slice.rs
@@ -33,19 +33,19 @@ impl<'a, T: 'a> core::ops::Deref for Slice<'a, T> {
     }
 }
 
-impl<'a, T: Debug> Debug for Slice<'a, T> {
+impl<T: Debug> Debug for Slice<'_, T> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         self.as_slice().fmt(f)
     }
 }
 
-impl<'a, T: Eq> PartialEq<Self> for Slice<'a, T> {
+impl<T: Eq> PartialEq<Self> for Slice<'_, T> {
     fn eq(&self, other: &Self) -> bool {
         **self == **other
     }
 }
 
-impl<'a, T: Eq> Eq for Slice<'a, T> {}
+impl<T: Eq> Eq for Slice<'_, T> {}
 
 /// Use to represent strings -- should be valid UTF-8.
 pub type CharSlice<'a> = Slice<'a, c_char>;
@@ -147,7 +147,7 @@ impl<'a, T: 'a> Slice<'a, T> {
     }
 }
 
-impl<'a, T> Default for Slice<'a, T> {
+impl<T> Default for Slice<'_, T> {
     fn default() -> Self {
         Self::empty()
     }

--- a/ddcommon/src/connector/named_pipe.rs
+++ b/ddcommon/src/connector/named_pipe.rs
@@ -34,10 +34,10 @@ pub fn named_pipe_path_from_uri(uri: &hyper::Uri) -> anyhow::Result<PathBuf> {
     )
     .map_err(|_| super::errors::Error::InvalidUrl)?;
 
-    return match String::from_utf8(path) {
+    match String::from_utf8(path) {
         Ok(s) => Ok(PathBuf::from(s.as_str())),
         _ => Err(super::errors::Error::InvalidUrl.into()),
-    };
+    }
 }
 
 #[test]

--- a/ddcommon/src/entity_id/unix/mod.rs
+++ b/ddcommon/src/entity_id/unix/mod.rs
@@ -59,6 +59,7 @@ fn compute_entity_id(
 
 fn get_cgroup_path() -> &'static str {
     // Safety: we assume set_cgroup_file is not called when it shouldn't
+    #[allow(static_mut_refs)]
     unsafe {
         TESTING_CGROUP_PATH
             .as_deref()
@@ -68,6 +69,7 @@ fn get_cgroup_path() -> &'static str {
 
 fn get_cgroup_mount_path() -> &'static str {
     // Safety: we assume set_cgroup_file is not called when it shouldn't
+    #[allow(static_mut_refs)]
     unsafe {
         TESTING_CGROUP_MOUNT_PATH
             .as_deref()

--- a/ddtelemetry/src/metrics.rs
+++ b/ddtelemetry/src/metrics.rs
@@ -173,7 +173,7 @@ pub struct MetricContextGuard<'a> {
     guard: MutexGuard<'a, InnerMetricContexts>,
 }
 
-impl<'a> MetricContextGuard<'a> {
+impl MetricContextGuard<'_> {
     pub fn read(&self, key: ContextKey) -> Option<&MetricContext> {
         self.guard.store.get(key.0 as usize)
     }

--- a/ipc/tarpc/plugins/src/lib.rs
+++ b/ipc/tarpc/plugins/src/lib.rs
@@ -452,7 +452,7 @@ struct ServiceGenerator<'a> {
     derive_serialize: Option<&'a TokenStream2>,
 }
 
-impl<'a> ServiceGenerator<'a> {
+impl ServiceGenerator<'_> {
     fn trait_service(&self) -> TokenStream2 {
         let &Self {
             attrs,
@@ -762,7 +762,7 @@ impl<'a> ServiceGenerator<'a> {
     }
 }
 
-impl<'a> ToTokens for ServiceGenerator<'a> {
+impl ToTokens for ServiceGenerator<'_> {
     fn to_tokens(&self, output: &mut TokenStream2) {
         output.extend(vec![
             self.trait_service(),

--- a/ipc/tarpc/plugins/tests/server.rs
+++ b/ipc/tarpc/plugins/tests/server.rs
@@ -14,6 +14,7 @@ trait Foo {
 
 #[test]
 fn type_generation_works() {
+    #[allow(non_local_definitions)]
     #[tarpc::server]
     impl Foo for () {
         async fn two_part(self, _: context::Context, s: String, i: i32) -> (String, i32) {

--- a/live-debugger-ffi/src/data.rs
+++ b/live-debugger-ffi/src/data.rs
@@ -16,7 +16,7 @@ pub struct CharSliceVec<'a> {
     pub string_count: usize,
 }
 
-impl<'a> Drop for CharSliceVec<'a> {
+impl Drop for CharSliceVec<'_> {
     fn drop(&mut self) {
         unsafe {
             Vec::from_raw_parts(
@@ -131,7 +131,7 @@ impl<'a> From<&'a datadog_live_debugger::SpanDecorationProbe> for SpanDecoration
 #[no_mangle]
 extern "C" fn drop_span_decoration_probe(_: SpanDecorationProbe) {}
 
-impl<'a> Drop for SpanDecorationProbe<'a> {
+impl Drop for SpanDecorationProbe<'_> {
     fn drop(&mut self) {
         unsafe {
             let tags = Vec::from_raw_parts(

--- a/live-debugger-ffi/src/evaluator.rs
+++ b/live-debugger-ffi/src/evaluator.rs
@@ -82,6 +82,7 @@ struct EvalCtx<'e> {
 
 impl<'e> EvalCtx<'e> {
     fn new(context: &'e mut c_void) -> Self {
+        #[allow(static_mut_refs)]
         EvalCtx {
             context,
             eval: unsafe { FFI_EVALUATOR.as_ref().unwrap() },

--- a/live-debugger/src/expr_defs.rs
+++ b/live-debugger/src/expr_defs.rs
@@ -124,7 +124,7 @@ pub enum Condition {
 
 struct NonAssocBoolOp<'a>(&'a Condition, bool);
 
-impl<'a> Display for NonAssocBoolOp<'a> {
+impl Display for NonAssocBoolOp<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         if self.1 {
             write!(f, "({})", self.0)

--- a/live-debugger/src/expr_eval.rs
+++ b/live-debugger/src/expr_eval.rs
@@ -48,7 +48,7 @@ pub enum IntermediateValue<'a, I> {
     Referenced(&'a I),
 }
 
-impl<'a, I> Clone for IntermediateValue<'a, I> {
+impl<I> Clone for IntermediateValue<'_, I> {
     fn clone(&self) -> Self {
         match self {
             IntermediateValue::String(s) => IntermediateValue::String(s.clone()),
@@ -235,7 +235,7 @@ struct Eval<'a, 'e, I, E: Evaluator<'e, I>> {
     it: Option<&'e I>,
 }
 
-impl<'a, 'e, I, E: Evaluator<'e, I>> Eval<'a, 'e, I, E> {
+impl<'e, I, E: Evaluator<'e, I>> Eval<'_, 'e, I, E> {
     fn iref_string(&mut self, value: &'e I) -> Cow<'e, str> {
         self.eval.get_string(value)
     }

--- a/profiling/src/api.rs
+++ b/profiling/src/api.rs
@@ -103,7 +103,7 @@ pub struct Label<'a> {
     pub num_unit: Option<&'a str>,
 }
 
-impl<'a> Label<'a> {
+impl Label<'_> {
     pub fn uses_at_most_one_of_str_and_num(&self) -> bool {
         self.str.is_none() || (self.num == 0 && self.num_unit.is_none())
     }

--- a/profiling/src/collections/string_table/wordpress_test_data.rs
+++ b/profiling/src/collections/string_table/wordpress_test_data.rs
@@ -8,7 +8,7 @@
 ///
 /// For various tests such as using MIRI, it's too slow to decompress, open,
 /// parse, and extract the strings on-demand.
-pub const WORDPRESS_STRINGS: [&str; 1059] = [
+pub static WORDPRESS_STRINGS: [&str; 1059] = [
 	"",
 	"sample",
 	"count",

--- a/remote-config/src/fetch/fetcher.rs
+++ b/remote-config/src/fetch/fetcher.rs
@@ -102,7 +102,7 @@ pub struct ConfigFetcherFilesLock<'a, S> {
     inner: MutexGuard<'a, HashMap<Arc<RemoteConfigPath>, StoredTargetFile<S>>>,
 }
 
-impl<'a, S> ConfigFetcherFilesLock<'a, S> {
+impl<S> ConfigFetcherFilesLock<'_, S> {
     /// Actually remove the file from the known files.
     /// It may only be expired if already marked as expiring.
     pub fn expire_file(&mut self, path: &RemoteConfigPath) {

--- a/remote-config/src/file_storage.rs
+++ b/remote-config/src/file_storage.rs
@@ -47,7 +47,7 @@ pub struct RawFile<P> {
 
 pub struct RawFileContentsGuard<'a, P>(MutexGuard<'a, RawFileData<P>>);
 
-impl<'a, P> Deref for RawFileContentsGuard<'a, P> {
+impl<P> Deref for RawFileContentsGuard<'_, P> {
     type Target = P;
 
     fn deref(&self) -> &Self::Target {

--- a/remote-config/src/path.rs
+++ b/remote-config/src/path.rs
@@ -88,7 +88,7 @@ impl RemoteConfigPath {
     }
 }
 
-impl<'a> Display for RemoteConfigPathRef<'a> {
+impl Display for RemoteConfigPathRef<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self.source {
             RemoteConfigSource::Datadog(id) => write!(

--- a/remote-config/src/targets.rs
+++ b/remote-config/src/targets.rs
@@ -56,7 +56,7 @@ impl<'a> TargetsList<'a> {
     }
 }
 
-impl<'a> TargetData<'a> {
+impl TargetData<'_> {
     pub fn try_parse_version(&self) -> Option<u64> {
         self.custom
             .get("v")

--- a/sidecar/src/log.rs
+++ b/sidecar/src/log.rs
@@ -129,7 +129,7 @@ where
     map: &'a TemporarilyRetainedMap<K, V>,
 }
 
-impl<'a, K, V> Drop for TemporarilyRetainedMapGuard<'a, K, V>
+impl<K, V> Drop for TemporarilyRetainedMapGuard<'_, K, V>
 where
     K: TemporarilyRetainedKeyParser<V> + Clone + Eq + Hash,
 {

--- a/sidecar/src/one_way_shared_memory.rs
+++ b/sidecar/src/one_way_shared_memory.rs
@@ -118,7 +118,7 @@ where
     OneWayShmReader<T, D>: ReaderOpener<T>,
 {
     // bool is true when it changed
-    pub fn read<'a>(&'a mut self) -> (bool, &[u8]) {
+    pub fn read<'a>(&'a mut self) -> (bool, &'a [u8]) {
         if let Some(ref handle) = self.handle {
             let source_data: &RawData =
                 unsafe { reinterpret_u8_as_u64_slice(handle.as_slice()) }.into();

--- a/spawn_worker/src/win32.rs
+++ b/spawn_worker/src/win32.rs
@@ -231,6 +231,7 @@ impl SpawnWorker {
         }
     }
 
+    #[allow(clippy::manual_c_str_literals)] // c"NUL" from 1.77 and up
     fn open_null(read: bool) -> HANDLE {
         let mut sa = SECURITY_ATTRIBUTES {
             nLength: std::mem::size_of::<SECURITY_ATTRIBUTES>() as DWORD,


### PR DESCRIPTION
# What does this PR do?

Locks down the nightly version of rust so that builds are reproducible and don't break accidentally.

* Use nightly-2024-10-21
* Fix clippy lints
* Change nextest version to 0.9.81 in all places

# Motivation

Changes in the nightly version of rust can break formatting, clippy linting and coverage, among other things. That is not a good developer experience.
