### PR TITLE
Allow attaching to the sidecar via gdb

### DIFF
--- a/trace-utils/Cargo.toml
+++ b/trace-utils/Cargo.toml
@@ -16,7 +16,7 @@ path = "benches/main.rs"
 
 [dependencies]
 anyhow = "1.0"
-hyper = { version = "0.14", features = ["client", "server", "backports", "deprecated"] }
+hyper = { version = "0.14", features = ["client", "server", "runtime", "backports", "deprecated"] }
 hyper-proxy = { version = "0.9.1", default-features = false, features = ["rustls"], optional = true }
 hyper-rustls = {version = "0.27", default-features = false, features = ["native-tokio", "http1", "tls12"]}
 serde = { version = "1.0.145", features = ["derive"] }


### PR DESCRIPTION
It worked when DD_SPAWN_WORKER_USE_EXEC=1 was set, but not generally. Having a /proc/<pid>/X path will tell gdb exactly where to find it, instead of a /proc/self/fd/X which is pointing into gdbs own process from the perspective of gdb.

This also prevented sidecar core dumps from being opened with gdb, which was rather ugly.

(Also updates the Cargo.toml of trace-utils to include the required hyper runtime, otherwise the server feature will fail to compile...)