### PR TITLE
add stale PR GH workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,10 @@ jobs:
     steps:
       - uses: actions/stale@v8
         with:
-          stale-pr-message: "This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs."
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not had recent activity.
+            It will be closed if no further activity occurs. To override this behavior, add the keep-open
+            label or update the PR.
           days-before-issue-stale: -1
           days-before-issue-close: -1
           days-before-pr-stale: 90

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,24 @@
+name: "Mark stale pull requests"
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-pr-message: "This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs."
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-stale: 90
+          days-before-pr-close: 14
+          stale-pr-label: "stale"
+          exempt-pr-labels: "keep-open"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           android: true
           dotnet: true
           haskell: true
-          large-packages: false
+          large-packages: true
           docker-images: false
           swap-storage: true
 


### PR DESCRIPTION
# What does this PR do?

Introduce the stale action for PRs.
- PRs with no activity for 90 days will be marked with a `stale` label and a comment will be added to the PR
- After being stale for 14 days the PR will be automatically closed
- Issues are not included in this (but can be later, if we want)
- Branches will not be auto-deleted (but they can be, if we want)
- You can avoid this action on a PR with the `keep-open` label

# Motivation

Good repository hygiene suggested by @hoolioh  

# Additional Notes

`stale` and `keep-open` labels have been added to the repo.

# How to test the change?

I don't think we can really test the action until it is merged into main.