### PR TITLE
Increase DogStatsD Buffer Size and Pattern Match Container Ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2020,6 +2020,7 @@ dependencies = [
  "ddsketch-agent",
  "fnv",
  "hashbrown 0.14.3",
+ "lazy_static",
  "mockito",
  "proptest",
  "protobuf",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2032,6 +2032,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-test",
  "ustr",
 ]
 
@@ -5794,6 +5795,27 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
+dependencies = [
+ "quote",
+ "syn 2.0.70",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,6 +1624,9 @@ dependencies = [
  "log",
  "tokio",
  "tokio-util",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/dogstatsd/Cargo.toml
+++ b/dogstatsd/Cargo.toml
@@ -15,6 +15,7 @@ hashbrown = { version = "0.14.3", default-features = false, features = ["inline-
 protobuf = { version = "3.5.0", default-features = false }
 ustr = { version = "1.0.0", default-features = false }
 fnv = { version = "1.0.7", default-features = false }
+lazy_static = { version = "1.5.0", default-features = false }
 reqwest = { version = "0.12.4", features = ["json", "http2", "rustls-tls"], default-features = false }
 serde = { version = "1.0.197", default-features = false, features = ["derive"] }
 serde_json = { version = "1.0.116", default-features = false, features = ["alloc"] }

--- a/dogstatsd/Cargo.toml
+++ b/dogstatsd/Cargo.toml
@@ -28,3 +28,4 @@ regex = { version = "1.10.6", default-features = false }
 [dev-dependencies]
 mockito = { version = "1.5.0", default-features = false }
 proptest = "1.4.0"
+tracing-test = { version = "0.2.5", default-features = false }

--- a/dogstatsd/src/dogstatsd.rs
+++ b/dogstatsd/src/dogstatsd.rs
@@ -197,8 +197,6 @@ single_machine_performance.rouster.metrics_max_timestamp_latency:1376.90870216|d
 
         assert!(!logs_contain("Failed to parse metric"));
         assert_eq!(parsed_metrics.len(), 0);
-
-        drop(aggregator);
     }
 
     #[tokio::test]
@@ -211,8 +209,6 @@ single_machine_performance.rouster.metrics_max_timestamp_latency:1376.90870216|d
 
         assert!(!logs_contain("Failed to parse metric"));
         assert_eq!(parsed_metrics.len(), 0);
-
-        drop(aggregator);
     }
 
     async fn setup_dogstatsd(statsd_string: &str) -> Arc<Mutex<Aggregator>> {

--- a/dogstatsd/src/dogstatsd.rs
+++ b/dogstatsd/src/dogstatsd.rs
@@ -32,6 +32,7 @@ impl BufferReader {
         match self {
             BufferReader::UdpSocketReader(socket) => {
                 // TODO(astuyve) this should be dynamic
+                // use 8KB max buffer size to match default value in Go Agent
                 let mut buf = [0; 8192]; // todo, do we want to make this dynamic? (not sure)
                 let (amt, src) = socket
                     .recv_from(&mut buf)

--- a/dogstatsd/src/dogstatsd.rs
+++ b/dogstatsd/src/dogstatsd.rs
@@ -86,7 +86,7 @@ impl DogStatsD {
     fn insert_metrics(&self, msg: Split<char>) {
         let all_valid_metrics: Vec<Metric> = msg
             .filter(|m| !m.is_empty())
-            .filter(|m| !m.starts_with("_sc|")) // exclude service checks
+            .filter(|m| !m.starts_with("_sc|") && !m.starts_with("_e{")) // exclude service checks and events
             .map(|m| m.replace('\n', ""))
             .filter_map(|m| match parse(m.as_str()) {
                 Ok(metric) => Some(metric),

--- a/dogstatsd/src/dogstatsd.rs
+++ b/dogstatsd/src/dogstatsd.rs
@@ -32,7 +32,7 @@ impl BufferReader {
         match self {
             BufferReader::UdpSocketReader(socket) => {
                 // TODO(astuyve) this should be dynamic
-                let mut buf = [0; 1024]; // todo, do we want to make this dynamic? (not sure)
+                let mut buf = [0; 8192]; // todo, do we want to make this dynamic? (not sure)
                 let (amt, src) = socket
                     .recv_from(&mut buf)
                     .await

--- a/dogstatsd/src/dogstatsd.rs
+++ b/dogstatsd/src/dogstatsd.rs
@@ -86,6 +86,7 @@ impl DogStatsD {
     fn insert_metrics(&self, msg: Split<char>) {
         let all_valid_metrics: Vec<Metric> = msg
             .filter(|m| !m.is_empty())
+            .filter(|m| !m.starts_with("_sc|")) // exclude service checks
             .map(|m| m.replace('\n', ""))
             .filter_map(|m| match parse(m.as_str()) {
                 Ok(metric) => Some(metric),

--- a/dogstatsd/src/metric.rs
+++ b/dogstatsd/src/metric.rs
@@ -5,12 +5,19 @@ use crate::errors::ParseError;
 use crate::{constants, datadog};
 use ddsketch_agent::DDSketch;
 use fnv::FnvHasher;
+use lazy_static::lazy_static;
 use protobuf::Chars;
 use regex::Regex;
 use std::hash::{Hash, Hasher};
 use ustr::Ustr;
 
 pub const EMPTY_TAGS: SortedTags = SortedTags { values: Vec::new() };
+
+lazy_static! {
+    pub static ref METRIC_REGEX: regex::Regex = Regex::new(
+        r"^(?P<name>[^:]+):(?P<values>[^|]+)\|(?P<type>[cgd])(?:\|@(?P<sample_rate>[\d.]+))?(?:\|#(?P<tags>[^|]+))?(?:\|c:(?P<container_id>[^|]+))?$",
+    ).expect("Failed to create metric regex");
+}
 
 #[derive(Clone, Debug)]
 pub enum MetricValue {
@@ -167,41 +174,37 @@ impl Metric {
 /// example aj-test.increment:1|c|#user:aj-test from 127.0.0.1:50983
 pub fn parse(input: &str) -> Result<Metric, ParseError> {
     // TODO must enforce / exploit constraints given in `constants`.
-    if let Ok(re) = Regex::new(
-        r"^(?P<name>[^:]+):(?P<values>[^|]+)\|(?P<type>[cgd])(?:\|@(?P<sample_rate>[\d.]+))?(?:\|#(?P<tags>[^|]+))?(?:\|c:(?P<container_id>[^|]+))?$",
-    ) {
-        if let Some(caps) = re.captures(input) {
-            // unused for now
-            // let sample_rate = caps.name("sample_rate").map(|m| m.as_str());
+    if let Some(caps) = METRIC_REGEX.captures(input) {
+        // unused for now
+        // let sample_rate = caps.name("sample_rate").map(|m| m.as_str());
 
-            let tags;
-            if let Some(tags_section) = caps.name("tags") {
-                tags = Some(SortedTags::parse(tags_section.as_str())?);
-            } else {
-                tags = None;
-            }
-            let val = first_value(caps.name("values").unwrap().as_str())?;
-            let metric_value = match caps.name("type").unwrap().as_str() {
-                "c" => MetricValue::Count(val),
-                "g" => MetricValue::Gauge(val),
-                "d" => {
-                    let sketch = &mut DDSketch::default();
-                    sketch.insert(val);
-                    MetricValue::Distribution(sketch.to_owned())
-                }
-                _ => {
-                    return Err(ParseError::Raw("Unsupported metric type"));
-                }
-            };
-            let name = Ustr::from(caps.name("name").unwrap().as_str());
-            let id = id(name, &tags);
-            return Ok(Metric {
-                name,
-                value: metric_value,
-                tags,
-                id,
-            });
+        let tags;
+        if let Some(tags_section) = caps.name("tags") {
+            tags = Some(SortedTags::parse(tags_section.as_str())?);
+        } else {
+            tags = None;
         }
+        let val = first_value(caps.name("values").unwrap().as_str())?;
+        let metric_value = match caps.name("type").unwrap().as_str() {
+            "c" => MetricValue::Count(val),
+            "g" => MetricValue::Gauge(val),
+            "d" => {
+                let sketch = &mut DDSketch::default();
+                sketch.insert(val);
+                MetricValue::Distribution(sketch.to_owned())
+            }
+            _ => {
+                return Err(ParseError::Raw("Unsupported metric type"));
+            }
+        };
+        let name = Ustr::from(caps.name("name").unwrap().as_str());
+        let id = id(name, &tags);
+        return Ok(Metric {
+            name,
+            value: metric_value,
+            tags,
+            id,
+        });
     }
     Err(ParseError::Raw("Invalid metric format"))
 }

--- a/dogstatsd/src/metric.rs
+++ b/dogstatsd/src/metric.rs
@@ -471,4 +471,10 @@ mod tests {
     fn invalid_dogstatsd_no_panic() {
         assert!(parse("somerandomstring|c+a;slda").is_err());
     }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn parse_container_id() {
+        assert!(parse("containerid.metric:0|c|#env:dev,client_transport:udp|c:0000000000000000000000000000000000000000000000000000000000000000").is_ok());
+    }
 }

--- a/dogstatsd/src/metric.rs
+++ b/dogstatsd/src/metric.rs
@@ -168,7 +168,7 @@ impl Metric {
 pub fn parse(input: &str) -> Result<Metric, ParseError> {
     // TODO must enforce / exploit constraints given in `constants`.
     if let Ok(re) = Regex::new(
-        r"^(?P<name>[^:]+):(?P<values>[^|]+)\|(?P<type>[cgd])(?:\|@(?P<sample_rate>[\d.]+))?(?:\|#(?P<tags>[^|]+))?$",
+        r"^(?P<name>[^:]+):(?P<values>[^|]+)\|(?P<type>[cgd])(?:\|@(?P<sample_rate>[\d.]+))?(?:\|#(?P<tags>[^|]+))?(?:\|c:(?P<container_id>[^|]+))?$",
     ) {
         if let Some(caps) = re.captures(input) {
             // unused for now

--- a/dogstatsd/src/metric.rs
+++ b/dogstatsd/src/metric.rs
@@ -14,7 +14,7 @@ use ustr::Ustr;
 pub const EMPTY_TAGS: SortedTags = SortedTags { values: Vec::new() };
 
 lazy_static! {
-    pub static ref METRIC_REGEX: regex::Regex = Regex::new(
+    static ref METRIC_REGEX: regex::Regex = Regex::new(
         r"^(?P<name>[^:]+):(?P<values>[^|]+)\|(?P<type>[cgd])(?:\|@(?P<sample_rate>[\d.]+))?(?:\|#(?P<tags>[^|]+))?(?:\|c:(?P<container_id>[^|]+))?$",
     ).expect("Failed to create metric regex");
 }

--- a/serverless/Cargo.toml
+++ b/serverless/Cargo.toml
@@ -12,6 +12,9 @@ datadog-trace-utils = { path = "../trace-utils" }
 dogstatsd = { path = "../dogstatsd" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"]}
 tokio-util = { version = "0.7", default-features = false }
+tracing = { version = "0.1", default-features = false }
+tracing-core = { version = "0.1", default-features = false }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["std", "registry", "fmt", "env-filter", "tracing-log"] }
 
 [[bin]]
 name = "datadog-serverless-trace-mini-agent"


### PR DESCRIPTION
# What does this PR do?

Fixes two issues that prevent DogStatsD metrics from being submitted in some environments.

* Increases buffer size from 1KB to 8KB
* Updates DogStatsD regex to account for container ids
* Lazily initialize static regex for dogstatsd metrics

# Motivation

https://datadoghq.atlassian.net/browse/SVLS-5799

# Additional Notes

Some DogStatsD messages in Azure Spring App environments were larger than 1KB, causing them to be truncated. These messages also include container ids with the pattern `c:*`.

[DogStatsD protocol v1.2](https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/?tab=metrics#dogstatsd-protocol-v12)

```
DEBUG Received message: datadog.dogstatsd.client.metrics:0|c|#env:dev,service:azure-spring-app,client:java,client_version:4.4.2,client_transport:udp|c:b9ee8edd7d87cbbcf378f30f8d303dd71e8899006fb4ea6369a774b1e5dd0fb3
datadog.dogstatsd.client.events:0|c|#env:dev,service:azure-spring-app,client:java,client_version:4.4.2,client_transport:udp|c:b9ee8edd7d87cbbcf378f30f8d303dd71e8899006fb4ea6369a774b1e5dd0fb3
datadog.dogstatsd.client.service_checks:0|c|#env:dev,service:azure-spring-app,client:java,client_version:4.4.2,client_transport:udp|c:b9ee8edd7d87cbbcf378f30f8d303dd71e8899006fb4ea6369a774b1e5dd0fb3
datadog.dogstatsd.client.bytes_sent:3576|c|#env:dev,service:azure-spring-app,client:java,client_version:4.4.2,client_transport:udp|c:b9ee8edd7d87cbbcf378f30f8d303dd71e8899006fb4ea6369a774b1e5dd0fb3
datadog.dogstatsd.client.bytes_dropped:0|c|#env:dev,service:azure-spring-app,client:java,client_version:4.4.2,client_transport:udp|c:b9ee8edd7d87cbbcf378f30f8d303dd71e8899006fb4ea6369a774b1e5dd0fb3
datadog.dogstatsd.client.packets_sent:3|c|#env from 127.0.0.1:33589
```

The max buffer size value of `8192` bytes is used to match the [default value](https://github.com/DataDog/datadog-agent/blob/8b3c3e25f6964aa1849ec1b7be5e004cf2abe6c6/pkg/config/config_template.yaml#L2154-L2158) used in the Go Agent.

Also updates serverless mini agent to emit logs from dogstatsd package to facilitate debugging.

# How to test the change?

See https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/2977497119/Serverless+Mini+Agent#Testing