### PR TITLE
fix(ddcommon): warning on unused import

### DIFF
--- a/ddcommon/src/connector/mod.rs
+++ b/ddcommon/src/connector/mod.rs
@@ -10,9 +10,6 @@ use hyper_rustls::ConfigBuilderExt;
 
 use lazy_static::lazy_static;
 
-#[cfg(not(feature = "use_webpki_roots"))]
-use rustls::pki_types::CertificateDer;
-
 use rustls::ClientConfig;
 use std::future::Future;
 use std::pin::Pin;


### PR DESCRIPTION
# What does this PR do?

This fixes the following warning:

```
warning: unused import: `rustls::pki_types::CertificateDer`
  --> ddcommon/src/connector/mod.rs:14:5
   |
14 | use rustls::pki_types::CertificateDer;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default
```

# Motivation

I want `main` to not have warnings.

# How to test the change?

Existing tests should work fine for both `use_webpki_roots` and `not(use_webpki_roots)`.
