### PR TITLE
Updates blazesym to 0.1.0rc1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,7 +8,7 @@ version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
- "gimli 0.31.1",
+ "gimli",
 ]
 
 [[package]]
@@ -590,22 +590,23 @@ checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
 
 [[package]]
 name = "blazesym"
-version = "0.2.0-rc.0"
+version = "0.2.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "519a0f9df086d6c4f44576558523a777c984454daeb124bee79bde69227360c4"
+checksum = "d750f0052cfee86c14cbc31eda95c14271e16347196fd4902df1a52e4411a090"
 dependencies = [
  "cpp_demangle",
- "gimli 0.30.0",
+ "gimli",
  "libc",
- "miniz_oxide 0.7.2",
+ "memmap2",
+ "miniz_oxide 0.8.0",
  "rustc-demangle",
 ]
 
 [[package]]
 name = "blazesym-c"
-version = "0.1.0-rc.0"
+version = "0.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09c03df5c33f265a7ae6de11a81c9ebb69c4ca632afa45e9fcf7a96c1d8cca0"
+checksum = "2211e3c85470018f689742cf705cbc8be1993ae6b50e0f73c54f7f5c530d6e74"
 dependencies = [
  "blazesym",
  "memoffset",
@@ -2441,20 +2442,14 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.30.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e1d97fbe9722ba9bbd0c97051c2956e726562b61f86a25a4360398a40edfc9"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 dependencies = [
  "fallible-iterator",
  "indexmap 2.2.6",
  "stable_deref_trait",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glibc_version"
@@ -3331,7 +3326,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
- "simd-adler32",
 ]
 
 [[package]]
@@ -3341,6 +3335,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]

--- a/crashtracker/src/crash_info/stacktrace.rs
+++ b/crashtracker/src/crash_info/stacktrace.rs
@@ -112,7 +112,7 @@ mod unix {
                 anyhow::ensure!(normed.outputs.len() == 1);
                 let (file_offset, meta_idx) = normed.outputs[0];
                 let meta = &normed.meta[meta_idx];
-                let elf = meta.elf().ok_or(anyhow::anyhow!("Not elf"))?;
+                let elf = meta.as_elf().ok_or(anyhow::anyhow!("Not elf"))?;
                 let resolver = ElfResolver::open(&elf.path)?;
                 let virt_address = resolver
                     .file_offset_to_virt_offset(file_offset)?

--- a/examples/ffi/symbolizer.cpp
+++ b/examples/ffi/symbolizer.cpp
@@ -18,7 +18,7 @@
 
 void symbolize_and_print_abs(blaze_symbolizer* symbolizer, uintptr_t addr) {
     std::vector<uintptr_t> addrs = {addr};
-    
+
     blaze_symbolize_src_process src = {
       .type_size = sizeof(blaze_symbolize_src_process),
       .pid = static_cast<uint32_t>(getpid()),
@@ -27,19 +27,19 @@ void symbolize_and_print_abs(blaze_symbolizer* symbolizer, uintptr_t addr) {
       .map_files = false,
       .reserved = {},
     };
-    const blaze_result* results = blaze_symbolize_process_abs_addrs(
+    const blaze_syms* syms = blaze_symbolize_process_abs_addrs(
         symbolizer, &src, addrs.data(), addrs.size());
-    assert(results);
+    assert(syms);
     bool found = false;
     for (size_t i = 0; i < addrs.size(); ++i) {
-        std::cout << "Address: " << addrs[i] << ", Symbolized: " << results->syms[i].name << std::endl;
-        if (std::string(results->syms[i].name).find("test_symbolizer") != std::string::npos){
+        std::cout << "Address: " << addrs[i] << ", Symbolized: " << syms->syms[i].name << std::endl;
+        if (std::string(syms->syms[i].name).find("test_symbolizer") != std::string::npos){
             found = true;
         }
     }
     assert(found);
-    // Free the results
-    blaze_result_free(results);
+    // Free the syms
+    blaze_syms_free(syms);
 }
 
 void test_symbolizer() {

--- a/symbolizer-ffi/Cargo.toml
+++ b/symbolizer-ffi/Cargo.toml
@@ -16,4 +16,4 @@ bench = false
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 # Should be kept in sync with the libdatadog crashtracker crate (also using blasesym)
-blazesym-c = "0.1.0-rc.0"
+blazesym-c = "0.1.0-rc.1"


### PR DESCRIPTION
# What does this PR do?

Seems like a prudent thing to do

# Motivation

Plus this upgrade happens when trying to cargo update, so why not?
