### PR TITLE
[Serverless Mini Agent] Update Namespace for Span Tags from Azure Spring Apps and Google Cloud Functions v1

### DIFF
--- a/trace-utils/src/trace_utils.rs
+++ b/trace-utils/src/trace_utils.rs
@@ -504,23 +504,21 @@ pub fn enrich_span_with_mini_agent_metadata(
 ) {
     if let Some(azure_spring_app_hostname) = &mini_agent_metadata.azure_spring_app_hostname {
         span.meta.insert(
-            "azurespringapp.hostname".to_string(),
+            "asa.hostname".to_string(),
             azure_spring_app_hostname.to_string(),
         );
     }
     if let Some(azure_spring_app_name) = &mini_agent_metadata.azure_spring_app_name {
-        span.meta.insert(
-            "azurespringapp.name".to_string(),
-            azure_spring_app_name.to_string(),
-        );
+        span.meta
+            .insert("asa.name".to_string(), azure_spring_app_name.to_string());
     }
     if let Some(gcp_project_id) = &mini_agent_metadata.gcp_project_id {
         span.meta
-            .insert("project_id".to_string(), gcp_project_id.to_string());
+            .insert("gcrfx.project_id".to_string(), gcp_project_id.to_string());
     }
     if let Some(gcp_region) = &mini_agent_metadata.gcp_region {
         span.meta
-            .insert("location".to_string(), gcp_region.to_string());
+            .insert("gcrfx.location".to_string(), gcp_region.to_string());
     }
     if let Some(mini_agent_version) = &mini_agent_metadata.version {
         span.meta.insert(


### PR DESCRIPTION
# What does this PR do?

Update namespace for span tags Azure Spring Apps and Google Cloud Functions v1.

# Motivation

Make sure span tags from each of these products have a namespace with a consistent naming pattern prior to GA.

https://datadoghq.atlassian.net/browse/SVLS-5915
https://datadoghq.atlassian.net/browse/SVLS-5918

# Additional Notes

* Azure Spring Apps: `azurespringapp` -> `asa`
* Google Cloud Functions v1: `gcrfx`

# How to test the change?

See https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/2977497119/Serverless+Mini+Agent#Testing