### PR TITLE
[APMSP-1512] Add metadata headers for stats

### DIFF
--- a/data-pipeline-ffi/src/trace_exporter.rs
+++ b/data-pipeline-ffi/src/trace_exporter.rs
@@ -60,7 +60,7 @@ pub unsafe extern "C" fn ddog_trace_exporter_new(
         .set_language_interpreter(language_interpreter.to_utf8_lossy().as_ref())
         .set_hostname(hostname.to_utf8_lossy().as_ref())
         .set_env(env.to_utf8_lossy().as_ref())
-        .set_version(version.to_utf8_lossy().as_ref())
+        .set_app_version(version.to_utf8_lossy().as_ref())
         .set_service(service.to_utf8_lossy().as_ref())
         .set_input_format(input_format)
         .set_output_format(output_format)

--- a/data-pipeline/examples/send-traces-with-stats.rs
+++ b/data-pipeline/examples/send-traces-with-stats.rs
@@ -34,7 +34,7 @@ fn main() {
         .set_url("http://localhost:8126")
         .set_hostname("test")
         .set_env("testing")
-        .set_version(env!("CARGO_PKG_VERSION"))
+        .set_app_version(env!("CARGO_PKG_VERSION"))
         .set_service("data-pipeline-test")
         .set_tracer_version(env!("CARGO_PKG_VERSION"))
         .set_language("rust")

--- a/data-pipeline/src/stats_exporter.rs
+++ b/data-pipeline/src/stats_exporter.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
+    borrow::Borrow,
+    collections::HashMap,
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc, Mutex,
@@ -10,30 +12,14 @@ use std::{
 };
 
 use datadog_trace_protobuf::pb;
-use ddcommon::{connector, tag::Tag, Endpoint};
+use ddcommon::{connector, Endpoint};
 use hyper;
 use tokio::select;
 use tokio_util::sync::CancellationToken;
 
-use crate::span_concentrator::SpanConcentrator;
+use crate::{span_concentrator::SpanConcentrator, trace_exporter::TracerMetadata};
 
 const STATS_ENDPOINT_PATH: &str = "/v0.6/stats";
-
-/// Metadata required in a ClientStatsPayload
-#[derive(Debug, Default, Clone)]
-pub struct LibraryMetadata {
-    pub hostname: String,
-    pub env: String,
-    pub version: String,
-    pub lang: String,
-    pub tracer_version: String,
-    pub runtime_id: String,
-    pub service: String,
-    pub container_id: String,
-    pub git_commit_sha: String,
-    /// Should be left empty by client, except for some specific environment
-    pub tags: Vec<Tag>,
-}
 
 /// An exporter that concentrates and sends stats to the agent
 #[derive(Debug)]
@@ -41,7 +27,7 @@ pub struct StatsExporter {
     flush_interval: time::Duration,
     concentrator: Arc<Mutex<SpanConcentrator>>,
     endpoint: Endpoint,
-    meta: LibraryMetadata,
+    meta: TracerMetadata,
     sequence_id: AtomicU64,
     client: ddcommon::HttpClient,
     cancellation_token: CancellationToken,
@@ -52,14 +38,14 @@ impl StatsExporter {
     ///
     /// - `flush_interval` the interval on which the concentrator is flushed
     /// - `concentrator` SpanConcentrator storing the stats to be sent to the agent
-    /// - `meta` the metadata used when sending the ClientStatsPayload to the agent
+    /// - `meta` metadata used in ClientStatsPayload and as headers to send stats to the agent.
     /// - `endpoint` the Endpoint used to send stats to the agent
     /// - `cancellation_token` Token used to safely shutdown the exporter by force flushing the
     ///   concentrator
     pub fn new(
         flush_interval: time::Duration,
         concentrator: Arc<Mutex<SpanConcentrator>>,
-        meta: LibraryMetadata,
+        meta: TracerMetadata,
         endpoint: Endpoint,
         cancellation_token: CancellationToken,
     ) -> Self {
@@ -95,15 +81,23 @@ impl StatsExporter {
             return Ok(());
         }
         let body = rmp_serde::encode::to_vec_named(&payload)?;
-        let req = self
+
+        let headers: HashMap<&'static str, String> = self.meta.borrow().into();
+
+        let mut req_builder = self
             .endpoint
             .into_request_builder(concat!("Libdatadog/", env!("CARGO_PKG_VERSION")))?
             .header(
                 hyper::header::CONTENT_TYPE,
                 ddcommon::header::APPLICATION_MSGPACK,
             )
-            .method(hyper::Method::POST)
-            .body(hyper::Body::from(body))?;
+            .method(hyper::Method::POST);
+
+        for (key, value) in &headers {
+            req_builder = req_builder.header(*key, value);
+        }
+
+        let req = req_builder.body(hyper::Body::from(body))?;
 
         let resp = self.client.request(req).await?;
 
@@ -128,7 +122,7 @@ impl StatsExporter {
     fn flush(&self, force_flush: bool) -> pb::ClientStatsPayload {
         let sequence = self.sequence_id.fetch_add(1, Ordering::Relaxed);
         encode_stats_payload(
-            self.meta.clone(),
+            self.meta.borrow(),
             sequence,
             self.concentrator
                 .lock()
@@ -158,24 +152,24 @@ impl StatsExporter {
 }
 
 fn encode_stats_payload(
-    meta: LibraryMetadata,
+    meta: &TracerMetadata,
     sequence: u64,
     buckets: Vec<pb::ClientStatsBucket>,
 ) -> pb::ClientStatsPayload {
     pb::ClientStatsPayload {
-        hostname: meta.hostname,
-        env: meta.env,
-        lang: meta.lang,
-        version: meta.version,
-        runtime_id: meta.runtime_id,
-        tracer_version: meta.tracer_version,
-        service: meta.service,
-        container_id: meta.container_id,
-        git_commit_sha: meta.git_commit_sha,
-        tags: meta.tags.into_iter().map(|t| t.to_string()).collect(),
+        hostname: meta.hostname.clone(),
+        env: meta.env.clone(),
+        lang: meta.language.clone(),
+        version: meta.version.clone(),
+        runtime_id: meta.runtime_id.clone(),
+        tracer_version: meta.tracer_version.clone(),
+        service: meta.service.clone(),
         sequence,
         stats: buckets,
-        // Agent-only field
+        // These fields will be set by the Agent
+        container_id: String::new(),
+        git_commit_sha: String::new(),
+        tags: Vec::new(),
         agent_aggregation: String::new(),
         image_tag: String::new(),
     }
@@ -211,12 +205,12 @@ mod tests {
         let _ = is_sync::<StatsExporter>;
     }
 
-    fn get_test_metadata() -> LibraryMetadata {
-        LibraryMetadata {
+    fn get_test_metadata() -> TracerMetadata {
+        TracerMetadata {
             hostname: "libdatadog-test".into(),
             env: "test".into(),
             version: "0.0.0".into(),
-            lang: "rust".into(),
+            language: "rust".into(),
             tracer_version: "0.0.0".into(),
             runtime_id: "e39d6d12-0752-489f-b488-cf80006c0378".into(),
             service: "stats_exporter_test".into(),

--- a/data-pipeline/src/stats_exporter.rs
+++ b/data-pipeline/src/stats_exporter.rs
@@ -160,7 +160,7 @@ fn encode_stats_payload(
         hostname: meta.hostname.clone(),
         env: meta.env.clone(),
         lang: meta.language.clone(),
-        version: meta.version.clone(),
+        version: meta.app_version.clone(),
         runtime_id: meta.runtime_id.clone(),
         tracer_version: meta.tracer_version.clone(),
         service: meta.service.clone(),
@@ -209,7 +209,7 @@ mod tests {
         TracerMetadata {
             hostname: "libdatadog-test".into(),
             env: "test".into(),
-            version: "0.0.0".into(),
+            app_version: "0.0.0".into(),
             language: "rust".into(),
             tracer_version: "0.0.0".into(),
             runtime_id: "e39d6d12-0752-489f-b488-cf80006c0378".into(),

--- a/data-pipeline/src/stats_exporter.rs
+++ b/data-pipeline/src/stats_exporter.rs
@@ -38,7 +38,7 @@ impl StatsExporter {
     ///
     /// - `flush_interval` the interval on which the concentrator is flushed
     /// - `concentrator` SpanConcentrator storing the stats to be sent to the agent
-    /// - `meta` metadata used in ClientStatsPayload and as headers to send stats to the agent.
+    /// - `meta` metadata used in ClientStatsPayload and as headers to send stats to the agent
     /// - `endpoint` the Endpoint used to send stats to the agent
     /// - `cancellation_token` Token used to safely shutdown the exporter by force flushing the
     ///   concentrator
@@ -166,9 +166,9 @@ fn encode_stats_payload(
         service: meta.service.clone(),
         sequence,
         stats: buckets,
+        git_commit_sha: meta.git_commit_sha.clone(),
         // These fields will be set by the Agent
         container_id: String::new(),
-        git_commit_sha: String::new(),
         tags: Vec::new(),
         agent_aggregation: String::new(),
         image_tag: String::new(),

--- a/data-pipeline/src/trace_exporter.rs
+++ b/data-pipeline/src/trace_exporter.rs
@@ -157,7 +157,7 @@ fn drop_chunks(traces: &mut Vec<Vec<pb::Span>>) -> DroppedP0Counts {
 pub struct TracerMetadata {
     pub hostname: String,
     pub env: String,
-    pub version: String,
+    pub app_version: String,
     pub runtime_id: String,
     pub service: String,
     pub tracer_version: String,
@@ -672,7 +672,7 @@ pub struct TraceExporterBuilder {
     url: Option<String>,
     hostname: String,
     env: String,
-    version: String,
+    app_version: String,
     service: String,
     tracer_version: String,
     language: String,
@@ -723,8 +723,9 @@ impl TraceExporterBuilder {
     }
 
     /// Set the app version which corresponds to the `version` meta tag
-    pub fn set_version(mut self, version: &str) -> Self {
-        version.clone_into(&mut self.version);
+    /// Only used when client-side stats is enabled
+    pub fn set_app_version(mut self, app_version: &str) -> Self {
+        app_version.clone_into(&mut self.app_version);
         self
     }
 
@@ -872,7 +873,7 @@ impl TraceExporterBuilder {
                 client_computed_top_level: self.client_computed_top_level,
                 hostname: self.hostname,
                 env: self.env,
-                version: self.version,
+                app_version: self.app_version,
                 runtime_id: uuid::Uuid::new_v4().to_string(),
                 service: self.service,
             },

--- a/data-pipeline/src/trace_exporter.rs
+++ b/data-pipeline/src/trace_exporter.rs
@@ -696,7 +696,7 @@ pub struct TraceExporterBuilder {
 }
 
 impl TraceExporterBuilder {
-    #[allow(missing_docs)]
+    /// Set url of the agent
     pub fn set_url(mut self, url: &str) -> Self {
         self.url = Some(url.to_owned());
         self
@@ -708,11 +708,15 @@ impl TraceExporterBuilder {
         self
     }
 
+    /// Set the hostname used for stats payload
+    /// Only used when client-side stats is enabled
     pub fn set_hostname(mut self, hostname: &str) -> Self {
         hostname.clone_into(&mut self.hostname);
         self
     }
 
+    /// Set the env used for stats payloads
+    /// Only used when client-side stats is enabled
     pub fn set_env(mut self, env: &str) -> Self {
         env.clone_into(&mut self.env);
         self
@@ -724,44 +728,47 @@ impl TraceExporterBuilder {
         self
     }
 
+    /// Set the service name used for stats payloads.
+    /// Only used when client-side stats is enabled
     pub fn set_service(mut self, service: &str) -> Self {
         service.clone_into(&mut self.service);
         self
     }
 
-    /// Set the `Datadog-Meta-Tracer-Version` on traces payload
+    /// Set the `git_commit_sha` corresponding to the `_dd.git.commit.sha` meta tag
+    /// Only used when client-side stats is enabled
+    pub fn set_git_commit_sha(mut self, git_commit_sha: &str) -> Self {
+        git_commit_sha.clone_into(&mut self.git_commit_sha);
+        self
+    }
+
+    /// Set the `Datadog-Meta-Tracer-Version` header
     pub fn set_tracer_version(mut self, tracer_version: &str) -> Self {
         tracer_version.clone_into(&mut self.tracer_version);
         self
     }
 
-    /// Set the `Datadog-Meta-Lang` on traces payload
+    /// Set the `Datadog-Meta-Lang` header
     pub fn set_language(mut self, lang: &str) -> Self {
         lang.clone_into(&mut self.language);
         self
     }
 
-    /// Set the `Datadog-Meta-Lang-Version` on traces payload
+    /// Set the `Datadog-Meta-Lang-Version` header
     pub fn set_language_version(mut self, lang_version: &str) -> Self {
         lang_version.clone_into(&mut self.language_version);
         self
     }
 
-    /// Set the `Datadog-Meta-Lang-Interpreter` on traces payload
+    /// Set the `Datadog-Meta-Lang-Interpreter` header
     pub fn set_language_interpreter(mut self, lang_interpreter: &str) -> Self {
         lang_interpreter.clone_into(&mut self.language_interpreter);
         self
     }
 
-    /// Set the `Datadog-Meta-Lang-Interpreter-Vendor` on traces payload
+    /// Set the `Datadog-Meta-Lang-Interpreter-Vendor` header
     pub fn set_language_interpreter_vendor(mut self, lang_interpreter_vendor: &str) -> Self {
         lang_interpreter_vendor.clone_into(&mut self.language_interpreter_vendor);
-        self
-    }
-
-    /// Set the `git_commit_sha` corresponding to the `_dd.git.commit.sha` meta tag
-    pub fn set_git_commit_sha(mut self, git_commit_sha: &str) -> Self {
-        git_commit_sha.clone_into(&mut self.git_commit_sha);
         self
     }
 


### PR DESCRIPTION
# What does this PR do?

- Add `Datadog-Meta-...` headers to stats
- Add `git_commit_sha` to TraceExporter meta for ClientStatsPayload
- Add `interpreter_vendor` to TraceExporter meta
- Rename the `version` field to `app_version` to be more explicit

This PR can be reviewed commit-by-commit

# Motivation

These headers are required by design doc

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
