### PR TITLE
[crashtracking] fix SA_ONSTACK

### DIFF
--- a/crashtracker/src/collector/api.rs
+++ b/crashtracker/src/collector/api.rs
@@ -211,6 +211,7 @@ fn get_sigaltstack() -> Option<libc::stack_t> {
     }
 }
 
+#[cfg(target_os = "linux")]
 #[test]
 fn test_altstack_use_create() -> anyhow::Result<()> {
     // This test initializes crashtracking in a fork, then waits on the exit status of the child.
@@ -336,6 +337,7 @@ fn test_altstack_use_create() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg(target_os = "linux")]
 #[test]
 fn test_altstack_use_nocreate() -> anyhow::Result<()> {
     // Similar to the other test, this one operates inside of a fork in order to prevent poisoning
@@ -461,6 +463,7 @@ fn test_altstack_use_nocreate() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg(target_os = "linux")]
 #[test]
 fn test_altstack_nouse() -> anyhow::Result<()> {
     // This checks that when we do not request the altstack, we do not get the altstack

--- a/crashtracker/src/collector/api.rs
+++ b/crashtracker/src/collector/api.rs
@@ -211,6 +211,7 @@ fn get_sigaltstack() -> Option<libc::stack_t> {
     }
 }
 
+#[cfg_attr(miri, ignore)]
 #[cfg(target_os = "linux")]
 #[test]
 fn test_altstack_use_create() -> anyhow::Result<()> {
@@ -337,6 +338,7 @@ fn test_altstack_use_create() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg_attr(miri, ignore)]
 #[cfg(target_os = "linux")]
 #[test]
 fn test_altstack_use_nocreate() -> anyhow::Result<()> {
@@ -463,6 +465,7 @@ fn test_altstack_use_nocreate() -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg_attr(miri, ignore)]
 #[cfg(target_os = "linux")]
 #[test]
 fn test_altstack_nouse() -> anyhow::Result<()> {

--- a/crashtracker/src/collector/api.rs
+++ b/crashtracker/src/collector/api.rs
@@ -189,9 +189,12 @@ fn test_altstack_paradox() -> anyhow::Result<()> {
         timeout_ms,
     );
 
-    assert!(
-        config.is_err(),
-        "Expected error when creating altstack without using it"
+    // This is slightly over-tuned to the language of the error message, but it'd require some
+    // novel engineering just for this test in order to tighten this up.
+    let err = config.unwrap_err();
+    assert_eq!(
+        err.to_string(),
+        "Cannot create an altstack without using it"
     );
     Ok(())
 }

--- a/crashtracker/src/collector/crash_handler.rs
+++ b/crashtracker/src/collector/crash_handler.rs
@@ -604,7 +604,7 @@ unsafe fn register_signal_handler(
     //   operation it is necessary to CREATE and USE the altstack.
     // - There are no known cases where it is useful to crate but not use the altstack--this case
     //   handled in `new()` for CrashtrackerConfiguration.
-    let extra_saflags = if config.create_alt_stack {
+    let extra_saflags = if config.use_alt_stack {
         SaFlags::SA_ONSTACK
     } else {
         SaFlags::empty()


### PR DESCRIPTION
# What does this PR do?

In my last crashtracking PR, I split up the configuration for _using_ and _enabling_ the altstack.  However, since this was really tricky to test, it wasn't tested, so of course there was a typo (`use` is unused and `create` implies both)

# Motivation

Fixing crashtracking

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Tests are implemented now for all variants
* use, but do not create
* create and use
* do not use, but create (paradox!)
* do not use, do not create