### PR TITLE
[crashtracking] Add explicit test for extra children

### DIFF
--- a/crashtracker/src/collector/api.rs
+++ b/crashtracker/src/collector/api.rs
@@ -708,8 +708,9 @@ fn test_waitall_nohang() -> anyhow::Result<()> {
                 }
             }
 
-            // Now, do the equivalent of the waitall loop.  One caveat here is that we do not want to hang
-            // the test, so we actually collect child exits in a busy WNOHANG loop.
+            // Now, do the equivalent of the waitall loop.
+            // One caveat is that we do not want to hang the test, so rather than an unbounded
+            // `waitpid()`, use WNOHANG within a timer loop.
             let timeout = std::time::Duration::from_millis(timeout_duration_ms);
             let start_time = std::time::Instant::now();
             loop {

--- a/crashtracker/src/collector/api.rs
+++ b/crashtracker/src/collector/api.rs
@@ -645,8 +645,8 @@ fn test_waitall_nohang() -> anyhow::Result<()> {
 
     let path_to_receiver_binary =
         "/tmp/libdatadog/bin/libdatadog-crashtracking-receiver".to_string();
-    let create_alt_stack = false;
-    let use_alt_stack = false;
+    let create_alt_stack = true; // doesn't matter, but most runtimes use it, so take it
+    let use_alt_stack = true;
     let resolve_frames = StacktraceCollection::EnabledWithInprocessSymbols;
     let stderr_filename = Some(format!("{dir}/stderr_{time}.txt"));
     let stdout_filename = Some(format!("{dir}/stdout_{time}.txt"));


### PR DESCRIPTION
# What does this PR do?

This patch adds a test without changing any functionality.  During development of a recent crashtracking fix, I had a C-language repro for this situation which I'd test against the FFI.  Now that the dust has settled a bit and we're doing some more feature work with crashtracking, it's time to add a regression test for this condition.

# Motivation

This was the most significant defect end-users have experienced for crashtracking to date.  We should check it explicitly.