### PR TITLE
Update blazesym to 0.2.0-rc.2

### DIFF
--- a/crashtracker/Cargo.toml
+++ b/crashtracker/Cargo.toml
@@ -25,7 +25,7 @@ receiver = []
 
 [target.'cfg(unix)'.dependencies]
 # Should be kept in sync with the libdatadog symbolizer crate (also using blasesym)
-blazesym = "0.2.0-rc.0"
+blazesym = "0.2.0-rc.2"
 
 [dependencies]
 anyhow = "1.0"

--- a/symbolizer-ffi/Cargo.toml
+++ b/symbolizer-ffi/Cargo.toml
@@ -16,4 +16,4 @@ bench = false
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 # Should be kept in sync with the libdatadog crashtracker crate (also using blasesym)
-blazesym-c = "0.1.0-rc.1"
+blazesym-c = "0.1.0-rc.2"

--- a/symbolizer-ffi/src/blazesym.h
+++ b/symbolizer-ffi/src/blazesym.h
@@ -1,10 +1,10 @@
 // BSD-3-Clause License
 // Synchronized from blazesym repository
-// https://github.com/libbpf/blazesym/blob/capi-v0.1.0-rc.1/capi/include/blazesym.h
+// https://github.com/libbpf/blazesym/blob/capi-v0.1.0-rc.2/capi/include/blazesym.h
 /*
  * Please refer to the documentation hosted at
  *
- *   https://docs.rs/blazesym-c/0.1.0-rc.1
+ *   https://docs.rs/blazesym-c/0.1.0-rc.2
  */
 
 


### PR DESCRIPTION
# What does this PR do?

Update blazesym to 0.2.0-rc.2

# Motivation

0.2.0-rc.2 contains [fix](https://github.com/libbpf/blazesym/pull/824) from @gleocadie to read build id in permissionless env.