### PR TITLE
Deduplicate Debugger diagnostics in sidecar

### DIFF
--- a/live-debugger-ffi/src/send_data.rs
+++ b/live-debugger-ffi/src/send_data.rs
@@ -100,7 +100,7 @@ pub extern "C" fn ddog_create_exception_snapshot<'a>(
 ) -> *mut DebuggerCapture<'a> {
     let snapshot = DebuggerPayload {
         service: service.to_utf8_lossy(),
-        ddsource: "dd_debugger",
+        ddsource: Cow::Borrowed("dd_debugger"),
         timestamp,
         message: None,
         debugger: DebuggerData::Snapshot(Snapshot {
@@ -159,7 +159,7 @@ pub extern "C" fn ddog_create_log_probe_snapshot<'a>(
 ) -> Box<DebuggerPayload<'a>> {
     Box::new(DebuggerPayload {
         service: service.to_utf8_lossy(),
-        ddsource: "dd_debugger",
+        ddsource: Cow::Borrowed("dd_debugger"),
         timestamp,
         message: message.map(|m| m.to_utf8_lossy()),
         debugger: DebuggerData::Snapshot(Snapshot {
@@ -334,7 +334,7 @@ pub extern "C" fn ddog_evaluation_error_snapshot<'a>(
 ) -> Box<DebuggerPayload<'a>> {
     Box::new(DebuggerPayload {
         service: service.to_utf8_lossy(),
-        ddsource: "dd_debugger",
+        ddsource: Cow::Borrowed("dd_debugger"),
         timestamp,
         message: Some(Cow::Owned(format!(
             "Evaluation errors for probe id {}",
@@ -397,7 +397,7 @@ pub fn ddog_debugger_diagnostics_create_unboxed<'a>(
     }
     DebuggerPayload {
         service,
-        ddsource: "dd_debugger",
+        ddsource: Cow::Borrowed("dd_debugger"),
         timestamp,
         message: Some(if probe.diagnostic_msg.len() > 0 {
             probe.diagnostic_msg.to_utf8_lossy()

--- a/live-debugger/src/debugger_defs.rs
+++ b/live-debugger/src/debugger_defs.rs
@@ -5,16 +5,16 @@ use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::collections::HashMap;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct DebuggerPayload<'a> {
     pub service: Cow<'a, str>,
-    pub ddsource: &'static str,
+    pub ddsource: Cow<'static, str>,
     pub timestamp: u64,
     pub debugger: DebuggerData<'a>,
     pub message: Option<Cow<'a, str>>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[allow(clippy::large_enum_variant)]
 pub enum DebuggerData<'a> {
@@ -22,7 +22,7 @@ pub enum DebuggerData<'a> {
     Diagnostics(Diagnostics<'a>),
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ProbeMetadataLocation<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub method: Option<Cow<'a, str>>,
@@ -30,7 +30,7 @@ pub struct ProbeMetadataLocation<'a> {
     pub r#type: Option<Cow<'a, str>>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct ProbeMetadata<'a> {
     pub id: Cow<'a, str>,
     pub location: ProbeMetadataLocation<'a>,
@@ -42,13 +42,13 @@ pub struct SnapshotEvaluationError {
     pub message: String,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct SnapshotStackFrame {
     pub expr: String,
     pub message: String,
 }
 
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Snapshot<'a> {
     pub language: Cow<'a, str>,
@@ -70,7 +70,7 @@ pub struct Snapshot<'a> {
     pub stack: Vec<SnapshotStackFrame>,
 }
 
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct Captures<'a> {
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub lines: HashMap<u32, Capture<'a>>,
@@ -81,7 +81,7 @@ pub struct Captures<'a> {
 }
 
 pub type Fields<'a> = HashMap<Cow<'a, str>, Value<'a>>;
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct Capture<'a> {
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     #[serde(rename = "staticFields")]
@@ -94,10 +94,10 @@ pub struct Capture<'a> {
     pub throwable: Option<Value<'a>>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct Entry<'a>(pub Value<'a>, pub Value<'a>);
 
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Value<'a> {
     pub r#type: Cow<'a, str>,
@@ -119,7 +119,7 @@ pub struct Value<'a> {
     pub size: Option<Cow<'a, str>>,
 }
 
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Diagnostics<'a> {
     pub probe_id: Cow<'a, str>,
@@ -134,7 +134,7 @@ pub struct Diagnostics<'a> {
     pub details: Option<Cow<'a, str>>,
 }
 
-#[derive(Serialize, Deserialize, Default, Copy, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Copy, Clone, Eq, PartialEq)]
 #[serde(rename_all = "UPPERCASE")]
 #[repr(C)]
 pub enum ProbeStatus {
@@ -147,7 +147,7 @@ pub enum ProbeStatus {
     Warning,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DiagnosticsError<'a> {
     pub r#type: Cow<'a, str>,

--- a/sidecar-ffi/src/lib.rs
+++ b/sidecar-ffi/src/lib.rs
@@ -701,6 +701,25 @@ pub unsafe extern "C" fn ddog_sidecar_send_debugger_datum(
 
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
+#[allow(improper_ctypes_definitions)] // DebuggerPayload is just a pointer, we hide its internals
+pub unsafe extern "C" fn ddog_sidecar_send_debugger_diagnostics<'a>(
+    transport: &mut Box<SidecarTransport>,
+    instance_id: &InstanceId,
+    queue_id: QueueId,
+    diagnostics_payload: DebuggerPayload<'a>,
+) -> MaybeError {
+    try_c!(blocking::send_debugger_diagnostics(
+        transport,
+        instance_id,
+        queue_id,
+        diagnostics_payload,
+    ));
+
+    MaybeError::None
+}
+
+#[no_mangle]
+#[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn ddog_sidecar_set_remote_config_data(
     transport: &mut Box<SidecarTransport>,
     instance_id: &InstanceId,

--- a/sidecar-ffi/src/lib.rs
+++ b/sidecar-ffi/src/lib.rs
@@ -702,11 +702,11 @@ pub unsafe extern "C" fn ddog_sidecar_send_debugger_datum(
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 #[allow(improper_ctypes_definitions)] // DebuggerPayload is just a pointer, we hide its internals
-pub unsafe extern "C" fn ddog_sidecar_send_debugger_diagnostics<'a>(
+pub unsafe extern "C" fn ddog_sidecar_send_debugger_diagnostics(
     transport: &mut Box<SidecarTransport>,
     instance_id: &InstanceId,
     queue_id: QueueId,
-    diagnostics_payload: DebuggerPayload<'a>,
+    diagnostics_payload: DebuggerPayload,
 ) -> MaybeError {
     try_c!(blocking::send_debugger_diagnostics(
         transport,

--- a/sidecar/src/service/blocking.rs
+++ b/sidecar/src/service/blocking.rs
@@ -366,11 +366,11 @@ pub fn send_debugger_data_shm_vec(
 /// # Returns
 ///
 /// An `io::Result<()>` indicating the result of the operation.
-pub fn send_debugger_diagnostics<'a>(
+pub fn send_debugger_diagnostics(
     transport: &mut SidecarTransport,
     instance_id: &InstanceId,
     queue_id: QueueId,
-    diagnostics_payload: DebuggerPayload<'a>,
+    diagnostics_payload: DebuggerPayload,
 ) -> io::Result<()> {
     transport.send(SidecarInterfaceRequest::SendDebuggerDiagnostics {
         instance_id: instance_id.clone(),

--- a/sidecar/src/service/debugger_diagnostics_bookkeeper.rs
+++ b/sidecar/src/service/debugger_diagnostics_bookkeeper.rs
@@ -1,0 +1,141 @@
+use datadog_live_debugger::debugger_defs::{
+    DebuggerData, DebuggerPayload, Diagnostics, ProbeStatus,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tokio::select;
+use tokio_util::sync::CancellationToken;
+
+pub struct DebuggerDiagnosticsBookkeeper {
+    active_by_runtime_id: Arc<Mutex<HashMap<String, DebuggerActiveData>>>,
+    cancel: CancellationToken,
+}
+
+struct LastProbeStatus {
+    status: ProbeStatus,
+    last_update: Instant,
+}
+
+#[derive(Default)]
+struct DebuggerActiveData {
+    pub active_probes: HashMap<String, LastProbeStatus>,
+}
+
+const MAX_TIME_BEFORE_FALLBACK: Duration = Duration::from_secs(300);
+const MAX_TIME_BEFORE_REMOVAL: Duration = Duration::from_secs(600);
+
+impl DebuggerDiagnosticsBookkeeper {
+    pub fn start() -> DebuggerDiagnosticsBookkeeper {
+        let buffer = DebuggerDiagnosticsBookkeeper {
+            active_by_runtime_id: Default::default(),
+            cancel: CancellationToken::new(),
+        };
+        let active = buffer.active_by_runtime_id.clone();
+        let cancel = buffer.cancel.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(MAX_TIME_BEFORE_REMOVAL / 2);
+            loop {
+                select! {
+                    _ = interval.tick() => {
+                        active.lock().unwrap().retain(|_, active| {
+                            active.active_probes.retain(|_, status| {
+                                status.last_update.elapsed() < MAX_TIME_BEFORE_REMOVAL
+                            });
+                            active.active_probes.len() != 0
+                        });
+                    },
+                    _ = cancel.cancelled() => {
+                        break;
+                    },
+                }
+            }
+        });
+        buffer
+    }
+
+    pub fn add_payload(&self, payload: &DebuggerPayload) -> bool {
+        if let DebuggerData::Diagnostics(diagnostics) = &payload.debugger {
+            let mut send = true;
+
+            fn insert_probe(active_data: &mut DebuggerActiveData, diagnostics: &Diagnostics) {
+                active_data.active_probes.insert(
+                    diagnostics.probe_id.to_string(),
+                    LastProbeStatus {
+                        status: diagnostics.status,
+                        last_update: Instant::now(),
+                    },
+                );
+            }
+
+            let mut buffers = self.active_by_runtime_id.lock().unwrap();
+            if let Some(buffer) = buffers.get_mut(diagnostics.runtime_id.as_ref()) {
+                if let Some(status) = buffer
+                    .active_probes
+                    .get_mut(diagnostics.runtime_id.as_ref())
+                {
+                    if !matches!(diagnostics.status, ProbeStatus::Received) {
+                        if matches!(status.status, ProbeStatus::Received)
+                            || (!matches!(diagnostics.status, ProbeStatus::Installed)
+                                && matches!(status.status, ProbeStatus::Installed))
+                        {
+                            if status.last_update.elapsed() < MAX_TIME_BEFORE_FALLBACK {
+                                send = false;
+                            }
+                        }
+                    }
+                    if send {
+                        status.last_update = Instant::now();
+                        if status.status != diagnostics.status {
+                            status.status = diagnostics.status;
+                        } else {
+                            send = false;
+                        }
+                    }
+                } else {
+                    insert_probe(buffer, &diagnostics);
+                }
+            } else {
+                buffers.insert(diagnostics.runtime_id.to_string(), {
+                    let mut data = DebuggerActiveData::default();
+                    insert_probe(&mut data, &diagnostics);
+                    data
+                });
+            }
+
+            send
+        } else {
+            unreachable!("This is only for diagnostics");
+        }
+    }
+
+    pub fn stats(&self) -> DebuggerDiagnosticsBookkeeperStats {
+        let buffers = self.active_by_runtime_id.lock().unwrap();
+        DebuggerDiagnosticsBookkeeperStats {
+            runtime_ids: buffers.len() as u32,
+            total_probes: buffers
+                .iter()
+                .map(|(_, active)| active.active_probes.len() as u32)
+                .sum(),
+        }
+    }
+}
+
+impl Default for DebuggerDiagnosticsBookkeeper {
+    fn default() -> Self {
+        Self::start()
+    }
+}
+
+impl Drop for DebuggerDiagnosticsBookkeeper {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DebuggerDiagnosticsBookkeeperStats {
+    runtime_ids: u32,
+    total_probes: u32,
+}

--- a/sidecar/src/service/debugger_diagnostics_bookkeeper.rs
+++ b/sidecar/src/service/debugger_diagnostics_bookkeeper.rs
@@ -1,3 +1,5 @@
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
 use datadog_live_debugger::debugger_defs::{
     DebuggerData, DebuggerPayload, Diagnostics, ProbeStatus,
 };
@@ -43,7 +45,7 @@ impl DebuggerDiagnosticsBookkeeper {
                             active.active_probes.retain(|_, status| {
                                 status.last_update.elapsed() < MAX_TIME_BEFORE_REMOVAL
                             });
-                            active.active_probes.len() != 0
+                            !active.active_probes.is_empty()
                         });
                     },
                     _ = cancel.cancelled() => {
@@ -70,21 +72,21 @@ impl DebuggerDiagnosticsBookkeeper {
             }
 
             let mut buffers = self.active_by_runtime_id.lock().unwrap();
-            if let Some(buffer) = buffers.get_mut(diagnostics.runtime_id.as_ref()) {
-                if let Some(status) = buffer
-                    .active_probes
-                    .get_mut(diagnostics.runtime_id.as_ref())
-                {
-                    if !matches!(diagnostics.status, ProbeStatus::Received) {
-                        if matches!(status.status, ProbeStatus::Received)
-                            || (!matches!(diagnostics.status, ProbeStatus::Installed)
-                                && matches!(status.status, ProbeStatus::Installed))
-                        {
-                            if status.last_update.elapsed() < MAX_TIME_BEFORE_FALLBACK {
-                                send = false;
-                            }
-                        }
-                    }
+            let runtime_id = diagnostics
+                .parent_id
+                .as_ref()
+                .unwrap_or(&diagnostics.runtime_id);
+            if let Some(buffer) = buffers.get_mut(runtime_id.as_ref()) {
+                if let Some(status) = buffer.active_probes.get_mut(diagnostics.probe_id.as_ref()) {
+                    // This is a bit confusing now, but clippy requested me to collapse this:
+                    // Essentially, we shall send if the last emitted/error/installed/etc. is older
+                    // than MAX_TIME_BEFORE_FALLBACK. If it's installed, we also
+                    // send it the current status is Received.
+                    send = matches!(status.status, ProbeStatus::Received)
+                        || (!matches!(diagnostics.status, ProbeStatus::Received)
+                            && (matches!(status.status, ProbeStatus::Installed)
+                                || !matches!(diagnostics.status, ProbeStatus::Installed)))
+                        || status.last_update.elapsed() > MAX_TIME_BEFORE_FALLBACK;
                     if send {
                         status.last_update = Instant::now();
                         if status.status != diagnostics.status {
@@ -94,12 +96,12 @@ impl DebuggerDiagnosticsBookkeeper {
                         }
                     }
                 } else {
-                    insert_probe(buffer, &diagnostics);
+                    insert_probe(buffer, diagnostics);
                 }
             } else {
-                buffers.insert(diagnostics.runtime_id.to_string(), {
+                buffers.insert(runtime_id.to_string(), {
                     let mut data = DebuggerActiveData::default();
-                    insert_probe(&mut data, &diagnostics);
+                    insert_probe(&mut data, diagnostics);
                     data
                 });
             }
@@ -138,4 +140,60 @@ impl Drop for DebuggerDiagnosticsBookkeeper {
 pub struct DebuggerDiagnosticsBookkeeperStats {
     runtime_ids: u32,
     total_probes: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datadog_live_debugger::debugger_defs::{
+        DebuggerData, DebuggerPayload, Diagnostics, ProbeStatus,
+    };
+    use std::borrow::Cow;
+
+    fn create_payload<'a>(
+        probe_id: &'a str,
+        runtime_id: &'a str,
+        status: ProbeStatus,
+    ) -> DebuggerPayload<'a> {
+        DebuggerPayload {
+            service: Default::default(),
+            ddsource: Default::default(),
+            timestamp: 0,
+            debugger: DebuggerData::Diagnostics(Diagnostics {
+                probe_id: Cow::Borrowed(probe_id),
+                runtime_id: Cow::Borrowed(runtime_id),
+                parent_id: None,
+                probe_version: 0,
+                status,
+                exception: None,
+                details: None,
+            }),
+            message: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_bookkeeper() {
+        let bookkeeper = DebuggerDiagnosticsBookkeeper::start();
+        assert!(bookkeeper.add_payload(&create_payload("1", "2", ProbeStatus::Received)));
+        // Second insert of same thing is rejected
+        assert!(!bookkeeper.add_payload(&create_payload("1", "2", ProbeStatus::Received)));
+        // Different thing is allowed
+        assert!(bookkeeper.add_payload(&create_payload("1", "3", ProbeStatus::Received)));
+        assert!(bookkeeper.add_payload(&create_payload("2", "2", ProbeStatus::Received)));
+
+        // We can move to installed
+        assert!(bookkeeper.add_payload(&create_payload("1", "2", ProbeStatus::Installed)));
+        // But not back
+        assert!(!bookkeeper.add_payload(&create_payload("1", "2", ProbeStatus::Received)));
+        assert!(!bookkeeper.add_payload(&create_payload("1", "2", ProbeStatus::Installed)));
+
+        // We can move to e.g. error or emitting
+        assert!(bookkeeper.add_payload(&create_payload("1", "2", ProbeStatus::Emitting)));
+        assert!(bookkeeper.add_payload(&create_payload("1", "2", ProbeStatus::Error)));
+        assert!(bookkeeper.add_payload(&create_payload("1", "2", ProbeStatus::Emitting)));
+        // But not back
+        assert!(!bookkeeper.add_payload(&create_payload("1", "2", ProbeStatus::Received)));
+        assert!(!bookkeeper.add_payload(&create_payload("1", "2", ProbeStatus::Installed)));
+    }
 }

--- a/sidecar/src/service/mod.rs
+++ b/sidecar/src/service/mod.rs
@@ -29,6 +29,7 @@ use sidecar_interface::{SidecarInterface, SidecarInterfaceRequest, SidecarInterf
 
 pub mod agent_info;
 pub mod blocking;
+mod debugger_diagnostics_bookkeeper;
 pub mod exception_hash_rate_limiter;
 mod instance_id;
 mod queue_id;

--- a/sidecar/src/service/sidecar_interface.rs
+++ b/sidecar/src/service/sidecar_interface.rs
@@ -130,6 +130,22 @@ pub trait SidecarInterface {
         debugger_type: DebuggerType,
     );
 
+    /// Submits debugger diagnostics.
+    /// They are small and bounded in size, hence it's fine to send them without shm.
+    /// Also, the sidecar server deserializes them to inspect and filter and avoid sending redundant
+    /// diagnostics payloads.
+    ///
+    /// # Arguments
+    /// * `instance_id` - The ID of the instance.
+    /// * `queue_id` - The unique identifier for the trace context.
+    /// * `diagnostics_payload` - The diagnostics data to send. (Sent as u8 json due to bincode
+    ///   limitations)
+    async fn send_debugger_diagnostics(
+        instance_id: InstanceId,
+        queue_id: QueueId,
+        diagnostics_payload: Vec<u8>,
+    );
+
     /// Acquire an exception hash rate limiter
     ///
     /// # Arguments


### PR DESCRIPTION
We were sending too much data and that made our backend sad.
Sending less data so that our backend can be happy again.

This avoids sending multiple diagnostics for individual runtime ids.