### PR TITLE
[crashtracker] Fixup link in RFC

### DIFF
--- a/docs/RFCs/0005-crashtracker-structured-log-format.md
+++ b/docs/RFCs/0005-crashtracker-structured-log-format.md
@@ -210,8 +210,8 @@ A stacktrace consists of
 
 ## Appendix A: Example output
 
-[Available here](artifacts/0002-crashtracker-example.json)
+[Available here](artifacts/0005-crashtracker-example.json)
 
 ## Appendix B: Json Schema
 
-[Available here](artifacts/0002-crashtracker-schema.json)
+[Available here](artifacts/0005-crashtracker-schema.json)


### PR DESCRIPTION
# What does this PR do?

Fixes a link in the RFC to point at the right file.

# Motivation

Oops!

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Click the new link, see it works.