### PR TITLE
[crashtracker] Implement RFC 0005

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,6 +1357,7 @@ dependencies = [
  "page_size",
  "portable-atomic",
  "rand",
+ "schemars",
  "serde",
  "serde_json",
  "tempfile",
@@ -2049,6 +2050,12 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "educe"
@@ -4776,6 +4783,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4856,6 +4887,17 @@ name = "serde_derive"
 version = "1.0.214"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crashtracker/Cargo.toml
+++ b/crashtracker/Cargo.toml
@@ -45,6 +45,7 @@ tokio = { version = "1.23", features = ["rt", "macros", "io-std", "io-util"] }
 http = "0.2"
 portable-atomic = { version = "1.6.0", features = ["serde"] }
 rand = "0.8.5"
+schemars = "0.8.21"
 
 [dev-dependencies]
 tempfile = { version = "3.3" }

--- a/crashtracker/src/crash_info/mod.rs
+++ b/crashtracker/src/crash_info/mod.rs
@@ -270,6 +270,9 @@ impl CrashInfo {
                 let path = ddcommon::decode_uri_path_in_authority(&endpoint.url)
                     .context("crash output file was not correctly formatted")?;
                 self.to_file(&path)?;
+                let new_path = path.with_extension("rfc5.json");
+                let rfc5: crate::rfc5_crash_info::CrashInfo = self.clone().into();
+                rfc5.to_file(&new_path)?;
             }
         }
 

--- a/crashtracker/src/lib.rs
+++ b/crashtracker/src/lib.rs
@@ -49,6 +49,7 @@ mod collector;
 mod crash_info;
 #[cfg(all(unix, feature = "receiver"))]
 mod receiver;
+mod rfc5_crash_info;
 #[cfg(all(unix, any(feature = "collector", feature = "receiver")))]
 mod shared;
 

--- a/crashtracker/src/rfc5_crash_info/error_data.rs
+++ b/crashtracker/src/rfc5_crash_info/error_data.rs
@@ -1,0 +1,64 @@
+use std::collections::HashMap;
+
+// Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+use super::stacktrace::StackTrace;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct ErrorData {
+    pub is_crash: bool,
+    pub kind: ErrorKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    pub source_type: SourceType,
+    pub stack: StackTrace,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub threads: Vec<ThreadData>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub enum SourceType {
+    Crashtracking,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub enum ErrorKind {
+    Panic,
+    UnhandledException,
+    UnixSignal,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct ThreadData {
+    pub crashed: bool,
+    pub name: String,
+    pub stack: StackTrace,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
+}
+
+impl From<(String, Vec<crate::StackFrame>)> for ThreadData {
+    fn from(value: (String, Vec<crate::StackFrame>)) -> Self {
+        let crashed = false; // Currently, only .Net uses this, and I believe they don't put the crashing thread here
+        let name = value.0;
+        let stack = value.1.into();
+        let state = None;
+        Self {
+            crashed,
+            name,
+            stack,
+            state,
+        }
+    }
+}
+
+pub fn thread_data_from_additional_stacktraces(
+    additional_stacktraces: HashMap<String, Vec<crate::StackFrame>>,
+) -> Vec<ThreadData> {
+    additional_stacktraces
+        .into_iter()
+        .map(|x| x.into())
+        .collect()
+}

--- a/crashtracker/src/rfc5_crash_info/error_data.rs
+++ b/crashtracker/src/rfc5_crash_info/error_data.rs
@@ -1,10 +1,9 @@
-use std::collections::HashMap;
-
 // Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 use super::stacktrace::StackTrace;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct ErrorData {

--- a/crashtracker/src/rfc5_crash_info/metadata.rs
+++ b/crashtracker/src/rfc5_crash_info/metadata.rs
@@ -1,0 +1,30 @@
+// Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct Metadata {
+    pub library_name: String,
+    pub library_version: String,
+    pub family: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    /// A list of "key:value" tuples.
+    pub tags: Vec<String>,
+}
+
+impl From<crate::crash_info::CrashtrackerMetadata> for Metadata {
+    fn from(value: crate::crash_info::CrashtrackerMetadata) -> Self {
+        let tags = value
+            .tags
+            .into_iter()
+            .map(|t: ddcommon::tag::Tag| t.to_string())
+            .collect();
+        Self {
+            library_name: value.library_name,
+            library_version: value.library_version,
+            family: value.family,
+            tags,
+        }
+    }
+}

--- a/crashtracker/src/rfc5_crash_info/mod.rs
+++ b/crashtracker/src/rfc5_crash_info/mod.rs
@@ -1,0 +1,138 @@
+// Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+mod error_data;
+mod metadata;
+mod os_info;
+mod proc_info;
+mod sig_info;
+mod spans;
+mod stacktrace;
+
+use anyhow::Context;
+use error_data::{thread_data_from_additional_stacktraces, ErrorData, ErrorKind, SourceType};
+use metadata::Metadata;
+use os_info::OsInfo;
+use proc_info::ProcInfo;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use sig_info::SigInfo;
+use spans::Span;
+use std::{collections::HashMap, fs::File, path::Path};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct CrashInfo {
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub counters: HashMap<String, i64>,
+    pub data_schema_version: String,
+    pub error: ErrorData,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub files: HashMap<String, Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fingerprint: Option<String>,
+    pub incomplete: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub log_messages: Vec<String>,
+    pub metadata: Metadata,
+    pub os_info: OsInfo,
+    pub proc_info: ProcInfo,
+    pub sig_info: SigInfo,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub span_ids: Vec<Span>,
+    pub timestamp: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub trace_ids: Vec<Span>,
+    pub uuid: String,
+}
+
+impl From<crate::crash_info::CrashInfo> for CrashInfo {
+    fn from(value: crate::crash_info::CrashInfo) -> Self {
+        let counters = value.counters;
+        let data_schema_version = String::from("1.0");
+        let error = {
+            let is_crash = true;
+            let kind = ErrorKind::UnixSignal;
+            let message = None;
+            let source_type = SourceType::Crashtracking;
+            let stack = value.stacktrace.into();
+            let threads = thread_data_from_additional_stacktraces(value.additional_stacktraces);
+            ErrorData {
+                is_crash,
+                kind,
+                message,
+                source_type,
+                stack,
+                threads,
+            }
+        };
+        let files = value.files;
+        let fingerprint = None;
+        let incomplete = value.incomplete;
+        let log_messages = vec![];
+        let metadata = value.metadata.unwrap().into();
+        let os_info = value.os_info.into();
+        let proc_info = value.proc_info.unwrap().into();
+        let sig_info = value.siginfo.unwrap().into();
+        let span_ids = value
+            .span_ids
+            .into_iter()
+            .map(|s| Span {
+                id: s.to_string(),
+                thread_name: None,
+            })
+            .collect();
+        let trace_ids = value
+            .trace_ids
+            .into_iter()
+            .map(|s| Span {
+                id: s.to_string(),
+                thread_name: None,
+            })
+            .collect();
+        let timestamp = value.timestamp.unwrap().to_string();
+        let uuid = value.uuid.to_string();
+        Self {
+            counters,
+            data_schema_version,
+            error,
+            files,
+            fingerprint,
+            incomplete,
+            log_messages,
+            metadata,
+            os_info,
+            proc_info,
+            sig_info,
+            span_ids,
+            trace_ids,
+            timestamp,
+            uuid,
+        }
+    }
+}
+
+impl CrashInfo {
+    /// Emit the CrashInfo as structured json in file `path`.
+    pub fn to_file(&self, path: &Path) -> anyhow::Result<()> {
+        let file = File::options()
+            .create(true)
+            .append(true)
+            .open(path)
+            .with_context(|| format!("Failed to create {}", path.display()))?;
+        serde_json::to_writer_pretty(file, self)
+            .with_context(|| format!("Failed to write json to {}", path.display()))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[ignore]
+    #[test]
+    /// Utility function to print the schema.
+    fn print_schema() {
+        let schema = schemars::schema_for!(CrashInfo);
+        println!("{}", serde_json::to_string_pretty(&schema).unwrap());
+    }
+}

--- a/crashtracker/src/rfc5_crash_info/os_info.rs
+++ b/crashtracker/src/rfc5_crash_info/os_info.rs
@@ -1,0 +1,27 @@
+// Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct OsInfo {
+    pub architecture: String,
+    pub bitness: String,
+    pub os_type: String,
+    pub version: String,
+}
+
+impl From<os_info::Info> for OsInfo {
+    fn from(value: os_info::Info) -> Self {
+        let architecture = value.architecture().unwrap_or("unknown").to_string();
+        let bitness = value.bitness().to_string();
+        let os_type = value.os_type().to_string();
+        let version = value.version().to_string();
+        Self {
+            architecture,
+            bitness,
+            os_type,
+            version,
+        }
+    }
+}

--- a/crashtracker/src/rfc5_crash_info/proc_info.rs
+++ b/crashtracker/src/rfc5_crash_info/proc_info.rs
@@ -1,0 +1,15 @@
+// Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct ProcInfo {
+    pid: u32,
+}
+
+impl From<crate::crash_info::ProcessInfo> for ProcInfo {
+    fn from(value: crate::crash_info::ProcessInfo) -> Self {
+        Self { pid: value.pid }
+    }
+}

--- a/crashtracker/src/rfc5_crash_info/sig_info.rs
+++ b/crashtracker/src/rfc5_crash_info/sig_info.rs
@@ -9,8 +9,8 @@ pub struct SigInfo {
     pub si_addr: Option<String>,
     pub si_code: libc::c_int,
     pub si_code_human_readable: SiCodes,
-    si_signo: libc::c_int,
-    si_signo_human_readable: SignalNames,
+    pub si_signo: libc::c_int,
+    pub si_signo_human_readable: SignalNames,
 }
 
 impl From<crate::SigInfo> for SigInfo {
@@ -42,6 +42,7 @@ pub enum SignalNames {
     SIGSYS,
 }
 
+#[cfg(unix)]
 impl From<libc::c_int> for SignalNames {
     fn from(value: libc::c_int) -> Self {
         match value {
@@ -51,6 +52,13 @@ impl From<libc::c_int> for SignalNames {
             libc::SIGSYS => SignalNames::SIGSYS,
             _ => panic!("Unexpected signal number: {value}"),
         }
+    }
+}
+
+#[cfg(not(unix))]
+impl From<libc::c_int> for SignalNames {
+    fn from(value: libc::c_int) -> Self {
+        unreachable!("Non-unix systems should not have Signals")
     }
 }
 

--- a/crashtracker/src/rfc5_crash_info/sig_info.rs
+++ b/crashtracker/src/rfc5_crash_info/sig_info.rs
@@ -57,7 +57,7 @@ impl From<libc::c_int> for SignalNames {
 
 #[cfg(not(unix))]
 impl From<libc::c_int> for SignalNames {
-    fn from(value: libc::c_int) -> Self {
+    fn from(_value: libc::c_int) -> Self {
         unreachable!("Non-unix systems should not have Signals")
     }
 }

--- a/crashtracker/src/rfc5_crash_info/sig_info.rs
+++ b/crashtracker/src/rfc5_crash_info/sig_info.rs
@@ -1,0 +1,79 @@
+// Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct SigInfo {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub si_addr: Option<String>,
+    pub si_code: libc::c_int,
+    pub si_code_human_readable: SiCodes,
+    si_signo: libc::c_int,
+    si_signo_human_readable: SignalNames,
+}
+
+impl From<crate::SigInfo> for SigInfo {
+    fn from(value: crate::SigInfo) -> Self {
+        let si_addr = value.faulting_address.map(|addr| format!("{addr:#018x}"));
+        // TODO, use the actual value when https://github.com/DataDog/libdatadog/pull/726 lands
+        let si_code = -1;
+        // TODO, use the actual value when https://github.com/DataDog/libdatadog/pull/726 lands
+        let si_code_human_readable = SiCodes::SI_USER;
+        let si_signo: libc::c_int = value.signum.try_into().unwrap(); // libc uses c_int, so this should fit.
+        let si_signo_human_readable = si_signo.into();
+        Self {
+            si_addr,
+            si_code,
+            si_code_human_readable,
+            si_signo,
+            si_signo_human_readable,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[allow(clippy::upper_case_acronyms, non_camel_case_types)]
+/// See https://man7.org/linux/man-pages/man7/signal.7.html
+pub enum SignalNames {
+    SIGABRT,
+    SIGBUS,
+    SIGSEGV,
+    SIGSYS,
+}
+
+impl From<libc::c_int> for SignalNames {
+    fn from(value: libc::c_int) -> Self {
+        match value {
+            libc::SIGABRT => SignalNames::SIGABRT,
+            libc::SIGBUS => SignalNames::SIGBUS,
+            libc::SIGSEGV => SignalNames::SIGSEGV,
+            libc::SIGSYS => SignalNames::SIGSYS,
+            _ => panic!("Unexpected signal number: {value}"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[allow(clippy::upper_case_acronyms, non_camel_case_types)]
+/// See https://man7.org/linux/man-pages/man2/sigaction.2.html
+pub enum SiCodes {
+    BUS_ADRALN,
+    BUS_ADRERR,
+    BUS_MCEERR_AO,
+    BUS_MCEERR_AR,
+    BUS_OBJERR,
+    SEGV_ACCERR,
+    SEGV_BNDERR,
+    SEGV_MAPERR,
+    SEGV_PKUERR,
+    SI_ASYNCIO,
+    SI_KERNEL,
+    SI_MESGQ,
+    SI_QUEUE,
+    SI_SIGIO,
+    SI_TIMER,
+    SI_TKILL,
+    SI_USER,
+    SYS_SECCOMP,
+}

--- a/crashtracker/src/rfc5_crash_info/spans.rs
+++ b/crashtracker/src/rfc5_crash_info/spans.rs
@@ -1,0 +1,11 @@
+// Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct Span {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub thread_name: Option<String>,
+}

--- a/crashtracker/src/rfc5_crash_info/stacktrace.rs
+++ b/crashtracker/src/rfc5_crash_info/stacktrace.rs
@@ -41,7 +41,7 @@ impl From<Vec<crate::StackFrame>> for StackTrace {
                     ),
                     crate::NormalizedAddressMeta::Pdb { path, guid, age } => (
                         Some(format!(
-                            "{}:{age}",
+                            "{}{age}",
                             byte_vec_as_hex(guid).unwrap_or_default()
                         )),
                         Some(BuildIdType::PDB),

--- a/crashtracker/src/rfc5_crash_info/stacktrace.rs
+++ b/crashtracker/src/rfc5_crash_info/stacktrace.rs
@@ -1,0 +1,178 @@
+// Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use crate::NormalizedAddress;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct StackTrace {
+    format: String,
+    frames: Vec<StackFrame>,
+}
+
+impl From<Vec<crate::StackFrame>> for StackTrace {
+    fn from(value: Vec<crate::StackFrame>) -> Self {
+        #[allow(clippy::type_complexity)]
+        fn convert_normalized_address(
+            value: Option<NormalizedAddress>,
+        ) -> (
+            Option<String>,      // build_id
+            Option<BuildIdType>, // build_id_type
+            Option<FileType>,    // file_type
+            Option<String>,      // path
+            Option<String>,      // relative_address
+        ) {
+            if let Some(normalized_address) = value {
+                let relative_address = Some(format!("{:#018x}", normalized_address.file_offset));
+                let (build_id, build_id_type, file_type, path) = match normalized_address.meta {
+                    crate::NormalizedAddressMeta::Apk(path_buf) => (
+                        None,
+                        None,
+                        Some(FileType::APK),
+                        Some(path_buf.to_string_lossy().to_string()),
+                    ),
+                    crate::NormalizedAddressMeta::Elf { path, build_id } => (
+                        byte_vec_as_hex(build_id),
+                        Some(BuildIdType::GNU),
+                        Some(FileType::ELF),
+                        Some(path.to_string_lossy().to_string()),
+                    ),
+                    crate::NormalizedAddressMeta::Pdb { path, guid, age } => (
+                        Some(format!(
+                            "{}:{age}",
+                            byte_vec_as_hex(guid).unwrap_or_default()
+                        )),
+                        Some(BuildIdType::PDB),
+                        Some(FileType::PDB),
+                        Some(path.to_string_lossy().to_string()),
+                    ),
+                    crate::NormalizedAddressMeta::Unknown => {
+                        eprintln!("Unexpected NormalizedAddressMeta::Unknown");
+                        (None, None, None, None)
+                    }
+                    crate::NormalizedAddressMeta::Unexpected(msg) => {
+                        eprintln!("Unexpected NormalizedAddressMeta::Unexpected({msg})");
+                        (None, None, None, None)
+                    }
+                };
+                (build_id, build_id_type, file_type, relative_address, path)
+            } else {
+                (None, None, None, None, None)
+            }
+        }
+
+        let format = String::from("Datadog Crashtracker 1.0");
+        // Todo: this will under-estimate the cap needed if there are inlined functions.
+        // Maybe not worth fixing this.
+        let mut frames = Vec::with_capacity(value.len());
+        for frame in value {
+            let ip = frame.ip;
+            let sp = frame.sp;
+            let symbol_address = frame.symbol_address;
+            let module_base_address = frame.module_base_address;
+
+            let (build_id, build_id_type, file_type, relative_address, path) =
+                convert_normalized_address(frame.normalized_ip);
+            let base_frame = StackFrame {
+                ip,
+                sp,
+                symbol_address,
+                module_base_address,
+                build_id,
+                build_id_type,
+                file_type,
+                relative_address,
+                path,
+                column: None,
+                file: None,
+                line: None,
+                function: None,
+            };
+            let names = frame.names.unwrap_or_default();
+            if names.is_empty() {
+                frames.push(base_frame);
+            } else {
+                for name in names {
+                    frames.push(StackFrame {
+                        column: name.colno,
+                        file: name.filename,
+                        function: name.name,
+                        line: name.lineno,
+                        ..base_frame.clone()
+                    })
+                }
+            }
+        }
+
+        Self { format, frames }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct StackFrame {
+    // Absolute addresses
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ip: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub module_base_address: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sp: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub symbol_address: Option<String>,
+
+    // Relative addresses
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_id_type: Option<BuildIdType>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file_type: Option<FileType>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub relative_address: Option<String>,
+
+    // Debug Info
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub column: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub function: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub line: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[allow(clippy::upper_case_acronyms)]
+pub enum BuildIdType {
+    GNU,
+    GO,
+    PDB,
+    PE,
+    SHA1,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[allow(clippy::upper_case_acronyms)]
+pub enum FileType {
+    APK,
+    ELF,
+    PDB,
+}
+
+fn byte_vec_as_hex(bv: Option<Vec<u8>>) -> Option<String> {
+    use std::fmt::Write;
+
+    if let Some(bv) = bv {
+        let mut s = String::new();
+        for byte in bv {
+            let _ = write!(&mut s, "{byte:X}");
+        }
+        Some(s)
+    } else {
+        None
+    }
+}


### PR DESCRIPTION
# What does this PR do?

* Adds a new datatype which implements RFC 0005.
* Adds a translation from the old to the new data-format.
* the `file://` output type now outputs RFC0005 format as well as the old format.

# Motivation

This is step 1 in implementing the RFC.

# Additional Notes

This is step 1 of a multi-step program to move crashtracker over to RFC5.  
For now, both dataformats will co-exist.
Future PRs will switch various parts of the API over to use the new format.
Once this is done, we can retire the old format.

# How to test the change?

Describe here in detail how the change can be validated.
