### PR TITLE
[chore] Reduce fuzz time to 30s for PRs

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -33,6 +33,6 @@ jobs:
         while read -r package test;
         do
           echo "****** Starting bolero test for $package $test ******" 1>&2
-          cargo bolero test -T 1min --package $package $test
+          cargo bolero test -T 30s --package $package $test
         done
         popd


### PR DESCRIPTION
# What does this PR do?

Reduces the time per fuzz test from 1min -> 30s for PRs.

# Motivation

The "profiling" fuzz tests take 18 min.  This is over our desired 10min CI budget.

# Additional Notes

This lowers coverage.  We should add a nightly job that runs the latest main for longer to get coverage back.

# How to test the change?

Describe here in detail how the change can be validated.
