### PR TITLE
Allow dynamic linking on Windows

### DIFF
--- a/tests/windows_package/windows_package.vcxproj
+++ b/tests/windows_package/windows_package.vcxproj
@@ -28,6 +28,7 @@
     <ProjectGuid>{d4ac517d-369b-40ef-889a-13ce58966a55}</ProjectGuid>
     <RootNamespace>windowspackage</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <LibDatadogDynamicLink>true</LibDatadogDynamicLink>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -87,8 +88,6 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies Condition=" '$(LibdatadogLibrary)' == 'dll' Or '$(LibdatadogLibrary)' == '' ">$(LibdatadogDynLibraries);%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition=" '$(LibdatadogLibrary)' == 'static' ">$(LibdatadogStaticLibraries);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -108,8 +107,6 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies Condition=" '$(LibdatadogLibrary)' == 'dll' Or '$(LibdatadogLibrary)' == '' ">$(LibdatadogDynLibraries);%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition=" '$(LibdatadogLibrary)' == 'static' ">$(LibdatadogStaticLibraries);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -125,8 +122,6 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies Condition=" '$(LibdatadogLibrary)' == 'dll' Or '$(LibdatadogLibrary)' == '' ">$(LibdatadogDynLibraries);%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition=" '$(LibdatadogLibrary)' == 'static' ">$(LibdatadogStaticLibraries);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -146,8 +141,6 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies Condition=" '$(LibdatadogLibrary)' == 'dll' Or '$(LibdatadogLibrary)' == '' ">$(LibdatadogDynLibraries);%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition=" '$(LibdatadogLibrary)' == 'static' ">$(LibdatadogStaticLibraries);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/tests/windows_package/windows_package.vcxproj
+++ b/tests/windows_package/windows_package.vcxproj
@@ -87,7 +87,8 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>$(LibDatadogDynLibs);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition=" '$(LibdatadogLibrary)' == 'dll' Or '$(LibdatadogLibrary)' == '' ">$(LibdatadogDynLibraries);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition=" '$(LibdatadogLibrary)' == 'static' ">$(LibdatadogStaticLibraries);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -107,7 +108,8 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>$(LibDatadogDynLibs);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition=" '$(LibdatadogLibrary)' == 'dll' Or '$(LibdatadogLibrary)' == '' ">$(LibdatadogDynLibraries);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition=" '$(LibdatadogLibrary)' == 'static' ">$(LibdatadogStaticLibraries);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -123,7 +125,8 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>$(LibDatadogDynLibs);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition=" '$(LibdatadogLibrary)' == 'dll' Or '$(LibdatadogLibrary)' == '' ">$(LibdatadogDynLibraries);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition=" '$(LibdatadogLibrary)' == 'static' ">$(LibdatadogStaticLibraries);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -143,7 +146,8 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>$(LibDatadogDynLibs);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition=" '$(LibdatadogLibrary)' == 'dll' Or '$(LibdatadogLibrary)' == '' ">$(LibdatadogDynLibraries);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition=" '$(LibdatadogLibrary)' == 'static' ">$(LibdatadogStaticLibraries);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/tests/windows_package/windows_package.vcxproj
+++ b/tests/windows_package/windows_package.vcxproj
@@ -87,6 +87,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>$(LibDatadogDynLibs);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -106,6 +107,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>$(LibDatadogDynLibs);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -121,6 +123,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>$(LibDatadogDynLibs);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -140,6 +143,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>$(LibDatadogDynLibs);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/windows/libdatadog.csproj
+++ b/windows/libdatadog.csproj
@@ -39,6 +39,8 @@
       PackagePath="include\native\datadog\data-pipeline.h" />
 
     <None Include="$(LibDatadogBinariesOutputDir)\x86_64-pc-windows-msvc\debug\datadog_profiling_ffi.lib"
+      Pack="true" PackagePath="build\native\lib\x64\debug\static\datadog_profiling_ffi.lib" />
+    <None Include="$(LibDatadogBinariesOutputDir)\x86_64-pc-windows-msvc\debug\datadog_profiling_ffi.dll.lib"
       Pack="true" PackagePath="build\native\lib\x64\debug\datadog_profiling_ffi.lib" />
     <None Include="$(LibDatadogBinariesOutputDir)\x86_64-pc-windows-msvc\debug\datadog_profiling_ffi.dll"
       Pack="true" PackagePath="build\native\lib\x64\debug\datadog_profiling_ffi.dll" />
@@ -46,6 +48,8 @@
       Pack="true" PackagePath="build\native\lib\x64\debug\datadog_profiling_ffi.pdb" />
 
     <None Include="$(LibDatadogBinariesOutputDir)\x86_64-pc-windows-msvc\release\datadog_profiling_ffi.lib"
+      Pack="true" PackagePath="build\native\lib\x64\release\static\datadog_profiling_ffi.lib" />
+    <None Include="$(LibDatadogBinariesOutputDir)\x86_64-pc-windows-msvc\release\datadog_profiling_ffi.dll.lib"
       Pack="true" PackagePath="build\native\lib\x64\release\datadog_profiling_ffi.lib" />
     <None Include="$(LibDatadogBinariesOutputDir)\x86_64-pc-windows-msvc\release\datadog_profiling_ffi.dll"
       Pack="true" PackagePath="build\native\lib\x64\release\datadog_profiling_ffi.dll" />
@@ -53,6 +57,8 @@
       Pack="true" PackagePath="build\native\lib\x64\release\datadog_profiling_ffi.pdb" />
 
     <None Include="$(LibDatadogBinariesOutputDir)\i686-pc-windows-msvc\debug\datadog_profiling_ffi.lib"
+      Pack="true" PackagePath="build\native\lib\x86\debug\static\datadog_profiling_ffi.lib" />
+    <None Include="$(LibDatadogBinariesOutputDir)\i686-pc-windows-msvc\debug\datadog_profiling_ffi.dll.lib"
       Pack="true" PackagePath="build\native\lib\x86\debug\datadog_profiling_ffi.lib" />
     <None Include="$(LibDatadogBinariesOutputDir)\i686-pc-windows-msvc\debug\datadog_profiling_ffi.dll"
       Pack="true" PackagePath="build\native\lib\x86\debug\datadog_profiling_ffi.dll" />
@@ -60,6 +66,8 @@
       Pack="true" PackagePath="build\native\lib\x86\debug\datadog_profiling_ffi.pdb" />
 
     <None Include="$(LibDatadogBinariesOutputDir)\i686-pc-windows-msvc\release\datadog_profiling_ffi.lib"
+      Pack="true" PackagePath="build\native\lib\x86\release\static\datadog_profiling_ffi.lib" />
+    <None Include="$(LibDatadogBinariesOutputDir)\i686-pc-windows-msvc\release\datadog_profiling_ffi.dll.lib"
       Pack="true" PackagePath="build\native\lib\x86\release\datadog_profiling_ffi.lib" />
     <None Include="$(LibDatadogBinariesOutputDir)\i686-pc-windows-msvc\release\datadog_profiling_ffi.dll"
       Pack="true" PackagePath="build\native\lib\x86\release\datadog_profiling_ffi.dll" />

--- a/windows/libdatadog.props
+++ b/windows/libdatadog.props
@@ -6,11 +6,11 @@
     <LIBDATADOG-PLATFORM Condition="'$(Platform)'=='Win32' OR '$(Platform)'=='x86'">x86</LIBDATADOG-PLATFORM>
   </PropertyGroup>
   <ItemGroup>
-  <LibdatadogLibs Include="$(MSBuildThisFileDirectory)..\..\build\native\lib\$(LIBDATADOG-PLATFORM)\$(Configuration)\*.lib" />
+  <LibDatadogStaticLibs Include="$(MSBuildThisFileDirectory)..\..\build\native\lib\$(LIBDATADOG-PLATFORM)\$(Configuration)\static\*.lib" />
+  <LibDatadogDynLibs Include="$(MSBuildThisFileDirectory)..\..\build\native\lib\$(LIBDATADOG-PLATFORM)\$(Configuration)\*.dll.lib" />
   </ItemGroup>
   <PropertyGroup>
     <!-- Expland the items to a property -->
-    <LibdatadogLibraries>@(LibdatadogLibs)</LibdatadogLibraries>
     <LibdatadogDependencies>PowrProf.lib;NtDll.lib;UserEnv.lib;Bcrypt.lib;crypt32.lib;wsock32.lib;ws2_32.lib;shlwapi.lib;Secur32.lib;Ncrypt.lib</LibdatadogDependencies>
   </PropertyGroup>
   <ItemDefinitionGroup>
@@ -18,7 +18,7 @@
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)..\..\include\native;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>$(LibdatadogLibraries);$(LibdatadogDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(LibdatadogDependencies);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 </Project>

--- a/windows/libdatadog.props
+++ b/windows/libdatadog.props
@@ -7,10 +7,12 @@
   </PropertyGroup>
   <ItemGroup>
   <LibDatadogStaticLibs Include="$(MSBuildThisFileDirectory)..\..\build\native\lib\$(LIBDATADOG-PLATFORM)\$(Configuration)\static\*.lib" />
-  <LibDatadogDynLibs Include="$(MSBuildThisFileDirectory)..\..\build\native\lib\$(LIBDATADOG-PLATFORM)\$(Configuration)\*.dll.lib" />
+  <LibDatadogDynLibs Include="$(MSBuildThisFileDirectory)..\..\build\native\lib\$(LIBDATADOG-PLATFORM)\$(Configuration)\*.lib" />
   </ItemGroup>
   <PropertyGroup>
     <!-- Expland the items to a property -->
+    <LibdatadogStaticLibraries>@(LibDatadogStaticLibs)</LibdatadogStaticLibraries>
+    <LibdatadogDynLibraries>@(LibDatadogDynLibs)</LibdatadogDynLibraries>
     <LibdatadogDependencies>PowrProf.lib;NtDll.lib;UserEnv.lib;Bcrypt.lib;crypt32.lib;wsock32.lib;ws2_32.lib;shlwapi.lib;Secur32.lib;Ncrypt.lib</LibdatadogDependencies>
   </PropertyGroup>
   <ItemDefinitionGroup>

--- a/windows/libdatadog.props
+++ b/windows/libdatadog.props
@@ -8,19 +8,46 @@
   <ItemGroup>
   <LibDatadogStaticLibs Include="$(MSBuildThisFileDirectory)..\..\build\native\lib\$(LIBDATADOG-PLATFORM)\$(Configuration)\static\*.lib" />
   <LibDatadogDynLibs Include="$(MSBuildThisFileDirectory)..\..\build\native\lib\$(LIBDATADOG-PLATFORM)\$(Configuration)\*.lib" />
+  <LibDatadogDlls Include="$(MSBuildThisFileDirectory)..\..\build\native\lib\$(LIBDATADOG-PLATFORM)\$(Configuration)\*.dll" />
+  <LibDatadogPdbs Include="$(MSBuildThisFileDirectory)..\..\build\native\lib\$(LIBDATADOG-PLATFORM)\$(Configuration)\*.pdb" />
   </ItemGroup>
   <PropertyGroup>
     <!-- Expland the items to a property -->
-    <LibdatadogStaticLibraries>@(LibDatadogStaticLibs)</LibdatadogStaticLibraries>
-    <LibdatadogDynLibraries>@(LibDatadogDynLibs)</LibdatadogDynLibraries>
-    <LibdatadogDependencies>PowrProf.lib;NtDll.lib;UserEnv.lib;Bcrypt.lib;crypt32.lib;wsock32.lib;ws2_32.lib;shlwapi.lib;Secur32.lib;Ncrypt.lib</LibdatadogDependencies>
+    <LibDatadogStaticLibraries>@(LibDatadogStaticLibs)</LibDatadogStaticLibraries>
+    <LibDatadogDynLibraries>@(LibDatadogDynLibs)</LibDatadogDynLibraries>
+    <LibDatadogDependencies>PowrProf.lib;NtDll.lib;UserEnv.lib;Bcrypt.lib;crypt32.lib;wsock32.lib;ws2_32.lib;shlwapi.lib;Secur32.lib;Ncrypt.lib</LibDatadogDependencies>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)..\..\include\native;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>$(LibdatadogDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(LibDatadogDynamicLink)' == 'true' OR '$(LibDatadogDynamicLink)' == ''">$(LibDatadogDynLibraries);$(LibDatadogDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(LibDatadogDynamicLink)' == 'false'">$(LibDatadogStaticLibraries);$(LibDatadogDependencies);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
+  <ItemGroup>
+     <LibDatadogFiles Include="@(LibDatadogDlls)" />
+     <LibDatadogFiles Include="@(LibDatadogPdbs)" />
+  </ItemGroup>
+  <Target Name="CopyLibDatadogDlls" AfterTargets="Build" Condition="'$(LibDatadogDynamicLink)' == 'true' OR '$(LibDatadogDynamicLink)' == ''">
+    <Copy
+      SourceFiles="@(LibDatadogFiles)"
+      DestinationFolder="$(OutDir)"
+      SkipUnchangedFiles="true" />
+  </Target>
+  <Target Name="RemoveLibDatadogDlls" AfterTargets="Clean">
+    <ItemGroup>
+      <FilesToDelete Include="@(LibDatadogFiles->'$(OutDir)%(Filename)%(Extension)')" />
+    </ItemGroup>
+    <Delete Files="@(FilesToDelete)"
+            TreatErrorsAsWarnings="true"
+            ContinueOnError="true">
+      <Output TaskParameter="DeletedFiles" ItemName="RemoveLibDatadogDlls" />
+    </Delete>
+
+    <Message Text="Deleted files: @(FilesToDelete)"
+             Importance="high"
+             Condition="'@(FilesToDelete)' != ''" />
+  </Target>
 </Project>


### PR DESCRIPTION
# What does this PR do?

Update nuget package to be able to link .NET profiler dynamically against libdatadog.

# Motivation

The package contained the dll but not the `lib` required to link dynamically in VS. The other `lib` file was used to link statically.



# How to test the change?

The package is tested in gitlab CI. If the build is green, it means the linking was correct.
I also download the nuget packages and tested it on my machine.
