### PR TITLE
[telemetry] Add missing origin field

### DIFF
--- a/crashtracker/src/crash_info/telemetry.rs
+++ b/crashtracker/src/crash_info/telemetry.rs
@@ -149,6 +149,7 @@ impl TelemetryCrashUploader {
             seq_id: 1,
             application: &metadata.application,
             host: &metadata.host,
+            origin: "Crashtracker",
             payload: &data::Payload::Logs(vec![data::Log {
                 message,
                 level: LogLevel::Error,

--- a/crashtracker/src/crash_info/telemetry.rs
+++ b/crashtracker/src/crash_info/telemetry.rs
@@ -149,7 +149,7 @@ impl TelemetryCrashUploader {
             seq_id: 1,
             application: &metadata.application,
             host: &metadata.host,
-            origin: "Crashtracker",
+            origin: Some("Crashtracker"),
             payload: &data::Payload::Logs(vec![data::Log {
                 message,
                 level: LogLevel::Error,

--- a/crashtracker/src/rfc5_crash_info/telemetry.rs
+++ b/crashtracker/src/rfc5_crash_info/telemetry.rs
@@ -136,6 +136,7 @@ impl TelemetryCrashUploader {
                 is_sensitive: true,
                 count: 1,
             }]),
+            origin: Some("Crashtracker"),
         };
         let client = ddtelemetry::worker::http_client::from_config(&self.cfg);
         let req = request_builder(&self.cfg)?

--- a/ddtelemetry/examples/tm-ping.rs
+++ b/ddtelemetry/examples/tm-ping.rs
@@ -35,7 +35,7 @@ fn build_request<'a>(
         tracer_time: SystemTime::UNIX_EPOCH.elapsed().map_or(0, |d| d.as_secs()),
         runtime_id: "runtime_id",
         seq_id: seq_id(),
-        origin: "tm-ping",
+        origin: Some("tm-ping"),
         application,
         host,
         payload,

--- a/ddtelemetry/examples/tm-ping.rs
+++ b/ddtelemetry/examples/tm-ping.rs
@@ -38,6 +38,7 @@ fn build_request<'a>(
             .unwrap_or(0),
         runtime_id: "runtime_id",
         seq_id: seq_id(),
+        origin: "tm-ping",
         application,
         host,
         payload,

--- a/ddtelemetry/examples/tm-send-sketch.rs
+++ b/ddtelemetry/examples/tm-send-sketch.rs
@@ -33,7 +33,7 @@ fn build_request<'a>(
         tracer_time: SystemTime::UNIX_EPOCH.elapsed().map_or(0, |d| d.as_secs()),
         runtime_id: "runtime_id",
         seq_id: seq_id(),
-        origin: "tm-send-sketch",
+        origin: Some("tm-send-sketch"),
         application,
         host,
         payload,

--- a/ddtelemetry/examples/tm-send-sketch.rs
+++ b/ddtelemetry/examples/tm-send-sketch.rs
@@ -36,6 +36,7 @@ fn build_request<'a>(
             .unwrap_or(0),
         runtime_id: "runtime_id",
         seq_id: seq_id(),
+        origin: "tm-send-sketch",
         application,
         host,
         payload,

--- a/ddtelemetry/src/data/common.rs
+++ b/ddtelemetry/src/data/common.rs
@@ -30,7 +30,8 @@ pub struct Telemetry<'a> {
     pub seq_id: u64,
     pub application: &'a Application,
     pub host: &'a Host,
-    pub origin: &'a str,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin: Option<&'a str>,
     #[serde(flatten)]
     pub payload: &'a Payload,
 }

--- a/ddtelemetry/src/data/common.rs
+++ b/ddtelemetry/src/data/common.rs
@@ -30,6 +30,7 @@ pub struct Telemetry<'a> {
     pub seq_id: u64,
     pub application: &'a Application,
     pub host: &'a Host,
+    pub origin: &'a str,
     #[serde(flatten)]
     pub payload: &'a Payload,
 }

--- a/ddtelemetry/src/worker/mod.rs
+++ b/ddtelemetry/src/worker/mod.rs
@@ -636,7 +636,7 @@ impl TelemetryWorker {
             runtime_id: &self.runtime_id,
             seq_id,
             host: &self.data.host,
-            origin: "unknown",
+            origin: None,
             application: &self.data.app,
             payload,
         };

--- a/ddtelemetry/src/worker/mod.rs
+++ b/ddtelemetry/src/worker/mod.rs
@@ -638,6 +638,7 @@ impl TelemetryWorker {
             runtime_id: &self.runtime_id,
             seq_id,
             host: &self.data.host,
+            origin: "unknown",
             application: &self.data.app,
             payload,
         };


### PR DESCRIPTION
# What does this PR do?

Adds the `origin` field, [defined in the backend](https://github.com/DataDog/dd-go/blob/prod/trace/apps/tracer-telemetry-intake/telemetry-payload/header.go#L88) but not currently implemented in libdatadog.

# Motivation

#727 We'd like to use this field in the crashtracker.

# Additional Notes

* I put placeholder values in for the different uses.  LMK if I should change them?
* The `ddcommon` request builder currently just sets "unknown".  I could plumb through an option to set a value, but this might be a breaking change.  Thoughts?

# How to test the change?

Describe here in detail how the change can be validated.
