### PR TITLE
chore: enable data-pipeline feature in shipped artifacts

### DIFF
--- a/build-profiling-ffi.sh
+++ b/build-profiling-ffi.sh
@@ -136,17 +136,27 @@ cp -v LICENSE LICENSE-3rdparty.yml NOTICE "$destdir/"
 
 
 datadog_profiling_ffi="datadog-profiling-ffi"
-FEATURES="--features crashtracker-collector,crashtracker-receiver,cbindgen,datadog-profiling-ffi/ddtelemetry-ffi,datadog-profiling-ffi/demangler"
+FEATURES=(
+    "cbindgen"
+    "crashtracker-collector"
+    "crashtracker-receiver"
+    "data-pipeline-ffi"
+    "datadog-profiling-ffi/ddtelemetry-ffi"
+    "datadog-profiling-ffi/demangler"
+)
 if [[ "$symbolizer" -eq 1 ]]; then
-    FEATURES="--features crashtracker-collector,crashtracker-receiver,cbindgen,datadog-profiling-ffi/ddtelemetry-ffi,cbindgen,datadog-profiling-ffi/ddtelemetry-ffi,datadog-profiling-ffi/demangler,symbolizer"
+    FEATURES+=("symbolizer")
 fi
 
 if [[ ! -z ${ARG_FEATURES} ]]; then
-    FEATURES="$FEATURES,$ARG_FEATURES"
+    FEATURES+=($ARG_FEATURES)
 fi
 
+FEATURES=$(IFS=, ; echo "${FEATURES[*]}")
+echo "Building for features: $FEATURES"
+
 # build inside the crate to use the config.toml file
-( cd profiling-ffi && DESTDIR="$destdir" cargo build ${FEATURES} --release --target "${target}")
+( cd profiling-ffi && DESTDIR="$destdir" cargo build --features $FEATURES --release --target "${target}" )
 
 # Remove _ffi suffix when copying
 shared_library_name="${library_prefix}datadog_profiling_ffi${shared_library_suffix}"

--- a/windows/build-artifacts.ps1
+++ b/windows/build-artifacts.ps1
@@ -21,11 +21,21 @@ if (![System.IO.Path]::IsPathRooted($output_dir)) {
 Write-Host "Building project into $($output_dir)" -ForegroundColor Magenta
 
 # build inside the crate to use the config.toml file
+$features = @(
+    "data-pipeline-ffi",
+    "datadog-profiling-ffi/crashtracker-collector",
+    "datadog-profiling-ffi/crashtracker-receiver",
+    "datadog-profiling-ffi/ddtelemetry-ffi",
+    "datadog-profiling-ffi/demangler"
+) -join ","
+
+Write-Host "Building for features: $features" -ForegroundColor Magenta
+
 pushd profiling-ffi
-Invoke-Call -ScriptBlock { cargo build --features datadog-profiling-ffi/ddtelemetry-ffi,datadog-profiling-ffi/crashtracker-receiver,datadog-profiling-ffi/crashtracker-collector,datadog-profiling-ffi/demangler --target i686-pc-windows-msvc --release --target-dir $output_dir }
-Invoke-Call -ScriptBlock { cargo build --features datadog-profiling-ffi/ddtelemetry-ffi,datadog-profiling-ffi/crashtracker-receiver,datadog-profiling-ffi/crashtracker-collector,datadog-profiling-ffi/demangler --target i686-pc-windows-msvc --target-dir $output_dir }
-Invoke-Call -ScriptBlock { cargo build --features datadog-profiling-ffi/ddtelemetry-ffi,datadog-profiling-ffi/crashtracker-receiver,datadog-profiling-ffi/crashtracker-collector,datadog-profiling-ffi/demangler --target x86_64-pc-windows-msvc --release --target-dir $output_dir }
-Invoke-Call -ScriptBlock { cargo build --features datadog-profiling-ffi/ddtelemetry-ffi,datadog-profiling-ffi/crashtracker-receiver,datadog-profiling-ffi/crashtracker-collector,datadog-profiling-ffi/demangler --target x86_64-pc-windows-msvc --target-dir $output_dir }
+Invoke-Call -ScriptBlock { cargo build --features $features --target i686-pc-windows-msvc --release --target-dir $output_dir }
+Invoke-Call -ScriptBlock { cargo build --features $features --target i686-pc-windows-msvc --target-dir $output_dir }
+Invoke-Call -ScriptBlock { cargo build --features $features --target x86_64-pc-windows-msvc --release --target-dir $output_dir }
+Invoke-Call -ScriptBlock { cargo build --features $features --target x86_64-pc-windows-msvc --target-dir $output_dir }
 popd
 
 Write-Host "Building tools" -ForegroundColor Magenta


### PR DESCRIPTION
# What does this PR do?

With this change, we will start shipping the data-pipeline code in the shipped artifacts.

I also made some refactor to make it easier to make such changes in future so we don't make mistake like `cbindgen,datadog-profiling-ffi/ddtelemetry-ffi` was included multiple times in past at https://github.com/DataDog/libdatadog/blob/c6ad4ff82852ed6d39fd618a602020b6ba623ed6/build-profiling-ffi.sh#L141

# Motivation

data-pipeline integration in .NET SDK requires data-pipeline stuff as per https://github.com/DataDog/dd-trace-dotnet/pull/6314, hence we need to start shipping the code so integrations can use it 

# How to test the change?

on mac
```
❯ ./build-profiling-ffi.sh bin
<truncated>
Building for features: cbindgen,crashtracker-collector,crashtracker-receiver,data-pipeline-ffi,datadog-profiling-ffi/ddtelemetry-ffi,datadog-profiling-ffi/demangler
<truncated>
[ 50%] Building C object CMakeFiles/libdatadog-crashtracking-receiver.dir/libdatadog-crashtracking-receiver.c.o
[100%] Linking C executable libdatadog-crashtracking-receiver
ld: warning: ignoring duplicate libraries: '-lSystem', '-liconv'
[100%] Built target libdatadog-crashtracking-receiver
Done.
```

on windows
```
❯ .\windows\build-artifacts.ps1 bin
<truncated>
Building for features: data-pipeline-ffi,datadog-profiling-ffi/crashtracker-collector,datadog-profiling-ffi/crashtracker-receiver,datadog-profiling-ffi/ddtelemetry-ffi,datadog-profiling-ffi/demangler
<truncated>
WARN: Missing `[defines]` entry for `feature = "receiver"` in cbindgen config.
WARN: Missing `[defines]` entry for `unix` in cbindgen config.
WARN: Missing `[defines]` entry for `feature = "receiver"` in cbindgen config.
Build finished
```