### PR TITLE
Initial move to use SendData in trace exporter (APMSP-1586)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,6 +1313,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_json",
+ "tinybytes",
  "tokio",
  "tokio-util",
  "uuid",

--- a/data-pipeline/Cargo.toml
+++ b/data-pipeline/Cargo.toml
@@ -31,6 +31,7 @@ dogstatsd-client = { path = "../dogstatsd-client"}
 datadog-trace-obfuscation = { path = "../trace-obfuscation" }
 uuid = { version = "1.10.0", features = ["v4"] }
 tokio-util = "0.7.11"
+tinybytes =  { path = "../tinybytes", features = ["bytes_string", "serialization"] }
 
 [lib]
 bench = false

--- a/data-pipeline/src/health_metrics.rs
+++ b/data-pipeline/src/health_metrics.rs
@@ -7,7 +7,8 @@ pub(crate) const STAT_SEND_TRACES: &str = "datadog.libdatadog.send.traces";
 pub(crate) const STAT_SEND_TRACES_ERRORS: &str = "datadog.libdatadog.send.traces.errors";
 pub(crate) const STAT_DESER_TRACES: &str = "datadog.libdatadog.deser_traces";
 pub(crate) const STAT_DESER_TRACES_ERRORS: &str = "datadog.libdatadog.deser_traces.errors";
-// pub(crate) const STAT_SER_TRACES_ERRORS: &str = "datadog.libdatadog.ser_traces.errors";
+#[allow(dead_code)] // TODO (APMSP-1584) Add support for health metrics when using trace utils
+pub(crate) const STAT_SER_TRACES_ERRORS: &str = "datadog.libdatadog.ser_traces.errors";
 
 pub(crate) enum HealthMetric {
     Count(&'static str, i64),

--- a/data-pipeline/src/health_metrics.rs
+++ b/data-pipeline/src/health_metrics.rs
@@ -7,7 +7,7 @@ pub(crate) const STAT_SEND_TRACES: &str = "datadog.libdatadog.send.traces";
 pub(crate) const STAT_SEND_TRACES_ERRORS: &str = "datadog.libdatadog.send.traces.errors";
 pub(crate) const STAT_DESER_TRACES: &str = "datadog.libdatadog.deser_traces";
 pub(crate) const STAT_DESER_TRACES_ERRORS: &str = "datadog.libdatadog.deser_traces.errors";
-pub(crate) const STAT_SER_TRACES_ERRORS: &str = "datadog.libdatadog.ser_traces.errors";
+// pub(crate) const STAT_SER_TRACES_ERRORS: &str = "datadog.libdatadog.ser_traces.errors";
 
 pub(crate) enum HealthMetric {
     Count(&'static str, i64),

--- a/data-pipeline/src/trace_exporter.rs
+++ b/data-pipeline/src/trace_exporter.rs
@@ -29,9 +29,12 @@ const STATS_ENDPOINT: &str = "/v0.6/stats";
 const INFO_ENDPOINT: &str = "/info";
 
 // Keys used for sampling
-// const SAMPLING_PRIORITY_KEY: &str = "_sampling_priority_v1";
-// const SAMPLING_SINGLE_SPAN_MECHANISM: &str = "_dd.span_sampling.mechanism";
-// const SAMPLING_ANALYTICS_RATE_KEY: &str = "_dd1.sr.eausr";
+#[allow(dead_code)] // TODO (APMSP-1583) these will be used with client side stats
+const SAMPLING_PRIORITY_KEY: &str = "_sampling_priority_v1";
+#[allow(dead_code)] // TODO (APMSP-1584) these will be used with client side stats
+const SAMPLING_SINGLE_SPAN_MECHANISM: &str = "_dd.span_sampling.mechanism";
+#[allow(dead_code)] // TODO (APMSP-1584) these will be used with client side stats
+const SAMPLING_ANALYTICS_RATE_KEY: &str = "_dd1.sr.eausr";
 
 /// TraceExporterInputFormat represents the format of the input traces.
 /// The input format can be either Proxy or V0.4, where V0.4 is the default.

--- a/data-pipeline/src/trace_exporter.rs
+++ b/data-pipeline/src/trace_exporter.rs
@@ -261,7 +261,6 @@ impl TraceExporter {
                 self.send_deser_ser(tinybytes::Bytes::copy_from_slice(data))
                 // TODO: APMSP-1582 - Refactor data-pipeline-ffi so we can leverage a type that
                 // implements tinybytes::UnderlyingBytes trait to avoid copying
-                // self.send_deser_ser(tinybytes::Bytes::copy_from_slice(data))
             }
         }
     }

--- a/data-pipeline/src/trace_exporter.rs
+++ b/data-pipeline/src/trace_exporter.rs
@@ -255,8 +255,11 @@ impl TraceExporter {
         match self.input_format {
             TraceExporterInputFormat::Proxy => self.send_proxy(data, trace_count),
             TraceExporterInputFormat::V04 => {
-// TODO: APMSP-1582 - Refactor data-pipeline-ffi so we can leverage a type that implements tinybytes::UnderlyingBytes trait to avoid copying                self.send_deser_ser(tinybytes::Bytes::copy_from_slice(data))
-            } 
+                self.send_deser_ser(tinybytes::Bytes::copy_from_slice(data))
+                // TODO: APMSP-1582 - Refactor data-pipeline-ffi so we can leverage a type that
+                // implements tinybytes::UnderlyingBytes trait to avoid copying
+                // self.send_deser_ser(tinybytes::Bytes::copy_from_slice(data))
+            }
         }
     }
 

--- a/data-pipeline/src/trace_exporter.rs
+++ b/data-pipeline/src/trace_exporter.rs
@@ -254,8 +254,8 @@ impl TraceExporter {
         match self.input_format {
             TraceExporterInputFormat::Proxy => self.send_proxy(data, trace_count),
             TraceExporterInputFormat::V04 => {
-                self.send_deser_ser(tinybytes::Bytes::copy_from_slice(data))
-            } //todo do we want to copy?
+// TODO: APMSP-1582 - Refactor data-pipeline-ffi so we can leverage a type that implements tinybytes::UnderlyingBytes trait to avoid copying                self.send_deser_ser(tinybytes::Bytes::copy_from_slice(data))
+            } 
         }
     }
 

--- a/data-pipeline/src/trace_exporter.rs
+++ b/data-pipeline/src/trace_exporter.rs
@@ -545,9 +545,9 @@ impl TraceExporter {
         }
     }
 
-    /// Add all spans from the given iterator into the stats concentrator
-    /// # Panic
-    /// Will panic if another thread panicked will holding the lock on `stats_concentrator`
+    // /// Add all spans from the given iterator into the stats concentrator
+    // /// # Panic
+    // /// Will panic if another thread panicked will holding the lock on `stats_concentrator`
     // fn add_spans_to_stats<'a>(&self, spans: impl Iterator<Item = &'a pb::Span>) {
     //     if let StatsComputationStatus::Enabled {
     //         stats_concentrator,

--- a/data-pipeline/src/trace_exporter.rs
+++ b/data-pipeline/src/trace_exporter.rs
@@ -905,7 +905,7 @@ mod tests {
     use datadog_trace_utils::span_v04::Span;
     use httpmock::prelude::*;
     use httpmock::MockServer;
-    use serde::Serialize;
+    // use serde::Serialize;
     use std::collections::HashMap;
     use std::net;
     use std::time::Duration;


### PR DESCRIPTION
# What does this PR do?
Moves TraceExporter to use trace utils send data functionality.

# Motivation
We want access to the retry functionality of trace utils as well as to start supporting TinyBytes so we have good performance here

# Additional Notes

There are a number of things to do after this is merged that have been commented out explicitly so that we can unblock others working in this area. (e.g. client stats)

# How to test the change?

Covered with unit and integration tests for now
