### PR TITLE
fix(crashtracker) : Fix crash when sending crashinfo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -187,6 +187,7 @@ jobs:
             cmake -S .. -DDatadog_ROOT=$LIBDD_OUTPUT_FOLDER -DBUILD_SYMBOLIZER=true
             cmake --build .
             ./symbolizer
+            ./crashinfo
           else
             cmake -S .. -DDatadog_ROOT=$LIBDD_OUTPUT_FOLDER
             cmake --build .

--- a/crashtracker-ffi/src/crash_info/datatypes.rs
+++ b/crashtracker-ffi/src/crash_info/datatypes.rs
@@ -247,6 +247,20 @@ impl<'a> TryFrom<SigInfo<'a>> for datadog_crashtracker::SigInfo {
 }
 
 #[repr(C)]
+pub struct ProcInfo {
+    pub pid: u32,
+}
+
+impl TryFrom<ProcInfo> for datadog_crashtracker::ProcessInfo {
+    type Error = anyhow::Error;
+
+    fn try_from(value: ProcInfo) -> anyhow::Result<Self> {
+        let pid = value.pid;
+        Ok(Self { pid })
+    }
+}
+
+#[repr(C)]
 pub struct Metadata<'a> {
     pub library_name: CharSlice<'a>,
     pub library_version: CharSlice<'a>,

--- a/crashtracker-ffi/src/crash_info/mod.rs
+++ b/crashtracker-ffi/src/crash_info/mod.rs
@@ -225,6 +225,25 @@ pub unsafe extern "C" fn ddog_crasht_CrashInfo_set_timestamp_to_now(
     .into()
 }
 
+/// Sets crashinfo procinfo
+///
+/// # Safety
+/// `crashinfo` must be a valid pointer to a `CrashInfo` object.
+#[no_mangle]
+#[must_use]
+pub unsafe extern "C" fn ddog_crasht_CrashInfo_set_procinfo(
+    crashinfo: *mut CrashInfo,
+    procinfo: ProcInfo,
+) -> Result {
+    (|| {
+        let crashinfo = crashinfo_ptr_to_inner(crashinfo)?;
+        let procinfo = procinfo.try_into()?;
+        crashinfo.set_procinfo(procinfo)
+    })()
+    .context("ddog_crasht_CrashInfo_set_procinfo failed")
+    .into()
+}
+
 /// Exports `crashinfo` to the backend at `endpoint`
 /// Note that we support the "file://" endpoint for local file output.
 /// # Safety

--- a/examples/ffi/crashinfo.cpp
+++ b/examples/ffi/crashinfo.cpp
@@ -165,6 +165,13 @@ int main(void) {
   check_result(ddog_crasht_CrashInfo_set_timestamp(crashinfo.get(), timestamp),
                "Failed to set timestamp");
 
+  ddog_crasht_ProcInfo procinfo = {
+    .pid = 42
+  };
+
+  check_result(ddog_crasht_CrashInfo_set_procinfo(crashinfo.get(), procinfo),
+               "Failed to set procinfo");
+
   auto endpoint = ddog_endpoint_from_filename(to_slice_c_char("/tmp/test"));
 
   check_result(ddog_crasht_CrashInfo_upload_to_endpoint(crashinfo.get(), endpoint),


### PR DESCRIPTION
# What does this PR do?

When calling `ddog_crasht_CrashInfo_upload_to_endpoint`, if the `ProcInfo`  is not set, the process crashes with panic
```
 thread '<unnamed>' panicked at crashtracker/src/rfc5_crash_info/mod.rs:74:41:
```

# Motivation

Fix a bug and missing API.


# How to test the change?

The `crashinfo` example runs in CI.
Added calls to `ddog_crasht_CrashInfo_set_procinfo` to fix the crash

