### PR TITLE
Bump version to 14.3.0 in preperation for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "build_common"
-version = "14.2.0"
+version = "14.3.0"
 dependencies = [
  "cbindgen",
  "serde",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "builder"
-version = "14.2.0"
+version = "14.3.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "data-pipeline"
-version = "14.2.0"
+version = "14.3.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1321,7 +1321,7 @@ dependencies = [
 
 [[package]]
 name = "data-pipeline-ffi"
-version = "14.2.0"
+version = "14.3.0"
 dependencies = [
  "build_common",
  "bytes",
@@ -1332,7 +1332,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-alloc"
-version = "14.2.0"
+version = "14.3.0"
 dependencies = [
  "allocator-api2",
  "bolero",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-crashtracker"
-version = "14.2.0"
+version = "14.3.0"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -1368,7 +1368,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-crashtracker-ffi"
-version = "14.2.0"
+version = "14.3.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1382,7 +1382,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-ddsketch"
-version = "14.2.0"
+version = "14.3.0"
 dependencies = [
  "prost 0.11.9",
  "prost-build 0.11.9",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling"
-version = "14.2.0"
+version = "14.3.0"
 dependencies = [
  "anyhow",
  "bitmaps",
@@ -1514,7 +1514,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-ffi"
-version = "14.2.0"
+version = "14.3.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1536,7 +1536,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-replayer"
-version = "14.2.0"
+version = "14.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-mini-agent"
-version = "14.2.0"
+version = "14.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1719,7 +1719,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-normalization"
-version = "14.2.0"
+version = "14.3.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1730,7 +1730,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-obfuscation"
-version = "14.2.0"
+version = "14.3.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-protobuf"
-version = "14.2.0"
+version = "14.3.0"
 dependencies = [
  "prost 0.11.9",
  "prost-build 0.11.9",
@@ -1761,7 +1761,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-utils"
-version = "14.2.0"
+version = "14.3.0"
 dependencies = [
  "anyhow",
  "bolero",
@@ -1795,7 +1795,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon"
-version = "14.2.0"
+version = "14.3.0"
 dependencies = [
  "anyhow",
  "cc",
@@ -1825,7 +1825,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon-ffi"
-version = "14.2.0"
+version = "14.3.0"
 dependencies = [
  "anyhow",
  "bolero",
@@ -1850,7 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry"
-version = "14.2.0"
+version = "14.3.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry-ffi"
-version = "14.2.0"
+version = "14.3.0"
 dependencies = [
  "build_common",
  "ddcommon",
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "dogstatsd"
-version = "14.2.0"
+version = "14.3.0"
 dependencies = [
  "datadog-protos",
  "ddsketch-agent",
@@ -2023,7 +2023,7 @@ dependencies = [
 
 [[package]]
 name = "dogstatsd-client"
-version = "14.2.0"
+version = "14.3.0"
 dependencies = [
  "anyhow",
  "cadence",
@@ -5268,7 +5268,7 @@ dependencies = [
 
 [[package]]
 name = "symbolizer-ffi"
-version = "14.2.0"
+version = "14.3.0"
 dependencies = [
  "blazesym-c",
  "build_common",
@@ -5594,7 +5594,7 @@ dependencies = [
 
 [[package]]
 name = "tinybytes"
-version = "14.2.0"
+version = "14.3.0"
 dependencies = [
  "once_cell",
  "pretty_assertions",
@@ -5866,7 +5866,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "14.2.0"
+version = "14.3.0"
 dependencies = [
  "lazy_static",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.76.0"
 edition = "2021"
-version = "14.2.0"
+version = "14.3.0"
 license = "Apache-2.0"
 
 [profile.dev]


### PR DESCRIPTION
# What does this PR do?

Bumps the version to 14.3.0 in preparation for release

# Motivation

We want to get the fix in #754 out as fast as possible

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
