### PR TITLE
fix(alloc): potentially dangling temporary

### DIFF
--- a/alloc/src/chain.rs
+++ b/alloc/src/chain.rs
@@ -288,10 +288,9 @@ impl<A: Allocator + Clone> Drop for ChainAllocator<A> {
                     // moved to the stack before the chunk is dropped, so it's
                     // alive and valid after the chunk is dropped below.
                     chain_node_ptr = unsafe {
-                        core::ptr::addr_of!((*non_null.as_ptr()).prev)
-                            .read()
-                            .get()
-                            .read()
+                        // Save to variable to avoid a dangling temporary.
+                        let unsafe_cell = core::ptr::addr_of!((*non_null.as_ptr()).prev).read();
+                        unsafe_cell.get().read()
                     };
 
                     // SAFETY: the chunk hasn't been dropped yet, and the

--- a/data-pipeline/src/trace_exporter.rs
+++ b/data-pipeline/src/trace_exporter.rs
@@ -918,6 +918,7 @@ mod tests {
     use tinybytes::BytesString;
     use tokio::time::sleep;
 
+    #[cfg_attr(all(miri, target_os = "macos"), ignore)]
     #[test]
     fn new() {
         let builder = TraceExporterBuilder::default();
@@ -951,6 +952,7 @@ mod tests {
         assert!(!exporter.metadata.client_computed_stats);
     }
 
+    #[cfg_attr(all(miri, target_os = "macos"), ignore)]
     #[test]
     fn new_defaults() {
         let builder = TraceExporterBuilder::default();

--- a/sidecar/src/service/debugger_diagnostics_bookkeeper.rs
+++ b/sidecar/src/service/debugger_diagnostics_bookkeeper.rs
@@ -172,6 +172,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(all(miri, target_os = "macos"), ignore)]
     #[tokio::test]
     async fn test_bookkeeper() {
         let bookkeeper = DebuggerDiagnosticsBookkeeper::start();

--- a/sidecar/src/service/session_info.rs
+++ b/sidecar/src/service/session_info.rs
@@ -308,6 +308,7 @@ mod tests {
     use super::*;
 
     #[tokio::test]
+    #[cfg_attr(all(miri, target_os = "macos"), ignore)]
     async fn test_get_runtime() {
         let session_info = SessionInfo::default();
         let runtime_id = "runtime1".to_string();

--- a/trace-mini-agent/src/config.rs
+++ b/trace-mini-agent/src/config.rs
@@ -122,6 +122,7 @@ mod tests {
     #[test]
     #[serial]
     fn test_error_if_no_api_key_env_var() {
+        env::remove_var("DD_API_KEY");
         let config = config::Config::new();
         assert!(config.is_err());
         assert_eq!(

--- a/trace-protobuf/src/pb_test.rs
+++ b/trace-protobuf/src/pb_test.rs
@@ -36,6 +36,7 @@ mod tests {
 
     use crate::pb::{ClientGroupedStats, ClientStatsBucket, ClientStatsPayload, Trilean::NotSet};
 
+    #[cfg_attr(all(miri, target_os = "macos"), ignore)]
     #[tokio::test]
     async fn test_deserialize_client_stats_payload() {
         let stats_json = r#"{

--- a/trace-utils/src/stats_utils.rs
+++ b/trace-utils/src/stats_utils.rs
@@ -85,6 +85,7 @@ mod tests {
     use serde_json::Value;
 
     #[tokio::test]
+    #[cfg_attr(all(miri, target_os = "macos"), ignore)]
     async fn test_get_stats_from_request_body() {
         let stats_json = r#"{
             "Hostname": "TestHost",
@@ -188,6 +189,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(all(miri, target_os = "macos"), ignore)]
     async fn test_get_stats_from_request_body_without_stats() {
         let stats_json = r#"{
             "Hostname": "TestHost",
@@ -239,6 +241,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(all(miri, target_os = "macos"), ignore)]
     async fn test_serialize_client_stats_payload_without_stats() {
         let client_stats_payload_without_stats = ClientStatsPayload {
             hostname: "TestHost".to_string(),

--- a/trace-utils/src/trace_utils.rs
+++ b/trace-utils/src/trace_utils.rs
@@ -743,6 +743,7 @@ mod tests {
 
     #[tokio::test]
     #[allow(clippy::type_complexity)]
+    #[cfg_attr(all(miri, target_os = "macos"), ignore)]
     async fn get_v05_traces_from_request_body() {
         let data: (
             Vec<String>,


### PR DESCRIPTION
# What does this PR do?

 1. Fixes a warning `dangling_pointers_from_temporaries`.
 2. Skips some tests on miri for MacOS.
 3. Fixes a test that doesn't fail for the right reason when running locally (because it can't figure out the cloud env it's running in, because it's not in a cloud env).

# Motivation

I was trying out the Rust 2024 edition which required a new nightly. There's now a warning for `dangling_pointers_from_temporaries`. This could be a false positive but I am not certain. It
seems prudent to fix it and figure out whether it's truly dangling later, if we have time.

The other fixes are just annoyances that happen when developing locally on a Mac.

# Additional Notes

Here's the warning:

```
warning: a dangling pointer will be produced because the temporary `UnsafeCell<ChainNodePtr<A>>` will be dropped
   --> alloc/src/chain.rs:293:30
    |
291 | /                         core::ptr::addr_of!((*non_null.as_ptr()).prev)
292 | |                             .read()
    | |___________________________________- this `UnsafeCell<ChainNodePtr<A>>` is deallocated at the end of the statement, bind it to a variable to extend its lifetime
293 |                               .get()
    |                                ^^^ this pointer will immediately be invalid
    |
    = note: pointers do not have a lifetime; when calling `get` the `UnsafeCell<ChainNodePtr<A>>` will be deallocated at the end of the statement because nothing is referencing it as far as the type system is concerned
    = help: for more information, see <https://doc.rust-lang.org/reference/destructors.html>
    = note: `#[warn(dangling_pointers_from_temporaries)]` on by default
```

# How to test the change?

No changes should be necessary.
