### PR TITLE
Fix builder cmake target directory.

### DIFF
--- a/builder/src/builder.rs
+++ b/builder/src/builder.rs
@@ -139,7 +139,12 @@ impl Builder {
 
     pub fn add_cmake(&self) {
         let libs = arch::NATIVE_LIBS.to_owned();
-        let cmake_path: PathBuf = [&self.target_dir, "DatadogConfig.cmake"].iter().collect();
+        let cmake_dir: PathBuf = [&self.target_dir, "cmake"].iter().collect();
+        fs::create_dir_all(cmake_dir).expect("Failed to create cmake dir");
+
+        let cmake_path: PathBuf = [&self.target_dir, "cmake", "DatadogConfig.cmake"]
+            .iter()
+            .collect();
         let mut origin = project_root();
         origin.push("cmake");
         origin.push("DatadogConfig.cmake.in");

--- a/builder/src/crashtracker.rs
+++ b/builder/src/crashtracker.rs
@@ -24,7 +24,6 @@ impl CrashTracker {
         if arch::BUILD_CRASHTRACKER {
             let mut datadog_root = project_root();
             datadog_root.push(self.target_dir.as_ref());
-            println!("ROOT: {}", datadog_root.to_str().unwrap());
 
             let mut crashtracker_dir = project_root();
             crashtracker_dir.push("crashtracker");

--- a/builder/src/crashtracker.rs
+++ b/builder/src/crashtracker.rs
@@ -22,11 +22,15 @@ pub struct CrashTracker {
 impl CrashTracker {
     fn gen_binaries(&self) -> Result<()> {
         if arch::BUILD_CRASHTRACKER {
+            let mut datadog_root = project_root();
+            datadog_root.push(self.target_dir.as_ref());
+            println!("ROOT: {}", datadog_root.to_str().unwrap());
+
             let mut crashtracker_dir = project_root();
             crashtracker_dir.push("crashtracker");
             let _dst = cmake::Config::new(crashtracker_dir.to_str().unwrap())
-                .define("Datadog_ROOT", self.target_dir.as_ref())
-                .define("CMAKE_INSTALL_PREFIX", self.target_dir.as_ref())
+                .define("Datadog_ROOT", datadog_root.to_str().unwrap())
+                .define("CMAKE_INSTALL_PREFIX", self.target_dir.to_string())
                 .build();
         }
 


### PR DESCRIPTION
# What does this PR do?

Fix cmake target directory during the artifact generation.

# Motivation

The builder could fail on certain scenarios.

# How to test the change?

Builder can be triggered by:

`cargo run --bin release --features profiling,telemetry,symbolizer,crashtracker,data-pipeline --release -- --out <path>`

After that it can be checked that all required artifacts should be in the desired output path