### PR TITLE
New API for Trace Exporter FFI

### DIFF
--- a/data-pipeline-ffi/cbindgen.toml
+++ b/data-pipeline-ffi/cbindgen.toml
@@ -21,6 +21,8 @@ renaming_overrides_prefixing = true
 "Slice_CChar" = "ddog_Slice_CChar"
 "Error" = "ddog_Error"
 "AgentResponse" = "ddog_AgentResponse"
+"ExporterErrorCode" = "ddog_TraceExporterErrorCode"
+"ExporterError" = "ddog_TraceExporterError"
 
 [export.mangle]
 rename_types = "PascalCase"

--- a/data-pipeline-ffi/cbindgen.toml
+++ b/data-pipeline-ffi/cbindgen.toml
@@ -20,6 +20,7 @@ renaming_overrides_prefixing = true
 "Slice_U8" = "ddog_Slice_U8"
 "Slice_CChar" = "ddog_Slice_CChar"
 "Error" = "ddog_Error"
+"AgentResponse" = "ddog_AgentResponse"
 
 [export.mangle]
 rename_types = "PascalCase"

--- a/data-pipeline-ffi/src/error.rs
+++ b/data-pipeline-ffi/src/error.rs
@@ -1,0 +1,47 @@
+// Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+/// Represent error codes that `Error` struct can hold
+#[repr(C)]
+#[derive(Debug, PartialEq)]
+pub enum TraceExporterErrorCode {
+    AddressInUse,
+    ConnectionAborted,
+    ConnectionRefused,
+    ConnectionReset,
+    HttpBodyFormat,
+    HttpBodyTooLong,
+    HttpClient,
+    HttpParse,
+    HttpServer,
+    HttpWrongStatus,
+    InvalidArgument,
+    InvalidData,
+    InvalidInput,
+    InvalidUrl,
+    IoError,
+    NetworkUnknown,
+    Serde,
+    TimedOut,
+}
+
+/// Stucture that contains error information that `TraceExporter` API can return.
+#[repr(C)]
+#[derive(Debug, PartialEq)]
+pub struct TraceExporterError {
+    pub code: TraceExporterErrorCode,
+}
+
+impl From<TraceExporterErrorCode> for TraceExporterError {
+    fn from(value: TraceExporterErrorCode) -> Self {
+        TraceExporterError { code: value }
+    }
+}
+
+/// Free
+#[no_mangle]
+pub unsafe extern "C" fn ddog_trace_exporter_error_free(
+    _error: ddcommon_ffi::Option<&mut TraceExporterError>,
+) {
+    // TODO: Placeholder function to remove dynamically allocated properties in Error.
+}

--- a/data-pipeline-ffi/src/error.rs
+++ b/data-pipeline-ffi/src/error.rs
@@ -1,10 +1,17 @@
 // Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+use data_pipeline::trace_exporter::error::{
+    BuilderErrorKind, NetworkErrorKind, TraceExporterError,
+};
+use std::ffi::{c_char, CString};
+use std::fmt::Display;
+use std::io::ErrorKind as IoErrorKind;
+
 /// Represent error codes that `Error` struct can hold
 #[repr(C)]
-#[derive(Debug, PartialEq)]
-pub enum TraceExporterErrorCode {
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum ExporterErrorCode {
     AddressInUse,
     ConnectionAborted,
     ConnectionRefused,
@@ -25,23 +32,130 @@ pub enum TraceExporterErrorCode {
     TimedOut,
 }
 
+impl Display for ExporterErrorCode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AddressInUse => write!(f, "Address already in use"),
+            Self::ConnectionAborted => write!(f, "Connection aborted"),
+            Self::ConnectionRefused => write!(f, "Connection refused"),
+            Self::ConnectionReset => write!(f, "Connection reset by peer"),
+            Self::HttpBodyFormat => write!(f, "Error parsing HTTP body"),
+            Self::HttpBodyTooLong => write!(f, "HTTP body too long"),
+            Self::HttpClient => write!(f, "HTTP error orgininated by client"),
+            Self::HttpParse => write!(f, "Error while parsing HTTP message"),
+            Self::HttpServer => write!(f, "HTTP error orgininated by server"),
+            Self::HttpWrongStatus => write!(f, "HTTP wrong status number"),
+            Self::InvalidArgument => write!(f, "Invalid argument provided"),
+            Self::InvalidData => write!(f, "Invalid data payload"),
+            Self::InvalidInput => write!(f, "Invalid input"),
+            Self::InvalidUrl => write!(f, "Invalid URL"),
+            Self::IoError => write!(f, "Input/Output error"),
+            Self::NetworkUnknown => write!(f, "Unknown network error"),
+            Self::Serde => write!(f, "Serialization/Deserialization error"),
+            Self::TimedOut => write!(f, "Operation timed out"),
+        }
+    }
+}
+
 /// Stucture that contains error information that `TraceExporter` API can return.
 #[repr(C)]
 #[derive(Debug, PartialEq)]
-pub struct TraceExporterError {
-    pub code: TraceExporterErrorCode,
+pub struct ExporterError {
+    pub code: ExporterErrorCode,
+    pub msg: *mut c_char,
 }
 
-impl From<TraceExporterErrorCode> for TraceExporterError {
-    fn from(value: TraceExporterErrorCode) -> Self {
-        TraceExporterError { code: value }
+impl ExporterError {
+    pub fn new(code: ExporterErrorCode, msg: &str) -> Self {
+        Self {
+            code,
+            msg: CString::new(msg).unwrap_or_default().into_raw(),
+        }
+    }
+}
+
+impl From<TraceExporterError> for ExporterError {
+    // add code here
+    fn from(value: TraceExporterError) -> Self {
+        let code = match &value {
+            TraceExporterError::Builder(e) => match e {
+                BuilderErrorKind::InvalidUri => ExporterErrorCode::InvalidUrl,
+            },
+            TraceExporterError::Deserialization(_) => ExporterErrorCode::Serde,
+            TraceExporterError::Io(e) => match e.kind() {
+                IoErrorKind::InvalidData => ExporterErrorCode::InvalidData,
+                IoErrorKind::InvalidInput => ExporterErrorCode::InvalidInput,
+                IoErrorKind::ConnectionReset => ExporterErrorCode::ConnectionReset,
+                IoErrorKind::ConnectionAborted => ExporterErrorCode::ConnectionAborted,
+                IoErrorKind::ConnectionRefused => ExporterErrorCode::ConnectionRefused,
+                IoErrorKind::TimedOut => ExporterErrorCode::TimedOut,
+                IoErrorKind::AddrInUse => ExporterErrorCode::AddressInUse,
+                _ => ExporterErrorCode::IoError,
+            },
+            TraceExporterError::Network(e) => match e.kind() {
+                NetworkErrorKind::Body => ExporterErrorCode::HttpBodyFormat,
+                NetworkErrorKind::Canceled => ExporterErrorCode::ConnectionAborted,
+                NetworkErrorKind::ConnectionClosed => ExporterErrorCode::ConnectionReset,
+                NetworkErrorKind::MessageTooLarge => ExporterErrorCode::HttpBodyTooLong,
+                NetworkErrorKind::Parse => ExporterErrorCode::HttpParse,
+                NetworkErrorKind::TimedOut => ExporterErrorCode::TimedOut,
+                NetworkErrorKind::Unknown => ExporterErrorCode::NetworkUnknown,
+                NetworkErrorKind::WrongStatus => ExporterErrorCode::HttpWrongStatus,
+            },
+            TraceExporterError::Request(e) => {
+                let status: u16 = e.status().into();
+                if (400..500).contains(&status) {
+                    ExporterErrorCode::HttpClient
+                } else {
+                    ExporterErrorCode::HttpServer
+                }
+            }
+            TraceExporterError::Serde(_) => ExporterErrorCode::Serde,
+        };
+        ExporterError::new(code, &value.to_string())
     }
 }
 
 /// Free
 #[no_mangle]
 pub unsafe extern "C" fn ddog_trace_exporter_error_free(
-    _error: ddcommon_ffi::Option<&mut TraceExporterError>,
+    error: ddcommon_ffi::Option<&mut ExporterError>,
 ) {
-    // TODO: Placeholder function to remove dynamically allocated properties in Error.
+    if let ddcommon_ffi::Option::Some(error) = error {
+        if !error.msg.is_null() {
+            drop(CString::from_raw(error.msg));
+            error.msg = std::ptr::null_mut();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CStr;
+    use std::ffi::CString;
+
+    #[test]
+    fn constructor_test() {
+        let code = ExporterErrorCode::InvalidArgument;
+        let error = ExporterError::new(code, &code.to_string());
+
+        assert_eq!(error.code, ExporterErrorCode::InvalidArgument);
+        let msg = unsafe { CString::from_raw(error.msg).into_string().unwrap() };
+        assert_eq!(msg, ExporterErrorCode::InvalidArgument.to_string());
+    }
+
+    #[test]
+    fn destructor_test() {
+        let code = ExporterErrorCode::InvalidArgument;
+        let mut error = ExporterError::new(code, &code.to_string());
+
+        assert_eq!(error.code, ExporterErrorCode::InvalidArgument);
+        let msg = unsafe { CStr::from_ptr(error.msg).to_string_lossy() };
+        assert_eq!(msg, ExporterErrorCode::InvalidArgument.to_string());
+
+        unsafe { ddog_trace_exporter_error_free(ddcommon_ffi::Option::Some(&mut error)) };
+
+        assert_eq!(error.msg, std::ptr::null_mut());
+    }
 }

--- a/data-pipeline-ffi/src/lib.rs
+++ b/data-pipeline-ffi/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+mod error;
 mod trace_exporter;

--- a/data-pipeline-ffi/src/trace_exporter.rs
+++ b/data-pipeline-ffi/src/trace_exporter.rs
@@ -1,7 +1,7 @@
 // Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::error::{ExporterError as Error, ExporterErrorCode as ErrorCode};
+use crate::error::{ExporterError, ExporterErrorCode as ErrorCode};
 use data_pipeline::trace_exporter::agent_response::AgentResponse;
 use data_pipeline::trace_exporter::{
     TraceExporter, TraceExporterInputFormat, TraceExporterOutputFormat,
@@ -12,10 +12,16 @@ use ddcommon_ffi::{
 };
 use std::{ptr::NonNull, time::Duration};
 
+macro_rules! gen_error {
+    ($l:expr) => {
+        Some(Box::new(ExporterError::new($l, &$l.to_string())))
+    };
+}
+
 /// The TraceExporterConfig object will hold the configuration properties for the TraceExporter.
 /// Once the configuration is passed to the TraceExporter constructor the config is no longer
 /// needed by the handle and it can be freed.
-#[derive(Default, PartialEq)]
+#[derive(Debug, Default, PartialEq)]
 pub struct TraceExporterConfig {
     url: Option<String>,
     tracer_version: Option<String>,
@@ -49,134 +55,125 @@ pub unsafe extern "C" fn ddog_trace_exporter_config_free(handle: Box<TraceExport
 /// Sets traces destination.
 #[no_mangle]
 pub unsafe extern "C" fn ddog_trace_exporter_config_set_url(
-    config: ddcommon_ffi::Option<&mut TraceExporterConfig>,
+    config: Option<&mut TraceExporterConfig>,
     url: CharSlice,
-) -> ddcommon_ffi::Option<Error> {
-    if let ddcommon_ffi::Option::Some(handle) = config {
+) -> Option<Box<ExporterError>> {
+    if let Some(handle) = config {
         handle.url = Some(url.to_utf8_lossy().to_string());
-        None.into()
+        None
     } else {
-        let code = ErrorCode::InvalidArgument;
-        ddcommon_ffi::Option::Some(Error::new(code, &code.to_string()))
+        gen_error!(ErrorCode::InvalidArgument)
     }
 }
 
 /// Sets tracer's version to be included in the headers request.
 #[no_mangle]
 pub unsafe extern "C" fn ddog_trace_exporter_config_set_tracer_version(
-    config: ddcommon_ffi::Option<&mut TraceExporterConfig>,
+    config: Option<&mut TraceExporterConfig>,
     version: CharSlice,
-) -> ddcommon_ffi::Option<Error> {
-    if let ddcommon_ffi::Option::Some(handle) = config {
+) -> Option<Box<ExporterError>> {
+    if let Option::Some(handle) = config {
         handle.tracer_version = Some(version.to_utf8_lossy().to_string());
-        None.into()
+        None
     } else {
-        let code = ErrorCode::InvalidArgument;
-        ddcommon_ffi::Option::Some(Error::new(code, &code.to_string()))
+        gen_error!(ErrorCode::InvalidArgument)
     }
 }
 
 /// Sets tracer's language to be included in the headers request.
 #[no_mangle]
 pub unsafe extern "C" fn ddog_trace_exporter_config_set_language(
-    config: ddcommon_ffi::Option<&mut TraceExporterConfig>,
+    config: Option<&mut TraceExporterConfig>,
     lang: CharSlice,
-) -> ddcommon_ffi::Option<Error> {
-    if let ddcommon_ffi::Option::Some(handle) = config {
+) -> Option<Box<ExporterError>> {
+    if let Option::Some(handle) = config {
         handle.language = Some(lang.to_utf8_lossy().to_string());
-        None.into()
+        None
     } else {
-        let code = ErrorCode::InvalidArgument;
-        ddcommon_ffi::Option::Some(Error::new(code, &code.to_string()))
+        gen_error!(ErrorCode::InvalidArgument)
     }
 }
 
 /// Sets tracer's language version to be included in the headers request.
 #[no_mangle]
 pub unsafe extern "C" fn ddog_trace_exporter_config_set_lang_version(
-    config: ddcommon_ffi::Option<&mut TraceExporterConfig>,
+    config: Option<&mut TraceExporterConfig>,
     version: CharSlice,
-) -> ddcommon_ffi::Option<Error> {
-    if let ddcommon_ffi::Option::Some(handle) = config {
+) -> Option<Box<ExporterError>> {
+    if let Option::Some(handle) = config {
         handle.language_version = Some(version.to_utf8_lossy().to_string());
-        None.into()
+        None
     } else {
-        let code = ErrorCode::InvalidArgument;
-        ddcommon_ffi::Option::Some(Error::new(code, &code.to_string()))
+        gen_error!(ErrorCode::InvalidArgument)
     }
 }
 
 /// Sets tracer's language interpreter to be included in the headers request.
 #[no_mangle]
 pub unsafe extern "C" fn ddog_trace_exporter_config_set_lang_interpreter(
-    config: ddcommon_ffi::Option<&mut TraceExporterConfig>,
+    config: Option<&mut TraceExporterConfig>,
     interpreter: CharSlice,
-) -> ddcommon_ffi::Option<Error> {
-    if let ddcommon_ffi::Option::Some(handle) = config {
+) -> Option<Box<ExporterError>> {
+    if let Option::Some(handle) = config {
         handle.language_interpreter = Some(interpreter.to_utf8_lossy().to_string());
-        None.into()
+        None
     } else {
-        let code = ErrorCode::InvalidArgument;
-        ddcommon_ffi::Option::Some(Error::new(code, &code.to_string()))
+        gen_error!(ErrorCode::InvalidArgument)
     }
 }
 
 /// Sets hostname information to be included in the headers request.
 #[no_mangle]
 pub unsafe extern "C" fn ddog_trace_exporter_config_set_hostname(
-    config: ddcommon_ffi::Option<&mut TraceExporterConfig>,
+    config: Option<&mut TraceExporterConfig>,
     hostname: CharSlice,
-) -> ddcommon_ffi::Option<Error> {
-    if let ddcommon_ffi::Option::Some(handle) = config {
+) -> Option<Box<ExporterError>> {
+    if let Option::Some(handle) = config {
         handle.hostname = Some(hostname.to_utf8_lossy().to_string());
-        None.into()
+        None
     } else {
-        let code = ErrorCode::InvalidArgument;
-        ddcommon_ffi::Option::Some(Error::new(code, &code.to_string()))
+        gen_error!(ErrorCode::InvalidArgument)
     }
 }
 
 /// Sets environmet information to be included in the headers request.
 #[no_mangle]
 pub unsafe extern "C" fn ddog_trace_exporter_config_set_env(
-    config: ddcommon_ffi::Option<&mut TraceExporterConfig>,
+    config: Option<&mut TraceExporterConfig>,
     env: CharSlice,
-) -> ddcommon_ffi::Option<Error> {
-    if let ddcommon_ffi::Option::Some(handle) = config {
+) -> Option<Box<ExporterError>> {
+    if let Option::Some(handle) = config {
         handle.env = Some(env.to_utf8_lossy().to_string());
-        None.into()
+        None
     } else {
-        let code = ErrorCode::InvalidArgument;
-        ddcommon_ffi::Option::Some(Error::new(code, &code.to_string()))
+        gen_error!(ErrorCode::InvalidArgument)
     }
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn ddog_trace_exporter_config_set_version(
-    config: ddcommon_ffi::Option<&mut TraceExporterConfig>,
+    config: Option<&mut TraceExporterConfig>,
     version: CharSlice,
-) -> ddcommon_ffi::Option<Error> {
-    if let ddcommon_ffi::Option::Some(handle) = config {
+) -> Option<Box<ExporterError>> {
+    if let Option::Some(handle) = config {
         handle.version = Some(version.to_utf8_lossy().to_string());
-        None.into()
+        None
     } else {
-        let code = ErrorCode::InvalidArgument;
-        ddcommon_ffi::Option::Some(Error::new(code, &code.to_string()))
+        gen_error!(ErrorCode::InvalidArgument)
     }
 }
 
 /// Sets service name to be included in the headers request.
 #[no_mangle]
 pub unsafe extern "C" fn ddog_trace_exporter_config_set_service(
-    config: ddcommon_ffi::Option<&mut TraceExporterConfig>,
+    config: Option<&mut TraceExporterConfig>,
     service: CharSlice,
-) -> ddcommon_ffi::Option<Error> {
-    if let ddcommon_ffi::Option::Some(handle) = config {
+) -> Option<Box<ExporterError>> {
+    if let Option::Some(handle) = config {
         handle.service = Some(service.to_utf8_lossy().to_string());
-        None.into()
+        None
     } else {
-        let code = ErrorCode::InvalidArgument;
-        ddcommon_ffi::Option::Some(Error::new(code, &code.to_string()))
+        gen_error!(ErrorCode::InvalidArgument)
     }
 }
 
@@ -189,9 +186,10 @@ pub unsafe extern "C" fn ddog_trace_exporter_config_set_service(
 #[no_mangle]
 pub unsafe extern "C" fn ddog_trace_exporter_new(
     out_handle: NonNull<Box<TraceExporter>>,
-    config: ddcommon_ffi::Option<&TraceExporterConfig>,
-) -> ddcommon_ffi::Option<Error> {
-    if let ddcommon_ffi::Option::Some(config) = config {
+    config: Option<&TraceExporterConfig>,
+) -> Option<Box<ExporterError>> {
+    if let Some(config) = config {
+        // let config = &*ptr;
         let mut builder = TraceExporter::builder()
             .set_url(config.url.as_ref().unwrap_or(&"".to_string()))
             .set_tracer_version(config.tracer_version.as_ref().unwrap_or(&"".to_string()))
@@ -218,13 +216,12 @@ pub unsafe extern "C" fn ddog_trace_exporter_new(
         match builder.build() {
             Ok(exporter) => {
                 out_handle.as_ptr().write(Box::new(exporter));
-                None.into()
+                None
             }
-            Err(err) => Some(Error::from(err)).into(),
+            Err(err) => Some(Box::new(ExporterError::from(err))),
         }
     } else {
-        let code = ErrorCode::InvalidArgument;
-        ddcommon_ffi::Option::Some(Error::new(code, &code.to_string()))
+        gen_error!(ErrorCode::InvalidArgument)
     }
 }
 
@@ -253,9 +250,9 @@ pub unsafe extern "C" fn ddog_trace_exporter_send(
     handle: &TraceExporter,
     trace: ByteSlice,
     trace_count: usize,
-    response: ddcommon_ffi::Option<&mut AgentResponse>,
-) -> ddcommon_ffi::Option<Error> {
-    if let ddcommon_ffi::Option::Some(result) = response {
+    response: Option<&mut AgentResponse>,
+) -> Option<Box<ExporterError>> {
+    if let Some(result) = response {
         let static_trace: ByteSlice<'static> = std::mem::transmute(trace);
         match handle.send(
             tinybytes::Bytes::from_static(static_trace.as_slice()),
@@ -263,13 +260,12 @@ pub unsafe extern "C" fn ddog_trace_exporter_send(
         ) {
             Ok(resp) => {
                 *result = resp;
-                None.into()
+                None
             }
-            Err(e) => Some(Error::from(e)).into(),
+            Err(e) => Some(Box::new(ExporterError::from(e))),
         }
     } else {
-        let code = ErrorCode::InvalidArgument;
-        ddcommon_ffi::Option::Some(Error::new(code, &code.to_string()))
+        gen_error!(ErrorCode::InvalidArgument)
     }
 }
 
@@ -277,7 +273,7 @@ pub unsafe extern "C" fn ddog_trace_exporter_send(
 mod tests {
     use super::*;
     use crate::error::ddog_trace_exporter_error_free;
-    use std::mem::MaybeUninit;
+    use std::{borrow::Borrow, mem::MaybeUninit};
 
     #[test]
     fn config_constructor_test() {
@@ -307,23 +303,21 @@ mod tests {
     #[test]
     fn config_url_test() {
         unsafe {
-            let mut error = ddog_trace_exporter_config_set_url(
-                ddcommon_ffi::Option::None,
-                CharSlice::from("http://localhost"),
-            );
-            assert_eq!(error.to_std_ref().unwrap().code, ErrorCode::InvalidArgument);
+            let error =
+                ddog_trace_exporter_config_set_url(None, CharSlice::from("http://localhost"));
+            assert_eq!(error.as_ref().unwrap().code, ErrorCode::InvalidArgument);
 
-            ddog_trace_exporter_error_free(error.as_mut());
+            ddog_trace_exporter_error_free(error);
 
-            let mut config = ddcommon_ffi::Option::Some(TraceExporterConfig::default());
+            let mut config = Some(TraceExporterConfig::default());
             let error = ddog_trace_exporter_config_set_url(
                 config.as_mut(),
                 CharSlice::from("http://localhost"),
             );
 
-            assert_eq!(error, ddcommon_ffi::Option::None);
+            assert_eq!(error, None);
 
-            let cfg = config.to_std_ref().unwrap();
+            let cfg = config.unwrap();
             assert_eq!(cfg.url.as_ref().unwrap(), "http://localhost");
         }
     }
@@ -331,22 +325,19 @@ mod tests {
     #[test]
     fn config_tracer_version() {
         unsafe {
-            let mut error = ddog_trace_exporter_config_set_tracer_version(
-                ddcommon_ffi::Option::None,
-                CharSlice::from("1.0"),
-            );
-            assert_eq!(error.to_std_ref().unwrap().code, ErrorCode::InvalidArgument);
+            let error = ddog_trace_exporter_config_set_tracer_version(None, CharSlice::from("1.0"));
+            assert_eq!(error.as_ref().unwrap().code, ErrorCode::InvalidArgument);
 
-            ddog_trace_exporter_error_free(error.as_mut());
+            ddog_trace_exporter_error_free(error);
 
-            let mut config = ddcommon_ffi::Option::Some(TraceExporterConfig::default());
+            let mut config = Some(TraceExporterConfig::default());
             let error = ddog_trace_exporter_config_set_tracer_version(
                 config.as_mut(),
                 CharSlice::from("1.0"),
             );
-            assert_eq!(error, ddcommon_ffi::Option::None);
+            assert_eq!(error, None);
 
-            let cfg = config.to_std_ref().unwrap();
+            let cfg = config.unwrap();
             assert_eq!(cfg.tracer_version.as_ref().unwrap(), "1.0");
         }
     }
@@ -354,21 +345,18 @@ mod tests {
     #[test]
     fn config_language() {
         unsafe {
-            let mut error = ddog_trace_exporter_config_set_language(
-                ddcommon_ffi::Option::None,
-                CharSlice::from("lang"),
-            );
-            assert_eq!(error.to_std_ref().unwrap().code, ErrorCode::InvalidArgument);
+            let error = ddog_trace_exporter_config_set_language(None, CharSlice::from("lang"));
+            assert_eq!(error.as_ref().unwrap().code, ErrorCode::InvalidArgument);
 
-            ddog_trace_exporter_error_free(error.as_mut());
+            ddog_trace_exporter_error_free(error);
 
-            let mut config = ddcommon_ffi::Option::Some(TraceExporterConfig::default());
+            let mut config = Some(TraceExporterConfig::default());
             let error =
                 ddog_trace_exporter_config_set_language(config.as_mut(), CharSlice::from("lang"));
 
-            assert_eq!(error, ddcommon_ffi::Option::None);
+            assert_eq!(error, None);
 
-            let cfg = config.to_std_ref().unwrap();
+            let cfg = config.unwrap();
             assert_eq!(cfg.language.as_ref().unwrap(), "lang");
         }
     }
@@ -376,23 +364,20 @@ mod tests {
     #[test]
     fn config_lang_version() {
         unsafe {
-            let mut error = ddog_trace_exporter_config_set_lang_version(
-                ddcommon_ffi::Option::None,
-                CharSlice::from("0.1"),
-            );
-            assert_eq!(error.to_std_ref().unwrap().code, ErrorCode::InvalidArgument);
+            let error = ddog_trace_exporter_config_set_lang_version(None, CharSlice::from("0.1"));
+            assert_eq!(error.as_ref().unwrap().code, ErrorCode::InvalidArgument);
 
-            ddog_trace_exporter_error_free(error.as_mut());
+            ddog_trace_exporter_error_free(error);
 
-            let mut config = ddcommon_ffi::Option::Some(TraceExporterConfig::default());
+            let mut config = Some(TraceExporterConfig::default());
             let error = ddog_trace_exporter_config_set_lang_version(
                 config.as_mut(),
                 CharSlice::from("0.1"),
             );
 
-            assert_eq!(error, ddcommon_ffi::Option::None);
+            assert_eq!(error, None);
 
-            let cfg = config.to_std_ref().unwrap();
+            let cfg = config.unwrap();
             assert_eq!(cfg.language_version.as_ref().unwrap(), "0.1");
         }
     }
@@ -400,23 +385,21 @@ mod tests {
     #[test]
     fn config_lang_interpreter_test() {
         unsafe {
-            let mut error = ddog_trace_exporter_config_set_lang_interpreter(
-                ddcommon_ffi::Option::None,
-                CharSlice::from("foo"),
-            );
-            assert_eq!(error.to_std_ref().unwrap().code, ErrorCode::InvalidArgument);
+            let error =
+                ddog_trace_exporter_config_set_lang_interpreter(None, CharSlice::from("foo"));
+            assert_eq!(error.as_ref().unwrap().code, ErrorCode::InvalidArgument);
 
-            ddog_trace_exporter_error_free(error.as_mut());
+            ddog_trace_exporter_error_free(error);
 
-            let mut config = ddcommon_ffi::Option::Some(TraceExporterConfig::default());
+            let mut config = Some(TraceExporterConfig::default());
             let error = ddog_trace_exporter_config_set_lang_interpreter(
                 config.as_mut(),
                 CharSlice::from("foo"),
             );
 
-            assert_eq!(error, ddcommon_ffi::Option::None);
+            assert_eq!(error, None);
 
-            let cfg = config.to_std_ref().unwrap();
+            let cfg = config.unwrap();
             assert_eq!(cfg.language_interpreter.as_ref().unwrap(), "foo");
         }
     }
@@ -424,23 +407,20 @@ mod tests {
     #[test]
     fn config_hostname_test() {
         unsafe {
-            let mut error = ddog_trace_exporter_config_set_hostname(
-                ddcommon_ffi::Option::None,
-                CharSlice::from("hostname"),
-            );
-            assert_eq!(error.to_std_ref().unwrap().code, ErrorCode::InvalidArgument);
+            let error = ddog_trace_exporter_config_set_hostname(None, CharSlice::from("hostname"));
+            assert_eq!(error.as_ref().unwrap().code, ErrorCode::InvalidArgument);
 
-            ddog_trace_exporter_error_free(error.as_mut());
+            ddog_trace_exporter_error_free(error);
 
-            let mut config = ddcommon_ffi::Option::Some(TraceExporterConfig::default());
+            let mut config = Some(TraceExporterConfig::default());
             let error = ddog_trace_exporter_config_set_hostname(
                 config.as_mut(),
                 CharSlice::from("hostname"),
             );
 
-            assert_eq!(error, ddcommon_ffi::Option::None);
+            assert_eq!(error, None);
 
-            let cfg = config.to_std_ref().unwrap();
+            let cfg = config.unwrap();
             assert_eq!(cfg.hostname.as_ref().unwrap(), "hostname");
         }
     }
@@ -448,21 +428,18 @@ mod tests {
     #[test]
     fn config_env_test() {
         unsafe {
-            let mut error = ddog_trace_exporter_config_set_env(
-                ddcommon_ffi::Option::None,
-                CharSlice::from("env-test"),
-            );
-            assert_eq!(error.to_std_ref().unwrap().code, ErrorCode::InvalidArgument);
+            let error = ddog_trace_exporter_config_set_env(None, CharSlice::from("env-test"));
+            assert_eq!(error.as_ref().unwrap().code, ErrorCode::InvalidArgument);
 
-            ddog_trace_exporter_error_free(error.as_mut());
+            ddog_trace_exporter_error_free(error);
 
-            let mut config = ddcommon_ffi::Option::Some(TraceExporterConfig::default());
+            let mut config = Some(TraceExporterConfig::default());
             let error =
                 ddog_trace_exporter_config_set_env(config.as_mut(), CharSlice::from("env-test"));
 
-            assert_eq!(error, ddcommon_ffi::Option::None);
+            assert_eq!(error, None);
 
-            let cfg = config.to_std_ref().unwrap();
+            let cfg = config.unwrap();
             assert_eq!(cfg.env.as_ref().unwrap(), "env-test");
         }
     }
@@ -470,21 +447,18 @@ mod tests {
     #[test]
     fn config_version_test() {
         unsafe {
-            let mut error = ddog_trace_exporter_config_set_version(
-                ddcommon_ffi::Option::None,
-                CharSlice::from("1.2"),
-            );
-            assert_eq!(error.to_std_ref().unwrap().code, ErrorCode::InvalidArgument);
+            let error = ddog_trace_exporter_config_set_version(None, CharSlice::from("1.2"));
+            assert_eq!(error.as_ref().unwrap().code, ErrorCode::InvalidArgument);
 
-            ddog_trace_exporter_error_free(error.as_mut());
+            ddog_trace_exporter_error_free(error);
 
-            let mut config = ddcommon_ffi::Option::Some(TraceExporterConfig::default());
+            let mut config = Some(TraceExporterConfig::default());
             let error =
                 ddog_trace_exporter_config_set_version(config.as_mut(), CharSlice::from("1.2"));
 
-            assert_eq!(error, ddcommon_ffi::Option::None);
+            assert_eq!(error, None);
 
-            let cfg = config.to_std_ref().unwrap();
+            let cfg = config.unwrap();
             assert_eq!(cfg.version.as_ref().unwrap(), "1.2");
         }
     }
@@ -492,21 +466,18 @@ mod tests {
     #[test]
     fn config_service_test() {
         unsafe {
-            let mut error = ddog_trace_exporter_config_set_service(
-                ddcommon_ffi::Option::None,
-                CharSlice::from("service"),
-            );
-            assert_eq!(error.to_std_ref().unwrap().code, ErrorCode::InvalidArgument);
+            let error = ddog_trace_exporter_config_set_service(None, CharSlice::from("service"));
+            assert_eq!(error.as_ref().unwrap().code, ErrorCode::InvalidArgument);
 
-            ddog_trace_exporter_error_free(error.as_mut());
+            ddog_trace_exporter_error_free(error);
 
-            let mut config = ddcommon_ffi::Option::Some(TraceExporterConfig::default());
+            let mut config = Some(TraceExporterConfig::default());
             let error =
                 ddog_trace_exporter_config_set_service(config.as_mut(), CharSlice::from("service"));
 
-            assert_eq!(error, ddcommon_ffi::Option::None);
+            assert_eq!(error, None);
 
-            let cfg = config.to_std_ref().unwrap();
+            let cfg = config.unwrap();
             assert_eq!(cfg.service.as_ref().unwrap(), "service");
         }
     }
@@ -519,20 +490,20 @@ mod tests {
 
             let mut cfg = config.assume_init();
             let error = ddog_trace_exporter_config_set_url(
-                ddcommon_ffi::Option::Some(cfg.as_mut()),
+                Some(cfg.as_mut()),
                 CharSlice::from("http://localhost"),
             );
-            assert_eq!(error, ddcommon_ffi::Option::None);
+            assert_eq!(error, None);
 
             let mut ptr: MaybeUninit<Box<TraceExporter>> = MaybeUninit::uninit();
 
             let ret = ddog_trace_exporter_new(
                 NonNull::new_unchecked(&mut ptr).cast(),
-                ddcommon_ffi::Option::Some(&cfg),
+                Some(cfg.borrow()),
             );
             let exporter = ptr.assume_init();
 
-            assert_eq!(ret, ddcommon_ffi::Option::None);
+            assert_eq!(ret, None);
 
             ddog_trace_exporter_free(exporter);
             ddog_trace_exporter_config_free(cfg);
@@ -546,25 +517,22 @@ mod tests {
             ddog_trace_exporter_config_new(NonNull::new_unchecked(&mut config).cast());
 
             let mut cfg = config.assume_init();
-            let mut error = ddog_trace_exporter_config_set_service(
-                ddcommon_ffi::Option::Some(cfg.as_mut()),
+            let error = ddog_trace_exporter_config_set_service(
+                Some(cfg.as_mut()),
                 CharSlice::from("service"),
             );
-            assert_eq!(error, ddcommon_ffi::Option::None);
+            assert_eq!(error, None);
 
-            ddog_trace_exporter_error_free(error.as_mut());
+            ddog_trace_exporter_error_free(error);
 
             let mut ptr: MaybeUninit<Box<TraceExporter>> = MaybeUninit::uninit();
 
-            let mut ret = ddog_trace_exporter_new(
-                NonNull::new_unchecked(&mut ptr).cast(),
-                ddcommon_ffi::Option::Some(&cfg),
-            );
+            let ret = ddog_trace_exporter_new(NonNull::new_unchecked(&mut ptr).cast(), Some(&cfg));
 
-            let error = ret.to_std_ref().unwrap();
+            let error = ret.as_ref().unwrap();
             assert_eq!(error.code, ErrorCode::InvalidUrl);
 
-            ddog_trace_exporter_error_free(ret.as_mut());
+            ddog_trace_exporter_error_free(ret);
 
             ddog_trace_exporter_config_free(cfg);
         }

--- a/data-pipeline-ffi/src/trace_exporter.rs
+++ b/data-pipeline-ffi/src/trace_exporter.rs
@@ -1,11 +1,8 @@
 // Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::error::{TraceExporterError as Error, TraceExporterErrorCode as ErrorCode};
+use crate::error::{ExporterError as Error, ExporterErrorCode as ErrorCode};
 use data_pipeline::trace_exporter::agent_response::AgentResponse;
-use data_pipeline::trace_exporter::error::{
-    BuilderErrorKind, NetworkErrorKind, TraceExporterError,
-};
 use data_pipeline::trace_exporter::{
     TraceExporter, TraceExporterInputFormat, TraceExporterOutputFormat,
 };
@@ -13,7 +10,6 @@ use ddcommon_ffi::{
     CharSlice,
     {slice::AsBytes, slice::ByteSlice},
 };
-use std::io::ErrorKind as IoErrorKind;
 use std::{ptr::NonNull, time::Duration};
 
 /// The TraceExporterConfig object will hold the configuration properties for the TraceExporter.
@@ -60,7 +56,8 @@ pub unsafe extern "C" fn ddog_trace_exporter_config_set_url(
         handle.url = Some(url.to_utf8_lossy().to_string());
         None.into()
     } else {
-        ddcommon_ffi::Option::Some(Error::from(ErrorCode::InvalidArgument))
+        let code = ErrorCode::InvalidArgument;
+        ddcommon_ffi::Option::Some(Error::new(code, &code.to_string()))
     }
 }
 
@@ -74,7 +71,8 @@ pub unsafe extern "C" fn ddog_trace_exporter_config_set_tracer_version(
         handle.tracer_version = Some(version.to_utf8_lossy().to_string());
         None.into()
     } else {
-        ddcommon_ffi::Option::Some(Error::from(ErrorCode::InvalidArgument))
+        let code = ErrorCode::InvalidArgument;
+        ddcommon_ffi::Option::Some(Error::new(code, &code.to_string()))
     }
 }
 
@@ -88,7 +86,8 @@ pub unsafe extern "C" fn ddog_trace_exporter_config_set_language(
         handle.language = Some(lang.to_utf8_lossy().to_string());
         None.into()
     } else {
-        ddcommon_ffi::Option::Some(Error::from(ErrorCode::InvalidArgument))
+        let code = ErrorCode::InvalidArgument;
+        ddcommon_ffi::Option::Some(Error::new(code, &code.to_string()))
     }
 }
 
@@ -102,7 +101,8 @@ pub unsafe extern "C" fn ddog_trace_exporter_config_set_lang_version(
         handle.language_version = Some(version.to_utf8_lossy().to_string());
         None.into()
     } else {
-        ddcommon_ffi::Option::Some(Error::from(ErrorCode::InvalidArgument))
+        let code = ErrorCode::InvalidArgument;
+        ddcommon_ffi::Option::Some(Error::new(code, &code.to_string()))
     }
 }
 
@@ -116,7 +116,8 @@ pub unsafe extern "C" fn ddog_trace_exporter_config_set_lang_interpreter(
         handle.language_interpreter = Some(interpreter.to_utf8_lossy().to_string());
         None.into()
     } else {
-        ddcommon_ffi::Option::Some(Error::from(ErrorCode::InvalidArgument))
+        let code = ErrorCode::InvalidArgument;
+        ddcommon_ffi::Option::Some(Error::new(code, &code.to_string()))
     }
 }
 
@@ -130,7 +131,8 @@ pub unsafe extern "C" fn ddog_trace_exporter_config_set_hostname(
         handle.hostname = Some(hostname.to_utf8_lossy().to_string());
         None.into()
     } else {
-        ddcommon_ffi::Option::Some(Error::from(ErrorCode::InvalidArgument))
+        let code = ErrorCode::InvalidArgument;
+        ddcommon_ffi::Option::Some(Error::new(code, &code.to_string()))
     }
 }
 
@@ -144,7 +146,8 @@ pub unsafe extern "C" fn ddog_trace_exporter_config_set_env(
         handle.env = Some(env.to_utf8_lossy().to_string());
         None.into()
     } else {
-        ddcommon_ffi::Option::Some(Error::from(ErrorCode::InvalidArgument))
+        let code = ErrorCode::InvalidArgument;
+        ddcommon_ffi::Option::Some(Error::new(code, &code.to_string()))
     }
 }
 
@@ -157,7 +160,8 @@ pub unsafe extern "C" fn ddog_trace_exporter_config_set_version(
         handle.version = Some(version.to_utf8_lossy().to_string());
         None.into()
     } else {
-        ddcommon_ffi::Option::Some(Error::from(ErrorCode::InvalidArgument))
+        let code = ErrorCode::InvalidArgument;
+        ddcommon_ffi::Option::Some(Error::new(code, &code.to_string()))
     }
 }
 
@@ -171,7 +175,8 @@ pub unsafe extern "C" fn ddog_trace_exporter_config_set_service(
         handle.service = Some(service.to_utf8_lossy().to_string());
         None.into()
     } else {
-        ddcommon_ffi::Option::Some(Error::from(ErrorCode::InvalidArgument))
+        let code = ErrorCode::InvalidArgument;
+        ddcommon_ffi::Option::Some(Error::new(code, &code.to_string()))
     }
 }
 
@@ -215,10 +220,11 @@ pub unsafe extern "C" fn ddog_trace_exporter_new(
                 out_handle.as_ptr().write(Box::new(exporter));
                 None.into()
             }
-            Err(err) => trace_exporter_error_to_ffi(err),
+            Err(err) => Some(Error::from(err)).into(),
         }
     } else {
-        ddcommon_ffi::Option::Some(Error::from(ErrorCode::InvalidArgument))
+        let code = ErrorCode::InvalidArgument;
+        ddcommon_ffi::Option::Some(Error::new(code, &code.to_string()))
     }
 }
 
@@ -251,91 +257,26 @@ pub unsafe extern "C" fn ddog_trace_exporter_send(
 ) -> ddcommon_ffi::Option<Error> {
     if let ddcommon_ffi::Option::Some(result) = response {
         let static_trace: ByteSlice<'static> = std::mem::transmute(trace);
-        match handle .send( tinybytes::Bytes::from_static(static_trace.as_slice()), trace_count,) {
+        match handle.send(
+            tinybytes::Bytes::from_static(static_trace.as_slice()),
+            trace_count,
+        ) {
             Ok(resp) => {
                 *result = resp;
                 None.into()
             }
-            Err(e) => trace_exporter_error_to_ffi(e),
+            Err(e) => Some(Error::from(e)).into(),
         }
     } else {
-        ddcommon_ffi::Option::Some(Error::from(ErrorCode::InvalidArgument))
-    }
-}
-
-fn trace_exporter_error_to_ffi(err: TraceExporterError) -> ddcommon_ffi::Option<Error> {
-    match err {
-        TraceExporterError::Builder(e) => match e {
-            BuilderErrorKind::InvalidUri => {
-                ddcommon_ffi::Option::Some(Error::from(ErrorCode::InvalidUrl))
-            }
-        },
-        TraceExporterError::Deserialization(_) => {
-            ddcommon_ffi::Option::Some(Error::from(ErrorCode::Serde))
-        }
-        TraceExporterError::Io(e) => match e.kind() {
-            IoErrorKind::InvalidData => {
-                ddcommon_ffi::Option::Some(Error::from(ErrorCode::InvalidData))
-            }
-            IoErrorKind::InvalidInput => {
-                ddcommon_ffi::Option::Some(Error::from(ErrorCode::InvalidInput))
-            }
-            IoErrorKind::ConnectionReset => {
-                ddcommon_ffi::Option::Some(Error::from(ErrorCode::ConnectionReset))
-            }
-            IoErrorKind::ConnectionAborted => {
-                ddcommon_ffi::Option::Some(Error::from(ErrorCode::ConnectionAborted))
-            }
-            IoErrorKind::ConnectionRefused => {
-                ddcommon_ffi::Option::Some(Error::from(ErrorCode::ConnectionRefused))
-            }
-            IoErrorKind::TimedOut => ddcommon_ffi::Option::Some(Error::from(ErrorCode::TimedOut)),
-            IoErrorKind::AddrInUse => {
-                ddcommon_ffi::Option::Some(Error::from(ErrorCode::AddressInUse))
-            }
-            _ => ddcommon_ffi::Option::Some(Error::from(ErrorCode::IoError)),
-        },
-        TraceExporterError::Network(e) => match e.kind() {
-            NetworkErrorKind::Body => {
-                ddcommon_ffi::Option::Some(Error::from(ErrorCode::HttpBodyFormat))
-            }
-            NetworkErrorKind::Canceled => {
-                ddcommon_ffi::Option::Some(Error::from(ErrorCode::ConnectionAborted))
-            }
-            NetworkErrorKind::ConnectionClosed => {
-                ddcommon_ffi::Option::Some(Error::from(ErrorCode::ConnectionReset))
-            }
-            NetworkErrorKind::MessageTooLarge => {
-                ddcommon_ffi::Option::Some(Error::from(ErrorCode::HttpBodyTooLong))
-            }
-            NetworkErrorKind::Parse => {
-                ddcommon_ffi::Option::Some(Error::from(ErrorCode::HttpParse))
-            }
-            NetworkErrorKind::TimedOut => {
-                ddcommon_ffi::Option::Some(Error::from(ErrorCode::TimedOut))
-            }
-            NetworkErrorKind::Unknown => {
-                ddcommon_ffi::Option::Some(Error::from(ErrorCode::NetworkUnknown))
-            }
-            NetworkErrorKind::WrongStatus => {
-                ddcommon_ffi::Option::Some(Error::from(ErrorCode::HttpWrongStatus))
-            }
-        },
-        TraceExporterError::Request(e) => {
-            let status: u16 = e.status().into();
-            if (400..500).contains(&status) {
-                ddcommon_ffi::Option::Some(Error::from(ErrorCode::HttpClient))
-            } else {
-                ddcommon_ffi::Option::Some(Error::from(ErrorCode::HttpServer))
-            }
-        }
-        TraceExporterError::Serde(_) => ddcommon_ffi::Option::Some(Error::from(ErrorCode::Serde)),
+        let code = ErrorCode::InvalidArgument;
+        ddcommon_ffi::Option::Some(Error::new(code, &code.to_string()))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::error::ddog_trace_exporter_error_free;
     use std::mem::MaybeUninit;
 
     #[test]
@@ -366,16 +307,13 @@ mod tests {
     #[test]
     fn config_url_test() {
         unsafe {
-            let error = ddog_trace_exporter_config_set_url(
+            let mut error = ddog_trace_exporter_config_set_url(
                 ddcommon_ffi::Option::None,
                 CharSlice::from("http://localhost"),
             );
-            assert_eq!(
-                error,
-                ddcommon_ffi::Option::Some(Error {
-                    code: ErrorCode::InvalidArgument
-                })
-            );
+            assert_eq!(error.to_std_ref().unwrap().code, ErrorCode::InvalidArgument);
+
+            ddog_trace_exporter_error_free(error.as_mut());
 
             let mut config = ddcommon_ffi::Option::Some(TraceExporterConfig::default());
             let error = ddog_trace_exporter_config_set_url(
@@ -393,16 +331,13 @@ mod tests {
     #[test]
     fn config_tracer_version() {
         unsafe {
-            let error = ddog_trace_exporter_config_set_tracer_version(
+            let mut error = ddog_trace_exporter_config_set_tracer_version(
                 ddcommon_ffi::Option::None,
                 CharSlice::from("1.0"),
             );
-            assert_eq!(
-                error,
-                ddcommon_ffi::Option::Some(Error {
-                    code: ErrorCode::InvalidArgument
-                })
-            );
+            assert_eq!(error.to_std_ref().unwrap().code, ErrorCode::InvalidArgument);
+
+            ddog_trace_exporter_error_free(error.as_mut());
 
             let mut config = ddcommon_ffi::Option::Some(TraceExporterConfig::default());
             let error = ddog_trace_exporter_config_set_tracer_version(
@@ -419,16 +354,13 @@ mod tests {
     #[test]
     fn config_language() {
         unsafe {
-            let error = ddog_trace_exporter_config_set_language(
+            let mut error = ddog_trace_exporter_config_set_language(
                 ddcommon_ffi::Option::None,
                 CharSlice::from("lang"),
             );
-            assert_eq!(
-                error,
-                ddcommon_ffi::Option::Some(Error {
-                    code: ErrorCode::InvalidArgument
-                })
-            );
+            assert_eq!(error.to_std_ref().unwrap().code, ErrorCode::InvalidArgument);
+
+            ddog_trace_exporter_error_free(error.as_mut());
 
             let mut config = ddcommon_ffi::Option::Some(TraceExporterConfig::default());
             let error =
@@ -444,16 +376,13 @@ mod tests {
     #[test]
     fn config_lang_version() {
         unsafe {
-            let error = ddog_trace_exporter_config_set_lang_version(
+            let mut error = ddog_trace_exporter_config_set_lang_version(
                 ddcommon_ffi::Option::None,
                 CharSlice::from("0.1"),
             );
-            assert_eq!(
-                error,
-                ddcommon_ffi::Option::Some(Error {
-                    code: ErrorCode::InvalidArgument
-                })
-            );
+            assert_eq!(error.to_std_ref().unwrap().code, ErrorCode::InvalidArgument);
+
+            ddog_trace_exporter_error_free(error.as_mut());
 
             let mut config = ddcommon_ffi::Option::Some(TraceExporterConfig::default());
             let error = ddog_trace_exporter_config_set_lang_version(
@@ -471,16 +400,13 @@ mod tests {
     #[test]
     fn config_lang_interpreter_test() {
         unsafe {
-            let error = ddog_trace_exporter_config_set_lang_interpreter(
+            let mut error = ddog_trace_exporter_config_set_lang_interpreter(
                 ddcommon_ffi::Option::None,
                 CharSlice::from("foo"),
             );
-            assert_eq!(
-                error,
-                ddcommon_ffi::Option::Some(Error {
-                    code: ErrorCode::InvalidArgument
-                })
-            );
+            assert_eq!(error.to_std_ref().unwrap().code, ErrorCode::InvalidArgument);
+
+            ddog_trace_exporter_error_free(error.as_mut());
 
             let mut config = ddcommon_ffi::Option::Some(TraceExporterConfig::default());
             let error = ddog_trace_exporter_config_set_lang_interpreter(
@@ -498,16 +424,13 @@ mod tests {
     #[test]
     fn config_hostname_test() {
         unsafe {
-            let error = ddog_trace_exporter_config_set_hostname(
+            let mut error = ddog_trace_exporter_config_set_hostname(
                 ddcommon_ffi::Option::None,
                 CharSlice::from("hostname"),
             );
-            assert_eq!(
-                error,
-                ddcommon_ffi::Option::Some(Error {
-                    code: ErrorCode::InvalidArgument
-                })
-            );
+            assert_eq!(error.to_std_ref().unwrap().code, ErrorCode::InvalidArgument);
+
+            ddog_trace_exporter_error_free(error.as_mut());
 
             let mut config = ddcommon_ffi::Option::Some(TraceExporterConfig::default());
             let error = ddog_trace_exporter_config_set_hostname(
@@ -525,16 +448,13 @@ mod tests {
     #[test]
     fn config_env_test() {
         unsafe {
-            let error = ddog_trace_exporter_config_set_env(
+            let mut error = ddog_trace_exporter_config_set_env(
                 ddcommon_ffi::Option::None,
                 CharSlice::from("env-test"),
             );
-            assert_eq!(
-                error,
-                ddcommon_ffi::Option::Some(Error {
-                    code: ErrorCode::InvalidArgument
-                })
-            );
+            assert_eq!(error.to_std_ref().unwrap().code, ErrorCode::InvalidArgument);
+
+            ddog_trace_exporter_error_free(error.as_mut());
 
             let mut config = ddcommon_ffi::Option::Some(TraceExporterConfig::default());
             let error =
@@ -550,16 +470,13 @@ mod tests {
     #[test]
     fn config_version_test() {
         unsafe {
-            let error = ddog_trace_exporter_config_set_version(
+            let mut error = ddog_trace_exporter_config_set_version(
                 ddcommon_ffi::Option::None,
                 CharSlice::from("1.2"),
             );
-            assert_eq!(
-                error,
-                ddcommon_ffi::Option::Some(Error {
-                    code: ErrorCode::InvalidArgument
-                })
-            );
+            assert_eq!(error.to_std_ref().unwrap().code, ErrorCode::InvalidArgument);
+
+            ddog_trace_exporter_error_free(error.as_mut());
 
             let mut config = ddcommon_ffi::Option::Some(TraceExporterConfig::default());
             let error =
@@ -575,16 +492,13 @@ mod tests {
     #[test]
     fn config_service_test() {
         unsafe {
-            let error = ddog_trace_exporter_config_set_service(
+            let mut error = ddog_trace_exporter_config_set_service(
                 ddcommon_ffi::Option::None,
                 CharSlice::from("service"),
             );
-            assert_eq!(
-                error,
-                ddcommon_ffi::Option::Some(Error {
-                    code: ErrorCode::InvalidArgument
-                })
-            );
+            assert_eq!(error.to_std_ref().unwrap().code, ErrorCode::InvalidArgument);
+
+            ddog_trace_exporter_error_free(error.as_mut());
 
             let mut config = ddcommon_ffi::Option::Some(TraceExporterConfig::default());
             let error =
@@ -632,21 +546,25 @@ mod tests {
             ddog_trace_exporter_config_new(NonNull::new_unchecked(&mut config).cast());
 
             let mut cfg = config.assume_init();
-            let error = ddog_trace_exporter_config_set_service(
+            let mut error = ddog_trace_exporter_config_set_service(
                 ddcommon_ffi::Option::Some(cfg.as_mut()),
                 CharSlice::from("service"),
             );
             assert_eq!(error, ddcommon_ffi::Option::None);
 
+            ddog_trace_exporter_error_free(error.as_mut());
+
             let mut ptr: MaybeUninit<Box<TraceExporter>> = MaybeUninit::uninit();
 
-            let ret = ddog_trace_exporter_new(
+            let mut ret = ddog_trace_exporter_new(
                 NonNull::new_unchecked(&mut ptr).cast(),
                 ddcommon_ffi::Option::Some(&cfg),
             );
 
-            let error = ret.to_std().unwrap();
+            let error = ret.to_std_ref().unwrap();
             assert_eq!(error.code, ErrorCode::InvalidUrl);
+
+            ddog_trace_exporter_error_free(ret.as_mut());
 
             ddog_trace_exporter_config_free(cfg);
         }

--- a/data-pipeline-ffi/src/trace_exporter.rs
+++ b/data-pipeline-ffi/src/trace_exporter.rs
@@ -1,88 +1,193 @@
 // Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::error::{TraceExporterError as Error, TraceExporterErrorCode as ErrorCode};
+use data_pipeline::trace_exporter::agent_response::AgentResponse;
+use data_pipeline::trace_exporter::error::{
+    BuilderErrorKind, NetworkErrorKind, TraceExporterError,
+};
 use data_pipeline::trace_exporter::{
-    ResponseCallback, TraceExporter, TraceExporterInputFormat, TraceExporterOutputFormat,
+    TraceExporter, TraceExporterInputFormat, TraceExporterOutputFormat,
 };
 use ddcommon_ffi::{
-    slice::{AsBytes, ByteSlice},
-    CharSlice, MaybeError,
+    CharSlice,
+    {slice::AsBytes, slice::ByteSlice},
 };
-use std::{ffi::c_char, ptr::NonNull, time::Duration};
+use std::io::ErrorKind as IoErrorKind;
+use std::{ptr::NonNull, time::Duration};
+
+#[derive(Default, PartialEq)]
+pub struct TraceExporterConfig {
+    url: Option<String>,
+    tracer_version: Option<String>,
+    language: Option<String>,
+    language_version: Option<String>,
+    language_interpreter: Option<String>,
+    hostname: Option<String>,
+    env: Option<String>,
+    version: Option<String>,
+    service: Option<String>,
+    input_format: TraceExporterInputFormat,
+    output_format: TraceExporterOutputFormat,
+    compute_stats: bool,
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ddog_trace_exporter_config_set_url(
+    config: ddcommon_ffi::Option<&mut TraceExporterConfig>,
+    url: CharSlice,
+) -> ddcommon_ffi::Option<Error> {
+    if let ddcommon_ffi::Option::Some(handle) = config {
+        handle.url = Some(url.to_utf8_lossy().to_string());
+        None.into()
+    } else {
+        ddcommon_ffi::Option::Some(Error::from(ErrorCode::InvalidArgument))
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ddog_trace_exporter_config_set_tracer_version(
+    config: ddcommon_ffi::Option<&mut TraceExporterConfig>,
+    version: CharSlice,
+) -> ddcommon_ffi::Option<Error> {
+    if let ddcommon_ffi::Option::Some(handle) = config {
+        handle.tracer_version = Some(version.to_utf8_lossy().to_string());
+        None.into()
+    } else {
+        ddcommon_ffi::Option::Some(Error::from(ErrorCode::InvalidArgument))
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ddog_trace_exporter_config_set_language(
+    config: ddcommon_ffi::Option<&mut TraceExporterConfig>,
+    lang: CharSlice,
+) -> ddcommon_ffi::Option<Error> {
+    if let ddcommon_ffi::Option::Some(handle) = config {
+        handle.language = Some(lang.to_utf8_lossy().to_string());
+        None.into()
+    } else {
+        ddcommon_ffi::Option::Some(Error::from(ErrorCode::InvalidArgument))
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ddog_trace_exporter_config_set_lang_version(
+    config: ddcommon_ffi::Option<&mut TraceExporterConfig>,
+    version: CharSlice,
+) -> ddcommon_ffi::Option<Error> {
+    if let ddcommon_ffi::Option::Some(handle) = config {
+        handle.language_version = Some(version.to_utf8_lossy().to_string());
+        None.into()
+    } else {
+        ddcommon_ffi::Option::Some(Error::from(ErrorCode::InvalidArgument))
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ddog_trace_exporter_config_set_lang_interpreter(
+    config: ddcommon_ffi::Option<&mut TraceExporterConfig>,
+    interpreter: CharSlice,
+) -> ddcommon_ffi::Option<Error> {
+    if let ddcommon_ffi::Option::Some(handle) = config {
+        handle.language_interpreter = Some(interpreter.to_utf8_lossy().to_string());
+        None.into()
+    } else {
+        ddcommon_ffi::Option::Some(Error::from(ErrorCode::InvalidArgument))
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ddog_trace_exporter_config_set_hostname(
+    config: ddcommon_ffi::Option<&mut TraceExporterConfig>,
+    hostname: CharSlice,
+) -> ddcommon_ffi::Option<Error> {
+    if let ddcommon_ffi::Option::Some(handle) = config {
+        handle.hostname = Some(hostname.to_utf8_lossy().to_string());
+        None.into()
+    } else {
+        ddcommon_ffi::Option::Some(Error::from(ErrorCode::InvalidArgument))
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ddog_trace_exporter_config_set_env(
+    config: ddcommon_ffi::Option<&mut TraceExporterConfig>,
+    env: CharSlice,
+) -> ddcommon_ffi::Option<Error> {
+    if let ddcommon_ffi::Option::Some(handle) = config {
+        handle.env = Some(env.to_utf8_lossy().to_string());
+        None.into()
+    } else {
+        ddcommon_ffi::Option::Some(Error::from(ErrorCode::InvalidArgument))
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ddog_trace_exporter_config_set_version(
+    config: ddcommon_ffi::Option<&mut TraceExporterConfig>,
+    version: CharSlice,
+) -> ddcommon_ffi::Option<Error> {
+    if let ddcommon_ffi::Option::Some(handle) = config {
+        handle.version = Some(version.to_utf8_lossy().to_string());
+        None.into()
+    } else {
+        ddcommon_ffi::Option::Some(Error::from(ErrorCode::InvalidArgument))
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ddog_trace_exporter_config_set_service(
+    config: ddcommon_ffi::Option<&mut TraceExporterConfig>,
+    service: CharSlice,
+) -> ddcommon_ffi::Option<Error> {
+    if let ddcommon_ffi::Option::Some(handle) = config {
+        handle.service = Some(service.to_utf8_lossy().to_string());
+        None.into()
+    } else {
+        ddcommon_ffi::Option::Some(Error::from(ErrorCode::InvalidArgument))
+    }
+}
 
 /// Create a new TraceExporter instance.
 ///
 /// # Arguments
 ///
 /// * `out_handle` - The handle to write the TraceExporter instance in.
-/// * `url` - The URL of the Datadog Agent to communicate with.
-/// * `tracer_version` - The version of the client library.
-/// * `language` - The language of the client library.
-/// * `language_version` - The version of the language of the client library.
-/// * `language_interpreter` - The interpreter of the language of the client library.
-/// * `hostname` - The hostname of the application, used for stats aggregation
-/// * `env` - The environment of the application, used for stats aggregation
-/// * `version` - The version of the application, used for stats aggregation
-/// * `service` - The service name of the application, used for stats aggregation
-/// * `input_format` - The input format of the traces. Setting this to Proxy will send the trace
-///   data to the Datadog Agent as is.
-/// * `output_format` - The output format of the traces to send to the Datadog Agent. If using the
-///   Proxy input format, this should be set to format if the trace data that will be passed through
-///   as is.
-/// * `agent_response_callback` - The callback into the client library that the TraceExporter uses
-///   for updated Agent JSON responses.
+/// * `config` - The configuration used to set up the TraceExporter handle.
 #[no_mangle]
 pub unsafe extern "C" fn ddog_trace_exporter_new(
     out_handle: NonNull<Box<TraceExporter>>,
-    url: CharSlice,
-    tracer_version: CharSlice,
-    language: CharSlice,
-    language_version: CharSlice,
-    language_interpreter: CharSlice,
-    hostname: CharSlice,
-    env: CharSlice,
-    version: CharSlice,
-    service: CharSlice,
-    input_format: TraceExporterInputFormat,
-    output_format: TraceExporterOutputFormat,
-    compute_stats: bool,
-    agent_response_callback: extern "C" fn(*const c_char),
-) -> MaybeError {
-    let callback_wrapper = ResponseCallbackWrapper {
-        response_callback: agent_response_callback,
-    };
-    // TODO - handle errors - https://datadoghq.atlassian.net/browse/APMSP-1095
-    let mut builder = TraceExporter::builder()
-        .set_url(url.to_utf8_lossy().as_ref())
-        .set_tracer_version(tracer_version.to_utf8_lossy().as_ref())
-        .set_language(language.to_utf8_lossy().as_ref())
-        .set_language_version(language_version.to_utf8_lossy().as_ref())
-        .set_language_interpreter(language_interpreter.to_utf8_lossy().as_ref())
-        .set_hostname(hostname.to_utf8_lossy().as_ref())
-        .set_env(env.to_utf8_lossy().as_ref())
-        .set_app_version(version.to_utf8_lossy().as_ref())
-        .set_service(service.to_utf8_lossy().as_ref())
-        .set_input_format(input_format)
-        .set_output_format(output_format)
-        .set_response_callback(Box::new(callback_wrapper));
-    if compute_stats {
-        builder = builder.enable_stats(Duration::from_secs(10))
-        // TODO: APMSP-1317 Enable peer tags aggregation and stats by span_kind based on agent
-        // configuration
-    }
-    let exporter = builder.build().unwrap();
-    out_handle.as_ptr().write(Box::new(exporter));
-    MaybeError::None
-}
+    config: ddcommon_ffi::Option<&TraceExporterConfig>,
+) -> ddcommon_ffi::Option<Error> {
+    if let ddcommon_ffi::Option::Some(config) = config {
+        let mut builder = TraceExporter::builder()
+            .set_url(config.url.as_ref().unwrap())
+            .set_tracer_version(config.tracer_version.as_ref().unwrap())
+            .set_language(config.language.as_ref().unwrap())
+            .set_language_version(config.language_version.as_ref().unwrap())
+            .set_language_interpreter(config.language_interpreter.as_ref().unwrap())
+            .set_hostname(config.hostname.as_ref().unwrap())
+            .set_env(config.env.as_ref().unwrap())
+            .set_app_version(config.version.as_ref().unwrap())
+            .set_service(config.service.as_ref().unwrap())
+            .set_input_format(config.input_format)
+            .set_output_format(config.output_format);
+        if config.compute_stats {
+            builder = builder.enable_stats(Duration::from_secs(10))
+            // TODO: APMSP-1317 Enable peer tags aggregation and stats by span_kind based on agent
+            // configuration
+        }
 
-struct ResponseCallbackWrapper {
-    response_callback: extern "C" fn(*const c_char),
-}
-
-impl ResponseCallback for ResponseCallbackWrapper {
-    fn call(&self, response: &str) {
-        let c_response = std::ffi::CString::new(response).unwrap();
-        (self.response_callback)(c_response.as_ptr());
+        match builder.build() {
+            Ok(exporter) => {
+                out_handle.as_ptr().write(Box::new(exporter));
+                None.into()
+            }
+            Err(err) => trace_exporter_error_to_ffi(err),
+        }
+    } else {
+        ddcommon_ffi::Option::Some(Error::from(ErrorCode::InvalidArgument))
     }
 }
 
@@ -110,19 +215,328 @@ pub unsafe extern "C" fn ddog_trace_exporter_send(
     handle: &TraceExporter,
     trace: ByteSlice,
     trace_count: usize,
-) -> MaybeError {
-    // necessary that the trace be static for the life of the FFI function call as the caller
-    // currently owns the memory.
-    //APMSP-1621 - Properly fix this sharp-edge by allocating memory on the Rust side
-    let static_trace: ByteSlice<'static> = std::mem::transmute(trace);
+    agent_resp: ddcommon_ffi::Option<&mut AgentResponse>,
+) -> ddcommon_ffi::Option<Error> {
+    if let ddcommon_ffi::Option::Some(result) = agent_resp {
+        let static_trace: ByteSlice<'static> = std::mem::transmute(trace);
+        match handle .send( tinybytes::Bytes::from_static(static_trace.as_slice()), trace_count,) {
+            Ok(resp) => {
+                *result = resp;
+                None.into()
+            }
+            Err(e) => trace_exporter_error_to_ffi(e),
+        }
+    } else {
+        ddcommon_ffi::Option::Some(Error::from(ErrorCode::InvalidArgument))
+    }
+}
 
-    // TODO: APMSP-1095 - properly handle errors from the send call
-    handle
-        .send(
-            tinybytes::Bytes::from_static(static_trace.as_slice()),
-            trace_count,
-        )
-        .unwrap_or(String::from(""));
+fn trace_exporter_error_to_ffi(err: TraceExporterError) -> ddcommon_ffi::Option<Error> {
+    match err {
+        TraceExporterError::Builder(e) => match e {
+            BuilderErrorKind::InvalidUri => {
+                ddcommon_ffi::Option::Some(Error::from(ErrorCode::InvalidUrl))
+            }
+        },
+        TraceExporterError::Deserialization(_) => {
+            ddcommon_ffi::Option::Some(Error::from(ErrorCode::Serde))
+        }
+        TraceExporterError::Io(e) => match e.kind() {
+            IoErrorKind::InvalidData => {
+                ddcommon_ffi::Option::Some(Error::from(ErrorCode::InvalidData))
+            }
+            IoErrorKind::InvalidInput => {
+                ddcommon_ffi::Option::Some(Error::from(ErrorCode::InvalidInput))
+            }
+            IoErrorKind::ConnectionReset => {
+                ddcommon_ffi::Option::Some(Error::from(ErrorCode::ConnectionReset))
+            }
+            IoErrorKind::ConnectionAborted => {
+                ddcommon_ffi::Option::Some(Error::from(ErrorCode::ConnectionAborted))
+            }
+            IoErrorKind::ConnectionRefused => {
+                ddcommon_ffi::Option::Some(Error::from(ErrorCode::ConnectionRefused))
+            }
+            IoErrorKind::TimedOut => ddcommon_ffi::Option::Some(Error::from(ErrorCode::TimedOut)),
+            IoErrorKind::AddrInUse => {
+                ddcommon_ffi::Option::Some(Error::from(ErrorCode::AddressInUse))
+            }
+            _ => ddcommon_ffi::Option::Some(Error::from(ErrorCode::IoError)),
+        },
+        TraceExporterError::Network(e) => match e.kind() {
+            NetworkErrorKind::Body => {
+                ddcommon_ffi::Option::Some(Error::from(ErrorCode::HttpBodyFormat))
+            }
+            NetworkErrorKind::Canceled => {
+                ddcommon_ffi::Option::Some(Error::from(ErrorCode::ConnectionAborted))
+            }
+            NetworkErrorKind::ConnectionClosed => {
+                ddcommon_ffi::Option::Some(Error::from(ErrorCode::ConnectionReset))
+            }
+            NetworkErrorKind::MessageTooLarge => {
+                ddcommon_ffi::Option::Some(Error::from(ErrorCode::HttpBodyTooLong))
+            }
+            NetworkErrorKind::Parse => {
+                ddcommon_ffi::Option::Some(Error::from(ErrorCode::HttpParse))
+            }
+            NetworkErrorKind::TimedOut => {
+                ddcommon_ffi::Option::Some(Error::from(ErrorCode::TimedOut))
+            }
+            NetworkErrorKind::Unknown => {
+                ddcommon_ffi::Option::Some(Error::from(ErrorCode::NetworkUnknown))
+            }
+            NetworkErrorKind::WrongStatus => {
+                ddcommon_ffi::Option::Some(Error::from(ErrorCode::HttpWrongStatus))
+            }
+        },
+        TraceExporterError::Request(e) => {
+            let status: u16 = e.status().into();
+            if (400..500).contains(&status) {
+                ddcommon_ffi::Option::Some(Error::from(ErrorCode::HttpClient))
+            } else {
+                ddcommon_ffi::Option::Some(Error::from(ErrorCode::HttpServer))
+            }
+        }
+        TraceExporterError::Serde(_) => ddcommon_ffi::Option::Some(Error::from(ErrorCode::Serde)),
+    }
+}
 
-    MaybeError::None
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_url_test() {
+        unsafe {
+            let error = ddog_trace_exporter_config_set_url(
+                ddcommon_ffi::Option::None,
+                CharSlice::from("http://localhost"),
+            );
+            assert_eq!(
+                error,
+                ddcommon_ffi::Option::Some(Error {
+                    code: ErrorCode::InvalidArgument
+                })
+            );
+
+            let mut config = ddcommon_ffi::Option::Some(TraceExporterConfig::default());
+            let error = ddog_trace_exporter_config_set_url(
+                config.as_mut(),
+                CharSlice::from("http://localhost"),
+            );
+
+            assert_eq!(error, ddcommon_ffi::Option::None);
+
+            let cfg = config.to_std_ref().unwrap();
+            assert_eq!(cfg.url.as_ref().unwrap(), "http://localhost");
+        }
+    }
+
+    #[test]
+    fn config_tracer_version() {
+        unsafe {
+            let error = ddog_trace_exporter_config_set_tracer_version(
+                ddcommon_ffi::Option::None,
+                CharSlice::from("1.0"),
+            );
+            assert_eq!(
+                error,
+                ddcommon_ffi::Option::Some(Error {
+                    code: ErrorCode::InvalidArgument
+                })
+            );
+
+            let mut config = ddcommon_ffi::Option::Some(TraceExporterConfig::default());
+            let error = ddog_trace_exporter_config_set_tracer_version(
+                config.as_mut(),
+                CharSlice::from("1.0"),
+            );
+            assert_eq!(error, ddcommon_ffi::Option::None);
+
+            let cfg = config.to_std_ref().unwrap();
+            assert_eq!(cfg.tracer_version.as_ref().unwrap(), "1.0");
+        }
+    }
+
+    #[test]
+    fn config_language() {
+        unsafe {
+            let error = ddog_trace_exporter_config_set_language(
+                ddcommon_ffi::Option::None,
+                CharSlice::from("lang"),
+            );
+            assert_eq!(
+                error,
+                ddcommon_ffi::Option::Some(Error {
+                    code: ErrorCode::InvalidArgument
+                })
+            );
+
+            let mut config = ddcommon_ffi::Option::Some(TraceExporterConfig::default());
+            let error =
+                ddog_trace_exporter_config_set_language(config.as_mut(), CharSlice::from("lang"));
+
+            assert_eq!(error, ddcommon_ffi::Option::None);
+
+            let cfg = config.to_std_ref().unwrap();
+            assert_eq!(cfg.language.as_ref().unwrap(), "lang");
+        }
+    }
+
+    #[test]
+    fn config_lang_version() {
+        unsafe {
+            let error = ddog_trace_exporter_config_set_lang_version(
+                ddcommon_ffi::Option::None,
+                CharSlice::from("0.1"),
+            );
+            assert_eq!(
+                error,
+                ddcommon_ffi::Option::Some(Error {
+                    code: ErrorCode::InvalidArgument
+                })
+            );
+
+            let mut config = ddcommon_ffi::Option::Some(TraceExporterConfig::default());
+            let error = ddog_trace_exporter_config_set_lang_version(
+                config.as_mut(),
+                CharSlice::from("0.1"),
+            );
+
+            assert_eq!(error, ddcommon_ffi::Option::None);
+
+            let cfg = config.to_std_ref().unwrap();
+            assert_eq!(cfg.language_version.as_ref().unwrap(), "0.1");
+        }
+    }
+
+    #[test]
+    fn config_lang_interpreter_test() {
+        unsafe {
+            let error = ddog_trace_exporter_config_set_lang_interpreter(
+                ddcommon_ffi::Option::None,
+                CharSlice::from("foo"),
+            );
+            assert_eq!(
+                error,
+                ddcommon_ffi::Option::Some(Error {
+                    code: ErrorCode::InvalidArgument
+                })
+            );
+
+            let mut config = ddcommon_ffi::Option::Some(TraceExporterConfig::default());
+            let error = ddog_trace_exporter_config_set_lang_interpreter(
+                config.as_mut(),
+                CharSlice::from("foo"),
+            );
+
+            assert_eq!(error, ddcommon_ffi::Option::None);
+
+            let cfg = config.to_std_ref().unwrap();
+            assert_eq!(cfg.language_interpreter.as_ref().unwrap(), "foo");
+        }
+    }
+
+    #[test]
+    fn config_hostname_test() {
+        unsafe {
+            let error = ddog_trace_exporter_config_set_hostname(
+                ddcommon_ffi::Option::None,
+                CharSlice::from("hostname"),
+            );
+            assert_eq!(
+                error,
+                ddcommon_ffi::Option::Some(Error {
+                    code: ErrorCode::InvalidArgument
+                })
+            );
+
+            let mut config = ddcommon_ffi::Option::Some(TraceExporterConfig::default());
+            let error = ddog_trace_exporter_config_set_hostname(
+                config.as_mut(),
+                CharSlice::from("hostname"),
+            );
+
+            assert_eq!(error, ddcommon_ffi::Option::None);
+
+            let cfg = config.to_std_ref().unwrap();
+            assert_eq!(cfg.hostname.as_ref().unwrap(), "hostname");
+        }
+    }
+
+    #[test]
+    fn config_env_test() {
+        unsafe {
+            let error = ddog_trace_exporter_config_set_env(
+                ddcommon_ffi::Option::None,
+                CharSlice::from("env-test"),
+            );
+            assert_eq!(
+                error,
+                ddcommon_ffi::Option::Some(Error {
+                    code: ErrorCode::InvalidArgument
+                })
+            );
+
+            let mut config = ddcommon_ffi::Option::Some(TraceExporterConfig::default());
+            let error =
+                ddog_trace_exporter_config_set_env(config.as_mut(), CharSlice::from("env-test"));
+
+            assert_eq!(error, ddcommon_ffi::Option::None);
+
+            let cfg = config.to_std_ref().unwrap();
+            assert_eq!(cfg.env.as_ref().unwrap(), "env-test");
+        }
+    }
+
+    #[test]
+    fn config_version_test() {
+        unsafe {
+            let error = ddog_trace_exporter_config_set_version(
+                ddcommon_ffi::Option::None,
+                CharSlice::from("1.2"),
+            );
+            assert_eq!(
+                error,
+                ddcommon_ffi::Option::Some(Error {
+                    code: ErrorCode::InvalidArgument
+                })
+            );
+
+            let mut config = ddcommon_ffi::Option::Some(TraceExporterConfig::default());
+            let error =
+                ddog_trace_exporter_config_set_version(config.as_mut(), CharSlice::from("1.2"));
+
+            assert_eq!(error, ddcommon_ffi::Option::None);
+
+            let cfg = config.to_std_ref().unwrap();
+            assert_eq!(cfg.version.as_ref().unwrap(), "1.2");
+        }
+    }
+
+    #[test]
+    fn config_service_test() {
+        unsafe {
+            let error = ddog_trace_exporter_config_set_service(
+                ddcommon_ffi::Option::None,
+                CharSlice::from("service"),
+            );
+            assert_eq!(
+                error,
+                ddcommon_ffi::Option::Some(Error {
+                    code: ErrorCode::InvalidArgument
+                })
+            );
+
+            let mut config = ddcommon_ffi::Option::Some(TraceExporterConfig::default());
+            let error =
+                ddog_trace_exporter_config_set_service(config.as_mut(), CharSlice::from("service"));
+
+            assert_eq!(error, ddcommon_ffi::Option::None);
+
+            let cfg = config.to_std_ref().unwrap();
+            assert_eq!(cfg.service.as_ref().unwrap(), "service");
+        }
+    }
+>>>>>>> 30db5f8f (Add new API and error handling to FFI layer.)
 }

--- a/data-pipeline/src/trace_exporter/agent_response.rs
+++ b/data-pipeline/src/trace_exporter/agent_response.rs
@@ -1,0 +1,116 @@
+// Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::Deserialize;
+use serde_json::{Map, Value};
+use std::io::Error as IoError;
+use std::io::ErrorKind as IoErrorKind;
+
+use crate::trace_exporter::error::TraceExporterError;
+use std::{f64, str::FromStr};
+
+#[derive(Debug, Deserialize)]
+pub struct Rates {
+    rate_by_service: Map<String, Value>,
+}
+
+impl Rates {
+    pub fn get(&self, service: &str, env: &str) -> Result<f64, IoError> {
+        for (id, value) in &self.rate_by_service {
+            let mut it = id
+                .split(',')
+                .filter_map(|pair| pair.split_once(':'))
+                .map(|(_, value)| value);
+
+            let srv_pair = (it.next().unwrap_or(""), it.next().unwrap_or(""));
+            if srv_pair == (service, env) {
+                return value
+                    .as_f64()
+                    .ok_or(IoError::from(IoErrorKind::InvalidData));
+            }
+        }
+        // Return default
+        if let Some(default) = self.rate_by_service.get("service:,env:") {
+            default
+                .as_f64()
+                .ok_or(IoError::from(IoErrorKind::InvalidData))
+        } else {
+            Err(IoError::from(IoErrorKind::NotFound))
+        }
+    }
+}
+
+impl FromStr for Rates {
+    type Err = TraceExporterError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let obj: Rates = serde_json::from_str(s)?;
+        Ok(obj)
+    }
+}
+
+#[derive(Debug, PartialEq)]
+#[repr(C)]
+pub struct AgentResponse(f64);
+
+impl From<f64> for AgentResponse {
+    fn from(value: f64) -> Self {
+        AgentResponse(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_test() {
+        let payload = r#"{
+            "rate_by_service": {
+                "service:foo,env:staging": 1.0,
+                "service:foo,env:prod": 0.3,
+                "service:,env:": 0.8
+            }
+        }"#;
+
+        let rates: Rates = payload.parse().unwrap();
+
+        assert_eq!(rates.rate_by_service.len(), 3);
+        assert_eq!(rates.get("foo", "staging").unwrap(), 1.0);
+        assert_eq!(rates.get("foo", "prod").unwrap(), 0.3);
+        assert_eq!(rates.get("bar", "bar-env").unwrap(), 0.8);
+    }
+
+    #[test]
+    fn parse_invalid_data_test() {
+        let payload = r#"{
+            "rate_by_service": {
+                "service:foo,env:staging": "",
+                "service:,env:": "" 
+            }
+        }"#;
+
+        let rates: Rates = payload.parse().unwrap();
+
+        assert_eq!(rates.rate_by_service.len(), 2);
+        assert!(rates
+            .get("foo", "staging")
+            .is_err_and(|e| e.kind() == IoErrorKind::InvalidData));
+        assert!(rates
+            .get("bar", "staging")
+            .is_err_and(|e| e.kind() == IoErrorKind::InvalidData));
+    }
+
+    #[test]
+    fn parse_invalid_payload_test() {
+        let payload = r#"{
+            "invalid": {
+                "service:foo,env:staging": "",
+                "service:,env:": "" 
+            }
+        }"#;
+
+        let res = payload.parse::<Rates>();
+
+        assert!(res.is_err());
+    }
+}

--- a/data-pipeline/src/trace_exporter/agent_response.rs
+++ b/data-pipeline/src/trace_exporter/agent_response.rs
@@ -9,12 +9,14 @@ use std::io::ErrorKind as IoErrorKind;
 use crate::trace_exporter::error::TraceExporterError;
 use std::{f64, str::FromStr};
 
+/// `Rates` contains all service's sampling rates returned by the agent.
 #[derive(Debug, Deserialize)]
 pub struct Rates {
     rate_by_service: Map<String, Value>,
 }
 
 impl Rates {
+    /// Get the sampling rate for a service and evironment pair.
     pub fn get(&self, service: &str, env: &str) -> Result<f64, IoError> {
         for (id, value) in &self.rate_by_service {
             let mut it = id
@@ -48,13 +50,17 @@ impl FromStr for Rates {
     }
 }
 
+/// `AgentResponse` structure holds agent response information upon successful request.
 #[derive(Debug, PartialEq)]
 #[repr(C)]
-pub struct AgentResponse(f64);
+pub struct AgentResponse {
+    /// Sampling rate for the current service.
+    rate: f64,
+}
 
 impl From<f64> for AgentResponse {
     fn from(value: f64) -> Self {
-        AgentResponse(value)
+        AgentResponse { rate: value }
     }
 }
 

--- a/data-pipeline/src/trace_exporter/error.rs
+++ b/data-pipeline/src/trace_exporter/error.rs
@@ -1,0 +1,163 @@
+// Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::trace_exporter::msgpack_decoder::v04::error::DecodeError;
+use hyper::http::StatusCode;
+use hyper::Error as HyperError;
+use serde_json::error::Error as SerdeError;
+use std::error::Error;
+use std::fmt::{Debug, Display};
+
+#[derive(Debug, PartialEq)]
+pub enum BuilderErrorKind {
+    InvalidUri,
+}
+
+impl Display for BuilderErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BuilderErrorKind::InvalidUri => write!(f, "Invalid URI"),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+pub enum NetworkErrorKind {
+    Body,
+    Canceled,
+    ConnectionClosed,
+    MessageTooLarge,
+    Parse,
+    TimedOut,
+    Unknown,
+    WrongStatus,
+}
+
+#[derive(Debug)]
+pub struct NetworkError {
+    kind: NetworkErrorKind,
+    source: HyperError,
+}
+
+impl Error for NetworkError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(&self.source)
+    }
+}
+
+impl NetworkError {
+    fn new(kind: NetworkErrorKind, source: HyperError) -> Self {
+        Self { kind, source }
+    }
+
+    pub fn kind(&self) -> NetworkErrorKind {
+        self.kind
+    }
+}
+
+impl Display for NetworkError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self.source().unwrap(), f)
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct RequestError {
+    code: StatusCode,
+    msg: String,
+}
+
+impl Display for RequestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            format_args!("Error code: {}, Response: {}", self.code, self.msg)
+        )
+    }
+}
+
+impl RequestError {
+    pub fn new(code: StatusCode, msg: &str) -> Self {
+        Self {
+            code,
+            msg: msg.to_owned(),
+        }
+    }
+
+    pub fn status(&self) -> StatusCode {
+        self.code
+    }
+}
+
+/// TraceExporterError holds different types of errors occurred when handling traces.
+#[derive(Debug)]
+pub enum TraceExporterError {
+    Builder(BuilderErrorKind),
+    Deserialization(DecodeError),
+    Io(std::io::Error),
+    Network(NetworkError),
+    Request(RequestError),
+    Serde(SerdeError),
+}
+
+impl From<serde_json::error::Error> for TraceExporterError {
+    fn from(value: SerdeError) -> Self {
+        TraceExporterError::Serde(value)
+    }
+}
+
+impl From<hyper::http::uri::InvalidUri> for TraceExporterError {
+    fn from(_value: hyper::http::uri::InvalidUri) -> Self {
+        TraceExporterError::Builder(BuilderErrorKind::InvalidUri)
+    }
+}
+
+impl From<HyperError> for TraceExporterError {
+    fn from(err: HyperError) -> Self {
+        if err.is_parse() {
+            TraceExporterError::Network(NetworkError::new(NetworkErrorKind::Parse, err))
+        } else if err.is_canceled() {
+            TraceExporterError::Network(NetworkError::new(NetworkErrorKind::Canceled, err))
+        } else if err.is_connect() {
+            TraceExporterError::Network(NetworkError::new(NetworkErrorKind::ConnectionClosed, err))
+        } else if err.is_parse_too_large() {
+            TraceExporterError::Network(NetworkError::new(NetworkErrorKind::MessageTooLarge, err))
+        } else if err.is_incomplete_message() || err.is_body_write_aborted() {
+            TraceExporterError::Network(NetworkError::new(NetworkErrorKind::Body, err))
+        } else if err.is_parse_status() {
+            TraceExporterError::Network(NetworkError::new(NetworkErrorKind::WrongStatus, err))
+        } else if err.is_timeout() {
+            TraceExporterError::Network(NetworkError::new(NetworkErrorKind::TimedOut, err))
+        } else {
+            TraceExporterError::Network(NetworkError::new(NetworkErrorKind::Unknown, err))
+        }
+    }
+}
+
+impl From<DecodeError> for TraceExporterError {
+    fn from(err: DecodeError) -> Self {
+        TraceExporterError::Deserialization(err)
+    }
+}
+
+impl From<std::io::Error> for TraceExporterError {
+    fn from(err: std::io::Error) -> Self {
+        TraceExporterError::Io(err)
+    }
+}
+
+impl Display for TraceExporterError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TraceExporterError::Builder(e) => std::fmt::Display::fmt(e, f),
+            TraceExporterError::Deserialization(e) => std::fmt::Display::fmt(e, f),
+            TraceExporterError::Io(e) => std::fmt::Display::fmt(e, f),
+            TraceExporterError::Network(e) => std::fmt::Display::fmt(e, f),
+            TraceExporterError::Request(e) => std::fmt::Display::fmt(e, f),
+            TraceExporterError::Serde(e) => std::fmt::Display::fmt(e, f),
+        }
+    }
+}
+
+impl Error for TraceExporterError {}

--- a/data-pipeline/src/trace_exporter/mod.rs
+++ b/data-pipeline/src/trace_exporter/mod.rs
@@ -1,6 +1,9 @@
 // Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
+pub mod agent_response;
+pub mod error;
 use crate::agent_info::{AgentInfoArc, AgentInfoFetcher};
+use crate::trace_exporter::error::{RequestError, TraceExporterError};
 use crate::{
     health_metrics, health_metrics::HealthMetric, span_concentrator::SpanConcentrator,
     stats_exporter,
@@ -23,6 +26,8 @@ use std::time::Duration;
 use std::{borrow::Borrow, collections::HashMap, str::FromStr, time};
 use tokio::{runtime::Runtime, task::JoinHandle};
 use tokio_util::sync::CancellationToken;
+
+use self::agent_response::{AgentResponse, Rates};
 
 const DEFAULT_STATS_ELIGIBLE_SPAN_KINDS: [&str; 4] = ["client", "server", "producer", "consumer"];
 const STATS_ENDPOINT: &str = "/v0.6/stats";
@@ -193,6 +198,7 @@ impl<'a> From<&'a TracerMetadata> for HashMap<&'static str, String> {
     }
 }
 
+#[derive(Debug)]
 enum StatsComputationStatus {
     /// Client-side stats has been disabled by the tracer
     Disabled,
@@ -227,13 +233,13 @@ enum StatsComputationStatus {
 /// another task to send stats when a time bucket expire. When this feature is enabled the
 /// TraceExporter drops all spans that may not be sampled by the agent.
 #[allow(missing_docs)]
+#[derive(Debug)]
 pub struct TraceExporter {
     endpoint: Endpoint,
     metadata: TracerMetadata,
     input_format: TraceExporterInputFormat,
     output_format: TraceExporterOutputFormat,
     // TODO - do something with the response callback - https://datadoghq.atlassian.net/browse/APMSP-1019
-    _response_callback: Option<Box<dyn ResponseCallback>>,
     runtime: Runtime,
     /// None if dogstatsd is disabled
     dogstatsd: Option<Client>,
@@ -253,16 +259,22 @@ impl TraceExporter {
 
     /// Send msgpack serialized traces to the agent
     #[allow(missing_docs)]
-    pub fn send(&self, data: tinybytes::Bytes, trace_count: usize) -> Result<String, String> {
+    pub fn send(&self, data: tinybytes::Bytes, trace_count: usize) -> Result<AgentResponse, TraceExporterError> {
         self.check_agent_info();
         match self.input_format {
             TraceExporterInputFormat::Proxy => self.send_proxy(data.as_ref(), trace_count),
             TraceExporterInputFormat::V04 => self.send_deser_ser(data),
         }
+        .and_then(|res| {
+            let rates = res.parse::<Rates>()?;
+
+            let rate = rates.get(&self.metadata.service, &self.metadata.env)?;
+            Ok(AgentResponse::from(rate))
+        })
     }
 
     /// Safely shutdown the TraceExporter and all related tasks
-    pub fn shutdown(self, timeout: Option<Duration>) -> Result<(), String> {
+    pub fn shutdown(self, timeout: Option<Duration>) -> Result<(), TraceExporterError> {
         if let Some(timeout) = timeout {
             match self.runtime.block_on(async {
                 tokio::time::timeout(timeout, async {
@@ -283,7 +295,7 @@ impl TraceExporter {
                 .await
             }) {
                 Ok(()) => Ok(()),
-                Err(_) => Err("Shutdown timed out".to_string()),
+                Err(e) => Err(TraceExporterError::Io(e.into())),
             }
         } else {
             self.runtime.block_on(async {
@@ -430,7 +442,7 @@ impl TraceExporter {
         }
     }
 
-    fn send_proxy(&self, data: &[u8], trace_count: usize) -> Result<String, String> {
+    fn send_proxy(&self, data: &[u8], trace_count: usize) -> Result<String, TraceExporterError> {
         self.send_data_to_url(
             data,
             trace_count,
@@ -443,93 +455,91 @@ impl TraceExporter {
         data: &[u8],
         trace_count: usize,
         uri: Uri,
-    ) -> Result<String, String> {
-        self.runtime
-            .block_on(async {
-                let mut req_builder = hyper::Request::builder()
-                    .uri(uri)
-                    .header(
-                        hyper::header::USER_AGENT,
-                        concat!("Tracer/", env!("CARGO_PKG_VERSION")),
-                    )
-                    .method(Method::POST);
+    ) -> Result<String, TraceExporterError> {
+        self.runtime.block_on(async {
+            let mut req_builder = hyper::Request::builder()
+                .uri(uri)
+                .header(
+                    hyper::header::USER_AGENT,
+                    concat!("Tracer/", env!("CARGO_PKG_VERSION")),
+                )
+                .method(Method::POST);
 
-                let headers: HashMap<&'static str, String> = self.metadata.borrow().into();
+            let headers: HashMap<&'static str, String> = self.metadata.borrow().into();
 
-                for (key, value) in &headers {
-                    req_builder = req_builder.header(*key, value);
-                }
-                req_builder = req_builder
-                    .header("Content-type", "application/msgpack")
-                    .header("X-Datadog-Trace-Count", trace_count.to_string().as_str());
-                let req = req_builder
-                    .body(Body::from(Bytes::copy_from_slice(data)))
-                    .unwrap();
+            for (key, value) in &headers {
+                req_builder = req_builder.header(*key, value);
+            }
+            req_builder = req_builder
+                .header("Content-type", "application/msgpack")
+                .header("X-Datadog-Trace-Count", trace_count.to_string().as_str());
+            let req = req_builder
+                .body(Body::from(Bytes::copy_from_slice(data)))
+                .unwrap();
 
-                match hyper::Client::builder()
-                    .build(connector::Connector::default())
-                    .request(req)
-                    .await
-                {
-                    Ok(response) => {
-                        let response_status = response.status();
-                        if !response_status.is_success() {
-                            let body_bytes = response.into_body().collect().await?.to_bytes();
-                            let response_body =
-                                String::from_utf8(body_bytes.to_vec()).unwrap_or_default();
-                            let resp_tag_res = &Tag::new("response_code", response_status.as_str());
-                            match resp_tag_res {
-                                Ok(resp_tag) => {
-                                    self.emit_metric(
-                                        HealthMetric::Count(
-                                            health_metrics::STAT_SEND_TRACES_ERRORS,
-                                            1,
-                                        ),
-                                        Some(vec![&resp_tag]),
-                                    );
-                                }
-                                Err(tag_err) => {
-                                    // This should really never happen as response_status is a
-                                    // `NonZeroU16`, but if the response status or tag requirements
-                                    // ever change in the future we still don't want to panic.
-                                    error!("Failed to serialize response_code to tag {}", tag_err)
-                                }
-                            }
-                            anyhow::bail!("Agent did not accept traces: {response_body}");
-                        }
-                        match response.into_body().collect().await {
-                            Ok(body) => {
-                                self.emit_metric(
-                                    HealthMetric::Count(
-                                        health_metrics::STAT_SEND_TRACES,
-                                        trace_count as i64,
-                                    ),
-                                    None,
-                                );
-                                Ok(String::from_utf8_lossy(&body.to_bytes()).to_string())
-                            }
-                            Err(err) => {
+            match hyper::Client::builder()
+                .build(connector::Connector::default())
+                .request(req)
+                .await
+            {
+                Ok(response) => {
+                    let response_status = response.status();
+                    if !response_status.is_success() {
+                        // TODO: remove unwrap
+                        let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+                        let response_body =
+                            String::from_utf8(body_bytes.to_vec()).unwrap_or_default();
+                        let resp_tag_res = &Tag::new("response_code", response_status.as_str());
+                        match resp_tag_res {
+                            Ok(resp_tag) => {
                                 self.emit_metric(
                                     HealthMetric::Count(health_metrics::STAT_SEND_TRACES_ERRORS, 1),
-                                    None,
+                                    Some(vec![&resp_tag]),
                                 );
-                                anyhow::bail!("Error reading agent response body: {err}");
+                            }
+                            Err(tag_err) => {
+                                // This should really never happen as response_status is a
+                                // `NonZeroU16`, but if the response status or tag requirements
+                                // ever change in the future we still don't want to panic.
+                                error!("Failed to serialize response_code to tag {}", tag_err)
                             }
                         }
+                        return Err(TraceExporterError::Request(RequestError::new(
+                            response_status,
+                            &response_body,
+                        )));
+                        //anyhow::bail!("Agent did not accept traces: {response_body}");
                     }
-                    Err(err) => {
-                        self.emit_metric(
-                            HealthMetric::Count(health_metrics::STAT_SEND_TRACES_ERRORS, 1),
-                            None,
-                        );
-                        anyhow::bail!("Failed to send traces: {err}")
+                    match response.into_body().collect().await {
+                        Ok(body) => {
+                            self.emit_metric(
+                                HealthMetric::Count(
+                                    health_metrics::STAT_SEND_TRACES,
+                                    trace_count as i64,
+                                ),
+                                None,
+                            );
+                            Ok(String::from_utf8_lossy(&body.to_bytes()).to_string())
+                        }
+                        Err(err) => {
+                            self.emit_metric(
+                                HealthMetric::Count(health_metrics::STAT_SEND_TRACES_ERRORS, 1),
+                                None,
+                            );
+                            Err(TraceExporterError::from(err))
+                            // anyhow::bail!("Error reading agent response body: {err}");
+                        }
                     }
                 }
-            })
-            .or_else(|err| {
-                error!("Error sending traces: {err}");
-                Ok(String::from("{}"))
-            })
+                Err(err) => {
+                    self.emit_metric(
+                        HealthMetric::Count(health_metrics::STAT_SEND_TRACES_ERRORS, 1),
+                        None,
+                    );
+                    Err(TraceExporterError::from(err))
+                }
+            }
+        })
     }
 
     /// Emit a health metric to dogstatsd
@@ -564,8 +574,7 @@ impl TraceExporter {
     //     }
     // }
 
-    fn send_deser_ser(&self, data: tinybytes::Bytes) -> Result<String, String> {
-        // let size = data.len();
+    fn send_deser_ser(&self, data: tinybytes::Bytes) -> Result<String, TraceExporterError> {
         // TODO base on input format
         let (traces, size) = match msgpack_decoder::v04::decoder::from_slice(data) {
             Ok(res) => res,
@@ -575,13 +584,16 @@ impl TraceExporter {
                     HealthMetric::Count(health_metrics::STAT_DESER_TRACES_ERRORS, 1),
                     None,
                 );
-                return Ok(String::from("{}"));
+                return Err(TraceExporterError::Deserialization(err));
             }
         };
 
         if traces.is_empty() {
             error!("No traces deserialized from the request body.");
-            return Ok(String::from("{}"));
+            // return Ok(String::from("{}"));
+            return Err(TraceExporterError::Io(std::io::Error::from(
+                std::io::ErrorKind::InvalidInput,
+            )));
         }
 
         let num_traces = traces.len();
@@ -657,7 +669,9 @@ impl TraceExporter {
                                 HealthMetric::Count(health_metrics::STAT_SEND_TRACES_ERRORS, 1),
                                 None,
                             );
-                            Ok(String::from("{}"))
+                            Err(TraceExporterError::Io(std::io::Error::from(
+                                std::io::ErrorKind::Other,
+                            )))
                         }
                     }
                 })
@@ -686,7 +700,6 @@ pub struct TraceExporterBuilder {
     git_commit_sha: String,
     input_format: TraceExporterInputFormat,
     output_format: TraceExporterOutputFormat,
-    response_callback: Option<Box<dyn ResponseCallback>>,
     dogstatsd_url: Option<String>,
     client_computed_stats: bool,
     client_computed_top_level: bool,
@@ -789,12 +802,6 @@ impl TraceExporterBuilder {
         self
     }
 
-    #[allow(missing_docs)]
-    pub fn set_response_callback(mut self, response_callback: Box<dyn ResponseCallback>) -> Self {
-        self.response_callback = Some(response_callback);
-        self
-    }
-
     /// Set the header indicating the tracer has computed the top-level tag
     pub fn set_client_computed_top_level(mut self) -> Self {
         self.client_computed_top_level = true;
@@ -830,7 +837,7 @@ impl TraceExporterBuilder {
     }
 
     #[allow(missing_docs)]
-    pub fn build(self) -> anyhow::Result<TraceExporter> {
+    pub fn build(self) -> Result<TraceExporter, TraceExporterError> {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()?;
@@ -883,7 +890,6 @@ impl TraceExporterBuilder {
             },
             input_format: self.input_format,
             output_format: self.output_format,
-            _response_callback: self.response_callback,
             client_computed_top_level: self.client_computed_top_level,
             runtime,
             dogstatsd,
@@ -903,11 +909,11 @@ pub trait ResponseCallback {
 
 #[cfg(test)]
 mod tests {
+    use self::error::BuilderErrorKind;
     use super::*;
     use datadog_trace_utils::span_v04::Span;
     use httpmock::prelude::*;
     use httpmock::MockServer;
-    // use serde::Serialize;
     use std::collections::HashMap;
     use std::net;
     use std::time::Duration;
@@ -1168,6 +1174,8 @@ mod tests {
         let builder = TraceExporterBuilder::default();
         let exporter = builder
             .set_url(&server.url("/"))
+            .set_service("test")
+            .set_env("staging")
             .set_tracer_version("v0.1")
             .set_language("nodejs")
             .set_language_version("1.0")
@@ -1192,7 +1200,8 @@ mod tests {
             })
         }
 
-        exporter.send(data, 1).unwrap();
+        let result = exporter.send(data, 1);
+        assert!(result.is_err());
         exporter.shutdown(None).unwrap();
 
         mock_traces.assert();
@@ -1230,6 +1239,8 @@ mod tests {
         let builder = TraceExporterBuilder::default();
         let exporter = builder
             .set_url(&server.url("/"))
+            .set_service("test")
+            .set_env("staging")
             .set_tracer_version("v0.1")
             .set_language("nodejs")
             .set_language_version("1.0")
@@ -1273,6 +1284,8 @@ mod tests {
     fn build_test_exporter(url: String, dogstatsd_url: String) -> TraceExporter {
         TraceExporterBuilder::default()
             .set_url(&url)
+            .set_service("test")
+            .set_env("staging")
             .set_dogstatsd_url(&dogstatsd_url)
             .set_tracer_version("v0.1")
             .set_language("nodejs")
@@ -1292,7 +1305,7 @@ mod tests {
         let _mock_traces = fake_agent.mock(|_, then| {
             then.status(200)
                 .header("content-type", "application/json")
-                .body("{}");
+                .body(r#"{ "rate_by_service": { "service:test,env:staging": 1.0, "service:test,env:prod": 0.3 } }"#);
         });
 
         let exporter = build_test_exporter(
@@ -1345,7 +1358,9 @@ mod tests {
         );
 
         let bad_payload = tinybytes::Bytes::copy_from_slice(b"some_bad_payload".as_ref());
-        let _result = exporter.send(bad_payload, 1).expect("failed to send trace");
+        let result = exporter.send(bad_payload, 1);
+
+        assert!(result.is_err());
 
         assert_eq!(
             &format!(
@@ -1381,7 +1396,8 @@ mod tests {
         let bytes = tinybytes::Bytes::from(
             rmp_serde::to_vec_named(&traces).expect("failed to serialize static trace"),
         );
-        let _result = exporter.send(bytes, 1).expect("failed to send trace");
+        let result = exporter.send(bytes, 1);
+        assert!(result.is_err());
 
         assert_eq!(
             &format!(
@@ -1400,5 +1416,146 @@ mod tests {
             ),
             &read(&stats_socket)
         );
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn agent_response_parse() {
+        let server = MockServer::start();
+        let _agent = server.mock(|_, then| {
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{
+                    "rate_by_service": {
+                        "service:test_service,env:testing":0.5,
+                        "service:another_service,env:testing":1
+                    }
+                }"#,
+                );
+        });
+
+        let exporter = TraceExporterBuilder::default()
+            .set_url(&server.url("/"))
+            .set_service("test_service")
+            .set_env("testing")
+            .set_tracer_version("v0.1")
+            .set_language("nodejs")
+            .set_language_version("1.0")
+            .set_language_interpreter("v8")
+            .build()
+            .unwrap();
+
+        let traces: Vec<Vec<Span>> = vec![vec![Span {
+            name: BytesString::from_slice(b"test").unwrap(),
+            ..Default::default()
+        }]];
+        let bytes = tinybytes::Bytes::from(
+            rmp_serde::to_vec_named(&traces).expect("failed to serialize static trace"),
+        );
+        let result = exporter.send(bytes, 1).unwrap();
+
+        assert_eq!(result, AgentResponse::from(0.5));
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn agent_response_parse_default() {
+        let server = MockServer::start();
+        let _agent = server.mock(|_, then| {
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(
+                    r#"{
+                    "rate_by_service": {
+                        "service:foo,env:staging": 1.0,
+                        "service:,env:": 0.8 
+                    }
+                }"#,
+                );
+        });
+
+        let exporter = TraceExporterBuilder::default()
+            .set_url(&server.url("/"))
+            .set_service("foo")
+            .set_env("foo-env")
+            .set_tracer_version("v0.1")
+            .set_language("nodejs")
+            .set_language_version("1.0")
+            .set_language_interpreter("v8")
+            .build()
+            .unwrap();
+
+        let traces: Vec<Vec<Span>> = vec![vec![Span {
+            name: BytesString::from_slice(b"test").unwrap(),
+            ..Default::default()
+        }]];
+        let bytes = tinybytes::Bytes::from(
+            rmp_serde::to_vec_named(&traces).expect("failed to serialize static trace"),
+        );
+        let result = exporter.send(bytes, 1).unwrap();
+
+        assert_eq!(result, AgentResponse::from(0.8));
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn builder_error() {
+        let exporter = TraceExporterBuilder::default()
+            .set_url("")
+            .set_service("foo")
+            .set_env("foo-env")
+            .set_tracer_version("v0.1")
+            .set_language("nodejs")
+            .set_language_version("1.0")
+            .set_language_interpreter("v8")
+            .build();
+
+        assert!(exporter.is_err());
+
+        let err = match exporter.unwrap_err() {
+            TraceExporterError::Builder(e) => Some(e),
+            _ => None,
+        }
+        .unwrap();
+
+        assert_eq!(err, BuilderErrorKind::InvalidUri);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn agent_response_error() {
+        let server = MockServer::start();
+        let _agent = server.mock(|_, then| {
+            then.status(500)
+                .header("content-type", "application/json")
+                .body(r#"{ "error": "Unavailable" }"#);
+        });
+
+        let exporter = TraceExporterBuilder::default()
+            .set_url(&server.url("/"))
+            .set_service("foo")
+            .set_env("foo-env")
+            .set_tracer_version("v0.1")
+            .set_language("nodejs")
+            .set_language_version("1.0")
+            .set_language_interpreter("v8")
+            .build()
+            .unwrap();
+
+        let traces: Vec<Vec<Span>> = vec![vec![Span {
+            name: BytesString::from_slice(b"test").unwrap(),
+            ..Default::default()
+        }]];
+        let bytes = tinybytes::Bytes::from(
+            rmp_serde::to_vec_named(&traces).expect("failed to serialize static trace"),
+        );
+        let code = match exporter.send(bytes, 1).unwrap_err() {
+            TraceExporterError::Request(e) => Some(e.status()),
+            _ => None,
+        }
+        .unwrap();
+
+        assert_eq!(code, 500);
     }
 }

--- a/ddcommon-ffi/src/option.rs
+++ b/ddcommon-ffi/src/option.rs
@@ -19,6 +19,13 @@ impl<T> Option<T> {
             Option::None => None,
         }
     }
+
+    pub fn as_mut(&mut self) -> Option<&mut T> {
+        match *self {
+            Option::Some(ref mut x) => Option::Some(x),
+            Option::None => Option::None,
+        }
+    }
 }
 
 impl<T> From<Option<T>> for std::option::Option<T> {

--- a/dogstatsd-client/src/lib.rs
+++ b/dogstatsd-client/src/lib.rs
@@ -68,6 +68,7 @@ pub enum DogStatsDAction<'a, T: AsRef<str>, V: IntoIterator<Item = &'a Tag>> {
 }
 
 /// A dogstatsd-client that flushes stats to a given endpoint. Use `new_flusher` to build one.
+#[derive(Debug)]
 pub struct Client {
     client: StatsdClient,
 }

--- a/examples/ffi/trace_exporter.c
+++ b/examples/ffi/trace_exporter.c
@@ -33,22 +33,15 @@ int main(int argc, char** argv)
     ddog_CharSlice env = DDOG_CHARSLICE_C("staging");
     ddog_CharSlice version = DDOG_CHARSLICE_C("1.0");
     ddog_CharSlice service = DDOG_CHARSLICE_C("test_app");
-    TRY(ddog_trace_exporter_new(
-        &trace_exporter,
-        url,
-        tracer_version,
-        language,
-        language_version,
-        language_interpreter,
-        hostname,
-        env,
-        version,
-        service,
-        DDOG_TRACE_EXPORTER_INPUT_FORMAT_PROXY,
-        DDOG_TRACE_EXPORTER_OUTPUT_FORMAT_V04,
-        true,
-        &agent_response_callback
-        ));
+
+
+    ddog_TraceExporterConfig *config;
+    ddog_trace_exporter_config_new(&config);
+    ddog_trace_exporter_config_set_url(config, url);
+    ddog_trace_exporter_config_set_tracer_version(config, tracer_version);
+    ddog_trace_exporter_config_set_language(config, language);
+
+    TRY(ddog_trace_exporter_new(&trace_exporter, config));
 
     if (trace_exporter == NULL)
     {
@@ -57,7 +50,9 @@ int main(int argc, char** argv)
     }
 
     ddog_ByteSlice buffer = { .ptr = NULL, .len=0 };
-    TRY(ddog_trace_exporter_send(trace_exporter, buffer, 0));
+    ddog_AgentResponse response;
+
+    TRY(ddog_trace_exporter_send(trace_exporter, buffer, 0, &response));
 
     ddog_trace_exporter_free(trace_exporter);
 

--- a/examples/ffi/trace_exporter.c
+++ b/examples/ffi/trace_exporter.c
@@ -1,28 +1,26 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <datadog/common.h>
 #include <datadog/data-pipeline.h>
 
-#define TRY(expr)                                                                                  \
-  {                                                                                                \
-    ddog_MaybeError err = expr;                                                                    \
-    if (err.tag == DDOG_OPTION_ERROR_SOME_ERROR) {                                                 \
-      ddog_CharSlice message = ddog_Error_message(&err.some);                                      \
-      fprintf(stderr, "ERROR: %.*s", (int)message.len, (char *)message.ptr);                       \
-      return 1;                                                                                    \
-    }                                                                                              \
-  }
+enum {
+    SUCCESS,
+    ERROR_SEND,
+};
 
-void agent_response_callback(const char* response)
-{
-    printf("Agent response: %s\n", response);
+void handle_error(ddog_TraceExporterError *err) {
+    fprintf(stderr, "Operation failed with error: %d, reason: %s\n", err->code, err->msg);
+    ddog_trace_exporter_error_free(err);
 }
 
 int main(int argc, char** argv)
 {
+    int error;
+
     ddog_TraceExporter* trace_exporter;
     ddog_CharSlice url = DDOG_CHARSLICE_C("http://localhost:8126/");
     ddog_CharSlice tracer_version = DDOG_CHARSLICE_C("v0.1");
@@ -35,26 +33,39 @@ int main(int argc, char** argv)
     ddog_CharSlice service = DDOG_CHARSLICE_C("test_app");
 
 
+    ddog_TraceExporterError *ret;
     ddog_TraceExporterConfig *config;
+
     ddog_trace_exporter_config_new(&config);
     ddog_trace_exporter_config_set_url(config, url);
     ddog_trace_exporter_config_set_tracer_version(config, tracer_version);
     ddog_trace_exporter_config_set_language(config, language);
 
-    TRY(ddog_trace_exporter_new(&trace_exporter, config));
 
-    if (trace_exporter == NULL)
-    {
-        printf("unable to build the trace exporter");
-        return 1;
-    }
+    ret = ddog_trace_exporter_new(&trace_exporter, config);
+
+    assert(ret == NULL);
+    assert(trace_exporter != NULL);
 
     ddog_ByteSlice buffer = { .ptr = NULL, .len=0 };
     ddog_AgentResponse response;
 
-    TRY(ddog_trace_exporter_send(trace_exporter, buffer, 0, &response));
+    ret = ddog_trace_exporter_send(trace_exporter, buffer, 0, &response);
+
+    assert(ret->code == DDOG_TRACE_EXPORTER_ERROR_CODE_SERDE);
+    if (ret) {
+        error = ERROR_SEND;
+        handle_error(ret);
+        goto error;
+    }
 
     ddog_trace_exporter_free(trace_exporter);
+    ddog_trace_exporter_config_free(config);
 
-    return 0;
+    return SUCCESS;
+
+error:
+    if (trace_exporter) { ddog_trace_exporter_free(trace_exporter); }
+    if (config) { ddog_trace_exporter_config_free(config); }
+    return error;
 }

--- a/trace-utils/src/send_data/mod.rs
+++ b/trace-utils/src/send_data/mod.rs
@@ -924,7 +924,8 @@ mod tests {
 
         mock.assert_hits_async(5).await;
 
-        assert!(res.last_result.is_err());
+        assert!(res.last_result.is_ok());
+        assert_eq!(res.last_result.unwrap().status(), 500);
         assert_eq!(res.errors_timeout, 0);
         assert_eq!(res.errors_network, 0);
         assert_eq!(res.errors_status_code, 1);

--- a/trace-utils/src/send_data/send_data_result.rs
+++ b/trace-utils/src/send_data/send_data_result.rs
@@ -3,7 +3,6 @@
 
 use crate::send_data::RequestResult;
 use anyhow::anyhow;
-use hyper::body::HttpBody;
 use hyper::{Body, Response};
 use std::collections::HashMap;
 
@@ -73,15 +72,7 @@ impl SendDataResult {
                     .or_default() += 1;
                 self.chunks_dropped += chunks;
                 self.requests_count += u64::from(attempts);
-
-                let body = response.into_body().collect().await;
-                let response_body = String::from_utf8(body.unwrap_or_default().to_bytes().to_vec())
-                    .unwrap_or_default();
-                self.last_result = Err(anyhow::format_err!(
-                    "{} - Server did not accept traces: {}",
-                    status_code,
-                    response_body,
-                ));
+                self.last_result = Ok(response);
             }
             RequestResult::TimeoutError((attempts, chunks)) => {
                 self.errors_timeout += 1;


### PR DESCRIPTION
# What does this PR do?

This PR tries to improve the FFI for the trace exporter API by:
* Use a builder approach by encapsulating configuration in a new structure.
* Forward agent responses by introducing a new data type called `Rates` which can be queried to get the sampling rate for a specific service name. The value will be passed to the library user by a new output parameter in `ddog_trace_exporter_send`.
* Improve error handling in the API by returning a new data type called `ddog_TraceExporterError` which contains new error codes and debug information.