### PR TITLE
Fixes log struct not being able to be sent through the sidecar RPC

### DIFF
--- a/ddtelemetry/src/data/payloads.rs
+++ b/ddtelemetry/src/data/payloads.rs
@@ -75,9 +75,9 @@ pub struct Log {
 
     #[serde(default)]
     pub stack_trace: Option<String>,
-    #[serde(skip_serializing_if = "String::is_empty", default)]
+    #[serde(default)]
     pub tags: String,
-    #[serde(skip_serializing_if = "std::ops::Not::not", default)]
+    #[serde(default)]
     pub is_sensitive: bool,
 }
 


### PR DESCRIPTION

# What does this PR do?

Removes `skip_serializing` field on the telemetry Log struct fields 

# Motivation

As it turns out, bincode (the encoding format used in the sidecar rpc format) does not support encoding of serde fields using skip_serializing_if https://docs.rs/bincode/2.0.0-alpha.1/bincode/serde/index.html#known-issues so sending logs through the sidecar would fail

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
