### PR TITLE
Support "default if null" behavior for msgpack decoding of v04

### DIFF
--- a/data-pipeline/src/trace_exporter/mod.rs
+++ b/data-pipeline/src/trace_exporter/mod.rs
@@ -592,7 +592,6 @@ impl TraceExporter {
 
         if traces.is_empty() {
             error!("No traces deserialized from the request body.");
-            // return Ok(String::from("{}"));
             return Err(TraceExporterError::Io(std::io::Error::from(
                 std::io::ErrorKind::InvalidInput,
             )));

--- a/data-pipeline/src/trace_exporter/mod.rs
+++ b/data-pipeline/src/trace_exporter/mod.rs
@@ -1358,6 +1358,7 @@ mod tests {
         let bytes = tinybytes::Bytes::from(
             rmp_serde::to_vec_named(&traces).expect("failed to serialize static trace"),
         );
+
         let _result = exporter.send(bytes, 1).expect("failed to send trace");
 
         assert_eq!(

--- a/trace-utils/src/msgpack_decoder/v04/decoder/mod.rs
+++ b/trace-utils/src/msgpack_decoder/v04/decoder/mod.rs
@@ -313,6 +313,15 @@ mod tests {
 
         (key, rmp_serde::to_vec_named(&map).unwrap())
     }
+    #[test]
+    fn test_empty_array() {
+        let encoded_data = vec![0x90];
+        let expected_size = encoded_data.len() - 1; // rmp_serde adds additional 0 byte
+        let (_decoded_traces, decoded_size) =
+            from_slice(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
+
+        assert_eq!(expected_size, decoded_size);
+    }
 
     #[test]
     fn test_decoder_size() {

--- a/trace-utils/src/msgpack_decoder/v04/decoder/mod.rs
+++ b/trace-utils/src/msgpack_decoder/v04/decoder/mod.rs
@@ -136,7 +136,7 @@ fn read_string_bytes(buf: &mut Bytes) -> Result<BytesString, DecodeError> {
 
 #[inline]
 fn read_nullable_string_bytes(buf: &mut Bytes) -> Result<BytesString, DecodeError> {
-    if let Some(empty_string) = handle_null_marker(buf, &|| BytesString::default()) {
+    if let Some(empty_string) = handle_null_marker(buf, BytesString::default) {
         Ok(empty_string)
     } else {
         read_string_bytes(buf)
@@ -164,7 +164,7 @@ fn read_str_map_to_bytes_strings(
 fn read_nullable_str_map_to_bytes_strings(
     buf: &mut Bytes,
 ) -> Result<HashMap<BytesString, BytesString>, DecodeError> {
-    if let Some(empty_map) = handle_null_marker(buf, &|| HashMap::default()) {
+    if let Some(empty_map) = handle_null_marker(buf, HashMap::default) {
         return Ok(empty_map);
     }
 
@@ -179,7 +179,7 @@ fn read_metric_pair(buf: &mut Bytes) -> Result<(BytesString, f64), DecodeError> 
     Ok((key, v))
 }
 fn read_metrics(buf: &mut Bytes) -> Result<HashMap<BytesString, f64>, DecodeError> {
-    if let Some(empty_map) = handle_null_marker(buf, &|| HashMap::default()) {
+    if let Some(empty_map) = handle_null_marker(buf, HashMap::default) {
         return Ok(empty_map);
     }
 
@@ -189,7 +189,7 @@ fn read_metrics(buf: &mut Bytes) -> Result<HashMap<BytesString, f64>, DecodeErro
 }
 
 fn read_meta_struct(buf: &mut Bytes) -> Result<HashMap<BytesString, Vec<u8>>, DecodeError> {
-    if let Some(empty_map) = handle_null_marker(buf, &|| HashMap::default()) {
+    if let Some(empty_map) = handle_null_marker(buf, HashMap::default) {
         return Ok(empty_map);
     }
 
@@ -277,7 +277,10 @@ fn read_map_len(buf: &mut &[u8]) -> Result<usize, DecodeError> {
 
 /// When you want to "peek" if the next value is a null marker, and only advance the buffer if it is
 /// null and return the default value. If it is not null, you can continue to decode as expected.
-fn handle_null_marker<T>(buf: &mut Bytes, default: &dyn Fn() -> T) -> Option<T> {
+fn handle_null_marker<T, F>(buf: &mut Bytes, default: F) -> Option<T>
+where
+    F: FnOnce() -> T,
+{
     let slice = unsafe { buf.as_mut_slice() };
 
     if slice.first() == Some(NULL_MARKER) {

--- a/trace-utils/src/msgpack_decoder/v04/decoder/span.rs
+++ b/trace-utils/src/msgpack_decoder/v04/decoder/span.rs
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    read_meta_struct, read_metrics, read_str_map_to_bytes_strings, read_string_bytes,
-    read_string_ref, span_link::read_span_links,
+    read_meta_struct, read_metrics, read_nullable_str_map_to_bytes_strings,
+    read_nullable_string_bytes, read_string_ref, span_link::read_span_links,
 };
 use crate::msgpack_decoder::v04::error::DecodeError;
-use crate::msgpack_decoder::v04::number::read_number_bytes;
+use crate::msgpack_decoder::v04::number::read_nullable_number_bytes;
 use crate::span_v04::{Span, SpanKey};
 use tinybytes::Bytes;
 
@@ -48,17 +48,17 @@ fn fill_span(span: &mut Span, buf: &mut Bytes) -> Result<(), DecodeError> {
         .map_err(|_| DecodeError::InvalidFormat("Invalid span key".to_owned()))?;
 
     match key {
-        SpanKey::Service => span.service = read_string_bytes(buf)?,
-        SpanKey::Name => span.name = read_string_bytes(buf)?,
-        SpanKey::Resource => span.resource = read_string_bytes(buf)?,
-        SpanKey::TraceId => span.trace_id = read_number_bytes(buf)?,
-        SpanKey::SpanId => span.span_id = read_number_bytes(buf)?,
-        SpanKey::ParentId => span.parent_id = read_number_bytes(buf)?,
-        SpanKey::Start => span.start = read_number_bytes(buf)?,
-        SpanKey::Duration => span.duration = read_number_bytes(buf)?,
-        SpanKey::Error => span.error = read_number_bytes(buf)?,
-        SpanKey::Type => span.r#type = read_string_bytes(buf)?,
-        SpanKey::Meta => span.meta = read_str_map_to_bytes_strings(buf)?,
+        SpanKey::Service => span.service = read_nullable_string_bytes(buf)?,
+        SpanKey::Name => span.name = read_nullable_string_bytes(buf)?,
+        SpanKey::Resource => span.resource = read_nullable_string_bytes(buf)?,
+        SpanKey::TraceId => span.trace_id = read_nullable_number_bytes(buf)?,
+        SpanKey::SpanId => span.span_id = read_nullable_number_bytes(buf)?,
+        SpanKey::ParentId => span.parent_id = read_nullable_number_bytes(buf)?,
+        SpanKey::Start => span.start = read_nullable_number_bytes(buf)?,
+        SpanKey::Duration => span.duration = read_nullable_number_bytes(buf)?,
+        SpanKey::Error => span.error = read_nullable_number_bytes(buf)?,
+        SpanKey::Type => span.r#type = read_nullable_string_bytes(buf)?,
+        SpanKey::Meta => span.meta = read_nullable_str_map_to_bytes_strings(buf)?,
         SpanKey::Metrics => span.metrics = read_metrics(buf)?,
         SpanKey::MetaStruct => span.meta_struct = read_meta_struct(buf)?,
         SpanKey::SpanLinks => span.span_links = read_span_links(buf)?,

--- a/trace-utils/src/msgpack_decoder/v04/decoder/span_link.rs
+++ b/trace-utils/src/msgpack_decoder/v04/decoder/span_link.rs
@@ -29,7 +29,7 @@ use tinybytes::Bytes;
 /// - Any `SpanLink` cannot be decoded.
 /// ```
 pub(crate) fn read_span_links(buf: &mut Bytes) -> Result<Vec<SpanLink>, DecodeError> {
-    if let Some(empty_vec) = handle_null_marker(buf, Vec::new()) {
+    if let Some(empty_vec) = handle_null_marker(buf, &|| Vec::default()) {
         return Ok(empty_vec);
     }
 

--- a/trace-utils/src/msgpack_decoder/v04/decoder/span_link.rs
+++ b/trace-utils/src/msgpack_decoder/v04/decoder/span_link.rs
@@ -29,7 +29,7 @@ use tinybytes::Bytes;
 /// - Any `SpanLink` cannot be decoded.
 /// ```
 pub(crate) fn read_span_links(buf: &mut Bytes) -> Result<Vec<SpanLink>, DecodeError> {
-    if let Some(empty_vec) = handle_null_marker(buf, &|| Vec::default()) {
+    if let Some(empty_vec) = handle_null_marker(buf, Vec::default) {
         return Ok(empty_vec);
     }
 

--- a/trace-utils/src/msgpack_decoder/v04/decoder/span_link.rs
+++ b/trace-utils/src/msgpack_decoder/v04/decoder/span_link.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::msgpack_decoder::v04::decoder::{
-    read_str_map_to_bytes_strings, read_string_bytes, read_string_ref,
+    handle_null_marker, read_str_map_to_bytes_strings, read_string_bytes, read_string_ref,
 };
 use crate::msgpack_decoder::v04::error::DecodeError;
 use crate::msgpack_decoder::v04::number::read_number_bytes;
@@ -29,6 +29,10 @@ use tinybytes::Bytes;
 /// - Any `SpanLink` cannot be decoded.
 /// ```
 pub(crate) fn read_span_links(buf: &mut Bytes) -> Result<Vec<SpanLink>, DecodeError> {
+    if let Some(empty_vec) = handle_null_marker(buf, Vec::new()) {
+        return Ok(empty_vec);
+    }
+
     match rmp::decode::read_marker(unsafe { buf.as_mut_slice() }).map_err(|_| {
         DecodeError::InvalidFormat("Unable to read marker for span links".to_owned())
     })? {


### PR DESCRIPTION
# What does this PR do?

Align the v0.4 msgpack decoder with the [pb definition for spans](https://github.com/DataDog/libdatadog/blob/fd011c1ad237ee29d1f52d51452f6da7124edc9e/trace-protobuf/src/pb.rs) to have "default if null" behavior for all top level span fields. 


# Motivation

Decoding errors encountered while integrating with .NET SDK

# Additional Notes

Also adjusted some decoding tests so we no longer have to ignore miri for them

# How to test the change?

Unit tests added
