### PR TITLE
doc: restrictions on bumping MSRV

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,13 @@ resolver = "2"
 # These are used by many packages, but not all. For instance, the sidecar and
 # serverless packages wanted to maintain their own version numbers. Some of
 # their depenencies also remain under their own versioning.
+#
+# When bumping the Rust version, make sure that the version is less than or
+# equal to latest Alpine Linux version, and also the latest RHEL 8.x and 9.x
+# releases (not stream):
+#  - https://rpms.remirepo.net/rpmphp/zoom.php?rpm=rust
+# The RHEL restrictions are for the dd-trace-php repository. Someone in the
+# community, Remi Collet, packages the extension for these systems.
 [workspace.package]
 rust-version = "1.76.0"
 edition = "2021"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ bash build-profiling-ffi.sh /opt/libdatadog
 
 #### Build Dependencies
 
-- Rust 1.76.0 or newer with cargo
+- Rust 1.76.0 or newer with cargo. See the Cargo.toml for information about bumping this version.
 - `cbindgen` 0.26
 - `cmake` and `protoc`
 


### PR DESCRIPTION
# What does this PR do?

Documents the restrictions that the PHP project imposes on bumping the MSRV.

# Motivation

I've been wanting to do this for a while, but wasn't unsure if Remi Collet would be comfortable with me putting this in the docs. I asked him on an issue the last time we bumped MSRV, and he said that's okay.

Alpine Linux released a new version, so that's specifically what prompted to open the PR _right now_.

# How to test the change?

No changes are made, this is just documentation.