### PR TITLE
Fix protobuf build-rs scripts re-executing and trashing incremental compilation cache

### DIFF
--- a/ddsketch/build.rs
+++ b/ddsketch/build.rs
@@ -36,6 +36,10 @@ fn main() -> Result<(), Box<dyn Error>> {
 
         prepend_to_file(HEADER.as_bytes(), &output_path.join("pb.rs"))?;
     }
+    #[cfg(not(feature = "generate-protobuf"))]
+    {
+        println!("cargo:rerun-if-changed=build.rs");
+    }
 
     Ok(())
 }

--- a/trace-protobuf/build.rs
+++ b/trace-protobuf/build.rs
@@ -19,6 +19,11 @@ fn main() -> Result<()> {
         // compiles the .proto files into rust structs
         generate_protobuf();
     }
+    #[cfg(not(feature = "generate-protobuf"))]
+    {
+        println!("cargo:rerun-if-changed=build.rs");
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
# What does this PR do?

Add a build directive to stop re-running build.rs on crates compiling proto definitions when we don't need to

# Motivation

Currently, the `build.rs` are re-run everytime, which prevents caching of crates depending on `ddsketch` and `trace-protobuf`.

This makes incremental re-build take longer than necessary.