### PR TITLE
[ffi][tests] Check that ffi::MaybeErr is None in tests invoking ffi functions 

### DIFF
--- a/ddcommon-ffi/src/option.rs
+++ b/ddcommon-ffi/src/option.rs
@@ -3,6 +3,7 @@
 
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq)]
+#[must_use]
 pub enum Option<T> {
     Some(T),
     None,
@@ -24,6 +25,13 @@ impl<T> Option<T> {
         match *self {
             Option::Some(ref mut x) => Option::Some(x),
             Option::None => Option::None,
+        }
+    }
+
+    pub fn unwrap_none(self) {
+        match self {
+            Option::Some(_) => panic!("Called ffi::Option::unwrap_none but option was Some(_)"),
+            Option::None => {}
         }
     }
 }

--- a/ddtelemetry-ffi/src/lib.rs
+++ b/ddtelemetry-ffi/src/lib.rs
@@ -254,14 +254,16 @@ mod tests {
             ddog_telemetry_builder_with_bool_config_telemetry_debug_logging_enabled(
                 &mut builder,
                 true,
-            );
+            )
+            .unwrap_none();
 
             let mut handle: MaybeUninit<Box<TelemetryWorkerHandle>> = MaybeUninit::uninit();
-            ddog_telemetry_builder_run(builder, NonNull::new(&mut handle).unwrap().cast());
+            ddog_telemetry_builder_run(builder, NonNull::new(&mut handle).unwrap().cast())
+                .unwrap_none();
             let handle = handle.assume_init();
 
-            ddog_telemetry_handle_start(&handle);
-            ddog_telemetry_handle_stop(&handle);
+            ddog_telemetry_handle_start(&handle).unwrap_none();
+            ddog_telemetry_handle_stop(&handle).unwrap_none();
             ddog_telemetry_handle_wait_for_shutdown(handle);
         }
     }
@@ -297,13 +299,15 @@ mod tests {
             ddog_telemetry_builder_with_bool_config_telemetry_debug_logging_enabled(
                 &mut builder,
                 true,
-            );
+            )
+            .unwrap_none();
 
             let mut handle: MaybeUninit<Box<TelemetryWorkerHandle>> = MaybeUninit::uninit();
             ddog_telemetry_builder_run_metric_logs(
                 builder,
                 NonNull::new(&mut handle).unwrap().cast(),
-            );
+            )
+            .unwrap_none();
             let handle = handle.assume_init();
 
             assert!(matches!(
@@ -329,7 +333,7 @@ mod tests {
                 true,
                 MetricNamespace::Apm,
             );
-            ddog_telemetry_handle_add_point(&handle, &context_key, 1.0);
+            ddog_telemetry_handle_add_point(&handle, &context_key, 1.0).unwrap_none();
 
             assert_eq!(ddog_telemetry_handle_stop(&handle), MaybeError::None);
             ddog_telemetry_handle_wait_for_shutdown(handle);

--- a/profiling-ffi/src/exporter.rs
+++ b/profiling-ffi/src/exporter.rs
@@ -590,7 +590,8 @@ mod tests {
         };
         let timeout_milliseconds = 90;
         unsafe {
-            ddog_prof_Exporter_set_timeout(Some(exporter.as_mut()), timeout_milliseconds);
+            ddog_prof_Exporter_set_timeout(Some(exporter.as_mut()), timeout_milliseconds)
+                .unwrap_none();
         }
 
         let build_result = unsafe {
@@ -663,7 +664,8 @@ mod tests {
         };
         let timeout_milliseconds = 90;
         unsafe {
-            ddog_prof_Exporter_set_timeout(Some(exporter.as_mut()), timeout_milliseconds);
+            ddog_prof_Exporter_set_timeout(Some(exporter.as_mut()), timeout_milliseconds)
+                .unwrap_none();
         }
 
         let raw_internal_metadata = CharSlice::from(
@@ -737,7 +739,8 @@ mod tests {
         };
         let timeout_milliseconds = 90;
         unsafe {
-            ddog_prof_Exporter_set_timeout(Some(exporter.as_mut()), timeout_milliseconds);
+            ddog_prof_Exporter_set_timeout(Some(exporter.as_mut()), timeout_milliseconds)
+                .unwrap_none();
         }
 
         let raw_internal_metadata = CharSlice::from("this is not a valid json string");
@@ -799,7 +802,8 @@ mod tests {
         };
         let timeout_milliseconds = 90;
         unsafe {
-            ddog_prof_Exporter_set_timeout(Some(exporter.as_mut()), timeout_milliseconds);
+            ddog_prof_Exporter_set_timeout(Some(exporter.as_mut()), timeout_milliseconds)
+                .unwrap_none();
         }
 
         let raw_info = CharSlice::from(
@@ -915,7 +919,8 @@ mod tests {
         };
         let timeout_milliseconds = 90;
         unsafe {
-            ddog_prof_Exporter_set_timeout(Some(exporter.as_mut()), timeout_milliseconds);
+            ddog_prof_Exporter_set_timeout(Some(exporter.as_mut()), timeout_milliseconds)
+                .unwrap_none();
         }
 
         let raw_info = CharSlice::from("this is not a valid json string");

--- a/sidecar-ffi/tests/sidecar.rs
+++ b/sidecar-ffi/tests/sidecar.rs
@@ -105,7 +105,7 @@ fn test_ddog_sidecar_register_app() {
             0,
             null(),
             0,
-        );
+        ).unwrap_none();
 
         let meta = ddog_sidecar_runtimeMeta_build(
             "language_name".into(),
@@ -122,7 +122,7 @@ fn test_ddog_sidecar_register_app() {
             &queue_id,
             "dependency_name".into(),
             "dependency_version".into(),
-        );
+        ).unwrap_none();
 
         // ddog_sidecar_telemetry_addIntegration(&mut transport, instance_id, &queue_id,
         // integration_name, integration_version) TODO add ability to add configuration
@@ -158,7 +158,7 @@ fn test_ddog_sidecar_register_app() {
             0,
             null(),
             0,
-        );
+        ).unwrap_none();
 
         //TODO: Shutdown the service
         // enough case: have C api that shutsdown telemetry worker

--- a/sidecar-ffi/tests/sidecar.rs
+++ b/sidecar-ffi/tests/sidecar.rs
@@ -105,7 +105,8 @@ fn test_ddog_sidecar_register_app() {
             0,
             null(),
             0,
-        ).unwrap_none();
+        )
+        .unwrap_none();
 
         let meta = ddog_sidecar_runtimeMeta_build(
             "language_name".into(),
@@ -122,7 +123,8 @@ fn test_ddog_sidecar_register_app() {
             &queue_id,
             "dependency_name".into(),
             "dependency_version".into(),
-        ).unwrap_none();
+        )
+        .unwrap_none();
 
         // ddog_sidecar_telemetry_addIntegration(&mut transport, instance_id, &queue_id,
         // integration_name, integration_version) TODO add ability to add configuration
@@ -158,7 +160,8 @@ fn test_ddog_sidecar_register_app() {
             0,
             null(),
             0,
-        ).unwrap_none();
+        )
+        .unwrap_none();
 
         //TODO: Shutdown the service
         // enough case: have C api that shutsdown telemetry worker


### PR DESCRIPTION
# What does this PR do?

* Add warning on unused ffi::Option
* Add unwrap_none method to assert the MaybeError is none in unit tests
* Call to unwrap_none on MaybeError in tests

# Motivation

The return values from these functions usually called from C, but also used in unit-tests was dropped without checking that there are no errors.

Now, ignoring a MaybeErr should produce a warning when building tests

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
