### PR TITLE
Fix undefined behaviors caused by unsafe null slice cast in the sidecar-ffi

### DIFF
--- a/sidecar-ffi/src/lib.rs
+++ b/sidecar-ffi/src/lib.rs
@@ -567,15 +567,17 @@ pub unsafe extern "C" fn ddog_sidecar_session_set_config(
             } else {
                 LogMethod::File(String::from(log_path.to_utf8_lossy()).into())
             },
-            remote_config_products: slice::from_raw_parts(
+            remote_config_products: ffi::Slice::from_raw_parts(
                 remote_config_products,
                 remote_config_products_count
             )
+            .as_slice()
             .to_vec(),
-            remote_config_capabilities: slice::from_raw_parts(
+            remote_config_capabilities: ffi::Slice::from_raw_parts(
                 remote_config_capabilities,
                 remote_config_capabilities_count
             )
+            .as_slice()
             .to_vec(),
         },
     ));

--- a/sidecar-ffi/tests/sidecar.rs
+++ b/sidecar-ffi/tests/sidecar.rs
@@ -68,7 +68,6 @@ fn test_ddog_sidecar_connection() {
 }
 
 #[test]
-#[ignore = "TODO: ci-flaky can't reproduce locally"]
 fn test_ddog_sidecar_register_app() {
     set_sidecar_per_process();
 

--- a/sidecar/src/setup/unix.rs
+++ b/sidecar/src/setup/unix.rs
@@ -82,8 +82,13 @@ impl Liaison for SharedDirLiaison {
     }
 
     fn ipc_per_process() -> Self {
-        //TODO: implement per pid handling
-        Self::new_default_location()
+        static PROCESS_RANDOM_ID: std::sync::OnceLock<u64> = std::sync::OnceLock::new();
+        let random_id = PROCESS_RANDOM_ID.get_or_init(|| rand::random());
+
+        let pid = std::process::id();
+        let liason_path =
+            env::temp_dir().join(format!("libdatadog.random_id_{random_id}.pid_{pid}"));
+        Self::new(liason_path)
     }
 }
 


### PR DESCRIPTION
# What does this PR do?

* Fix null pointer used in slice::from_raw_parts, this is safety conditions as the pointer for slices should not be null
* Fix flakyness issue of the test exhibiting the issue and unskip it in CI

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
