### PR TITLE
[crashtracker] Refactor: Use the new FFI helper macros to cleanup the code

### DIFF
--- a/crashtracker-ffi/src/collector/counters.rs
+++ b/crashtracker-ffi/src/collector/counters.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::datatypes::OpTypes;
-use anyhow::Context;
-use ddcommon_ffi::VoidResult;
+use ::function_name::named;
+use ddcommon_ffi::{wrap_with_void_ffi_result, VoidResult};
 
 /// Resets all counters to 0.
 /// Expected to be used after a fork, to reset the counters on the child
@@ -15,34 +15,31 @@ use ddcommon_ffi::VoidResult;
 /// No safety concerns.
 #[no_mangle]
 #[must_use]
+#[named]
 pub unsafe extern "C" fn ddog_crasht_reset_counters() -> VoidResult {
-    datadog_crashtracker::reset_counters()
-        .context("ddog_crasht_reset_counters failed")
-        .into()
+    wrap_with_void_ffi_result!({ datadog_crashtracker::reset_counters()? })
 }
 
 #[no_mangle]
 #[must_use]
+#[named]
 /// Atomically increments the count associated with `op`.
 /// Useful for tracking what operations were occuring when a crash occurred.
 ///
 /// # Safety
 /// No safety concerns.
 pub unsafe extern "C" fn ddog_crasht_begin_op(op: OpTypes) -> VoidResult {
-    datadog_crashtracker::begin_op(op)
-        .context("ddog_crasht_begin_op failed")
-        .into()
+    wrap_with_void_ffi_result!({ datadog_crashtracker::begin_op(op)? })
 }
 
 #[no_mangle]
 #[must_use]
+#[named]
 /// Atomically decrements the count associated with `op`.
 /// Useful for tracking what operations were occuring when a crash occurred.
 ///
 /// # Safety
 /// No safety concerns.
 pub unsafe extern "C" fn ddog_crasht_end_op(op: OpTypes) -> VoidResult {
-    datadog_crashtracker::end_op(op)
-        .context("ddog_crasht_end_op failed")
-        .into()
+    wrap_with_void_ffi_result!({ datadog_crashtracker::end_op(op)? })
 }

--- a/crashtracker-ffi/src/collector/datatypes.rs
+++ b/crashtracker-ffi/src/collector/datatypes.rs
@@ -99,22 +99,6 @@ impl<'a> TryFrom<Config<'a>> for datadog_crashtracker::CrashtrackerConfiguration
 }
 
 #[repr(C)]
-pub enum UsizeResult {
-    Ok(usize),
-    #[allow(dead_code)]
-    Err(Error),
-}
-
-impl From<anyhow::Result<usize>> for UsizeResult {
-    fn from(value: anyhow::Result<usize>) -> Self {
-        match value {
-            Ok(x) => Self::Ok(x),
-            Err(err) => Self::Err(err.into()),
-        }
-    }
-}
-
-#[repr(C)]
 pub enum CrashtrackerGetCountersResult {
     Ok([i64; OpTypes::SIZE as usize]),
     #[allow(dead_code)]

--- a/crashtracker-ffi/src/collector/spans.rs
+++ b/crashtracker-ffi/src/collector/spans.rs
@@ -1,10 +1,8 @@
 // Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::UsizeResult;
-use anyhow::Context;
-use ddcommon_ffi::VoidResult;
-
+use ddcommon_ffi::{wrap_with_ffi_result, wrap_with_void_ffi_result, Result, VoidResult};
+use function_name::named;
 /// Resets all stored spans to 0.
 /// Expected to be used after a fork, to reset the spans on the child
 /// ATOMICITY:
@@ -15,10 +13,9 @@ use ddcommon_ffi::VoidResult;
 /// No safety concerns.
 #[no_mangle]
 #[must_use]
+#[named]
 pub unsafe extern "C" fn ddog_crasht_clear_span_ids() -> VoidResult {
-    datadog_crashtracker::clear_spans()
-        .context("ddog_crasht_clear_span_ids failed")
-        .into()
+    wrap_with_void_ffi_result!({ datadog_crashtracker::clear_spans()? })
 }
 
 /// Resets all stored traces to 0.
@@ -31,14 +28,14 @@ pub unsafe extern "C" fn ddog_crasht_clear_span_ids() -> VoidResult {
 /// No safety concerns.
 #[no_mangle]
 #[must_use]
+#[named]
 pub unsafe extern "C" fn ddog_crasht_clear_trace_ids() -> VoidResult {
-    datadog_crashtracker::clear_traces()
-        .context("ddog_crasht_clear_trace_ids failed")
-        .into()
+    wrap_with_void_ffi_result!({ datadog_crashtracker::clear_traces()? })
 }
 
 #[no_mangle]
 #[must_use]
+#[named]
 /// Atomically registers an active traceId.
 /// Useful for tracking what operations were occurring when a crash occurred.
 /// 0 is reserved for "NoId"
@@ -58,15 +55,16 @@ pub unsafe extern "C" fn ddog_crasht_clear_trace_ids() -> VoidResult {
 ///
 /// # Safety
 /// No safety concerns.
-pub unsafe extern "C" fn ddog_crasht_insert_trace_id(id_high: u64, id_low: u64) -> UsizeResult {
-    let id: u128 = (id_high as u128) << 64 | (id_low as u128);
-    datadog_crashtracker::insert_trace(id)
-        .context("ddog_crasht_insert_trace_id failed")
-        .into()
+pub unsafe extern "C" fn ddog_crasht_insert_trace_id(id_high: u64, id_low: u64) -> Result<usize> {
+    wrap_with_ffi_result!({
+        let id: u128 = (id_high as u128) << 64 | (id_low as u128);
+        datadog_crashtracker::insert_trace(id)
+    })
 }
 
 #[no_mangle]
 #[must_use]
+#[named]
 /// Atomically registers an active SpanId.
 /// Useful for tracking what operations were occurring when a crash occurred.
 /// 0 is reserved for "NoId".
@@ -86,15 +84,16 @@ pub unsafe extern "C" fn ddog_crasht_insert_trace_id(id_high: u64, id_low: u64) 
 ///
 /// # Safety
 /// No safety concerns.
-pub unsafe extern "C" fn ddog_crasht_insert_span_id(id_high: u64, id_low: u64) -> UsizeResult {
-    let id: u128 = (id_high as u128) << 64 | (id_low as u128);
-    datadog_crashtracker::insert_span(id)
-        .context("ddog_crasht_insert_span_id failed")
-        .into()
+pub unsafe extern "C" fn ddog_crasht_insert_span_id(id_high: u64, id_low: u64) -> Result<usize> {
+    wrap_with_ffi_result!({
+        let id: u128 = (id_high as u128) << 64 | (id_low as u128);
+        datadog_crashtracker::insert_span(id)
+    })
 }
 
 #[no_mangle]
 #[must_use]
+#[named]
 /// Atomically removes a completed SpanId.
 /// Useful for tracking what operations were occurring when a crash occurred.
 /// 0 is reserved for "NoId"
@@ -120,14 +119,15 @@ pub unsafe extern "C" fn ddog_crasht_remove_span_id(
     id_low: u64,
     idx: usize,
 ) -> VoidResult {
-    let id: u128 = (id_high as u128) << 64 | (id_low as u128);
-    datadog_crashtracker::remove_span(id, idx)
-        .context("ddog_crasht_remove_span_id failed")
-        .into()
+    wrap_with_void_ffi_result!({
+        let id: u128 = (id_high as u128) << 64 | (id_low as u128);
+        datadog_crashtracker::remove_span(id, idx)?
+    })
 }
 
 #[no_mangle]
 #[must_use]
+#[named]
 /// Atomically removes a completed TraceId.
 /// Useful for tracking what operations were occurring when a crash occurred.
 /// 0 is reserved for "NoId"
@@ -153,8 +153,8 @@ pub unsafe extern "C" fn ddog_crasht_remove_trace_id(
     id_low: u64,
     idx: usize,
 ) -> VoidResult {
-    let id: u128 = (id_high as u128) << 64 | (id_low as u128);
-    datadog_crashtracker::remove_trace(id, idx)
-        .context("ddog_crasht_remove_trace_id failed")
-        .into()
+    wrap_with_void_ffi_result!({
+        let id: u128 = (id_high as u128) << 64 | (id_low as u128);
+        datadog_crashtracker::remove_trace(id, idx)?
+    })
 }

--- a/crashtracker-ffi/src/receiver.rs
+++ b/crashtracker-ffi/src/receiver.rs
@@ -1,10 +1,11 @@
 // Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::Context;
-use ddcommon_ffi::{slice::AsBytes, CharSlice, VoidResult};
+use ::function_name::named;
+use ddcommon_ffi::{slice::AsBytes, wrap_with_void_ffi_result, CharSlice, VoidResult};
 #[no_mangle]
 #[must_use]
+#[named]
 /// Receives data from a crash collector via a pipe on `stdin`, formats it into
 /// `CrashInfo` json, and emits it to the endpoint/file defined in `config`.
 ///
@@ -16,13 +17,12 @@ use ddcommon_ffi::{slice::AsBytes, CharSlice, VoidResult};
 /// # Safety
 /// No safety concerns
 pub unsafe extern "C" fn ddog_crasht_receiver_entry_point_stdin() -> VoidResult {
-    datadog_crashtracker::receiver_entry_point_stdin()
-        .context("ddog_crasht_receiver_entry_point_stdin failed")
-        .into()
+    wrap_with_void_ffi_result!({ datadog_crashtracker::receiver_entry_point_stdin()? })
 }
 
 #[no_mangle]
 #[must_use]
+#[named]
 /// Receives data from a crash collector via a pipe on `stdin`, formats it into
 /// `CrashInfo` json, and emits it to the endpoint/file defined in `config`.
 ///
@@ -37,10 +37,7 @@ pub unsafe extern "C" fn ddog_crasht_receiver_entry_point_stdin() -> VoidResult 
 pub unsafe extern "C" fn ddog_crasht_receiver_entry_point_unix_socket(
     socket_path: CharSlice,
 ) -> VoidResult {
-    (|| {
-        let socket_path = socket_path.try_to_utf8()?;
-        datadog_crashtracker::receiver_entry_point_unix_socket(socket_path)
-    })()
-    .context("ddog_crasht_receiver_entry_point_unix_socket failed")
-    .into()
+    wrap_with_void_ffi_result!({
+        datadog_crashtracker::receiver_entry_point_unix_socket(socket_path.try_to_utf8()?)?
+    })
 }

--- a/crashtracker/src/shared/configuration.rs
+++ b/crashtracker/src/shared/configuration.rs
@@ -31,7 +31,7 @@ pub struct CrashtrackerConfiguration {
     pub unix_socket_path: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct CrashtrackerReceiverConfig {
     pub args: Vec<String>,
     pub env: Vec<(String, String)>,

--- a/ddcommon-ffi/src/result.rs
+++ b/ddcommon-ffi/src/result.rs
@@ -32,6 +32,15 @@ pub enum Result<T> {
     Err(Error),
 }
 
+impl<T> Result<T> {
+    pub fn unwrap(self) -> T {
+        match self {
+            Self::Ok(v) => v,
+            Self::Err(err) => panic!("{err}"),
+        }
+    }
+}
+
 impl<T> From<anyhow::Result<T>> for Result<T> {
     fn from(value: anyhow::Result<T>) -> Self {
         match value {

--- a/examples/ffi/crashtracking.c
+++ b/examples/ffi/crashtracking.c
@@ -21,8 +21,8 @@ void handle_result(ddog_VoidResult result) {
   }
 }
 
-uintptr_t handle_uintptr_t_result(ddog_crasht_UsizeResult result) {
-  if (result.tag == DDOG_CRASHT_USIZE_RESULT_ERR) {
+uintptr_t handle_uintptr_t_result(ddog_crasht_Result_Usize result) {
+  if (result.tag == DDOG_CRASHT_RESULT_USIZE_ERR_USIZE) {
     ddog_CharSlice message = ddog_Error_message(&result.err);
     fprintf(stderr, "%.*s\n", (int)message.len, message.ptr);
     ddog_Error_drop(&result.err);


### PR DESCRIPTION
# What does this PR do?

Uses the macros introduced in #752 throught the rest of crashtracker

# Motivation

Just look at how much nicer the code is.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
