### PR TITLE
Remove unused container id testing logic

### DIFF
--- a/ddcommon/src/entity_id/mod.rs
+++ b/ddcommon/src/entity_id/mod.rs
@@ -92,23 +92,3 @@ pub fn get_external_env() -> Option<&'static str> {
     }
     DD_EXTERNAL_ENV.as_deref()
 }
-
-/// Set the path to cgroup file to mock it during tests
-/// # Safety
-/// Must not be called in multi-threaded contexts
-pub unsafe fn set_cgroup_file(_file: String) {
-    #[cfg(unix)]
-    {
-        unix::set_cgroup_file(_file)
-    }
-}
-
-/// Set cgroup mount path to mock during tests
-/// # Safety
-/// Must not be called in multi-threaded contexts
-pub unsafe fn set(_path: String) {
-    #[cfg(unix)]
-    {
-        unix::set_cgroup_mount_path(_path)
-    }
-}

--- a/ddcommon/src/entity_id/unix/mod.rs
+++ b/ddcommon/src/entity_id/unix/mod.rs
@@ -15,11 +15,6 @@ const DEFAULT_CGROUP_MOUNT_PATH: &str = "/sys/fs/cgroup";
 /// the base controller used to identify the cgroup v1 mount point in the cgroupMounts map.
 const CGROUP_V1_BASE_CONTROLLER: &str = "memory";
 
-/// stores overridable cgroup path - used in end-to-end testing to "stub" cgroup values
-static mut TESTING_CGROUP_PATH: Option<String> = None;
-/// stores overridable cgroup mount path     
-static mut TESTING_CGROUP_MOUNT_PATH: Option<String> = None;
-
 #[derive(Debug, Clone, PartialEq)]
 pub enum CgroupFileParsingError {
     ContainerIdNotFound,
@@ -58,37 +53,11 @@ fn compute_entity_id(
 }
 
 fn get_cgroup_path() -> &'static str {
-    // Safety: we assume set_cgroup_file is not called when it shouldn't
-    #[allow(static_mut_refs)]
-    unsafe {
-        TESTING_CGROUP_PATH
-            .as_deref()
-            .unwrap_or(DEFAULT_CGROUP_PATH)
-    }
+    DEFAULT_CGROUP_PATH
 }
 
 fn get_cgroup_mount_path() -> &'static str {
-    // Safety: we assume set_cgroup_file is not called when it shouldn't
-    #[allow(static_mut_refs)]
-    unsafe {
-        TESTING_CGROUP_MOUNT_PATH
-            .as_deref()
-            .unwrap_or(DEFAULT_CGROUP_MOUNT_PATH)
-    }
-}
-
-/// Set the path to cgroup file to mock it during tests
-/// # Safety
-/// Must not be called in multi-threaded contexts
-pub unsafe fn set_cgroup_file(file: String) {
-    TESTING_CGROUP_PATH = Some(file)
-}
-
-/// Set cgroup mount path to mock during tests
-/// # Safety
-/// Must not be called in multi-threaded contexts
-pub unsafe fn set_cgroup_mount_path(path: String) {
-    TESTING_CGROUP_MOUNT_PATH = Some(path)
+    DEFAULT_CGROUP_MOUNT_PATH
 }
 
 /// Returns the `container_id` if available in the cgroup file, otherwise returns `None`


### PR DESCRIPTION
# What does this PR do?

Remove unused container id testing logic

# Motivation

The logic is dead-code and uses `static mut` to replace default values, which I don't think would be the right approach to do these tests anyway.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
