### PR TITLE
[dogstatsd] Use Saluki as a dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1552,7 +1552,7 @@ dependencies = [
 [[package]]
 name = "datadog-protos"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/saluki/?rev=a5b640d1d2ba3a0cd8a32a4137bccba2b648bd00#a5b640d1d2ba3a0cd8a32a4137bccba2b648bd00"
+source = "git+https://github.com/DataDog/saluki/?rev=c89b58e5784b985819baf11f13f7d35876741222#c89b58e5784b985819baf11f13f7d35876741222"
 dependencies = [
  "bytes",
  "prost 0.13.3",
@@ -1844,7 +1844,7 @@ dependencies = [
 [[package]]
 name = "ddsketch-agent"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/saluki/?rev=a5b640d1d2ba3a0cd8a32a4137bccba2b648bd00#a5b640d1d2ba3a0cd8a32a4137bccba2b648bd00"
+source = "git+https://github.com/DataDog/saluki/?rev=c89b58e5784b985819baf11f13f7d35876741222#c89b58e5784b985819baf11f13f7d35876741222"
 dependencies = [
  "datadog-protos",
  "float-cmp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1552,7 +1552,7 @@ dependencies = [
 [[package]]
 name = "datadog-protos"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/saluki-backport/?rev=3c5d87ab82dea4a1a98ef0c60fb3659ca35c2751#3c5d87ab82dea4a1a98ef0c60fb3659ca35c2751"
+source = "git+https://github.com/DataDog/saluki/?rev=a5b640d1d2ba3a0cd8a32a4137bccba2b648bd00#a5b640d1d2ba3a0cd8a32a4137bccba2b648bd00"
 dependencies = [
  "bytes",
  "prost 0.13.3",
@@ -1844,10 +1844,10 @@ dependencies = [
 [[package]]
 name = "ddsketch-agent"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/saluki-backport/?rev=3c5d87ab82dea4a1a98ef0c60fb3659ca35c2751#3c5d87ab82dea4a1a98ef0c60fb3659ca35c2751"
+source = "git+https://github.com/DataDog/saluki/?rev=a5b640d1d2ba3a0cd8a32a4137bccba2b648bd00#a5b640d1d2ba3a0cd8a32a4137bccba2b648bd00"
 dependencies = [
  "datadog-protos",
- "float_eq",
+ "float-cmp",
  "ordered-float 4.5.0",
  "smallvec",
 ]
@@ -2206,12 +2206,6 @@ checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
 ]
-
-[[package]]
-name = "float_eq"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a80e3145d8ad11ba0995949bbcf48b9df2be62772b3d351ef017dff6ecb853"
 
 [[package]]
 name = "fnv"

--- a/dogstatsd/Cargo.toml
+++ b/dogstatsd/Cargo.toml
@@ -9,8 +9,8 @@ license.workspace = true
 bench = false
 
 [dependencies]
-datadog-protos = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki-backport/", rev = "3c5d87ab82dea4a1a98ef0c60fb3659ca35c2751" }
-ddsketch-agent = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki-backport/", rev = "3c5d87ab82dea4a1a98ef0c60fb3659ca35c2751" }
+datadog-protos = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "a5b640d1d2ba3a0cd8a32a4137bccba2b648bd00" }
+ddsketch-agent = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "a5b640d1d2ba3a0cd8a32a4137bccba2b648bd00" }
 hashbrown = { version = "0.14.3", default-features = false, features = ["inline-more"] }
 protobuf = { version = "3.5.0", default-features = false }
 ustr = { version = "1.0.0", default-features = false }

--- a/dogstatsd/Cargo.toml
+++ b/dogstatsd/Cargo.toml
@@ -9,8 +9,8 @@ license.workspace = true
 bench = false
 
 [dependencies]
-datadog-protos = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "a5b640d1d2ba3a0cd8a32a4137bccba2b648bd00" }
-ddsketch-agent = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "a5b640d1d2ba3a0cd8a32a4137bccba2b648bd00" }
+datadog-protos = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "c89b58e5784b985819baf11f13f7d35876741222" }
+ddsketch-agent = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "c89b58e5784b985819baf11f13f7d35876741222" }
 hashbrown = { version = "0.14.3", default-features = false, features = ["inline-more"] }
 protobuf = { version = "3.5.0", default-features = false }
 ustr = { version = "1.0.0", default-features = false }


### PR DESCRIPTION
# What does this PR do?

Use saluki instead of saluki-backport as a dependency in dogstatsd.

# Motivation

A slightly modified version of [saluki](https://github.com/DataDog/saluki) was created in [saluki-backport](https://github.com/DataDog/saluki-backport) to be compatible with Rust 1.76.0. Now that we're upgrading to Rust 1.78.0 we can use the original saluki project again.

https://datadoghq.atlassian.net/browse/SVLS-5527

# Additional Notes

saluki originally forked for https://github.com/DataDog/libdatadog/pull/606

# How to test the change?
