### PR TITLE
[trace-mini-agent] change logs from `info` to `debug`

### DIFF
--- a/trace-mini-agent/src/http_utils.rs
+++ b/trace-mini-agent/src/http_utils.rs
@@ -7,7 +7,7 @@ use hyper::{
     Body, Response, StatusCode,
 };
 use serde_json::json;
-use tracing::{error, info};
+use tracing::{debug, error};
 
 /// Does two things:
 /// 1. Logs the given message. A success status code (within 200-299) will cause an info log to be
@@ -23,7 +23,7 @@ pub fn log_and_create_http_response(
     status: StatusCode,
 ) -> http::Result<Response<Body>> {
     if status.is_success() {
-        info!("{message}");
+        debug!("{message}");
     } else {
         error!("{message}");
     }
@@ -46,7 +46,7 @@ pub fn log_and_create_traces_success_http_response(
     message: &str,
     status: StatusCode,
 ) -> http::Result<Response<Body>> {
-    info!("{message}");
+    debug!("{message}");
     let body = json!({"rate_by_service":{"service:,env:":1}}).to_string();
     Response::builder().status(status).body(Body::from(body))
 }

--- a/trace-mini-agent/src/mini_agent.rs
+++ b/trace-mini-agent/src/mini_agent.rs
@@ -9,7 +9,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::mpsc::{self, Receiver, Sender};
-use tracing::{debug, error, info};
+use tracing::{debug, error};
 
 use crate::http_utils::log_and_create_http_response;
 use crate::{config, env_verifier, stats_flusher, stats_processor, trace_flusher, trace_processor};
@@ -121,7 +121,7 @@ impl MiniAgent {
 
         let server = server_builder.serve(make_svc);
 
-        info!("Mini Agent started: listening on port {MINI_AGENT_PORT}");
+        debug!("Mini Agent started: listening on port {MINI_AGENT_PORT}");
         debug!(
             "Time taken start the Mini Agent: {} ms",
             now.elapsed().as_millis()

--- a/trace-mini-agent/src/stats_flusher.rs
+++ b/trace-mini-agent/src/stats_flusher.rs
@@ -4,7 +4,7 @@
 use async_trait::async_trait;
 use std::{sync::Arc, time};
 use tokio::sync::{mpsc::Receiver, Mutex};
-use tracing::{debug, error, info};
+use tracing::{debug, error};
 
 use datadog_trace_protobuf::pb;
 use datadog_trace_utils::stats_utils;
@@ -61,7 +61,7 @@ impl StatsFlusher for ServerlessStatsFlusher {
         if stats.is_empty() {
             return;
         }
-        info!("Flushing {} stats", stats.len());
+        debug!("Flushing {} stats", stats.len());
 
         let stats_payload = stats_utils::construct_stats_payload(stats);
 
@@ -82,7 +82,7 @@ impl StatsFlusher for ServerlessStatsFlusher {
         )
         .await
         {
-            Ok(_) => info!("Successfully flushed stats"),
+            Ok(_) => debug!("Successfully flushed stats"),
             Err(e) => {
                 error!("Error sending stats: {e:?}")
             }

--- a/trace-mini-agent/src/stats_processor.rs
+++ b/trace-mini-agent/src/stats_processor.rs
@@ -7,7 +7,7 @@ use std::time::UNIX_EPOCH;
 use async_trait::async_trait;
 use hyper::{http, Body, Request, Response, StatusCode};
 use tokio::sync::mpsc::Sender;
-use tracing::info;
+use tracing::debug;
 
 use datadog_trace_protobuf::pb;
 use datadog_trace_utils::stats_utils;
@@ -38,7 +38,7 @@ impl StatsProcessor for ServerlessStatsProcessor {
         req: Request<Body>,
         tx: Sender<pb::ClientStatsPayload>,
     ) -> http::Result<Response<Body>> {
-        info!("Recieved trace stats to process");
+        debug!("Received trace stats to process");
         let (parts, body) = req.into_parts();
 
         if let Some(response) = http_utils::verify_request_content_length(

--- a/trace-mini-agent/src/trace_flusher.rs
+++ b/trace-mini-agent/src/trace_flusher.rs
@@ -4,7 +4,7 @@
 use async_trait::async_trait;
 use std::{sync::Arc, time};
 use tokio::sync::{mpsc::Receiver, Mutex};
-use tracing::{error, info};
+use tracing::{debug, error};
 
 use datadog_trace_utils::trace_utils;
 use datadog_trace_utils::trace_utils::SendData;
@@ -53,7 +53,7 @@ impl TraceFlusher for ServerlessTraceFlusher {
         if traces.is_empty() {
             return;
         }
-        info!("Flushing {} traces", traces.len());
+        debug!("Flushing {} traces", traces.len());
 
         for traces in trace_utils::coalesce_send_data(traces) {
             match traces
@@ -61,7 +61,7 @@ impl TraceFlusher for ServerlessTraceFlusher {
                 .await
                 .last_result
             {
-                Ok(_) => info!("Successfully flushed traces"),
+                Ok(_) => debug!("Successfully flushed traces"),
                 Err(e) => {
                     error!("Error sending trace: {e:?}")
                     // TODO: Retries

--- a/trace-mini-agent/src/trace_processor.rs
+++ b/trace-mini-agent/src/trace_processor.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use hyper::{http, Body, Request, Response, StatusCode};
 use tokio::sync::mpsc::Sender;
-use tracing::info;
+use tracing::debug;
 
 use datadog_trace_obfuscation::obfuscate::obfuscate_span;
 use datadog_trace_protobuf::pb;
@@ -63,7 +63,7 @@ impl TraceProcessor for ServerlessTraceProcessor {
         tx: Sender<trace_utils::SendData>,
         mini_agent_metadata: Arc<trace_utils::MiniAgentMetadata>,
     ) -> http::Result<Response<Body>> {
-        info!("Recieved traces to process");
+        debug!("Received traces to process");
         let (parts, body) = req.into_parts();
 
         if let Some(response) = http_utils::verify_request_content_length(


### PR DESCRIPTION
# What does this PR do?

Changes logs that were `info` to be `debug`

# Motivation

Info is too noisy for customers.
Also [DataDog/datadog-lambda-extension#496](https://github.com/DataDog/datadog-lambda-extension/issues/496)

# Additional Notes

n/a

# How to test the change?

n/a
