### PR TITLE
[fix] Add back set_cgroup_file function.

### DIFF
--- a/ddcommon/Cargo.toml
+++ b/ddcommon/Cargo.toml
@@ -71,3 +71,5 @@ maplit = "1.0"
 [features]
 default = []
 use_webpki_roots = ["hyper-rustls/webpki-roots"]
+# Enable this feature to enable stubbing of cgroup
+cgroup_testing = []

--- a/ddcommon/Cargo.toml
+++ b/ddcommon/Cargo.toml
@@ -72,4 +72,5 @@ maplit = "1.0"
 default = []
 use_webpki_roots = ["hyper-rustls/webpki-roots"]
 # Enable this feature to enable stubbing of cgroup
+# php directly import this crate and uses functions gated by this feature for their test
 cgroup_testing = []

--- a/ddcommon/src/entity_id/mod.rs
+++ b/ddcommon/src/entity_id/mod.rs
@@ -61,6 +61,7 @@ const EXTERNAL_ENV_ENVIRONMENT_VARIABLE: &str = "DD_EXTERNAL_ENV";
 mod unix;
 
 /// Set the path to cgroup file to mock it during tests
+#[cfg(feature = "cgroup_testing")]
 pub fn set_cgroup_file(_file: String) {
     #[cfg(unix)]
     {

--- a/ddcommon/src/entity_id/mod.rs
+++ b/ddcommon/src/entity_id/mod.rs
@@ -60,6 +60,14 @@ const EXTERNAL_ENV_ENVIRONMENT_VARIABLE: &str = "DD_EXTERNAL_ENV";
 #[cfg(unix)]
 mod unix;
 
+/// Set the path to cgroup file to mock it during tests
+pub fn set_cgroup_file(_file: String) {
+    #[cfg(unix)]
+    {
+        unix::set_cgroup_file(_file)
+    }
+}
+
 /// Returns the `container_id` if available in the cgroup file, otherwise returns `None`
 pub fn get_container_id() -> Option<&'static str> {
     #[cfg(unix)]


### PR DESCRIPTION
# What does this PR do?

Add back set_cgroup_file function. This adds a static variable used to override the default cgroup path.

# Motivation

This code was removed in #795, but this function is unfortunately directly imported and used in ddtrace-php here https://github.com/DataDog/dd-trace-php/blob/0926c77c3b8e0d41dd79774f89cd5f3dbbf2a03c/components-rs/lib.rs#L46-L49 so we cannot remove it.

They also use this feature in their tests

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
