### PR TITLE
[Crashtracking] Add missing telemetry headers

### DIFF
--- a/crashtracker/src/crash_info/telemetry.rs
+++ b/crashtracker/src/crash_info/telemetry.rs
@@ -168,11 +168,11 @@ impl TelemetryCrashUploader {
             )
             .header(
                 ddtelemetry::worker::http_client::header::API_VERSION,
-                ddtelemetry::data::ApiVersion::V2.to_str()
+                ddtelemetry::data::ApiVersion::V2.to_str(),
             )
             .header(
                 ddtelemetry::worker::http_client::header::REQUEST_TYPE,
-                "logs"
+                "logs",
             )
             .body(serde_json::to_string(&payload)?.into())?;
 

--- a/crashtracker/src/crash_info/telemetry.rs
+++ b/crashtracker/src/crash_info/telemetry.rs
@@ -12,7 +12,6 @@ use ddtelemetry::{
     build_host,
     data::{self, Application, LogLevel},
     worker::http_client::request_builder,
-    worker::http_client::header
 };
 
 struct TelemetryMetadata {

--- a/crashtracker/src/crash_info/telemetry.rs
+++ b/crashtracker/src/crash_info/telemetry.rs
@@ -12,6 +12,7 @@ use ddtelemetry::{
     build_host,
     data::{self, Application, LogLevel},
     worker::http_client::request_builder,
+    worker::http_client::header
 };
 
 struct TelemetryMetadata {
@@ -165,6 +166,14 @@ impl TelemetryCrashUploader {
             .header(
                 http::header::CONTENT_TYPE,
                 ddcommon::header::APPLICATION_JSON,
+            )
+            .header(
+                ddtelemetry::worker::http_client::header::API_VERSION,
+                ddtelemetry::data::ApiVersion::V2.to_str()
+            )
+            .header(
+                ddtelemetry::worker::http_client::header::REQUEST_TYPE,
+                "logs"
             )
             .body(serde_json::to_string(&payload)?.into())?;
 

--- a/crashtracker/src/rfc5_crash_info/telemetry.rs
+++ b/crashtracker/src/rfc5_crash_info/telemetry.rs
@@ -147,11 +147,11 @@ impl TelemetryCrashUploader {
             )
             .header(
                 ddtelemetry::worker::http_client::header::API_VERSION,
-                ddtelemetry::data::ApiVersion::V2.to_str()
+                ddtelemetry::data::ApiVersion::V2.to_str(),
             )
             .header(
                 ddtelemetry::worker::http_client::header::REQUEST_TYPE,
-                "logs"
+                "logs",
             )
             .body(serde_json::to_string(&payload)?.into())?;
 

--- a/crashtracker/src/rfc5_crash_info/telemetry.rs
+++ b/crashtracker/src/rfc5_crash_info/telemetry.rs
@@ -139,11 +139,19 @@ impl TelemetryCrashUploader {
             origin: Some("Crashtracker"),
         };
         let client = ddtelemetry::worker::http_client::from_config(&self.cfg);
-        let req = request_builder(&self.cfg)?
+        let req = request_buil der(&self.cfg)?
             .method(http::Method::POST)
             .header(
                 http::header::CONTENT_TYPE,
                 ddcommon::header::APPLICATION_JSON,
+            )
+            .header(
+                ddtelemetry::worker::http_client::header::API_VERSION,
+                ddtelemetry::data::ApiVersion::V2.to_str()
+            )
+            .header(
+                ddtelemetry::worker::http_client::header::REQUEST_TYPE,
+                "logs"
             )
             .body(serde_json::to_string(&payload)?.into())?;
 

--- a/crashtracker/src/rfc5_crash_info/telemetry.rs
+++ b/crashtracker/src/rfc5_crash_info/telemetry.rs
@@ -139,7 +139,7 @@ impl TelemetryCrashUploader {
             origin: Some("Crashtracker"),
         };
         let client = ddtelemetry::worker::http_client::from_config(&self.cfg);
-        let req = request_buil der(&self.cfg)?
+        let req = request_builder(&self.cfg)?
             .method(http::Method::POST)
             .header(
                 http::header::CONTENT_TYPE,


### PR DESCRIPTION
# What does this PR do?

Adds `api_version` and `request_type` headers to the telemetry messages sent by crashtracking.

# Motivation

Those headers are actually marked as required in the specification. I'm not actually sure _why_ it has worked until now (maybe the agent is adding them?) but it messes up with some tests.
