### PR TITLE
[ddcommon] unpin `cc` crate

### DIFF
--- a/ddcommon/Cargo.toml
+++ b/ddcommon/Cargo.toml
@@ -27,7 +27,7 @@ hyper = { version = "0.14", features = [
     "backports",
     "deprecated"
 ], default-features = false }
-cc = "=1.1.31"
+cc = "1.1.31"
 hyper-util = "0.1.3"
 lazy_static = "1.4"
 log = { version = "0.4" }


### PR DESCRIPTION
# What does this PR do?

Unpins `cc` crate

# Motivation

Cannot build downstream when depending on `ddcommon`

# Additional Notes

Just unpinning setting the minimum to what the pin was.

# How to test the change?

Checks
