### PR TITLE
Fix generated cbindgen compilation for crashtracker FFI

### DIFF
--- a/crashtracker-ffi/src/crash_info/sig_info.rs
+++ b/crashtracker-ffi/src/crash_info/sig_info.rs
@@ -6,22 +6,22 @@ use ddcommon_ffi::{slice::AsBytes, CharSlice};
 
 #[repr(C)]
 pub struct SigInfo<'a> {
-    pub si_addr: CharSlice<'a>,
-    pub si_code: libc::c_int,
-    pub si_code_human_readable: SiCodes,
-    pub si_signo: libc::c_int,
-    pub si_signo_human_readable: SignalNames,
+    pub addr: CharSlice<'a>,
+    pub code: libc::c_int,
+    pub code_human_readable: SiCodes,
+    pub signo: libc::c_int,
+    pub signo_human_readable: SignalNames,
 }
 
 impl<'a> TryFrom<SigInfo<'a>> for datadog_crashtracker::rfc5_crash_info::SigInfo {
     type Error = anyhow::Error;
     fn try_from(value: SigInfo<'a>) -> anyhow::Result<Self> {
         Ok(Self {
-            si_addr: value.si_addr.try_to_string_option()?,
-            si_code: value.si_code,
-            si_code_human_readable: value.si_code_human_readable,
-            si_signo: value.si_signo,
-            si_signo_human_readable: value.si_signo_human_readable,
+            si_addr: value.addr.try_to_string_option()?,
+            si_code: value.code,
+            si_code_human_readable: value.code_human_readable,
+            si_signo: value.signo,
+            si_signo_human_readable: value.signo_human_readable,
         })
     }
 }


### PR DESCRIPTION
I had this very interesting issue:

```
./components-rs/common.h:1174:18: error: expected ';' at end of declaration list
 1174 |   ddog_CharSlice si_addr;
      |                  ^
/usr/include/aarch64-linux-gnu/bits/types/siginfo_t.h:138:27: note: expanded from macro 'si_addr'
  138 | #define si_addr         _sifields._sigfault.si_addr
      |                                  ^
```

Essentially, the si_* fields are redefined by libc headers, making usage of these keywords fail compilation. Renaming it to fix the compilation issue.