### PR TITLE
Revert rasp products

### DIFF
--- a/remote-config/src/path.rs
+++ b/remote-config/src/path.rs
@@ -22,7 +22,6 @@ pub enum RemoteConfigProduct {
     AsmDD,
     AsmFeatures,
     AsmRaspLfi,
-    AsmRaspSsrf,
     LiveDebugger,
 }
 
@@ -36,7 +35,6 @@ impl Display for RemoteConfigProduct {
             RemoteConfigProduct::AsmData => "ASM_DATA",
             RemoteConfigProduct::AsmFeatures => "ASM_FEATURES",
             RemoteConfigProduct::AsmRaspLfi => "ASM_RASP_LFI",
-            RemoteConfigProduct::AsmRaspSsrf => "ASM_RASP_SSRF",
         };
         write!(f, "{}", str)
     }
@@ -85,7 +83,6 @@ impl RemoteConfigPath {
                 "ASM_DATA" => RemoteConfigProduct::AsmData,
                 "ASM_FEATURES" => RemoteConfigProduct::AsmFeatures,
                 "ASM_RASP_LFI" => RemoteConfigProduct::AsmRaspLfi,
-                "ASM_RASP_SSRF" => RemoteConfigProduct::AsmRaspSsrf,
                 product => anyhow::bail!("Unknown product {}", product),
             },
             config_id: parts[parts.len() - 2],

--- a/remote-config/src/path.rs
+++ b/remote-config/src/path.rs
@@ -21,7 +21,6 @@ pub enum RemoteConfigProduct {
     Asm,
     AsmDD,
     AsmFeatures,
-    AsmRaspLfi,
     LiveDebugger,
 }
 
@@ -34,7 +33,6 @@ impl Display for RemoteConfigProduct {
             RemoteConfigProduct::AsmDD => "ASM_DD",
             RemoteConfigProduct::AsmData => "ASM_DATA",
             RemoteConfigProduct::AsmFeatures => "ASM_FEATURES",
-            RemoteConfigProduct::AsmRaspLfi => "ASM_RASP_LFI",
         };
         write!(f, "{}", str)
     }
@@ -82,7 +80,6 @@ impl RemoteConfigPath {
                 "ASM_DD" => RemoteConfigProduct::AsmDD,
                 "ASM_DATA" => RemoteConfigProduct::AsmData,
                 "ASM_FEATURES" => RemoteConfigProduct::AsmFeatures,
-                "ASM_RASP_LFI" => RemoteConfigProduct::AsmRaspLfi,
                 product => anyhow::bail!("Unknown product {}", product),
             },
             config_id: parts[parts.len() - 2],


### PR DESCRIPTION
# What does this PR do?

Neither SSRF or LFI are products and instead they are capabilities. They shouldn't have added here. This PR reverts that.

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
