### PR TITLE
Add new error in order to handle empty agent responses.

### DIFF
--- a/data-pipeline-ffi/src/error.rs
+++ b/data-pipeline-ffi/src/error.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use data_pipeline::trace_exporter::error::{
-    BuilderErrorKind, NetworkErrorKind, TraceExporterError,
+    AgentErrorKind, BuilderErrorKind, NetworkErrorKind, TraceExporterError,
 };
 use std::ffi::{c_char, CString};
 use std::fmt::Display;
@@ -19,6 +19,7 @@ pub enum ExporterErrorCode {
     HttpBodyFormat,
     HttpBodyTooLong,
     HttpClient,
+    HttpEmptyBody,
     HttpParse,
     HttpServer,
     HttpUnknown,
@@ -43,6 +44,7 @@ impl Display for ExporterErrorCode {
             Self::HttpBodyFormat => write!(f, "Error parsing HTTP body"),
             Self::HttpBodyTooLong => write!(f, "HTTP body too long"),
             Self::HttpClient => write!(f, "HTTP error orgininated by client"),
+            Self::HttpEmptyBody => write!(f, "HTTP empty body"),
             Self::HttpParse => write!(f, "Error while parsing HTTP message"),
             Self::HttpServer => write!(f, "HTTP error orgininated by server"),
             Self::HttpWrongStatus => write!(f, "HTTP wrong status number"),
@@ -79,6 +81,9 @@ impl ExporterError {
 impl From<TraceExporterError> for ExporterError {
     fn from(value: TraceExporterError) -> Self {
         let code = match &value {
+            TraceExporterError::Agent(e) => match e {
+                AgentErrorKind::EmptyResponse => ExporterErrorCode::HttpEmptyBody,
+            },
             TraceExporterError::Builder(e) => match e {
                 BuilderErrorKind::InvalidUri => ExporterErrorCode::InvalidUrl,
             },

--- a/data-pipeline/src/trace_exporter/error.rs
+++ b/data-pipeline/src/trace_exporter/error.rs
@@ -9,6 +9,19 @@ use std::error::Error;
 use std::fmt::{Debug, Display};
 
 #[derive(Debug, PartialEq)]
+pub enum AgentErrorKind {
+    EmptyResponse,
+}
+
+impl Display for AgentErrorKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AgentErrorKind::EmptyResponse => write!(f, "Agent empty response"),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
 pub enum BuilderErrorKind {
     InvalidUri,
 }
@@ -93,6 +106,7 @@ impl RequestError {
 /// TraceExporterError holds different types of errors that occur when handling traces.
 #[derive(Debug)]
 pub enum TraceExporterError {
+    Agent(AgentErrorKind),
     Builder(BuilderErrorKind),
     Deserialization(DecodeError),
     Io(std::io::Error),
@@ -150,6 +164,7 @@ impl From<std::io::Error> for TraceExporterError {
 impl Display for TraceExporterError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            TraceExporterError::Agent(e) => std::fmt::Display::fmt(e, f),
             TraceExporterError::Builder(e) => std::fmt::Display::fmt(e, f),
             TraceExporterError::Deserialization(e) => std::fmt::Display::fmt(e, f),
             TraceExporterError::Io(e) => std::fmt::Display::fmt(e, f),


### PR DESCRIPTION
# What does this PR do?

Old API agent’s versions could send an empty response.  That means  there won’t be a  sampling rate announced so there’s the need of handling that specific case in the trace exporter instead of a returning a generic IO error. This way the tracer can apply its own heuristic in that case.

# Motivation

Support older agent's API versions.
