### PR TITLE
APMSP-1711 check CARGO_TARGET_DIR when calculating artifact location for bin tests

### DIFF
--- a/bin_tests/src/lib.rs
+++ b/bin_tests/src/lib.rs
@@ -5,7 +5,6 @@ pub mod modes;
 
 use std::{collections::HashMap, env, ops::DerefMut, path::PathBuf, process, sync::Mutex};
 
-use anyhow::Ok;
 use once_cell::sync::OnceCell;
 
 /// This crate implements an abstraction over compilation with cargo with the purpose
@@ -69,6 +68,11 @@ fn inner_build_artifact(c: &ArtifactsBuild) -> anyhow::Result<PathBuf> {
     /// it's directory
     static ARTIFACT_DIR: OnceCell<PathBuf> = OnceCell::new();
     let artifact_dir = ARTIFACT_DIR.get_or_init(|| {
+        // If the CARGO_TARGET_DIR env var is set, then just use that.
+        if let Ok(env_target_dir) = env::var("CARGO_TARGET_DIR") {
+            return PathBuf::from(env_target_dir);
+        }
+
         let test_bin_location = PathBuf::from(env::args().next().unwrap());
         let mut location_components = test_bin_location.components().rev().peekable();
         loop {


### PR DESCRIPTION
# What does this PR do?

When bin_tests generate binaries check if `$CARGO_TARGET_DIR` is set, and the target directory is not the default `target/`. If this is the case then use this as the root of the artifact location.

# Motivation

bin_tests fail when attempting to execute them inside a linux docker container that has $CARGO_TARGET_DIR set in order to avoid build conflicts with the host OS.  

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
