### PR TITLE
chore: [SVLS-5992] clearer dogstatsd Flusher API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,6 +1067,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5cd0c57ef83705837b1cb872c973eff82b070846d3e23668322b2c0f8246d0"
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1945,6 +1954,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "unicode-xid",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2030,6 +2061,7 @@ version = "14.3.1"
 dependencies = [
  "datadog-protos",
  "ddsketch-agent",
+ "derive_more",
  "fnv",
  "hashbrown 0.14.5",
  "lazy_static",
@@ -6103,6 +6135,12 @@ name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,15 +1067,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5cd0c57ef83705837b1cb872c973eff82b070846d3e23668322b2c0f8246d0"
 
 [[package]]
-name = "convert_case"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1968,7 +1959,6 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
- "convert_case",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -6135,12 +6125,6 @@ name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-xid"

--- a/dogstatsd/Cargo.toml
+++ b/dogstatsd/Cargo.toml
@@ -11,7 +11,7 @@ bench = false
 [dependencies]
 datadog-protos = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "c89b58e5784b985819baf11f13f7d35876741222" }
 ddsketch-agent = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "c89b58e5784b985819baf11f13f7d35876741222" }
-derive_more = { version = "1.0.0", features = ["full"] }
+derive_more = { version = "1.0.0", features = ["display", "into"] }
 hashbrown = { version = "0.14.3", default-features = false, features = ["inline-more"] }
 protobuf = { version = "3.5.0", default-features = false }
 ustr = { version = "1.0.0", default-features = false }

--- a/dogstatsd/Cargo.toml
+++ b/dogstatsd/Cargo.toml
@@ -11,6 +11,7 @@ bench = false
 [dependencies]
 datadog-protos = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "c89b58e5784b985819baf11f13f7d35876741222" }
 ddsketch-agent = { version = "0.1.0", default-features = false, git = "https://github.com/DataDog/saluki/", rev = "c89b58e5784b985819baf11f13f7d35876741222" }
+derive_more = { version = "1.0.0", features = ["full"] }
 hashbrown = { version = "0.14.3", default-features = false, features = ["inline-more"] }
 protobuf = { version = "3.5.0", default-features = false }
 ustr = { version = "1.0.0", default-features = false }

--- a/dogstatsd/src/datadog.rs
+++ b/dogstatsd/src/datadog.rs
@@ -38,12 +38,12 @@ impl Site {
 #[error("Invalid URL prefix: {0}")]
 pub struct UrlPrefixError(String);
 
-fn validate_url_prefix(prefix: &String) -> Result<(), UrlPrefixError> {
+fn validate_url_prefix(prefix: &str) -> Result<(), UrlPrefixError> {
     let re = Regex::new(r"^https?://[a-zA-Z0-9._-]+$").expect("invalid regex");
     if re.is_match(prefix) {
         Ok(())
     } else {
-        Err(UrlPrefixError(prefix.clone()))
+        Err(UrlPrefixError(prefix.to_owned()))
     }
 }
 

--- a/dogstatsd/src/datadog.rs
+++ b/dogstatsd/src/datadog.rs
@@ -14,7 +14,6 @@ use std::time::Duration;
 use tracing::{debug, error};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display, Into)]
-#[display("{}", _0)]
 pub struct Site(String);
 
 #[derive(thiserror::Error, Debug, Clone, PartialEq)]
@@ -49,7 +48,6 @@ fn validate_url_prefix(prefix: &String) -> Result<(), UrlPrefixError> {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display, Into)]
-#[display("{}", _0)]
 pub struct DdUrl(String);
 
 impl DdUrl {
@@ -62,7 +60,6 @@ impl DdUrl {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display, Into)]
-#[display("{}", _0)]
 pub struct DdDdUrl(String);
 
 impl DdDdUrl {
@@ -75,7 +72,6 @@ impl DdDdUrl {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display, Into)]
-#[display("{}", _0)]
 pub struct MetricsIntakeUrlPrefixOverride(String);
 
 impl MetricsIntakeUrlPrefixOverride {
@@ -125,7 +121,6 @@ mod test {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
-#[display("{}", _0)]
 pub struct MetricsIntakeUrlPrefix(String);
 
 #[derive(thiserror::Error, Debug, Clone, PartialEq)]

--- a/dogstatsd/src/datadog.rs
+++ b/dogstatsd/src/datadog.rs
@@ -4,23 +4,18 @@
 //!Types to serialize data into the Datadog API
 
 use datadog_protos::metrics::SketchPayload;
+use derive_more::Display;
 use protobuf::Message;
 use regex::Regex;
 use reqwest;
 use serde::{Serialize, Serializer};
 use serde_json;
-use std::fmt;
 use std::time::Duration;
 use tracing::{debug, error};
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
+#[display("{}", _0)]
 pub struct Site(String);
-
-impl fmt::Display for Site {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
 
 #[derive(thiserror::Error, Debug, Clone, PartialEq)]
 #[error("Invalid site: {0}")]
@@ -57,14 +52,9 @@ fn validate_url_prefix(prefix: &String) -> Result<(), UrlPrefixError> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
+#[display("{}", _0)]
 pub struct DdUrl(String);
-
-impl fmt::Display for DdUrl {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
 
 impl DdUrl {
     pub fn new(prefix: String) -> Result<Self, UrlPrefixError> {
@@ -79,14 +69,9 @@ impl DdUrl {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
+#[display("{}", _0)]
 pub struct DdDdUrl(String);
-
-impl fmt::Display for DdDdUrl {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
 
 impl DdDdUrl {
     pub fn new(prefix: String) -> Result<Self, UrlPrefixError> {
@@ -101,14 +86,9 @@ impl DdDdUrl {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
+#[display("{}", _0)]
 pub struct MetricsIntakeUrlPrefixOverride(String);
-
-impl fmt::Display for MetricsIntakeUrlPrefixOverride {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
 
 impl MetricsIntakeUrlPrefixOverride {
     pub fn maybe_new(dd_url: Option<DdUrl>, dd_dd_url: Option<DdDdUrl>) -> Option<Self> {
@@ -160,14 +140,9 @@ mod test {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
+#[display("{}", _0)]
 pub struct MetricsIntakeUrlPrefix(String);
-
-impl fmt::Display for MetricsIntakeUrlPrefix {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
 
 #[derive(thiserror::Error, Debug, Clone, PartialEq)]
 #[error("Missing intake URL configuration")]

--- a/dogstatsd/src/datadog.rs
+++ b/dogstatsd/src/datadog.rs
@@ -4,7 +4,7 @@
 //!Types to serialize data into the Datadog API
 
 use datadog_protos::metrics::SketchPayload;
-use derive_more::Display;
+use derive_more::{Display, Into};
 use protobuf::Message;
 use regex::Regex;
 use reqwest;
@@ -13,7 +13,7 @@ use serde_json;
 use std::time::Duration;
 use tracing::{debug, error};
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display, Into)]
 #[display("{}", _0)]
 pub struct Site(String);
 
@@ -33,10 +33,6 @@ impl Site {
             Err(SiteError(site))
         }
     }
-
-    pub fn into_string(self) -> String {
-        self.0
-    }
 }
 
 #[derive(thiserror::Error, Debug, Clone, PartialEq)]
@@ -52,7 +48,7 @@ fn validate_url_prefix(prefix: &String) -> Result<(), UrlPrefixError> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display, Into)]
 #[display("{}", _0)]
 pub struct DdUrl(String);
 
@@ -63,13 +59,9 @@ impl DdUrl {
             Err(e) => Err(e),
         }
     }
-
-    pub fn into_string(self) -> String {
-        self.0
-    }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display, Into)]
 #[display("{}", _0)]
 pub struct DdDdUrl(String);
 
@@ -80,13 +72,9 @@ impl DdDdUrl {
             Err(e) => Err(e),
         }
     }
-
-    pub fn into_string(self) -> String {
-        self.0
-    }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display, Into)]
 #[display("{}", _0)]
 pub struct MetricsIntakeUrlPrefixOverride(String);
 
@@ -94,13 +82,9 @@ impl MetricsIntakeUrlPrefixOverride {
     pub fn maybe_new(dd_url: Option<DdUrl>, dd_dd_url: Option<DdDdUrl>) -> Option<Self> {
         match (dd_url, dd_dd_url) {
             (None, None) => None,
-            (_, Some(dd_dd_url)) => Some(Self(dd_dd_url.into_string())),
-            (Some(dd_url), None) => Some(Self(dd_url.into_string())),
+            (_, Some(dd_dd_url)) => Some(Self(dd_dd_url.into())),
+            (Some(dd_url), None) => Some(Self(dd_url.into())),
         }
-    }
-
-    pub fn into_string(self) -> String {
-        self.0
     }
 }
 
@@ -178,7 +162,7 @@ impl MetricsIntakeUrlPrefix {
     ) -> Result<Self, MissingIntakeUrlError> {
         match (site, overridden_prefix) {
             (None, None) => Err(MissingIntakeUrlError),
-            (_, Some(prefix)) => Ok(Self::new(prefix.into_string())),
+            (_, Some(prefix)) => Ok(Self::new(prefix.into())),
             (Some(site), None) => Ok(Self::from_site(site)),
         }
     }

--- a/dogstatsd/src/datadog.rs
+++ b/dogstatsd/src/datadog.rs
@@ -59,7 +59,7 @@ impl DdApi {
         };
         DdApi {
             api_key,
-            intake_url_prefix: intake_url_prefix,
+            intake_url_prefix,
             client,
         }
     }

--- a/dogstatsd/src/datadog.rs
+++ b/dogstatsd/src/datadog.rs
@@ -15,7 +15,7 @@ use tracing::{debug, error};
 #[derive(Debug)]
 pub struct DdApi {
     api_key: String,
-    fqdn_site: String,
+    intake_url_prefix: String,
     client: reqwest::Client,
 }
 
@@ -36,7 +36,7 @@ impl DdApi {
         };
         DdApi {
             api_key,
-            fqdn_site: site,
+            intake_url_prefix: site,
             client,
         }
     }
@@ -46,7 +46,7 @@ impl DdApi {
         let body = serde_json::to_vec(&series).expect("failed to serialize series");
         debug!("Sending body: {:?}", &series);
 
-        let url = format!("{}/api/v2/series", &self.fqdn_site);
+        let url = format!("{}/api/v2/series", &self.intake_url_prefix);
         let resp = self
             .client
             .post(&url)
@@ -74,7 +74,7 @@ impl DdApi {
     }
 
     pub async fn ship_distributions(&self, sketches: &SketchPayload) {
-        let url = format!("{}/api/beta/sketches", &self.fqdn_site);
+        let url = format!("{}/api/beta/sketches", &self.intake_url_prefix);
         debug!("Sending distributions: {:?}", &sketches);
         // TODO maybe go to coded output stream if we incrementally
         // add sketch payloads to the buffer

--- a/dogstatsd/src/datadog.rs
+++ b/dogstatsd/src/datadog.rs
@@ -31,7 +31,7 @@ impl Site {
         // Datadog sites are generally domain names. In particular, they shouldn't have any slashes
         // in them. We expect this to be coming from a `DD_SITE` environment variable or the `site`
         // config field.
-        let re = Regex::new(r"^[a-zA-Z0-9._-]+$").unwrap();
+        let re = Regex::new(r"^[a-zA-Z0-9._-]+$").expect("invalid regex");
         if re.is_match(&site) {
             Ok(Site(site))
         } else {
@@ -49,7 +49,7 @@ impl Site {
 pub struct UrlPrefixError(String);
 
 fn validate_url_prefix(prefix: &String) -> Result<(), UrlPrefixError> {
-    let re = Regex::new(r"^https?://[a-zA-Z0-9._-]+$").unwrap();
+    let re = Regex::new(r"^https?://[a-zA-Z0-9._-]+$").expect("invalid regex");
     if re.is_match(prefix) {
         Ok(())
     } else {

--- a/dogstatsd/src/datadog.rs
+++ b/dogstatsd/src/datadog.rs
@@ -23,7 +23,7 @@ impl DdApi {
     #[must_use]
     pub fn new(
         api_key: String,
-        site: String,
+        intake_url_prefix: String,
         https_proxy: Option<String>,
         timeout: Duration,
     ) -> Self {
@@ -36,7 +36,7 @@ impl DdApi {
         };
         DdApi {
             api_key,
-            intake_url_prefix: site,
+            intake_url_prefix: intake_url_prefix,
             client,
         }
     }

--- a/dogstatsd/src/datadog.rs
+++ b/dogstatsd/src/datadog.rs
@@ -28,8 +28,8 @@ pub struct SiteError(String);
 
 impl Site {
     pub fn new(site: String) -> Result<Self, SiteError> {
-        // Datadog sites are generally domain names. In particular, they shouldn't have any slashes in
-        // them. We expect this to be coming from a `DD_SITE` environment variable or the `site`
+        // Datadog sites are generally domain names. In particular, they shouldn't have any slashes
+        // in them. We expect this to be coming from a `DD_SITE` environment variable or the `site`
         // config field.
         let re = Regex::new(r"^[a-zA-Z0-9._-]+$").unwrap();
         if re.is_match(&site) {
@@ -50,7 +50,7 @@ pub struct UrlPrefixError(String);
 
 fn validate_url_prefix(prefix: &String) -> Result<(), UrlPrefixError> {
     let re = Regex::new(r"^https?://[a-zA-Z0-9._-]+$").unwrap();
-    if re.is_match(&prefix) {
+    if re.is_match(prefix) {
         Ok(())
     } else {
         Err(UrlPrefixError(prefix.clone()))
@@ -130,10 +130,7 @@ mod test {
 
     #[test]
     fn override_can_be_empty() {
-        assert_eq!(
-            MetricsIntakeUrlPrefixOverride::maybe_new(None, None),
-            None
-        );
+        assert_eq!(MetricsIntakeUrlPrefixOverride::maybe_new(None, None), None);
     }
 
     #[test]
@@ -143,7 +140,9 @@ mod test {
                 Some(DdUrl::new("http://a_dd_url".to_string()).unwrap()),
                 Some(DdDdUrl::new("https://a_dd_dd_url".to_string()).unwrap())
             ),
-            Some(MetricsIntakeUrlPrefixOverride("https://a_dd_dd_url".to_string()))
+            Some(MetricsIntakeUrlPrefixOverride(
+                "https://a_dd_dd_url".to_string()
+            ))
         );
     }
 
@@ -154,7 +153,9 @@ mod test {
                 Some(DdUrl::new("http://a_dd_url".to_string()).unwrap()),
                 None
             ),
-            Some(MetricsIntakeUrlPrefixOverride("http://a_dd_url".to_string()))
+            Some(MetricsIntakeUrlPrefixOverride(
+                "http://a_dd_url".to_string()
+            ))
         );
     }
 }

--- a/dogstatsd/src/datadog.rs
+++ b/dogstatsd/src/datadog.rs
@@ -10,12 +10,35 @@ use serde::{Serialize, Serializer};
 use serde_json;
 use std::time::Duration;
 use tracing::{debug, error};
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct IntakeUrlPrefix(String);
+
+impl fmt::Display for IntakeUrlPrefix {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl IntakeUrlPrefix {
+    pub fn new(prefix: String) -> Self {
+        // Maybe we will validate this in the future, but for now we assume that the prefix is
+        // sensible.
+        IntakeUrlPrefix(prefix)
+    }
+
+    #[inline]
+    pub fn from_site(site: String) -> Self {
+        IntakeUrlPrefix(format!("https://api.{}", site))
+    }
+}
 
 /// Interface for the `DogStatsD` metrics intake API.
 #[derive(Debug)]
 pub struct DdApi {
     api_key: String,
-    intake_url_prefix: String,
+    intake_url_prefix: IntakeUrlPrefix,
     client: reqwest::Client,
 }
 
@@ -23,7 +46,7 @@ impl DdApi {
     #[must_use]
     pub fn new(
         api_key: String,
-        intake_url_prefix: String,
+        intake_url_prefix: IntakeUrlPrefix,
         https_proxy: Option<String>,
         timeout: Duration,
     ) -> Self {

--- a/dogstatsd/src/datadog.rs
+++ b/dogstatsd/src/datadog.rs
@@ -12,7 +12,7 @@ use std::fmt;
 use std::time::Duration;
 use tracing::{debug, error};
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Site(String);
 
 impl fmt::Display for Site {
@@ -31,7 +31,7 @@ impl Site {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DdUrl(String);
 
 impl fmt::Display for DdUrl {
@@ -50,7 +50,7 @@ impl DdUrl {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DdDdUrl(String);
 
 impl fmt::Display for DdDdUrl {
@@ -69,7 +69,7 @@ impl DdDdUrl {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct IntakeUrlPrefix(String);
 
 impl fmt::Display for IntakeUrlPrefix {

--- a/dogstatsd/src/datadog.rs
+++ b/dogstatsd/src/datadog.rs
@@ -8,9 +8,9 @@ use protobuf::Message;
 use reqwest;
 use serde::{Serialize, Serializer};
 use serde_json;
+use std::fmt;
 use std::time::Duration;
 use tracing::{debug, error};
-use std::fmt;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct IntakeUrlPrefix(String);

--- a/dogstatsd/src/flusher.rs
+++ b/dogstatsd/src/flusher.rs
@@ -13,14 +13,6 @@ pub struct Flusher {
     aggregator: Arc<Mutex<Aggregator>>,
 }
 
-#[inline]
-#[must_use]
-#[deprecated(note = "please use IntakeUrlPrefix::from_site instead")]
-// This function is deprecated becaause its name is misleading. It is not actually building Fully Qualified Domain Name.
-pub fn build_fqdn_metrics(site: String) -> String {
-    format!("https://api.{site}")
-}
-
 pub struct FlusherConfig {
     pub api_key: String,
     pub aggregator: Arc<Mutex<Aggregator>>,

--- a/dogstatsd/src/flusher.rs
+++ b/dogstatsd/src/flusher.rs
@@ -21,17 +21,27 @@ pub fn build_fqdn_metrics(site: String) -> String {
     format!("https://api.{site}")
 }
 
+pub struct FlusherConfig {
+    pub api_key: String,
+    pub aggregator: Arc<Mutex<Aggregator>>,
+    pub intake_url_prefix: IntakeUrlPrefix,
+    pub https_proxy: Option<String>,
+    pub timeout: Duration,
+}
+
 #[allow(clippy::await_holding_lock)]
 impl Flusher {
-    pub fn new(
-        api_key: String,
-        aggregator: Arc<Mutex<Aggregator>>,
-        intake_url_prefix: IntakeUrlPrefix,
-        https_proxy: Option<String>,
-        timeout: Duration,
-    ) -> Self {
-        let dd_api = datadog::DdApi::new(api_key, intake_url_prefix, https_proxy, timeout);
-        Flusher { dd_api, aggregator }
+    pub fn new(params: FlusherConfig) -> Self {
+        let dd_api = datadog::DdApi::new(
+            params.api_key,
+            params.intake_url_prefix,
+            params.https_proxy,
+            params.timeout,
+        );
+        Flusher {
+            dd_api: dd_api,
+            aggregator: params.aggregator,
+        }
     }
 
     pub async fn flush(&mut self) {

--- a/dogstatsd/src/flusher.rs
+++ b/dogstatsd/src/flusher.rs
@@ -23,11 +23,11 @@ impl Flusher {
     pub fn new(
         api_key: String,
         aggregator: Arc<Mutex<Aggregator>>,
-        site: String,
+        intake_url_prefix: String,
         https_proxy: Option<String>,
         timeout: Duration,
     ) -> Self {
-        let dd_api = datadog::DdApi::new(api_key, site, https_proxy, timeout);
+        let dd_api = datadog::DdApi::new(api_key, intake_url_prefix, https_proxy, timeout);
         Flusher { dd_api, aggregator }
     }
 

--- a/dogstatsd/src/flusher.rs
+++ b/dogstatsd/src/flusher.rs
@@ -3,7 +3,7 @@
 
 use crate::aggregator::Aggregator;
 use crate::datadog;
-use datadog::IntakeUrlPrefix;
+use datadog::MetricsIntakeUrlPrefix;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tracing::debug;
@@ -16,7 +16,7 @@ pub struct Flusher {
 pub struct FlusherConfig {
     pub api_key: String,
     pub aggregator: Arc<Mutex<Aggregator>>,
-    pub intake_url_prefix: IntakeUrlPrefix,
+    pub metrics_intake_url_prefix: MetricsIntakeUrlPrefix,
     pub https_proxy: Option<String>,
     pub timeout: Duration,
 }
@@ -26,7 +26,7 @@ impl Flusher {
     pub fn new(params: FlusherConfig) -> Self {
         let dd_api = datadog::DdApi::new(
             params.api_key,
-            params.intake_url_prefix,
+            params.metrics_intake_url_prefix,
             params.https_proxy,
             params.timeout,
         );

--- a/dogstatsd/src/flusher.rs
+++ b/dogstatsd/src/flusher.rs
@@ -31,7 +31,7 @@ impl Flusher {
             params.timeout,
         );
         Flusher {
-            dd_api: dd_api,
+            dd_api,
             aggregator: params.aggregator,
         }
     }

--- a/dogstatsd/src/flusher.rs
+++ b/dogstatsd/src/flusher.rs
@@ -23,16 +23,16 @@ pub struct FlusherConfig {
 
 #[allow(clippy::await_holding_lock)]
 impl Flusher {
-    pub fn new(params: FlusherConfig) -> Self {
+    pub fn new(config: FlusherConfig) -> Self {
         let dd_api = datadog::DdApi::new(
-            params.api_key,
-            params.metrics_intake_url_prefix,
-            params.https_proxy,
-            params.timeout,
+            config.api_key,
+            config.metrics_intake_url_prefix,
+            config.https_proxy,
+            config.timeout,
         );
         Flusher {
             dd_api,
-            aggregator: params.aggregator,
+            aggregator: config.aggregator,
         }
     }
 

--- a/dogstatsd/src/flusher.rs
+++ b/dogstatsd/src/flusher.rs
@@ -6,6 +6,7 @@ use crate::datadog;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tracing::debug;
+use datadog::IntakeUrlPrefix;
 
 pub struct Flusher {
     dd_api: datadog::DdApi,
@@ -14,6 +15,8 @@ pub struct Flusher {
 
 #[inline]
 #[must_use]
+#[deprecated(note="please use IntakeUrlPrefix::from_site instead")]
+// This function is deprecated becaause its name is misleading. It is not actually building Fully Qualified Domain Name.
 pub fn build_fqdn_metrics(site: String) -> String {
     format!("https://api.{site}")
 }
@@ -23,7 +26,7 @@ impl Flusher {
     pub fn new(
         api_key: String,
         aggregator: Arc<Mutex<Aggregator>>,
-        intake_url_prefix: String,
+        intake_url_prefix: IntakeUrlPrefix,
         https_proxy: Option<String>,
         timeout: Duration,
     ) -> Self {

--- a/dogstatsd/src/flusher.rs
+++ b/dogstatsd/src/flusher.rs
@@ -3,10 +3,10 @@
 
 use crate::aggregator::Aggregator;
 use crate::datadog;
+use datadog::IntakeUrlPrefix;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tracing::debug;
-use datadog::IntakeUrlPrefix;
 
 pub struct Flusher {
     dd_api: datadog::DdApi,
@@ -15,7 +15,7 @@ pub struct Flusher {
 
 #[inline]
 #[must_use]
-#[deprecated(note="please use IntakeUrlPrefix::from_site instead")]
+#[deprecated(note = "please use IntakeUrlPrefix::from_site instead")]
 // This function is deprecated becaause its name is misleading. It is not actually building Fully Qualified Domain Name.
 pub fn build_fqdn_metrics(site: String) -> String {
     format!("https://api.{site}")

--- a/dogstatsd/src/flusher.rs
+++ b/dogstatsd/src/flusher.rs
@@ -3,13 +3,13 @@
 
 use crate::aggregator::Aggregator;
 use crate::datadog;
-use datadog::MetricsIntakeUrlPrefix;
+use datadog::{DdApi, MetricsIntakeUrlPrefix};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tracing::debug;
 
 pub struct Flusher {
-    dd_api: datadog::DdApi,
+    dd_api: DdApi,
     aggregator: Arc<Mutex<Aggregator>>,
 }
 
@@ -24,7 +24,7 @@ pub struct FlusherConfig {
 #[allow(clippy::await_holding_lock)]
 impl Flusher {
     pub fn new(config: FlusherConfig) -> Self {
-        let dd_api = datadog::DdApi::new(
+        let dd_api = DdApi::new(
             config.api_key,
             config.metrics_intake_url_prefix,
             config.https_proxy,

--- a/dogstatsd/tests/integration_test.rs
+++ b/dogstatsd/tests/integration_test.rs
@@ -7,6 +7,7 @@ use dogstatsd::{
     constants::CONTEXTS,
     dogstatsd::{DogStatsD, DogStatsDConfig},
     flusher::Flusher,
+    datadog::IntakeUrlPrefix,
 };
 use mockito::Server;
 use std::sync::{Arc, Mutex};
@@ -40,7 +41,7 @@ async fn dogstatsd_server_ships_series() {
     let mut metrics_flusher = Flusher::new(
         "mock-api-key".to_string(),
         Arc::clone(&metrics_aggr),
-        mock_server.url(),
+        IntakeUrlPrefix::new(mock_server.url()),
         None,
         std::time::Duration::from_secs(5),
     );

--- a/dogstatsd/tests/integration_test.rs
+++ b/dogstatsd/tests/integration_test.rs
@@ -41,7 +41,10 @@ async fn dogstatsd_server_ships_series() {
     let mut metrics_flusher = Flusher::new(FlusherConfig {
         api_key: "mock-api-key".to_string(),
         aggregator: Arc::clone(&metrics_aggr),
-        intake_url_prefix: IntakeUrlPrefix::new(mock_server.url()),
+        intake_url_prefix: unsafe {
+            // This skips validation, but we don't care in this test.
+            IntakeUrlPrefix::new_unchecked(mock_server.url())
+        },
         https_proxy: None,
         timeout: std::time::Duration::from_secs(5),
     });

--- a/dogstatsd/tests/integration_test.rs
+++ b/dogstatsd/tests/integration_test.rs
@@ -5,7 +5,7 @@ use dogstatsd::metric::SortedTags;
 use dogstatsd::{
     aggregator::Aggregator as MetricsAggregator,
     constants::CONTEXTS,
-    datadog::IntakeUrlPrefix,
+    datadog::MetricsIntakeUrlPrefix,
     dogstatsd::{DogStatsD, DogStatsDConfig},
     flusher::{Flusher, FlusherConfig},
 };
@@ -41,9 +41,9 @@ async fn dogstatsd_server_ships_series() {
     let mut metrics_flusher = Flusher::new(FlusherConfig {
         api_key: "mock-api-key".to_string(),
         aggregator: Arc::clone(&metrics_aggr),
-        intake_url_prefix: unsafe {
+        metrics_intake_url_prefix: unsafe {
             // This skips validation, but we don't care in this test.
-            IntakeUrlPrefix::new_unchecked(mock_server.url())
+            MetricsIntakeUrlPrefix::new_unchecked(mock_server.url())
         },
         https_proxy: None,
         timeout: std::time::Duration::from_secs(5),

--- a/dogstatsd/tests/integration_test.rs
+++ b/dogstatsd/tests/integration_test.rs
@@ -7,7 +7,7 @@ use dogstatsd::{
     constants::CONTEXTS,
     datadog::IntakeUrlPrefix,
     dogstatsd::{DogStatsD, DogStatsDConfig},
-    flusher::Flusher,
+    flusher::{Flusher, FlusherConfig},
 };
 use mockito::Server;
 use std::sync::{Arc, Mutex};
@@ -38,13 +38,13 @@ async fn dogstatsd_server_ships_series() {
 
     let _ = start_dogstatsd(&metrics_aggr).await;
 
-    let mut metrics_flusher = Flusher::new(
-        "mock-api-key".to_string(),
-        Arc::clone(&metrics_aggr),
-        IntakeUrlPrefix::new(mock_server.url()),
-        None,
-        std::time::Duration::from_secs(5),
-    );
+    let mut metrics_flusher = Flusher::new(FlusherConfig {
+        api_key: "mock-api-key".to_string(),
+        aggregator: Arc::clone(&metrics_aggr),
+        intake_url_prefix: IntakeUrlPrefix::new(mock_server.url()),
+        https_proxy: None,
+        timeout: std::time::Duration::from_secs(5),
+    });
 
     let server_address = "127.0.0.1:18125";
     let socket = UdpSocket::bind("0.0.0.0:0")

--- a/dogstatsd/tests/integration_test.rs
+++ b/dogstatsd/tests/integration_test.rs
@@ -5,9 +5,9 @@ use dogstatsd::metric::SortedTags;
 use dogstatsd::{
     aggregator::Aggregator as MetricsAggregator,
     constants::CONTEXTS,
+    datadog::IntakeUrlPrefix,
     dogstatsd::{DogStatsD, DogStatsDConfig},
     flusher::Flusher,
-    datadog::IntakeUrlPrefix,
 };
 use mockito::Server;
 use std::sync::{Arc, Mutex};

--- a/dogstatsd/tests/integration_test.rs
+++ b/dogstatsd/tests/integration_test.rs
@@ -5,7 +5,7 @@ use dogstatsd::metric::SortedTags;
 use dogstatsd::{
     aggregator::Aggregator as MetricsAggregator,
     constants::CONTEXTS,
-    datadog::MetricsIntakeUrlPrefix,
+    datadog::{DdDdUrl, MetricsIntakeUrlPrefix, MetricsIntakeUrlPrefixOverride},
     dogstatsd::{DogStatsD, DogStatsDConfig},
     flusher::{Flusher, FlusherConfig},
 };
@@ -41,10 +41,14 @@ async fn dogstatsd_server_ships_series() {
     let mut metrics_flusher = Flusher::new(FlusherConfig {
         api_key: "mock-api-key".to_string(),
         aggregator: Arc::clone(&metrics_aggr),
-        metrics_intake_url_prefix: unsafe {
-            // This skips validation, but we don't care in this test.
-            MetricsIntakeUrlPrefix::new_unchecked(mock_server.url())
-        },
+        metrics_intake_url_prefix: MetricsIntakeUrlPrefix::new(
+            None,
+            MetricsIntakeUrlPrefixOverride::maybe_new(
+                None,
+                Some(DdDdUrl::new(mock_server.url()).expect("failed to create URL")),
+            ),
+        )
+        .expect("failed to create URL"),
         https_proxy: None,
         timeout: std::time::Duration::from_secs(5),
     });

--- a/serverless/src/main.rs
+++ b/serverless/src/main.rs
@@ -15,7 +15,7 @@ use datadog_trace_mini_agent::{
 use dogstatsd::{
     aggregator::Aggregator as MetricsAggregator,
     constants::CONTEXTS,
-    datadog::IntakeUrlPrefix,
+    datadog::{IntakeUrlPrefix, Site},
     dogstatsd::{DogStatsD, DogStatsDConfig},
     flusher::{Flusher, FlusherConfig},
 };
@@ -160,7 +160,12 @@ async fn start_dogstatsd(
             let metrics_flusher = Flusher::new(FlusherConfig {
                 api_key: dd_api_key,
                 aggregator: Arc::clone(&metrics_aggr),
-                intake_url_prefix: IntakeUrlPrefix::from_site(dd_site),
+                intake_url_prefix: IntakeUrlPrefix::from_site_or_dd_urls(
+                    Some(Site::new(dd_site)),
+                    None,
+                    None,
+                )
+                .expect("Failed to create intake URL prefix"),
                 https_proxy,
                 timeout: DOGSTATSD_TIMEOUT_DURATION,
             });

--- a/serverless/src/main.rs
+++ b/serverless/src/main.rs
@@ -15,7 +15,7 @@ use datadog_trace_mini_agent::{
 use dogstatsd::{
     aggregator::Aggregator as MetricsAggregator,
     constants::CONTEXTS,
-    datadog::{IntakeUrlPrefix, Site},
+    datadog::{MetricsIntakeUrlPrefix, Site},
     dogstatsd::{DogStatsD, DogStatsDConfig},
     flusher::{Flusher, FlusherConfig},
 };
@@ -160,7 +160,7 @@ async fn start_dogstatsd(
             let metrics_flusher = Flusher::new(FlusherConfig {
                 api_key: dd_api_key,
                 aggregator: Arc::clone(&metrics_aggr),
-                intake_url_prefix: IntakeUrlPrefix::from_site_or_dd_urls(
+                metrics_intake_url_prefix: MetricsIntakeUrlPrefix::from_site_or_dd_urls(
                     Some(Site::new(dd_site)),
                     None,
                     None,

--- a/serverless/src/main.rs
+++ b/serverless/src/main.rs
@@ -160,7 +160,7 @@ async fn start_dogstatsd(
             let metrics_flusher = Flusher::new(FlusherConfig {
                 api_key: dd_api_key,
                 aggregator: Arc::clone(&metrics_aggr),
-                metrics_intake_url_prefix: MetricsIntakeUrlPrefix::from_site_or_override(
+                metrics_intake_url_prefix: MetricsIntakeUrlPrefix::new(
                     Some(Site::new(dd_site).expect("Failed to parse site")),
                     None,
                 )

--- a/serverless/src/main.rs
+++ b/serverless/src/main.rs
@@ -161,7 +161,7 @@ async fn start_dogstatsd(
                 api_key: dd_api_key,
                 aggregator: Arc::clone(&metrics_aggr),
                 intake_url_prefix: IntakeUrlPrefix::from_site(dd_site),
-                https_proxy: https_proxy,
+                https_proxy,
                 timeout: DOGSTATSD_TIMEOUT_DURATION,
             });
             Some(metrics_flusher)

--- a/serverless/src/main.rs
+++ b/serverless/src/main.rs
@@ -160,9 +160,8 @@ async fn start_dogstatsd(
             let metrics_flusher = Flusher::new(FlusherConfig {
                 api_key: dd_api_key,
                 aggregator: Arc::clone(&metrics_aggr),
-                metrics_intake_url_prefix: MetricsIntakeUrlPrefix::from_site_or_dd_urls(
+                metrics_intake_url_prefix: MetricsIntakeUrlPrefix::from_site_or_override(
                     Some(Site::new(dd_site).expect("Failed to parse site")),
-                    None,
                     None,
                 )
                 .expect("Failed to create intake URL prefix"),

--- a/serverless/src/main.rs
+++ b/serverless/src/main.rs
@@ -16,7 +16,8 @@ use dogstatsd::{
     aggregator::Aggregator as MetricsAggregator,
     constants::CONTEXTS,
     dogstatsd::{DogStatsD, DogStatsDConfig},
-    flusher::{build_fqdn_metrics, Flusher},
+    flusher::Flusher,
+    datadog::IntakeUrlPrefix,
 };
 
 use dogstatsd::metric::EMPTY_TAGS;
@@ -159,7 +160,7 @@ async fn start_dogstatsd(
             let metrics_flusher = Flusher::new(
                 dd_api_key,
                 Arc::clone(&metrics_aggr),
-                build_fqdn_metrics(dd_site),
+                IntakeUrlPrefix::from_site(dd_site),
                 https_proxy,
                 DOGSTATSD_TIMEOUT_DURATION,
             );

--- a/serverless/src/main.rs
+++ b/serverless/src/main.rs
@@ -17,7 +17,7 @@ use dogstatsd::{
     constants::CONTEXTS,
     datadog::IntakeUrlPrefix,
     dogstatsd::{DogStatsD, DogStatsDConfig},
-    flusher::Flusher,
+    flusher::{Flusher, FlusherConfig},
 };
 
 use dogstatsd::metric::EMPTY_TAGS;
@@ -157,13 +157,13 @@ async fn start_dogstatsd(
 
     let metrics_flusher = match dd_api_key {
         Some(dd_api_key) => {
-            let metrics_flusher = Flusher::new(
-                dd_api_key,
-                Arc::clone(&metrics_aggr),
-                IntakeUrlPrefix::from_site(dd_site),
-                https_proxy,
-                DOGSTATSD_TIMEOUT_DURATION,
-            );
+            let metrics_flusher = Flusher::new(FlusherConfig {
+                api_key: dd_api_key,
+                aggregator: Arc::clone(&metrics_aggr),
+                intake_url_prefix: IntakeUrlPrefix::from_site(dd_site),
+                https_proxy: https_proxy,
+                timeout: DOGSTATSD_TIMEOUT_DURATION,
+            });
             Some(metrics_flusher)
         }
         None => {

--- a/serverless/src/main.rs
+++ b/serverless/src/main.rs
@@ -161,7 +161,7 @@ async fn start_dogstatsd(
                 api_key: dd_api_key,
                 aggregator: Arc::clone(&metrics_aggr),
                 metrics_intake_url_prefix: MetricsIntakeUrlPrefix::from_site_or_dd_urls(
-                    Some(Site::new(dd_site)),
+                    Some(Site::new(dd_site).expect("Failed to parse site")),
                     None,
                     None,
                 )

--- a/serverless/src/main.rs
+++ b/serverless/src/main.rs
@@ -15,9 +15,9 @@ use datadog_trace_mini_agent::{
 use dogstatsd::{
     aggregator::Aggregator as MetricsAggregator,
     constants::CONTEXTS,
+    datadog::IntakeUrlPrefix,
     dogstatsd::{DogStatsD, DogStatsDConfig},
     flusher::Flusher,
-    datadog::IntakeUrlPrefix,
 };
 
 use dogstatsd::metric::EMPTY_TAGS;


### PR DESCRIPTION
# What does this PR do?

Adds structure to the dogstatsd `Flusher::new` api, including a better name for the old `site` parameter and a type for it.

# Motivation

The old `site` parameter for `Flusher::new` was misleading since it wasn't supposed to be the `DD_SITE` value but instead the URL prefix for that `DD_SITE`'s api for intake.

# How to test the change?

Ran the test suite.
