### PR TITLE
[Serverless Mini Agent] Bump datadog-serverless-trace-mini-agent version to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-serverless-trace-mini-agent"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "datadog-trace-mini-agent",
  "datadog-trace-protobuf",

--- a/serverless/Cargo.toml
+++ b/serverless/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datadog-serverless-trace-mini-agent"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
# What does this PR do?

Bumps datadog-serverless-trace-mini-agent version to 0.10.0.

# Motivation

Upcoming mini agent release

# Additional Notes


# How to test the change?

