### PR TITLE
Don't redact env tokens from debugger probe snapshots

### DIFF
--- a/live-debugger/src/redacted_names.rs
+++ b/live-debugger/src/redacted_names.rs
@@ -37,7 +37,6 @@ lazy_static! {
         b"dburl",
         b"encryptionkey",
         b"encryptionkeyid",
-        b"env",
         b"geolocation",
         b"gpgkey",
         b"ipaddress",


### PR DESCRIPTION
# What does this PR do?

Remove `env` from list of tokens to redact from Dynamic Instrumentation probe snapshots.

# Motivation

Feature parity

# Additional Notes

Depends on: https://github.com/DataDog/system-tests/pull/3827
