### PR TITLE
fix: support tag that are not key-value pairs

### DIFF
--- a/dogstatsd/src/metric.rs
+++ b/dogstatsd/src/metric.rs
@@ -263,7 +263,7 @@ pub fn id(name: Ustr, tags: &Option<SortedTags>) -> u64 {
     hasher.finish()
 }
 // <METRIC_NAME>:<VALUE>:<VALUE>:<VALUE>|<TYPE>|@<SAMPLE_RATE>|#<TAG_KEY_1>:<TAG_VALUE_1>,
-// <TAG_KEY_2>:<TAG_VALUE_2>,<TAG_NO_VALUE3|T<METRIC_TIMESTAMP>|c:<CONTAINER_ID>
+// <TAG_KEY_2>:<TAG_VALUE_2>,<TAG_NO_VALUE_3>|T<METRIC_TIMESTAMP>|c:<CONTAINER_ID>
 //
 // Types:
 //  * c -- COUNT, allows packed values, summed

--- a/dogstatsd/src/metric.rs
+++ b/dogstatsd/src/metric.rs
@@ -91,7 +91,11 @@ impl SortedTags {
             if v.is_empty() {
                 tags_as_chars.push(Chars::from(k.to_string()));
             } else {
-                tags_as_chars.push(format!("{}:{}", k, v).into());
+                let mut a_tag = String::with_capacity(k.len() + v.len() + 1);
+                a_tag.push_str(k);
+                a_tag.push(':');
+                a_tag.push_str(v);
+                tags_as_chars.push(a_tag.into());
             }
         }
         tags_as_chars
@@ -103,7 +107,11 @@ impl SortedTags {
             if v.is_empty() {
                 tags_as_vec.push(k.to_string());
             } else {
-                tags_as_vec.push(format!("{}:{}", k, v));
+                let mut a_tag = String::with_capacity(k.len() + v.len() + 1);
+                a_tag.push_str(k);
+                a_tag.push(':');
+                a_tag.push_str(v);
+                tags_as_vec.push(a_tag);
             }
         }
         tags_as_vec

--- a/dogstatsd/src/metric.rs
+++ b/dogstatsd/src/metric.rs
@@ -527,7 +527,7 @@ mod tests {
             .unwrap()
             .values
             .iter()
-            .any(|(k, v)| k == "v1.65.1" && v == ""));
+            .any(|(k, v)| k == "v1.65.1" && v.is_empty()));
     }
 
     #[test]

--- a/dogstatsd/src/metric.rs
+++ b/dogstatsd/src/metric.rs
@@ -511,7 +511,25 @@ mod tests {
 
     #[test]
     fn parse_tag_no_value() {
-        assert!(parse("datadog.tracer.flush_triggered:1|c|#lang:go,lang_version:go1.22.10,_dd.origin:lambda,runtime-id:d66f501c-d09b-4d0d-970f-515235c4eb56,v1.65.1,service:aws.lambda,reason:scheduled").is_ok());
+        let result = parse("datadog.tracer.flush_triggered:1|c|#lang:go,lang_version:go1.22.10,_dd.origin:lambda,runtime-id:d66f501c-d09b-4d0d-970f-515235c4eb56,v1.65.1,service:aws.lambda,reason:scheduled");
+        assert!(result.is_ok());
+        assert!(result
+            .unwrap()
+            .tags
+            .unwrap()
+            .values
+            .iter()
+            .any(|(k, v)| k == "v1.65.1" && v == ""));
+    }
+
+    #[test]
+    fn parse_tag_multi_column() {
+        let result = parse("datadog.tracer.flush_triggered:1|c|#lang:go:and:something:else");
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap().tags.unwrap().values[0],
+            (Ustr::from("lang"), Ustr::from("go:and:something:else"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
Allow tags that are not a pair key:value to be passed. Use an empty string as value and do not serialize a column with empty string in that case