### PR TITLE
Add a docker image that can be used for local linux dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 build/
 cmake-build-debug
 deliverables
+docker-linux-target
 target
 tmp
 __fuzz__

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Here's an example of using on of these scripts, placing the output inside `/opt/
 bash build-profiling-ffi.sh /opt/libdatadog
 ```
 
-#### Build Dependencies
+#### Build dependencies
 
 - Rust 1.78.0 or newer with cargo. See the Cargo.toml for information about bumping this version.
 - `cbindgen` 0.26
@@ -69,6 +69,25 @@ The simplest way to install [cargo-nextest][nt] is to use `cargo install` like t
 cargo install --locked 'cargo-nextest@0.9.85'
 ```
 
+#### Docker container
+A dockerfile is provided to run tests in a Ubuntu linux environment. This is particularly useful for running and debugging linux-only tests on macOS.
+
+To build the docker image, from the root directory of the libdatadog project run
+```bash
+docker build -f local-linux.Dockerfile -t libdatadog-linux .
+``` 
+
+To start the docker container, you can run
+```bash
+docker run -it --privileged -v "$(pwd)":/libdatadog -v cargo-cache:/home/user/.cargo libdatadog-linux
+```
+
+This will:
+1. Start the container in privileged mode to allow the container to run docker-in-docker, which is necessary for some integration tests.
+1. Mount the current directory (the root of the libdatadog workspace) into the container at `/libdatadog`.
+1. Mount a named volume `cargo-cache` to cache the cargo dependencies at ~/.cargo. This is helpful to avoid re-downloading dependencies every time you start the container, but isn't absolutely necessary.
+
+The `$CARGO_TARGET_DIR` environment variable is set to `/libdatadog/docker-linux-target` in the container, so cargo will use the target directory in the mounted volume to avoid conflicts with the host's default target directory of `libdatadog/target`.
 #### Skipping tracing integration tests
 
 Tracing integration tests require docker to be installed and running. If you don't have docker installed or you want to skip these tests, you can run:

--- a/local-linux.Dockerfile
+++ b/local-linux.Dockerfile
@@ -1,0 +1,52 @@
+# Note: This image is intended to be used for local development and testing and not for building release
+# artifacts or CI runners.
+FROM ubuntu:latest
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    gnupg \
+    lsb-release \
+    build-essential \
+    cmake \
+    protobuf-compiler \
+    docker.io \
+    sudo \
+    && rm -rf /var/lib/apt/lists/*
+
+# Docker-in-Docker configuration (necessary for integration tests)
+RUN mkdir -p /var/lib/docker
+EXPOSE 2375
+
+# allow non-root to write to the dockerd logs
+RUN mkdir -p /var/log/dockerd && \
+    chmod 777 /var/log/dockerd
+
+# Shell script that starts dockerd and switches to user. We need to start as root for docker-in-docker then
+# switch to a non-root user for tests.
+RUN echo '#!/usr/bin/env bash\n\
+dockerd --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2375 > /var/log/dockerd/dockerd.log 2>&1 &\n\
+exec su - user\n' \
+    > /usr/local/bin/start-dockerd.sh
+
+RUN chmod +x /usr/local/bin/start-dockerd.sh
+
+#create and use a non-root user. This is necessary for certain tests that expect the user to not be root.
+RUN useradd -m -u 1001 -g 1000 -s /bin/bash user
+RUN usermod -aG docker root
+RUN usermod -aG docker user
+
+WORKDIR /home/user
+
+# Install Rust toolchain for user in the usual ~/.cargo location
+# NOTE: Rust stable and nightly versions should be updated here whenever we bump the MSRV for libdatadog
+RUN su - user -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
+RUN su - user -c "cargo install --locked 'cargo-nextest@0.9.67'"
+RUN su - user -c "rustup install nightly-2024-12-16"
+RUN su - user -c "bash -lc 'rustup default 1.78.0'"
+
+# Use a different target to not interfere with the host which may be a different arch
+RUN echo 'export CARGO_TARGET_DIR=/libdatadog/docker-linux-target' >> /home/user/.bashrc
+
+CMD ["/usr/local/bin/start-dockerd.sh"]


### PR DESCRIPTION
# What does this PR do?

Add an ubuntu docker image that can be used for local development, testing, debugging of linux-only functionality on non-linux hosts. 

# Motivation

What inspired you to submit this pull request?

We plan on adding an integration test to `trace-utils` that is linux-only in a follow-up PR.  

Anything else we should know when reviewing?
As mentioned in the dockerfile this image is not intended to overlap or interfere with other images we maintain for CI or releasing. It's exists to reduce the feedback loop for debugging linux-only tests for those of us on macOS. 

# How to test the change?
The readme has been updated with instructions on how to use the image. 

