### PR TITLE
resources are only dd.internal.resource tags

### DIFF
--- a/dogstatsd/src/aggregator.rs
+++ b/dogstatsd/src/aggregator.rs
@@ -318,7 +318,7 @@ pub mod tests {
 
     const PRECISION: f64 = 0.000_000_01;
 
-    const SINGLE_METRIC_SIZE: usize = 216; // taken from the test, size of a serialized metric with one tag and 1 digit counter value
+    const SINGLE_METRIC_SIZE: usize = 193; // taken from the test, size of a serialized metric with one tag and 1 digit counter value
     const SINGLE_DISTRIBUTION_SIZE: u64 = 140;
     const DEFAULT_TAGS: &str =
         "dd_extension_version:63-next,architecture:x86_64,_dd.compute_stats:1";
@@ -663,7 +663,7 @@ pub mod tests {
     fn consume_metrics_batch_bytes() {
         let expected_metrics_per_batch = 2;
         let total_number_of_metrics = 5;
-        let two_metrics_size = 420;
+        let two_metrics_size = 374;
         let max_bytes = SINGLE_METRIC_SIZE * expected_metrics_per_batch + 13;
         let mut aggregator = Aggregator {
             tags: to_sorted_tags(),

--- a/dogstatsd/src/aggregator.rs
+++ b/dogstatsd/src/aggregator.rs
@@ -450,7 +450,7 @@ pub mod tests {
     fn to_series() {
         let mut aggregator = Aggregator::new(EMPTY_TAGS, 2).unwrap();
 
-        let metric1 = parse("test:1|c|#k:v").expect("metric parse failed");
+        let metric1 = parse("test:1|c|#k1:v1,k2:v2").expect("metric parse failed");
         let metric2 = parse("foo:1|c|#k:v").expect("metric parse failed");
         let metric3 = parse("bar:1|c|#k:v").expect("metric parse failed");
 
@@ -459,6 +459,7 @@ pub mod tests {
 
         assert_eq!(aggregator.map.len(), 2);
         assert_eq!(aggregator.to_series().len(), 2);
+        // to_series should not mutate the state
         assert_eq!(aggregator.map.len(), 2);
         assert_eq!(aggregator.to_series().len(), 2);
         assert_eq!(aggregator.map.len(), 2);

--- a/dogstatsd/src/datadog.rs
+++ b/dogstatsd/src/datadog.rs
@@ -242,10 +242,10 @@ pub(crate) struct Point {
 /// A named resource
 pub(crate) struct Resource {
     /// The name of this resource
-    pub(crate) name: &'static str,
+    pub(crate) name: String,
     #[serde(rename = "type")]
     /// The kind of this resource
-    pub(crate) kind: &'static str,
+    pub(crate) kind: String,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/dogstatsd/src/metric.rs
+++ b/dogstatsd/src/metric.rs
@@ -104,12 +104,18 @@ impl SortedTags {
 
     pub(crate) fn to_resources(&self) -> Vec<datadog::Resource> {
         let mut resources = Vec::with_capacity(constants::MAX_TAGS);
-        for (kind, name) in &self.values {
-            let resource = datadog::Resource {
-                name: name.as_str(), // val
-                kind: kind.as_str(), // key
-            };
-            resources.push(resource);
+        for (key, val) in &self.values {
+            if key == "dd.internal.resource" {
+                //anything coming in via dd.internal.resource:<value> has to be a key/value pair
+                // (e.g., dd.internal.resource:key:value)
+                if let Some(valid_name_kind) = val.split_once(':') {
+                    let resource = datadog::Resource {
+                        name: valid_name_kind.0.to_string(),
+                        kind: valid_name_kind.1.to_string(),
+                    };
+                    resources.push(resource);
+                }
+            }
         }
         resources
     }

--- a/dogstatsd/src/metric.rs
+++ b/dogstatsd/src/metric.rs
@@ -512,4 +512,15 @@ mod tests {
             panic!("Expected UnsupportedType error");
         }
     }
+
+    #[test]
+    fn sorting_tags() {
+        let mut tags = SortedTags::parse("z:z0,b:b2,c:c3").unwrap();
+        tags.extend(&SortedTags::parse("z1:z11,d:d4,e:e5,f:f6").unwrap());
+        tags.extend(&SortedTags::parse("a:a1").unwrap());
+        assert_eq!(tags.values.len(), 8);
+        let first_element = tags.values.first().unwrap();
+        assert_eq!(first_element.0, Ustr::from("a"));
+        assert_eq!(first_element.1, Ustr::from("a1"));
+    }
 }


### PR DESCRIPTION
avoid sending duplicates tags as resources when they are not prefixed with `dd.internal.resource`