### PR TITLE
Rename Mini Agent Version tag to Serverless Compat Version

### DIFF
--- a/serverless/src/main.rs
+++ b/serverless/src/main.rs
@@ -50,8 +50,8 @@ pub async fn main() {
         .ok();
     debug!("Starting serverless trace mini agent");
 
-    let mini_agent_version = env!("CARGO_PKG_VERSION").to_string();
-    env::set_var("DD_MINI_AGENT_VERSION", mini_agent_version);
+    let serverless_compat_version = env!("CARGO_PKG_VERSION").to_string();
+    env::set_var("DD_SERVERLESS_COMPAT_VERSION", serverless_compat_version);
 
     let env_filter = format!("h2=off,hyper=off,rustls=off,{}", log_level);
 

--- a/trace-utils/src/test_utils/mod.rs
+++ b/trace-utils/src/test_utils/mod.rs
@@ -153,6 +153,10 @@ pub fn create_test_gcp_span(
         "dummy_version".to_string(),
     );
     span.meta.insert(
+        "_dd.serverless_compat_version".to_string(),
+        "dummy_version".to_string(),
+    );
+    span.meta.insert(
         "gcrfx.project_id".to_string(),
         "dummy_project_id".to_string(),
     );
@@ -203,6 +207,7 @@ pub fn create_test_gcp_json_span(
                 "runtime-id": "test-runtime-id-value",
                 "gcrfx.project_id": "dummy_project_id",
                 "_dd.mini_agent_version": "dummy_version",
+                "_dd.serverless_compat_version": "dummy_version",
                 "gcrfx.resource_name": "projects/dummy_project_id/locations/dummy_region_west/functions/dummy_function_name",
                 "gcrfx.location": "dummy_region_west"
             },

--- a/trace-utils/src/test_utils/mod.rs
+++ b/trace-utils/src/test_utils/mod.rs
@@ -149,10 +149,6 @@ pub fn create_test_gcp_span(
         span_links: vec![],
     };
     span.meta.insert(
-        "_dd.mini_agent_version".to_string(),
-        "dummy_version".to_string(),
-    );
-    span.meta.insert(
         "_dd.serverless_compat_version".to_string(),
         "dummy_version".to_string(),
     );
@@ -206,7 +202,6 @@ pub fn create_test_gcp_json_span(
                 "env": "test-env",
                 "runtime-id": "test-runtime-id-value",
                 "gcrfx.project_id": "dummy_project_id",
-                "_dd.mini_agent_version": "dummy_version",
                 "_dd.serverless_compat_version": "dummy_version",
                 "gcrfx.resource_name": "projects/dummy_project_id/locations/dummy_region_west/functions/dummy_function_name",
                 "gcrfx.location": "dummy_region_west"

--- a/trace-utils/src/trace_utils.rs
+++ b/trace-utils/src/trace_utils.rs
@@ -490,7 +490,7 @@ impl Default for MiniAgentMetadata {
             azure_spring_app_name: Default::default(),
             gcp_project_id: Default::default(),
             gcp_region: Default::default(),
-            version: env::var("DD_MINI_AGENT_VERSION").ok(),
+            version: env::var("DD_SERVERLESS_COMPAT_VERSION").ok(),
         }
     }
 }
@@ -509,10 +509,14 @@ pub fn enrich_span_with_mini_agent_metadata(
         span.meta
             .insert("asa.name".to_string(), azure_spring_app_name.to_string());
     }
-    if let Some(mini_agent_version) = &mini_agent_metadata.version {
+    if let Some(serverless_compat_version) = &mini_agent_metadata.version {
         span.meta.insert(
             "_dd.mini_agent_version".to_string(),
-            mini_agent_version.to_string(),
+            serverless_compat_version.to_string(),
+        );
+        span.meta.insert(
+            "_dd.serverless_compat_version".to_string(),
+            serverless_compat_version.to_string(),
         );
     }
 }

--- a/trace-utils/src/trace_utils.rs
+++ b/trace-utils/src/trace_utils.rs
@@ -511,10 +511,6 @@ pub fn enrich_span_with_mini_agent_metadata(
     }
     if let Some(serverless_compat_version) = &mini_agent_metadata.version {
         span.meta.insert(
-            "_dd.mini_agent_version".to_string(),
-            serverless_compat_version.to_string(),
-        );
-        span.meta.insert(
             "_dd.serverless_compat_version".to_string(),
             serverless_compat_version.to_string(),
         );


### PR DESCRIPTION
# What does this PR do?

Renames `_dd.mini_agent_version` tag to `_dd.serverless_compat_version`.

# Motivation

Moving away from calling this solution the "Serverless Mini Agent" to calling it the "Serverless Compatibility Layer" instead.

https://datadoghq.atlassian.net/browse/SVLS-6117

# Additional Notes

# How to test the change?

https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/2977497119/Serverless+Mini+Agent#Testing
