### PR TITLE
Prepare 15.0.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "build_common"
-version = "14.3.1"
+version = "15.0.0"
 dependencies = [
  "cbindgen",
  "serde",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "builder"
-version = "14.3.1"
+version = "15.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "data-pipeline"
-version = "14.3.1"
+version = "15.0.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1321,7 +1321,7 @@ dependencies = [
 
 [[package]]
 name = "data-pipeline-ffi"
-version = "14.3.1"
+version = "15.0.0"
 dependencies = [
  "build_common",
  "data-pipeline",
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-alloc"
-version = "14.3.1"
+version = "15.0.0"
 dependencies = [
  "allocator-api2",
  "bolero",
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-crashtracker"
-version = "14.3.1"
+version = "15.0.0"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -1370,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-crashtracker-ffi"
-version = "14.3.1"
+version = "15.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1386,7 +1386,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-ddsketch"
-version = "14.3.1"
+version = "15.0.0"
 dependencies = [
  "prost 0.11.9",
  "prost-build 0.11.9",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling"
-version = "14.3.1"
+version = "15.0.0"
 dependencies = [
  "anyhow",
  "bitmaps",
@@ -1540,7 +1540,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-ffi"
-version = "14.3.1"
+version = "15.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1563,7 +1563,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-replayer"
-version = "14.3.1"
+version = "15.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1724,7 +1724,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-mini-agent"
-version = "14.3.1"
+version = "15.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1746,7 +1746,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-normalization"
-version = "14.3.1"
+version = "15.0.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-obfuscation"
-version = "14.3.1"
+version = "15.0.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1775,7 +1775,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-protobuf"
-version = "14.3.1"
+version = "15.0.0"
 dependencies = [
  "prost 0.11.9",
  "prost-build 0.11.9",
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-utils"
-version = "14.3.1"
+version = "15.0.0"
 dependencies = [
  "anyhow",
  "bolero",
@@ -1822,7 +1822,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon"
-version = "14.3.1"
+version = "15.0.0"
 dependencies = [
  "anyhow",
  "cc",
@@ -1852,7 +1852,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon-ffi"
-version = "14.3.1"
+version = "15.0.0"
 dependencies = [
  "anyhow",
  "bolero",
@@ -1877,7 +1877,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry"
-version = "14.3.1"
+version = "15.0.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1903,7 +1903,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry-ffi"
-version = "14.3.1"
+version = "15.0.0"
 dependencies = [
  "build_common",
  "ddcommon",
@@ -2047,7 +2047,7 @@ dependencies = [
 
 [[package]]
 name = "dogstatsd"
-version = "14.3.1"
+version = "15.0.0"
 dependencies = [
  "datadog-protos",
  "ddsketch-agent",
@@ -2072,7 +2072,7 @@ dependencies = [
 
 [[package]]
 name = "dogstatsd-client"
-version = "14.3.1"
+version = "15.0.0"
 dependencies = [
  "anyhow",
  "cadence",
@@ -5339,7 +5339,7 @@ dependencies = [
 
 [[package]]
 name = "symbolizer-ffi"
-version = "14.3.1"
+version = "15.0.0"
 dependencies = [
  "blazesym-c",
  "build_common",
@@ -5665,7 +5665,7 @@ dependencies = [
 
 [[package]]
 name = "tinybytes"
-version = "14.3.1"
+version = "15.0.0"
 dependencies = [
  "once_cell",
  "pretty_assertions",
@@ -5937,7 +5937,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "14.3.1"
+version = "15.0.0"
 dependencies = [
  "lazy_static",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.78.0"
 edition = "2021"
-version = "14.3.1"
+version = "15.0.0"
 license = "Apache-2.0"
 
 [profile.dev]

--- a/build-profiling-ffi.sh
+++ b/build-profiling-ffi.sh
@@ -143,6 +143,7 @@ FEATURES=(
     "data-pipeline-ffi"
     "datadog-profiling-ffi/ddtelemetry-ffi"
     "datadog-profiling-ffi/demangler"
+    "datadog-library-config-ffi"
 )
 if [[ "$symbolizer" -eq 1 ]]; then
     FEATURES+=("symbolizer")
@@ -227,10 +228,10 @@ echo "Generating $destdir/include/libdatadog headers..."
 rm -r $destdir/include/datadog/
 mkdir $destdir/include/datadog/
 
-CBINDGEN_HEADERS="common.h profiling.h telemetry.h crashtracker.h data-pipeline.h"
+CBINDGEN_HEADERS="common.h profiling.h telemetry.h crashtracker.h data-pipeline.h library-config.h"
 # When optional features are added, don't forget to also include the headers here
 case $ARG_FEATURES in
-    datadog-library-config-ffi) CBINDGEN_HEADERS="$CBINDGEN_HEADERS library-config.h"
+    # datadog-library-config-ffi) CBINDGEN_HEADERS="$CBINDGEN_HEADERS library-config.h"
 esac
 
 CBINDGEN_HEADERS_DESTS=""

--- a/build-profiling-ffi.sh
+++ b/build-profiling-ffi.sh
@@ -231,7 +231,6 @@ mkdir $destdir/include/datadog/
 CBINDGEN_HEADERS="common.h profiling.h telemetry.h crashtracker.h data-pipeline.h library-config.h"
 # When optional features are added, don't forget to also include the headers here
 case $ARG_FEATURES in
-    # datadog-library-config-ffi) CBINDGEN_HEADERS="$CBINDGEN_HEADERS library-config.h"
 esac
 
 CBINDGEN_HEADERS_DESTS=""


### PR DESCRIPTION
# What does this PR do?

* Bump workspace version to 15.0.0
* Build configuration-ffi by default with the profiling artifacts so we can distribute it in the next release

# Motivation

The major version increase is necessary because of some breaking changes in the crashtracker APIs.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
