### PR TITLE
[crashtracker] Receiver speaks RFC5

### DIFF
--- a/bin_tests/src/bin/crashtracker_bin_test.rs
+++ b/bin_tests/src/bin/crashtracker_bin_test.rs
@@ -17,7 +17,7 @@ mod unix {
     use std::path::Path;
 
     use datadog_crashtracker::{
-        self as crashtracker, CrashtrackerConfiguration, CrashtrackerMetadata,
+        self as crashtracker, rfc5_crash_info::Metadata, CrashtrackerConfiguration,
         CrashtrackerReceiverConfig,
     };
     use ddcommon::{tag, Endpoint};
@@ -60,7 +60,7 @@ mod unix {
             unix_socket_path: Some("".to_string()),
         };
 
-        let metadata = CrashtrackerMetadata {
+        let metadata = Metadata {
             library_name: "libdatadog".to_owned(),
             library_version: "1.0.0".to_owned(),
             family: "native".to_owned(),
@@ -69,7 +69,10 @@ mod unix {
                 tag!("service_version", "bar"),
                 tag!("runtime-id", "xyz"),
                 tag!("language", "native"),
-            ],
+            ]
+            .into_iter()
+            .map(|x| x.to_string())
+            .collect(),
         };
 
         // Set the behavior of the test, run setup, and do the pre-init test

--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -125,7 +125,7 @@ fn test_crash_tracking_bin(crash_tracking_receiver_profile: BuildProfile, mode: 
             "si_code": 1,
             "si_code_human_readable": "UNKNOWN",
             "si_signo": 11,
-            "si_signo_human_readable": "SIGSEGV"
+            "si_signo_human_readable": "SIGSEGV",
         }),
         crash_payload["sig_info"]
     );
@@ -185,8 +185,8 @@ fn assert_telemetry_message(crash_telemetry: &[u8]) {
             "si_addr:0x0000000000000000",
             "si_code_human_readable:UNKNOWN",
             "si_code:1",
-            "si_signo_human_readable:UNKNOWN",
-            "si_signo:1",
+            "si_signo_human_readable:SIGSEGV",
+            "si_signo:11",
         ]),
         tags
     );

--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -125,7 +125,7 @@ fn test_crash_tracking_bin(crash_tracking_receiver_profile: BuildProfile, mode: 
           "signame": "SIGSEGV",
           "faulting_address": 0,
         }),
-        crash_payload["siginfo"]
+        crash_payload["sig_info"]
     );
 
     let crash_telemetry = fs::read(fixtures.crash_telemetry_path)

--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -121,9 +121,11 @@ fn test_crash_tracking_bin(crash_tracking_receiver_profile: BuildProfile, mode: 
     );
     assert_eq!(
         serde_json::json!({
-          "signum": 11,
-          "signame": "SIGSEGV",
-          "faulting_address": 0,
+            "si_addr": "0x0000000000000000",
+            "si_code": 1,
+            "si_code_human_readable": "UNKNOWN",
+            "si_signo": 11,
+            "si_signo_human_readable": "SIGSEGV"
         }),
         crash_payload["sig_info"]
     );

--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -185,7 +185,8 @@ fn assert_telemetry_message(crash_telemetry: &[u8]) {
         .split(',')
         .filter(|t| !t.starts_with("uuid:"))
         .collect::<std::collections::HashSet<_>>();
-    assert_eq!(
+    // As above, ARM OSX can have a si_code of 2.
+    assert!(
         std::collections::HashSet::from_iter([
             "data_schema_version:1.0",
             "incomplete:false",
@@ -199,8 +200,21 @@ fn assert_telemetry_message(crash_telemetry: &[u8]) {
             "si_code:1",
             "si_signo_human_readable:SIGSEGV",
             "si_signo:11",
-        ]),
-        tags
+        ]) == tags
+            || std::collections::HashSet::from_iter([
+                "data_schema_version:1.0",
+                "incomplete:false",
+                "is_crash:true",
+                "profiler_collecting_sample:1",
+                "profiler_inactive:0",
+                "profiler_serializing:0",
+                "profiler_unwinding:0",
+                "si_addr:0x0000000000000000",
+                "si_code_human_readable:UNKNOWN",
+                "si_code:2",
+                "si_signo_human_readable:SIGSEGV",
+                "si_signo:11",
+            ]) == tags
     );
     assert_eq!(telemetry_payload["payload"][0]["is_sensitive"], true);
 }

--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -175,13 +175,18 @@ fn assert_telemetry_message(crash_telemetry: &[u8]) {
         .collect::<std::collections::HashSet<_>>();
     assert_eq!(
         std::collections::HashSet::from_iter([
-            "signum:11",
-            "profiler_unwinding:0",
+            "data_schema_version:1.0",
+            "incomplete:false",
+            "is_crash:true",
             "profiler_collecting_sample:1",
             "profiler_inactive:0",
             "profiler_serializing:0",
-            "signame:SIGSEGV",
-            "faulting_address:0x0000000000000000",
+            "profiler_unwinding:0",
+            "si_addr:0x0000000000000000",
+            "si_code_human_readable:UNKNOWN",
+            "si_code:1",
+            "si_signo_human_readable:UNKNOWN",
+            "si_signo:1",
         ]),
         tags
     );

--- a/crashtracker-ffi/src/crash_info/builder.rs
+++ b/crashtracker-ffi/src/crash_info/builder.rs
@@ -176,11 +176,12 @@ pub unsafe extern "C" fn ddog_crasht_CrashInfoBuilder_with_incomplete(
 pub unsafe extern "C" fn ddog_crasht_CrashInfoBuilder_with_log_message(
     mut builder: *mut Handle<CrashInfoBuilder>,
     message: CharSlice,
+    also_print: bool,
 ) -> VoidResult {
     wrap_with_void_ffi_result!({
         builder
             .to_inner_mut()?
-            .with_log_message(message.try_to_string()?)?;
+            .with_log_message(message.try_to_string()?, also_print)?;
     })
 }
 

--- a/crashtracker-ffi/src/crash_info/metadata.rs
+++ b/crashtracker-ffi/src/crash_info/metadata.rs
@@ -32,22 +32,3 @@ impl<'a> TryFrom<Metadata<'a>> for datadog_crashtracker::rfc5_crash_info::Metada
         })
     }
 }
-
-impl<'a> TryFrom<Metadata<'a>> for datadog_crashtracker::CrashtrackerMetadata {
-    type Error = anyhow::Error;
-    fn try_from(value: Metadata<'a>) -> anyhow::Result<Self> {
-        let library_name = value.library_name.try_to_string()?;
-        let library_version = value.library_version.try_to_string()?;
-        let family = value.family.try_to_string()?;
-        let tags = value
-            .tags
-            .map(|tags| tags.iter().cloned().collect())
-            .unwrap_or_default();
-        Ok(Self {
-            library_name,
-            library_version,
-            family,
-            tags,
-        })
-    }
-}

--- a/crashtracker/src/collector/api.rs
+++ b/crashtracker/src/collector/api.rs
@@ -5,8 +5,8 @@
 use crate::{
     clear_spans, clear_traces,
     collector::crash_handler::{configure_receiver, register_crash_handlers, restore_old_handlers},
-    crash_info::CrashtrackerMetadata,
     reset_counters,
+    rfc5_crash_info::Metadata,
     shared::configuration::CrashtrackerReceiverConfig,
     update_config, update_metadata, CrashtrackerConfiguration,
 };
@@ -48,7 +48,7 @@ pub fn shutdown_crash_handler() -> anyhow::Result<()> {
 pub fn on_fork(
     config: CrashtrackerConfiguration,
     receiver_config: CrashtrackerReceiverConfig,
-    metadata: CrashtrackerMetadata,
+    metadata: Metadata,
 ) -> anyhow::Result<()> {
     clear_spans()?;
     clear_traces()?;
@@ -77,7 +77,7 @@ pub fn on_fork(
 pub fn init(
     config: CrashtrackerConfiguration,
     receiver_config: CrashtrackerReceiverConfig,
-    metadata: CrashtrackerMetadata,
+    metadata: Metadata,
 ) -> anyhow::Result<()> {
     update_metadata(metadata)?;
     update_config(config)?;
@@ -131,7 +131,7 @@ fn test_crash() -> anyhow::Result<()> {
         timeout_ms,
         None,
     )?;
-    let metadata = CrashtrackerMetadata::new(
+    let metadata = Metadata::new(
         "libname".to_string(),
         "version".to_string(),
         "family".to_string(),
@@ -145,11 +145,11 @@ fn test_crash() -> anyhow::Result<()> {
     super::insert_trace(99399939399939393993)?;
 
     let tag = tag!("apple", "banana");
-    let metadata2 = CrashtrackerMetadata::new(
+    let metadata2 = Metadata::new(
         "libname".to_string(),
         "version".to_string(),
         "family".to_string(),
-        vec![tag],
+        vec![tag.to_string()],
     );
     update_metadata(metadata2).expect("metadata");
 

--- a/crashtracker/src/collector/api.rs
+++ b/crashtracker/src/collector/api.rs
@@ -256,7 +256,7 @@ fn test_altstack_use_create() -> anyhow::Result<()> {
         timeout_ms,
         None,
     )?;
-    let metadata = CrashtrackerMetadata::new(
+    let metadata = Metadata::new(
         "libname".to_string(),
         "version".to_string(),
         "family".to_string(),
@@ -383,7 +383,7 @@ fn test_altstack_use_nocreate() -> anyhow::Result<()> {
         timeout_ms,
         None,
     )?;
-    let metadata = CrashtrackerMetadata::new(
+    let metadata = Metadata::new(
         "libname".to_string(),
         "version".to_string(),
         "family".to_string(),
@@ -510,7 +510,7 @@ fn test_altstack_nouse() -> anyhow::Result<()> {
         timeout_ms,
         None,
     )?;
-    let metadata = CrashtrackerMetadata::new(
+    let metadata = Metadata::new(
         "libname".to_string(),
         "version".to_string(),
         "family".to_string(),
@@ -673,7 +673,7 @@ fn test_waitall_nohang() -> anyhow::Result<()> {
         None,
     )?;
 
-    let metadata = CrashtrackerMetadata::new(
+    let metadata = Metadata::new(
         "libname".to_string(),
         "version".to_string(),
         "family".to_string(),

--- a/crashtracker/src/collector/counters.rs
+++ b/crashtracker/src/collector/counters.rs
@@ -101,6 +101,7 @@ pub fn emit_counters(w: &mut impl Write) -> anyhow::Result<()> {
         writeln!(w, "{{\"{}\": {}}}", OpTypes::name(i)?, c.load(SeqCst))?;
     }
     writeln!(w, "{DD_CRASHTRACK_END_COUNTERS}")?;
+    w.flush()?;
     Ok(())
 }
 

--- a/crashtracker/src/collector/crash_handler.rs
+++ b/crashtracker/src/collector/crash_handler.rs
@@ -6,7 +6,7 @@
 
 use super::emitters::emit_crashreport;
 use super::saguard::SaGuard;
-use crate::crash_info::CrashtrackerMetadata;
+use crate::rfc5_crash_info::Metadata;
 use crate::shared::configuration::{CrashtrackerConfiguration, CrashtrackerReceiverConfig};
 use crate::shared::constants::*;
 use anyhow::Context;
@@ -256,7 +256,7 @@ fn wait_for_pollhup(target_fd: RawFd, timeout_ms: i32) -> anyhow::Result<bool> {
 // `Box::from_raw` to recreate the box, then dropping it.
 static ALTSTACK_INIT: AtomicBool = AtomicBool::new(false);
 static OLD_HANDLERS: AtomicPtr<OldHandlers> = AtomicPtr::new(ptr::null_mut());
-static METADATA: AtomicPtr<(CrashtrackerMetadata, String)> = AtomicPtr::new(ptr::null_mut());
+static METADATA: AtomicPtr<(Metadata, String)> = AtomicPtr::new(ptr::null_mut());
 static CONFIG: AtomicPtr<(CrashtrackerConfiguration, String)> = AtomicPtr::new(ptr::null_mut());
 static RECEIVER_CONFIG: AtomicPtr<CrashtrackerReceiverConfig> = AtomicPtr::new(ptr::null_mut());
 static RECEIVER_ARGS: AtomicPtr<PreparedExecve> = AtomicPtr::new(ptr::null_mut());
@@ -316,7 +316,7 @@ fn make_receiver(config: &CrashtrackerReceiverConfig) -> anyhow::Result<Receiver
 ///     No other crash-handler functions should be called concurrently.
 /// ATOMICITY:
 ///     This function uses a swap on an atomic pointer.
-pub fn update_metadata(metadata: CrashtrackerMetadata) -> anyhow::Result<()> {
+pub fn update_metadata(metadata: Metadata) -> anyhow::Result<()> {
     let metadata_string = serde_json::to_string(&metadata)?;
     let box_ptr = Box::into_raw(Box::new((metadata, metadata_string)));
     let old = METADATA.swap(box_ptr, SeqCst);
@@ -390,7 +390,7 @@ pub fn configure_receiver(config: CrashtrackerReceiverConfig) {
 extern "C" fn handle_posix_sigaction(signum: i32, sig_info: *mut siginfo_t, ucontext: *mut c_void) {
     // Handle the signal.  Note this has a guard to ensure that we only generate
     // one crash report per process.
-    let _ = handle_posix_signal_impl(signum, sig_info);
+    let _ = handle_posix_signal_impl(sig_info);
 
     // Once we've handled the signal, chain to any previous handlers.
     // SAFETY: This was created by [register_crash_handlers].  There is a tiny
@@ -496,7 +496,7 @@ fn receiver_finish(receiver: Receiver, start_time: Instant, timeout_ms: u32) {
     }
 }
 
-fn handle_posix_signal_impl(signum: i32, sig_info: *mut siginfo_t) -> anyhow::Result<()> {
+fn handle_posix_signal_impl(sig_info: *mut siginfo_t) -> anyhow::Result<()> {
     // If this is a SIGSEGV signal, it could be called due to a stack overflow. In that case, since
     // this signal allocates to the stack and cannot guarantee it is running without SA_NODEFER, it
     // is possible that we will re-emit the signal. Contemporary unices handle this just fine (no
@@ -538,14 +538,6 @@ fn handle_posix_signal_impl(signum: i32, sig_info: *mut siginfo_t) -> anyhow::Re
     let timeout_ms = config.timeout_ms;
     let start_time = Instant::now(); // This is the time at which the signal was received
 
-    // Derive the faulting address from `sig_info`
-    let faulting_address: Option<usize> =
-        if !sig_info.is_null() && (signum == libc::SIGSEGV || signum == libc::SIGBUS) {
-            unsafe { Some((*sig_info).si_addr() as usize) }
-        } else {
-            None
-        };
-
     // During the execution of this signal handler, block ALL other signals, especially because we
     // cannot control whether or not we run with SA_NODEFER (crashtracker might have been chained).
     // The especially problematic signals are SIGCHLD and SIGPIPE, which are possibly delivered due
@@ -581,8 +573,7 @@ fn handle_posix_signal_impl(signum: i32, sig_info: *mut siginfo_t) -> anyhow::Re
         config,
         config_str,
         metadata_string,
-        signum,
-        faulting_address,
+        sig_info,
     );
 
     let _ = unix_stream.flush();

--- a/crashtracker/src/collector/emitters.rs
+++ b/crashtracker/src/collector/emitters.rs
@@ -92,7 +92,6 @@ pub(crate) fn emit_crashreport(
     emit_config(pipe, config_str)?;
     emit_siginfo(pipe, sig_info)?;
     emit_procinfo(pipe)?;
-    pipe.flush()?;
     emit_counters(pipe)?;
     emit_spans(pipe)?;
     emit_traces(pipe)?;

--- a/crashtracker/src/collector/emitters.rs
+++ b/crashtracker/src/collector/emitters.rs
@@ -8,6 +8,8 @@ use crate::shared::constants::*;
 use crate::CrashtrackerConfiguration;
 use crate::StacktraceCollection;
 use anyhow::Context;
+use backtrace::Frame;
+use libc::siginfo_t;
 use std::{
     fs::File,
     io::{Read, Write},
@@ -31,67 +33,51 @@ unsafe fn emit_backtrace_by_frames(
 ) -> anyhow::Result<()> {
     // https://docs.rs/backtrace/latest/backtrace/index.html
     writeln!(w, "{DD_CRASHTRACK_BEGIN_STACKTRACE}")?;
-    backtrace::trace_unsynchronized(|frame| {
-        // Write the values we can get without resolving, since these seem to
-        // be crash safe in my experiments.
-        write!(w, "{{").unwrap();
-        write!(w, "\"ip\": \"{:?}\", ", frame.ip()).unwrap();
+
+    // Absolute addresses appear to be safer to collect during a crash than debug info.
+    fn emit_absolute_addresses(w: &mut impl Write, frame: &Frame) -> anyhow::Result<()> {
+        write!(w, "\"ip\": \"{:?}\"", frame.ip())?;
         if let Some(module_base_address) = frame.module_base_address() {
-            write!(w, "\"module_base_address\": \"{module_base_address:?}\", ",).unwrap();
+            write!(w, ", \"module_base_address\": \"{module_base_address:?}\"",)?;
         }
-        write!(w, "\"sp\": \"{:?}\", ", frame.sp()).unwrap();
-        write!(w, "\"symbol_address\": \"{:?}\"", frame.symbol_address()).unwrap();
+        write!(w, ", \"sp\": \"{:?}\"", frame.sp())?;
+        write!(w, ", \"symbol_address\": \"{:?}\"", frame.symbol_address())?;
+        Ok(())
+    }
+
+    backtrace::trace_unsynchronized(|frame| {
         if resolve_frames == StacktraceCollection::EnabledWithInprocessSymbols {
-            write!(w, ", \"names\": [").unwrap();
-
-            let mut first = true;
-            // This can give multiple answers in the case of inlined functions
-            // https://docs.rs/backtrace/latest/backtrace/fn.resolve.html
-            // Store them all into an array of names
-            unsafe {
-                backtrace::resolve_frame_unsynchronized(frame, |symbol| {
-                    if !first {
-                        write!(w, ", ").unwrap();
-                    }
-                    write!(w, "{{").unwrap();
-                    let mut comma_needed = false;
-                    if let Some(name) = symbol.name() {
-                        write!(w, "\"name\": \"{}\"", name).unwrap();
-                        comma_needed = true;
-                    }
-                    if let Some(filename) = symbol.filename() {
-                        if comma_needed {
-                            write!(w, ", ").unwrap();
-                        }
-                        write!(w, "\"filename\": {:?}", filename).unwrap();
-                        comma_needed = true;
-                    }
-                    if let Some(colno) = symbol.colno() {
-                        if comma_needed {
-                            write!(w, ", ").unwrap();
-                        }
-                        write!(w, "\"colno\": {}", colno).unwrap();
-                        comma_needed = true;
-                    }
-
-                    if let Some(lineno) = symbol.lineno() {
-                        if comma_needed {
-                            write!(w, ", ").unwrap();
-                        }
-                        write!(w, "\"lineno\": {}", lineno).unwrap();
-                    }
-
-                    write!(w, "}}").unwrap();
-
-                    first = false;
-                });
-            }
-            write!(w, "]").unwrap();
+            backtrace::resolve_frame_unsynchronized(frame, |symbol| {
+                write!(w, "{{").unwrap();
+                emit_absolute_addresses(w, frame).unwrap();
+                if let Some(column) = symbol.colno() {
+                    write!(w, ", \"column\": {column}").unwrap();
+                }
+                if let Some(file) = symbol.filename() {
+                    // The debug printer for path already wraps it in `"` marks.
+                    write!(w, ", \"file\": {file:?}").unwrap();
+                }
+                if let Some(function) = symbol.name() {
+                    write!(w, ", \"function\": \"{function}\"").unwrap();
+                }
+                if let Some(line) = symbol.lineno() {
+                    write!(w, ", \"line\": {line}").unwrap();
+                }
+                writeln!(w, "}}").unwrap();
+                // Flush eagerly to ensure that each frame gets emitted even if the next one fails
+                w.flush().unwrap();
+            });
+        } else {
+            write!(w, "{{").unwrap();
+            emit_absolute_addresses(w, frame).unwrap();
+            writeln!(w, "}}").unwrap();
+            // Flush eagerly to ensure that each frame gets emitted even if the next one fails
+            w.flush().unwrap();
         }
-        writeln!(w, "}}").unwrap();
         true // keep going to the next frame
     });
     writeln!(w, "{DD_CRASHTRACK_END_STACKTRACE}").unwrap();
+    w.flush()?;
     Ok(())
 }
 
@@ -100,20 +86,16 @@ pub(crate) fn emit_crashreport(
     config: &CrashtrackerConfiguration,
     config_str: &str,
     metadata_string: &str,
-    signum: i32,
-    faulting_address: Option<usize>,
+    sig_info: *mut siginfo_t,
 ) -> anyhow::Result<()> {
     emit_metadata(pipe, metadata_string)?;
     emit_config(pipe, config_str)?;
-    emit_siginfo(pipe, signum, faulting_address)?;
+    emit_siginfo(pipe, sig_info)?;
     emit_procinfo(pipe)?;
     pipe.flush()?;
     emit_counters(pipe)?;
-    pipe.flush()?;
     emit_spans(pipe)?;
-    pipe.flush()?;
     emit_traces(pipe)?;
-    pipe.flush()?;
 
     #[cfg(target_os = "linux")]
     emit_proc_self_maps(pipe)?;
@@ -137,6 +119,7 @@ fn emit_config(w: &mut impl Write, config_str: &str) -> anyhow::Result<()> {
     writeln!(w, "{DD_CRASHTRACK_BEGIN_CONFIG}")?;
     writeln!(w, "{}", config_str)?;
     writeln!(w, "{DD_CRASHTRACK_END_CONFIG}")?;
+    w.flush()?;
     Ok(())
 }
 
@@ -144,6 +127,7 @@ fn emit_metadata(w: &mut impl Write, metadata_str: &str) -> anyhow::Result<()> {
     writeln!(w, "{DD_CRASHTRACK_BEGIN_METADATA}")?;
     writeln!(w, "{}", metadata_str)?;
     writeln!(w, "{DD_CRASHTRACK_END_METADATA}")?;
+    w.flush()?;
     Ok(())
 }
 
@@ -152,6 +136,7 @@ fn emit_procinfo(w: &mut impl Write) -> anyhow::Result<()> {
     let pid = nix::unistd::getpid();
     writeln!(w, "{{\"pid\": {pid} }}")?;
     writeln!(w, "{DD_CRASHTRACK_END_PROCINFO}")?;
+    w.flush()?;
     Ok(())
 }
 
@@ -164,29 +149,47 @@ fn emit_proc_self_maps(w: &mut impl Write) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn emit_siginfo(
-    w: &mut impl Write,
-    signum: i32,
-    faulting_address: Option<usize>,
-) -> anyhow::Result<()> {
-    let signame = if signum == libc::SIGSEGV {
-        "SIGSEGV"
-    } else if signum == libc::SIGBUS {
-        "SIGBUS"
-    } else {
-        "UNKNOWN"
+fn emit_siginfo(w: &mut impl Write, sig_info: *mut siginfo_t) -> anyhow::Result<()> {
+    anyhow::ensure!(!sig_info.is_null());
+
+    let si_signo = unsafe { (*sig_info).si_signo };
+    let si_signo_human_readable = match si_signo {
+        libc::SIGABRT => "SIGABRT",
+        libc::SIGBUS => "SIGBUS",
+        libc::SIGSEGV => "SIGSEGV",
+        libc::SIGSYS => "SIGSYS",
+        _ => "UNKNOWN",
     };
 
-    writeln!(w, "{DD_CRASHTRACK_BEGIN_SIGINFO}")?;
-    if let Some(addr) = faulting_address {
-        writeln!(
-            w,
-            "{{\"signum\": {signum}, \"signame\": \"{signame}\", \"faulting_address\": {addr}}}"
-        )?;
+    // Derive the faulting address from `sig_info`
+    let si_addr: Option<usize> = if si_signo == libc::SIGSEGV || si_signo == libc::SIGBUS {
+        unsafe { Some((*sig_info).si_addr() as usize) }
     } else {
-        writeln!(w, "{{\"signum\": {signum}, \"signame\": \"{signame}\"}}")?;
+        None
     };
+
+    let si_code = unsafe { (*sig_info).si_code };
+    // TODO
+    let si_code_human_readable = "UNKNOWN";
+
+    writeln!(w, "{DD_CRASHTRACK_BEGIN_SIGINFO}")?;
+    write!(w, "{{")?;
+    write!(w, "\"si_code\": {si_code}")?;
+    write!(
+        w,
+        ", \"si_code_human_readable\": \"{si_code_human_readable}\""
+    )?;
+    write!(w, ", \"si_signo\": {si_signo}")?;
+    write!(
+        w,
+        ", \"si_signo_human_readable\": \"{si_signo_human_readable}\""
+    )?;
+    if let Some(si_addr) = si_addr {
+        write!(w, ", \"si_addr\": \"{si_addr:#018x}\"")?;
+    }
+    writeln!(w, "}}")?;
     writeln!(w, "{DD_CRASHTRACK_END_SIGINFO}")?;
+    w.flush()?;
     Ok(())
 }
 

--- a/crashtracker/src/collector/spans.rs
+++ b/crashtracker/src/collector/spans.rs
@@ -19,6 +19,7 @@ pub fn emit_spans(w: &mut impl Write) -> anyhow::Result<()> {
     writeln!(w, "{DD_CRASHTRACK_BEGIN_SPAN_IDS}")?;
     ACTIVE_SPANS.emit(w)?;
     writeln!(w, "{DD_CRASHTRACK_END_SPAN_IDS}")?;
+    w.flush()?;
     Ok(())
 }
 
@@ -40,6 +41,7 @@ pub fn emit_traces(w: &mut impl Write) -> anyhow::Result<()> {
     writeln!(w, "{DD_CRASHTRACK_BEGIN_TRACE_IDS}")?;
     ACTIVE_TRACES.emit(w)?;
     writeln!(w, "{DD_CRASHTRACK_END_TRACE_IDS}")?;
+    w.flush()?;
     Ok(())
 }
 
@@ -84,7 +86,7 @@ impl<const LEN: usize> AtomicU128Set<LEN> {
                         write!(w, ", ")?;
                     }
                     first = false;
-                    write!(w, "{v}")?;
+                    write!(w, "{{\"id\": \"{v}\"}}")?;
                 }
             }
         }

--- a/crashtracker/src/collector/spans.rs
+++ b/crashtracker/src/collector/spans.rs
@@ -217,7 +217,10 @@ mod tests {
         let mut buf = Vec::new();
         s.emit(&mut buf).unwrap();
         let actual = String::from_utf8(buf).unwrap();
-        assert!(actual == "[42, 21]\n" || actual == "[21, 42]\n");
+        assert!(
+            actual == "[{\"id\": \"42\"}, {\"id\": \"21\"}]\n"
+                || actual == "[{\"id\": \"21\"}, {\"id\": \"42\"}]\n"
+        );
     }
 
     fn remove_and_compare(

--- a/crashtracker/src/receiver/mod.rs
+++ b/crashtracker/src/receiver/mod.rs
@@ -74,10 +74,8 @@ mod tests {
         let join_handle2 = tokio::spawn(send_report(Duration::from_secs(2), sender));
 
         let crash_report = join_handle1.await??;
-        assert!(matches!(
-            crash_report,
-            CrashReportStatus::PartialCrashReport(_, _, _)
-        ));
+        let (_config, crashinfo) = crash_report.expect("Expect a report");
+        assert!(crashinfo.incomplete);
         let sender_error = join_handle2.await?.unwrap_err().to_string();
         assert_eq!(sender_error, "Broken pipe (os error 32)");
         Ok(())
@@ -95,7 +93,8 @@ mod tests {
         let join_handle2 = tokio::spawn(send_report(Duration::from_secs(1), sender));
 
         let crash_report = join_handle1.await??;
-        assert!(matches!(crash_report, CrashReportStatus::CrashReport(_, _)));
+        let (_config, crashinfo) = crash_report.expect("Expect a report");
+        assert!(crashinfo.incomplete);
         join_handle2.await??;
         Ok(())
     }

--- a/crashtracker/src/receiver/mod.rs
+++ b/crashtracker/src/receiver/mod.rs
@@ -12,8 +12,9 @@ mod receive_report;
 #[cfg(test)]
 mod tests {
     use super::receive_report::*;
+    use crate::rfc5_crash_info::{SiCodes, SigInfo, SignalNames};
     use crate::shared::constants::*;
-    use crate::{CrashtrackerConfiguration, SigInfo, StacktraceCollection};
+    use crate::{CrashtrackerConfiguration, StacktraceCollection};
     use std::time::Duration;
     use tokio::io::{AsyncWriteExt, BufReader};
     use tokio::net::UnixStream;
@@ -34,9 +35,11 @@ mod tests {
         to_socket(
             sender,
             serde_json::to_string(&SigInfo {
-                signame: Some("SIGSEGV".to_string()),
-                signum: 11,
-                faulting_address: None,
+                si_addr: None,
+                si_code: 2,
+                si_code_human_readable: SiCodes::BUS_ADRALN,
+                si_signo: 11,
+                si_signo_human_readable: SignalNames::SIGSEGV,
             })?,
         )
         .await?;

--- a/crashtracker/src/rfc5_crash_info/metadata.rs
+++ b/crashtracker/src/rfc5_crash_info/metadata.rs
@@ -15,6 +15,22 @@ pub struct Metadata {
     pub tags: Vec<String>,
 }
 
+impl Metadata {
+    pub fn new(
+        library_name: String,
+        library_version: String,
+        family: String,
+        tags: Vec<String>,
+    ) -> Self {
+        Self {
+            library_name,
+            library_version,
+            family,
+            tags,
+        }
+    }
+}
+
 impl UnknownValue for Metadata {
     fn unknown_value() -> Self {
         Self {

--- a/crashtracker/src/rfc5_crash_info/sig_info.rs
+++ b/crashtracker/src/rfc5_crash_info/sig_info.rs
@@ -41,6 +41,7 @@ pub enum SignalNames {
     SIGBUS,
     SIGSEGV,
     SIGSYS,
+    UNKNOWN,
 }
 
 #[cfg(unix)]
@@ -86,6 +87,7 @@ pub enum SiCodes {
     SI_TKILL,
     SI_USER,
     SYS_SECCOMP,
+    UNKNOWN,
 }
 
 #[cfg(test)]

--- a/crashtracker/src/rfc5_crash_info/telemetry.rs
+++ b/crashtracker/src/rfc5_crash_info/telemetry.rs
@@ -198,11 +198,11 @@ fn extract_crash_info_tags(crash_info: &CrashInfo) -> anyhow::Result<String> {
             ",si_code_human_readable:{:?}",
             siginfo.si_code_human_readable
         )?;
-        write!(&mut tags, ",si_signo:{}", siginfo.si_code)?;
+        write!(&mut tags, ",si_signo:{}", siginfo.si_signo)?;
         write!(
             &mut tags,
             ",si_signo_human_readable:{:?}",
-            siginfo.si_code_human_readable
+            siginfo.si_signo_human_readable
         )?;
     }
     Ok(tags)

--- a/crashtracker/src/rfc5_crash_info/telemetry.rs
+++ b/crashtracker/src/rfc5_crash_info/telemetry.rs
@@ -285,8 +285,8 @@ mod tests {
                 "si_addr:0x0000000000001234",
                 "si_code_human_readable:SEGV_BNDERR",
                 "si_code:1",
-                "si_signo_human_readable:SEGV_BNDERR",
-                "si_signo:1",
+                "si_signo_human_readable:SIGSEGV",
+                "si_signo:11",
                 "uuid:1d6b97cb-968c-40c9-af6e-e4b4d71e8781",
             ]),
             tags


### PR DESCRIPTION
# What does this PR do?

Modifies the crashtracker receiver and emitter to speak RFC5, rather than the old ad-hoc format.

# Motivation

This is the last step before fully tearing out the old format

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Existing tests