### PR TITLE
library-config conditional build

### DIFF
--- a/examples/ffi/CMakeLists.txt
+++ b/examples/ffi/CMakeLists.txt
@@ -19,6 +19,21 @@ endfunction()
 # Uncomment to debug build commands
 # set(CMAKE_VERBOSE_MAKEFILE ON)
 
+# Datadog_ROOT is set by the find_package(Datadog) call
+set(library_config_header "${Datadog_ROOT}/include/datadog/library-config.h")
+
+if(EXISTS "${library_config_header}")
+  message(STATUS "Header file found: ${library_config_header}")
+  
+  add_executable(library_config library_config.c)
+  target_link_libraries(library_config PRIVATE Datadog::Profiling)
+  set_vcruntime_link_type(library_config ${VCRUNTIME_LINK_TYPE})
+
+else()
+  message(INFO "Header file not found: ${library_config_header}. Skipping library_config example.")
+  message(INFO "Please build libdatadog with the associated feature enabled.")
+endif()
+
 add_executable(exporter exporter.cpp)
 # needed for designated initializers
 target_compile_features(exporter PRIVATE cxx_std_20)
@@ -29,7 +44,6 @@ add_executable(crashinfo crashinfo.cpp)
 # needed for designated initializers
 target_compile_features(crashinfo PRIVATE cxx_std_20)
 target_link_libraries(crashinfo PRIVATE Datadog::Profiling)
-
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   target_compile_definitions(exporter PUBLIC _CRT_SECURE_NO_WARNINGS)
@@ -66,7 +80,3 @@ add_executable(array_queue array_queue.cpp)
 target_compile_features(array_queue PRIVATE cxx_std_20)
 target_link_libraries(array_queue PRIVATE Datadog::Profiling)
 set_vcruntime_link_type(array_queue ${VCRUNTIME_LINK_TYPE})
-
-add_executable(library_config library_config.c)
-target_link_libraries(library_config PRIVATE Datadog::Profiling)
-set_vcruntime_link_type(library_config ${VCRUNTIME_LINK_TYPE})


### PR DESCRIPTION
# What does this PR do?

Adjust the build of library config example using the existence of the associated header

# Motivation

Avoiding build failures when building the examples with missing features

# Additional Notes

I can extend this pattern to all examples if we like it

# How to test the change?

Describe here in detail how the change can be validated.
```
cmake --build ./examples/ffi/build
```