### PR TITLE
[crashtracking] Little improvements to the FFI api

### DIFF
--- a/crashtracker-ffi/cbindgen.toml
+++ b/crashtracker-ffi/cbindgen.toml
@@ -35,6 +35,8 @@ renaming_overrides_prefixing = true
 "Vec_Tag" = "ddog_Vec_Tag"
 "Vec_U8" = "ddog_Vec_U8"
 "VoidResult" = "ddog_VoidResult"
+"StringWrapper" = "ddog_StringWrapper"
+"StringWrapperResult" = "ddog_StringWrapperResult"
 
 [export.mangle]
 rename_types = "PascalCase"

--- a/crashtracker-ffi/cbindgen.toml
+++ b/crashtracker-ffi/cbindgen.toml
@@ -37,6 +37,10 @@ renaming_overrides_prefixing = true
 "VoidResult" = "ddog_VoidResult"
 "StringWrapper" = "ddog_StringWrapper"
 "StringWrapperResult" = "ddog_StringWrapperResult"
+"CrashInfoBuilderNewResult" = " ddog_crasht_CrashInfoBuilder_NewResult"
+"StackTraceNewResult" = " ddog_crasht_StackTrace_NewResult"
+"StackFrameNewResult" = "ddog_crasht_StackFrame_NewResult"
+"CrashInfoNewResult" = "ddog_crasht_CrashInfo_NewResult"
 
 [export.mangle]
 rename_types = "PascalCase"

--- a/crashtracker-ffi/src/crash_info/builder.rs
+++ b/crashtracker-ffi/src/crash_info/builder.rs
@@ -313,9 +313,13 @@ pub unsafe extern "C" fn ddog_crasht_CrashInfoBuilder_with_stack(
 #[named]
 pub unsafe extern "C" fn ddog_crasht_CrashInfoBuilder_with_thread(
     mut builder: *mut Handle<CrashInfoBuilder>,
-    thread: ThreadData,
+    mut thread: ThreadData,
 ) -> VoidResult {
     wrap_with_void_ffi_result!({
+        if thread.crashed {
+            let stack = (thread.stack.to_inner_mut())?.clone();
+            builder.to_inner_mut()?.with_stack(stack)?;
+        }
         builder.to_inner_mut()?.with_thread(thread.try_into()?)?;
     })
 }

--- a/crashtracker-ffi/src/crash_info/sig_info.rs
+++ b/crashtracker-ffi/src/crash_info/sig_info.rs
@@ -2,22 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use datadog_crashtracker::{SiCodes, SignalNames};
-use ddcommon_ffi::{slice::AsBytes, CharSlice};
+use ddcommon_ffi::ToHexStr;
 
 #[repr(C)]
-pub struct SigInfo<'a> {
-    pub addr: CharSlice<'a>,
+pub struct SigInfo {
+    pub addr: usize,
     pub code: libc::c_int,
     pub code_human_readable: SiCodes,
     pub signo: libc::c_int,
     pub signo_human_readable: SignalNames,
 }
 
-impl<'a> TryFrom<SigInfo<'a>> for datadog_crashtracker::SigInfo {
+impl TryFrom<SigInfo> for datadog_crashtracker::SigInfo {
     type Error = anyhow::Error;
-    fn try_from(value: SigInfo<'a>) -> anyhow::Result<Self> {
+    fn try_from(value: SigInfo) -> anyhow::Result<Self> {
         Ok(Self {
-            si_addr: value.addr.try_to_string_option()?,
+            si_addr: Some(value.addr.to_hex_str()),
             si_code: value.code,
             si_code_human_readable: value.code_human_readable,
             si_signo: value.signo,

--- a/crashtracker-ffi/src/crash_info/sig_info.rs
+++ b/crashtracker-ffi/src/crash_info/sig_info.rs
@@ -2,22 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use datadog_crashtracker::{SiCodes, SignalNames};
-use ddcommon_ffi::ToHexStr;
+use ddcommon_ffi::{slice::AsBytes, CharSlice};
 
 #[repr(C)]
-pub struct SigInfo {
-    pub addr: usize,
+pub struct SigInfo<'a> {
+    pub addr: CharSlice<'a>,
     pub code: libc::c_int,
     pub code_human_readable: SiCodes,
     pub signo: libc::c_int,
     pub signo_human_readable: SignalNames,
 }
 
-impl TryFrom<SigInfo> for datadog_crashtracker::SigInfo {
+impl<'a> TryFrom<SigInfo<'a>> for datadog_crashtracker::SigInfo {
     type Error = anyhow::Error;
-    fn try_from(value: SigInfo) -> anyhow::Result<Self> {
+    fn try_from(value: SigInfo<'a>) -> anyhow::Result<Self> {
         Ok(Self {
-            si_addr: Some(value.addr.to_hex_str()),
+            si_addr: value.addr.try_to_string_option()?,
             si_code: value.code,
             si_code_human_readable: value.code_human_readable,
             si_signo: value.signo,

--- a/crashtracker-ffi/src/crash_info/stackframe.rs
+++ b/crashtracker-ffi/src/crash_info/stackframe.rs
@@ -4,10 +4,9 @@
 use ::function_name::named;
 use datadog_crashtracker::{BuildIdType, FileType, StackFrame};
 use ddcommon_ffi::{
-    slice::AsBytes, wrap_with_void_ffi_result, CharSlice, Error, Handle, ToInner, VoidResult,
+    slice::AsBytes, utils::ToHexStr, wrap_with_void_ffi_result, CharSlice, Error, Handle, ToInner,
+    VoidResult,
 };
-
-use ddcommon_ffi::ToHexStr;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //                                              FFI API                                           //

--- a/crashtracker-ffi/src/crash_info/stackframe.rs
+++ b/crashtracker-ffi/src/crash_info/stackframe.rs
@@ -4,7 +4,7 @@
 use ::function_name::named;
 use datadog_crashtracker::{BuildIdType, FileType, StackFrame};
 use ddcommon_ffi::{
-    slice::AsBytes, wrap_with_void_ffi_result, CharSlice, Handle, Result, ToInner, VoidResult,
+    slice::AsBytes, wrap_with_void_ffi_result, CharSlice, Error, Handle, ToInner, VoidResult,
 };
 
 use ddcommon_ffi::ToHexStr;
@@ -13,13 +13,20 @@ use ddcommon_ffi::ToHexStr;
 //                                              FFI API                                           //
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+#[allow(dead_code)]
+#[repr(C)]
+pub enum StackFrameNewResult {
+    Ok(Handle<StackFrame>),
+    Err(Error),
+}
+
 /// Create a new StackFrame, and returns an opaque reference to it.
 /// # Safety
 /// No safety issues.
 #[no_mangle]
 #[must_use]
-pub unsafe extern "C" fn ddog_crasht_StackFrame_new() -> Result<Handle<StackFrame>> {
-    ddcommon_ffi::Result::Ok(StackFrame::new().into())
+pub unsafe extern "C" fn ddog_crasht_StackFrame_new() -> StackFrameNewResult {
+    StackFrameNewResult::Ok(StackFrame::new().into())
 }
 
 /// # Safety

--- a/crashtracker-ffi/src/crash_info/stackframe.rs
+++ b/crashtracker-ffi/src/crash_info/stackframe.rs
@@ -7,6 +7,8 @@ use ddcommon_ffi::{
     slice::AsBytes, wrap_with_void_ffi_result, CharSlice, Handle, Result, ToInner, VoidResult,
 };
 
+use ddcommon_ffi::ToHexStr;
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //                                              FFI API                                           //
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -41,10 +43,10 @@ pub unsafe extern "C" fn ddog_crasht_StackFrame_drop(frame: *mut Handle<StackFra
 #[named]
 pub unsafe extern "C" fn ddog_crasht_StackFrame_with_ip(
     mut frame: *mut Handle<StackFrame>,
-    ip: CharSlice,
+    ip: usize,
 ) -> VoidResult {
     wrap_with_void_ffi_result!({
-        frame.to_inner_mut()?.ip = ip.try_to_string_option()?;
+        frame.to_inner_mut()?.ip = Some(ip.to_hex_str());
     })
 }
 
@@ -57,10 +59,10 @@ pub unsafe extern "C" fn ddog_crasht_StackFrame_with_ip(
 #[named]
 pub unsafe extern "C" fn ddog_crasht_StackFrame_with_module_base_address(
     mut frame: *mut Handle<StackFrame>,
-    module_base_address: CharSlice,
+    module_base_address: usize,
 ) -> VoidResult {
     wrap_with_void_ffi_result!({
-        frame.to_inner_mut()?.module_base_address = module_base_address.try_to_string_option()?;
+        frame.to_inner_mut()?.module_base_address = Some(module_base_address.to_hex_str());
     })
 }
 
@@ -73,10 +75,10 @@ pub unsafe extern "C" fn ddog_crasht_StackFrame_with_module_base_address(
 #[named]
 pub unsafe extern "C" fn ddog_crasht_StackFrame_with_sp(
     mut frame: *mut Handle<StackFrame>,
-    sp: CharSlice,
+    sp: usize,
 ) -> VoidResult {
     wrap_with_void_ffi_result!({
-        frame.to_inner_mut()?.sp = sp.try_to_string_option()?;
+        frame.to_inner_mut()?.sp = Some(sp.to_hex_str());
     })
 }
 
@@ -89,10 +91,10 @@ pub unsafe extern "C" fn ddog_crasht_StackFrame_with_sp(
 #[named]
 pub unsafe extern "C" fn ddog_crasht_StackFrame_with_symbol_address(
     mut frame: *mut Handle<StackFrame>,
-    symbol_address: CharSlice,
+    symbol_address: usize,
 ) -> VoidResult {
     wrap_with_void_ffi_result!({
-        frame.to_inner_mut()?.symbol_address = symbol_address.try_to_string_option()?;
+        frame.to_inner_mut()?.symbol_address = Some(symbol_address.to_hex_str());
     })
 }
 
@@ -169,10 +171,10 @@ pub unsafe extern "C" fn ddog_crasht_StackFrame_with_path(
 #[named]
 pub unsafe extern "C" fn ddog_crasht_StackFrame_with_relative_address(
     mut frame: *mut Handle<StackFrame>,
-    relative_address: CharSlice,
+    relative_address: usize,
 ) -> VoidResult {
     wrap_with_void_ffi_result!({
-        frame.to_inner_mut()?.relative_address = relative_address.try_to_string_option()?;
+        frame.to_inner_mut()?.relative_address = Some(relative_address.to_hex_str());
     })
 }
 

--- a/crashtracker-ffi/src/crash_info/stacktrace.rs
+++ b/crashtracker-ffi/src/crash_info/stacktrace.rs
@@ -3,19 +3,26 @@
 
 use ::function_name::named;
 use datadog_crashtracker::{StackFrame, StackTrace};
-use ddcommon_ffi::{wrap_with_void_ffi_result, Handle, Result, ToInner, VoidResult};
+use ddcommon_ffi::{wrap_with_void_ffi_result, Error, Handle, ToInner, VoidResult};
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 //                                              FFI API                                           //
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[allow(dead_code)]
+#[repr(C)]
+pub enum StackTraceNewResult {
+    Ok(Handle<StackTrace>),
+    Err(Error),
+}
 
 /// Create a new StackTrace, and returns an opaque reference to it.
 /// # Safety
 /// No safety issues.
 #[no_mangle]
 #[must_use]
-pub unsafe extern "C" fn ddog_crasht_StackTrace_new() -> Result<Handle<StackTrace>> {
-    ddcommon_ffi::Result::Ok(StackTrace::new_incomplete().into())
+pub unsafe extern "C" fn ddog_crasht_StackTrace_new() -> StackTraceNewResult {
+    StackTraceNewResult::Ok(StackTrace::new_incomplete().into())
 }
 
 /// # Safety

--- a/crashtracker-ffi/src/demangler/datatypes.rs
+++ b/crashtracker-ffi/src/demangler/datatypes.rs
@@ -1,42 +1,8 @@
 // Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use ddcommon_ffi::{Error, StringWrapper};
-
 #[repr(C)]
 pub enum DemangleOptions {
     Complete,
     NameOnly,
-}
-
-#[repr(C)]
-pub enum StringWrapperResult {
-    Ok(StringWrapper),
-    #[allow(dead_code)]
-    Err(Error),
-}
-
-// Useful for testing
-impl StringWrapperResult {
-    pub fn unwrap(self) -> StringWrapper {
-        match self {
-            StringWrapperResult::Ok(s) => s,
-            StringWrapperResult::Err(e) => panic!("{e}"),
-        }
-    }
-}
-
-impl From<anyhow::Result<String>> for StringWrapperResult {
-    fn from(value: anyhow::Result<String>) -> Self {
-        match value {
-            Ok(x) => Self::Ok(x.into()),
-            Err(err) => Self::Err(err.into()),
-        }
-    }
-}
-
-impl From<String> for StringWrapperResult {
-    fn from(value: String) -> Self {
-        Self::Ok(value.into())
-    }
 }

--- a/crashtracker-ffi/src/demangler/mod.rs
+++ b/crashtracker-ffi/src/demangler/mod.rs
@@ -4,7 +4,7 @@ mod datatypes;
 pub use datatypes::*;
 
 use ::function_name::named;
-use ddcommon_ffi::{slice::AsBytes, wrap_with_ffi_result, CharSlice, Result, StringWrapper};
+use ddcommon_ffi::{slice::AsBytes, wrap_with_ffi_result, CharSlice, StringWrapperResult};
 use symbolic_common::Name;
 use symbolic_demangle::Demangle;
 
@@ -20,7 +20,7 @@ use symbolic_demangle::Demangle;
 pub unsafe extern "C" fn ddog_crasht_demangle(
     name: CharSlice,
     options: DemangleOptions,
-) -> Result<StringWrapper> {
+) -> StringWrapperResult {
     wrap_with_ffi_result!({
         let name = name.to_utf8_lossy();
         let name = Name::from(name);
@@ -28,7 +28,7 @@ pub unsafe extern "C" fn ddog_crasht_demangle(
             DemangleOptions::Complete => symbolic_demangle::DemangleOptions::complete(),
             DemangleOptions::NameOnly => symbolic_demangle::DemangleOptions::name_only(),
         };
-        anyhow::Ok(name.demangle(options).unwrap_or_default().into())
+        anyhow::Ok(name.demangle(options).unwrap_or_default())
     })
 }
 

--- a/crashtracker/src/crash_info/stacktrace.rs
+++ b/crashtracker/src/crash_info/stacktrace.rs
@@ -193,7 +193,6 @@ pub enum BuildIdType {
     GNU,
     GO,
     PDB,
-    PE,
     SHA1,
 }
 
@@ -203,7 +202,7 @@ pub enum BuildIdType {
 pub enum FileType {
     APK,
     ELF,
-    PDB,
+    PE,
 }
 
 #[cfg(unix)]

--- a/ddcommon-ffi/src/string.rs
+++ b/ddcommon-ffi/src/string.rs
@@ -3,6 +3,7 @@
 
 use crate::slice::CharSlice;
 use crate::vec::Vec;
+use crate::Error;
 
 /// A wrapper for returning owned strings from FFI
 #[derive(Debug)]
@@ -80,5 +81,37 @@ pub trait ToHexStr {
 impl ToHexStr for usize {
     fn to_hex_str(&self) -> String {
         format!("0x{:X}", self)
+    }
+}
+
+#[repr(C)]
+#[allow(dead_code)]
+pub enum StringWrapperResult {
+    Ok(StringWrapper),
+    Err(Error),
+}
+
+// Useful for testing
+impl StringWrapperResult {
+    pub fn unwrap(self) -> StringWrapper {
+        match self {
+            StringWrapperResult::Ok(s) => s,
+            StringWrapperResult::Err(e) => panic!("{e}"),
+        }
+    }
+}
+
+impl From<anyhow::Result<String>> for StringWrapperResult {
+    fn from(value: anyhow::Result<String>) -> Self {
+        match value {
+            Ok(x) => Self::Ok(x.into()),
+            Err(err) => Self::Err(err.into()),
+        }
+    }
+}
+
+impl From<String> for StringWrapperResult {
+    fn from(value: String) -> Self {
+        Self::Ok(value.into())
     }
 }

--- a/ddcommon-ffi/src/string.rs
+++ b/ddcommon-ffi/src/string.rs
@@ -72,3 +72,13 @@ pub unsafe extern "C" fn ddog_StringWrapper_message(s: Option<&StringWrapper>) -
         Some(s) => CharSlice::from(s.as_ref()),
     }
 }
+
+pub trait ToHexStr {
+    fn to_hex_str(&self) -> String;
+}
+
+impl ToHexStr for usize {
+    fn to_hex_str(&self) -> String {
+        format!("0x{:X}", self)
+    }
+}

--- a/ddcommon-ffi/src/string.rs
+++ b/ddcommon-ffi/src/string.rs
@@ -74,16 +74,6 @@ pub unsafe extern "C" fn ddog_StringWrapper_message(s: Option<&StringWrapper>) -
     }
 }
 
-pub trait ToHexStr {
-    fn to_hex_str(&self) -> String;
-}
-
-impl ToHexStr for usize {
-    fn to_hex_str(&self) -> String {
-        format!("0x{:X}", self)
-    }
-}
-
 #[repr(C)]
 #[allow(dead_code)]
 pub enum StringWrapperResult {

--- a/ddcommon-ffi/src/utils.rs
+++ b/ddcommon-ffi/src/utils.rs
@@ -28,3 +28,13 @@ macro_rules! wrap_with_void_ffi_result {
         .into()
     }};
 }
+
+pub trait ToHexStr {
+    fn to_hex_str(&self) -> String;
+}
+
+impl ToHexStr for usize {
+    fn to_hex_str(&self) -> String {
+        format!("0x{:X}", self)
+    }
+}

--- a/examples/ffi/crashinfo.cpp
+++ b/examples/ffi/crashinfo.cpp
@@ -53,7 +53,7 @@ CHECK_RESULT(ddog_Vec_Tag_PushResult, DDOG_VEC_TAG_PUSH_RESULT_OK)
     }                                                                                              \
   };                                                                                               \
   std::unique_ptr<ddog_crasht_Handle_##typ, typ##Deleter> extract_result(                          \
-      ddog_crasht_Result_Handle##typ result, const char *msg) {                                    \
+      ddog_crasht_##typ##_NewResult result, const char *msg) {                                    \
     if (result.tag != ok_tag) {                                                                    \
       print_error(msg, result.err);                                                                \
       ddog_Error_drop(&result.err);                                                                \
@@ -65,10 +65,10 @@ CHECK_RESULT(ddog_Vec_Tag_PushResult, DDOG_VEC_TAG_PUSH_RESULT_OK)
   }
 
 EXTRACT_RESULT(CrashInfoBuilder,
-               DDOG_CRASHT_RESULT_HANDLE_CRASH_INFO_BUILDER_OK_HANDLE_CRASH_INFO_BUILDER)
-EXTRACT_RESULT(CrashInfo, DDOG_CRASHT_RESULT_HANDLE_CRASH_INFO_OK_HANDLE_CRASH_INFO)
-EXTRACT_RESULT(StackTrace, DDOG_CRASHT_RESULT_HANDLE_STACK_TRACE_OK_HANDLE_STACK_TRACE)
-EXTRACT_RESULT(StackFrame, DDOG_CRASHT_RESULT_HANDLE_STACK_FRAME_OK_HANDLE_STACK_FRAME)
+               DDOG_CRASHT_CRASH_INFO_BUILDER_NEW_RESULT_OK)
+EXTRACT_RESULT(CrashInfo, DDOG_CRASHT_CRASH_INFO_NEW_RESULT_OK)
+EXTRACT_RESULT(StackTrace, DDOG_CRASHT_STACK_TRACE_NEW_RESULT_OK)
+EXTRACT_RESULT(StackFrame, DDOG_CRASHT_STACK_FRAME_NEW_RESULT_OK)
 
 std::optional<std::string> demangle(std::string const& name)
 {

--- a/examples/ffi/crashinfo.cpp
+++ b/examples/ffi/crashinfo.cpp
@@ -87,10 +87,9 @@ void add_stacktrace(ddog_crasht_Handle_CrashInfoBuilder *builder) {
 
   // Windows style frame with normalization
   auto pbd_frame = extract_result(ddog_crasht_StackFrame_new(), "failed to make StackFrame");
-  check_result(ddog_crasht_StackFrame_with_ip(pbd_frame.get(), to_slice_c_char("0xDEADBEEF")),
+  check_result(ddog_crasht_StackFrame_with_ip(pbd_frame.get(), 3735928559), // 0xDEADBEEF
                "failed to add ip");
-  check_result(ddog_crasht_StackFrame_with_module_base_address(pbd_frame.get(),
-                                                               to_slice_c_char("0xABBAABBA")),
+  check_result(ddog_crasht_StackFrame_with_module_base_address(pbd_frame.get(), 2881137594), // 0xABBAABBA"
                "failed to add module_base_address");
   check_result(
       ddog_crasht_StackFrame_with_build_id(pbd_frame.get(), to_slice_c_char("abcdef12345")),
@@ -104,7 +103,7 @@ void add_stacktrace(ddog_crasht_Handle_CrashInfoBuilder *builder) {
                    pbd_frame.get(), to_slice_c_char("C:/Program Files/best_program_ever.exe")),
                "failed to add path");
   check_result(
-      ddog_crasht_StackFrame_with_relative_address(pbd_frame.get(), to_slice_c_char("0xBABEF00D")),
+      ddog_crasht_StackFrame_with_relative_address(pbd_frame.get(), 3133075469), // 0xBABEF00D
       "failed to add relative address");
   // This operation consumes the frame, so use .release here
   check_result(ddog_crasht_StackTrace_push_frame(stacktrace.get(), pbd_frame.release(), true),
@@ -112,10 +111,9 @@ void add_stacktrace(ddog_crasht_Handle_CrashInfoBuilder *builder) {
 
   // ELF style frame with normalization
   auto elf_frame = extract_result(ddog_crasht_StackFrame_new(), "failed to make StackFrame");
-  check_result(ddog_crasht_StackFrame_with_ip(elf_frame.get(), to_slice_c_char("0xDEADBEEF")),
+  check_result(ddog_crasht_StackFrame_with_ip(elf_frame.get(), 3735928559), // 0xDEADBEEF
                "failed to add ip");
-  check_result(ddog_crasht_StackFrame_with_module_base_address(elf_frame.get(),
-                                                               to_slice_c_char("0xABBAABBA")),
+  check_result(ddog_crasht_StackFrame_with_module_base_address(elf_frame.get(), 2881137594), // 0xABBAABBA"
                "failed to add module_base_address");
   check_result(
       ddog_crasht_StackFrame_with_build_id(elf_frame.get(), to_slice_c_char("987654321fedcba0")),
@@ -129,7 +127,7 @@ void add_stacktrace(ddog_crasht_Handle_CrashInfoBuilder *builder) {
                                                 to_slice_c_char("/usr/bin/awesome-gnu-utility.so")),
                "failed to add path");
   check_result(
-      ddog_crasht_StackFrame_with_relative_address(elf_frame.get(), to_slice_c_char("0xBABEF00D")),
+      ddog_crasht_StackFrame_with_relative_address(elf_frame.get(), 3133075469), // 0xBABEF00D
       "failed to add relative address");
   // This operation consumes the frame, so use .release here
   check_result(ddog_crasht_StackTrace_push_frame(stacktrace.get(), elf_frame.release(), true),

--- a/examples/ffi/crashinfo.cpp
+++ b/examples/ffi/crashinfo.cpp
@@ -122,7 +122,7 @@ void add_windows_style_frame(ddog_crasht_Handle_StackTrace* stacktrace) {
   check_result(
       ddog_crasht_StackFrame_with_build_id_type(pbd_frame.get(), DDOG_CRASHT_BUILD_ID_TYPE_PDB),
       "failed to add build id type");
-  check_result(ddog_crasht_StackFrame_with_file_type(pbd_frame.get(), DDOG_CRASHT_FILE_TYPE_PDB),
+  check_result(ddog_crasht_StackFrame_with_file_type(pbd_frame.get(), DDOG_CRASHT_FILE_TYPE_PE),
                "failed to add file type");
   check_result(ddog_crasht_StackFrame_with_path(
                    pbd_frame.get(), to_slice_c_char("C:/Program Files/best_program_ever.exe")),
@@ -242,7 +242,7 @@ int main(void) {
                "Failed to set os_info");
 
   auto sigInfo = ddog_crasht_SigInfo {
-    .addr = 0XBABEF00D,
+    .addr = "0xBABEF00D",
     .code = 16,
     .code_human_readable = DDOG_CRASHT_SI_CODES_UNKNOWN,
     .signo = -1,

--- a/profiling-ffi/cbindgen.toml
+++ b/profiling-ffi/cbindgen.toml
@@ -47,6 +47,8 @@ renaming_overrides_prefixing = true
 "Slice_File" = "ddog_prof_Exporter_Slice_File"
 "ManagedStringStorage" = "ddog_prof_ManagedStringStorage"
 "ManagedStringId" = "ddog_prof_ManagedStringId"
+"StringWrapper" = "ddog_StringWrapper"
+"StringWrapperResult" = "ddog_StringWrapperResult"
 
 [export.mangle]
 rename_types = "PascalCase"

--- a/profiling-ffi/src/string_storage.rs
+++ b/profiling-ffi/src/string_storage.rs
@@ -4,7 +4,7 @@
 use anyhow::Context;
 use datadog_profiling::collections::string_storage::ManagedStringStorage as InternalManagedStringStorage;
 use ddcommon_ffi::slice::AsBytes;
-use ddcommon_ffi::{CharSlice, Error, MaybeError, Slice, StringWrapper};
+use ddcommon_ffi::{CharSlice, Error, MaybeError, Slice, StringWrapperResult};
 use libc::c_void;
 use std::mem::MaybeUninit;
 use std::num::NonZeroU32;
@@ -198,13 +198,6 @@ pub unsafe extern "C" fn ddog_prof_ManagedStringStorage_unintern_all(
     }
 }
 
-#[repr(C)]
-#[allow(dead_code)]
-pub enum StringWrapperResult {
-    Ok(StringWrapper),
-    Err(Error),
-}
-
 #[must_use]
 #[no_mangle]
 /// Returns a string given its id.
@@ -285,15 +278,6 @@ impl From<anyhow::Result<ManagedStringId>> for ManagedStringStorageInternResult 
     fn from(value: anyhow::Result<ManagedStringId>) -> Self {
         match value {
             Ok(v) => Self::Ok(v),
-            Err(err) => Self::Err(err.into()),
-        }
-    }
-}
-
-impl From<anyhow::Result<String>> for StringWrapperResult {
-    fn from(value: anyhow::Result<String>) -> Self {
-        match value {
-            Ok(v) => Self::Ok(v.into()),
             Err(err) => Self::Err(err.into()),
         }
     }


### PR DESCRIPTION
# What does this PR do?

This PR tries to improve a bit the crashtracker ffi APIs.

# Motivation

The goal is to simplify the crashtracker ffi API and adding code in the `crashinfo.cpp` example.

# Implementation

- When passing an address, instead of asking for a string, pass a `usize` (expecting it to be 64bit on x86_64, and 32bit on x86 architecture) and build a `0x`-prefixed string from it.
- *Experimental* : 
`ddog_crasht_CrashInfoBuilder_with_stack` adds the callstack of the crashing threads but only the callstack.
If we want to add the crashing thread (`ThreadData`), we have to duplicate the callstack and make one calls to `ddog_crasht_CrashInfoBuilder_with_stack` and `ddog_crasht_CrashInfoBuilder_with_thread`.
Instead, we check the `crashed` field, and call into `with_stack` to add a duplicate of the callstack thread (if it's true) and call into `with_thread` with the thread data 
Maybe we could remove the `ddog_crasht_CrashInfoBuilder_with_stack` ?
* Add `XXXNewResult` types to have shorter symbols for the generated code.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
