### PR TITLE
fix(library_config): Add Windows build support

### DIFF
--- a/windows/build-artifacts.ps1
+++ b/windows/build-artifacts.ps1
@@ -26,7 +26,8 @@ $features = @(
     "datadog-profiling-ffi/crashtracker-collector",
     "datadog-profiling-ffi/crashtracker-receiver",
     "datadog-profiling-ffi/ddtelemetry-ffi",
-    "datadog-profiling-ffi/demangler"
+    "datadog-profiling-ffi/demangler",
+    "datadog-library-config-ffi"
 ) -join ","
 
 Write-Host "Building for features: $features" -ForegroundColor Magenta
@@ -49,6 +50,7 @@ Invoke-Call -ScriptBlock { cbindgen --crate datadog-profiling-ffi --config profi
 Invoke-Call -ScriptBlock { cbindgen --crate ddtelemetry-ffi --config ddtelemetry-ffi/cbindgen.toml --output $output_dir\telemetry.h }
 Invoke-Call -ScriptBlock { cbindgen --crate data-pipeline-ffi --config data-pipeline-ffi/cbindgen.toml --output $output_dir"\data-pipeline.h" }
 Invoke-Call -ScriptBlock { cbindgen --crate datadog-crashtracker-ffi --config crashtracker-ffi/cbindgen.toml --output $output_dir"\crashtracker.h" }
-Invoke-Call -ScriptBlock { .\target\release\dedup_headers $output_dir"\common.h"  $output_dir"\profiling.h" $output_dir"\telemetry.h" $output_dir"\data-pipeline.h" $output_dir"\crashtracker.h"}
+Invoke-Call -ScriptBlock { cbindgen --crate datadog-library-config-ffi --config library-config-ffi/cbindgen.toml --output $output_dir"\library-config.h" }
+Invoke-Call -ScriptBlock { .\target\release\dedup_headers $output_dir"\common.h"  $output_dir"\profiling.h" $output_dir"\telemetry.h" $output_dir"\data-pipeline.h" $output_dir"\crashtracker.h" $output_dir"\library-config.h"}
 
 Write-Host "Build finished"  -ForegroundColor Magenta

--- a/windows/libdatadog.csproj
+++ b/windows/libdatadog.csproj
@@ -37,6 +37,8 @@
       PackagePath="include\native\datadog\crashtracker.h" />
     <None Include="$(LibDatadogBinariesOutputDir)\data-pipeline.h" Pack="true"
       PackagePath="include\native\datadog\data-pipeline.h" />
+    <None Include="$(LibDatadogBinariesOutputDir)\library-config.h" Pack="true"
+      PackagePath="include\native\datadog\library-config.h" />
 
     <None Include="$(LibDatadogBinariesOutputDir)\x86_64-pc-windows-msvc\debug\datadog_profiling_ffi.lib"
       Pack="true" PackagePath="build\native\lib\x64\debug\static\datadog_profiling_ffi.lib" />


### PR DESCRIPTION
# What does this PR do?

Adds Windows build of the `library_config` crate

# Motivation

Making it work in .NET

# Additional Notes

The paths will need to be adjusted for Windows but this will be done in another PR (likely https://github.com/DataDog/libdatadog/pull/840)

# How to test the change?

Just check the `library-config.h` file is present in the Windows build artifact from the Gitlab CI.
