### PR TITLE
Make runtime configurable

### DIFF
--- a/data-pipeline/src/telemetry/mod.rs
+++ b/data-pipeline/src/telemetry/mod.rs
@@ -25,6 +25,7 @@ pub struct TelemetryClientBuilder {
     language_version: Option<String>,
     tracer_version: Option<String>,
     config: ddtelemetry::config::Config,
+    runtime_id: Option<String>,
 }
 
 impl TelemetryClientBuilder {
@@ -68,17 +69,29 @@ impl TelemetryClientBuilder {
         self
     }
 
+    /// Sets runtime id for the telemetry client.
+    pub fn set_runtime_id(mut self, id: &str) -> Self {
+        self.runtime_id = Some(id.to_string());
+        self
+    }
+
     /// Builds the telemetry client.
     pub async fn build(self) -> Result<TelemetryClient, TelemetryError> {
-        let (worker, handle) = TelemetryWorkerBuilder::new_fetch_host(
+        let mut builder = TelemetryWorkerBuilder::new_fetch_host(
             self.service_name.unwrap(),
             self.language.unwrap(),
             self.language_version.unwrap(),
             self.tracer_version.unwrap(),
-        )
-        .spawn_with_config(self.config)
-        .await
-        .map_err(|e| TelemetryError::Builder(e.to_string()))?;
+        );
+
+        if let Some(id) = self.runtime_id {
+            builder.runtime_id = Some(id);
+        }
+
+        let (worker, handle) = builder
+            .spawn_with_config(self.config)
+            .await
+            .map_err(|e| TelemetryError::Builder(e.to_string()))?;
 
         Ok(TelemetryClient {
             handle,
@@ -533,5 +546,40 @@ mod tests {
         client.shutdown().await;
         let _ = client.handle.await;
         telemetry_srv.assert_hits_async(1).await;
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn runtime_id_test() {
+        let server = MockServer::start_async().await;
+
+        let telemetry_srv = server
+            .mock_async(|when, then| {
+                when.method(POST).body_contains(r#""runtime_id":"foo""#);
+                then.status(200).body("");
+            })
+            .await;
+
+        let result = TelemetryClientBuilder::default()
+            .set_service_name("test_service")
+            .set_language("test_language")
+            .set_language_version("test_language_version")
+            .set_tracer_version("test_tracer_version")
+            .set_url(&server.url("/"))
+            .set_hearbeat(100)
+            .set_runtime_id("foo")
+            .build()
+            .await;
+
+        assert!(result.is_ok());
+
+        let client = result.unwrap();
+
+        client.start().await;
+        client.shutdown().await;
+        let _ = client.handle.await;
+
+        // Check for 2 hits: app-started and app-closing.
+        telemetry_srv.assert_hits_async(2).await;
     }
 }


### PR DESCRIPTION
# What does this PR do?

Makes the `runtime_id` property configurable by library clients.
