### PR TITLE
fix: tolerate empty trace payload body

### DIFF
--- a/trace-utils/src/trace_utils.rs
+++ b/trace-utils/src/trace_utils.rs
@@ -46,10 +46,6 @@ pub async fn get_traces_from_request_body(
         }
     };
 
-    if traces.is_empty() {
-        anyhow::bail!("No traces deserialized from the request body.")
-    }
-
     Ok((size, traces))
 }
 

--- a/trace-utils/src/tracer_payload.rs
+++ b/trace-utils/src/tracer_payload.rs
@@ -465,6 +465,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[test]
     fn test_try_into_empty() {
         let empty_data = vec![0x90];

--- a/trace-utils/src/tracer_payload.rs
+++ b/trace-utils/src/tracer_payload.rs
@@ -271,10 +271,6 @@ impl<'a, T: TraceChunkProcessor + 'a> TryInto<TracerPayloadCollection>
                     *size_ref = size;
                 }
 
-                if traces.is_empty() {
-                    anyhow::bail!("No traces deserialized from the request body.");
-                }
-
                 Ok(collect_trace_chunks(
                     TraceCollection::V04(traces),
                     self.tracer_header_tags,

--- a/trace-utils/src/tracer_payload.rs
+++ b/trace-utils/src/tracer_payload.rs
@@ -466,6 +466,28 @@ mod tests {
     }
 
     #[test]
+    fn test_try_into_empty() {
+        let empty_data = vec![0x90];
+        let data = tinybytes::Bytes::from(empty_data);
+
+        let tracer_header_tags = &TracerHeaderTags::default();
+
+        let result: anyhow::Result<TracerPayloadCollection> = TracerPayloadParams::new(
+            data,
+            tracer_header_tags,
+            &mut DefaultTraceChunkProcessor,
+            false,
+            TraceEncoding::V04,
+        )
+        .try_into();
+
+        assert!(result.is_ok());
+
+        let collection = result.unwrap();
+        assert_eq!(0, collection.size());
+    }
+
+    #[test]
     fn test_try_into_meta_metrics_success() {
         let dummy_trace = create_trace();
         let expected = vec![dummy_trace.clone()];


### PR DESCRIPTION
# What does this PR do?
Removes a condition where we return an error to the API client if the trace payload is empty

# Motivation
dotnet sends an empty trace payload as a liveliness check. When we return the error, it causes ddtrace-dotnet to leak file descriptors as per [this issue](https://github.com/DataDog/datadog-lambda-extension/issues/533).
Note that 1024 file descriptors is the maximum allowed for Lambda, and afterwards the function is killed (hence the spikey graph)

Here's a screenshot with this fix and without:
![image](https://github.com/user-attachments/assets/b886dc07-d4c6-4e97-9f7a-ea42cf41f70c)

# Additional Notes
I believe this change was simply good error handling, and not necessarily an intentional behavior change. We still should investigate the high fd use here for dotnet, and I'm working with that team to identify why we're using so many.

# How to test the change?
My smoke tests should be sufficient, I'm happy to show you the result or help you build your own. We will of course test this fully in self-monitoring before releasing.
