### PR TITLE
profiling: update DatadogConfig cmake to be used for windows builds

### DIFF
--- a/cmake/DatadogConfig.cmake.in
+++ b/cmake/DatadogConfig.cmake.in
@@ -14,19 +14,21 @@ find_path(Datadog_INCLUDE_DIR datadog/profiling.h HINTS ${Datadog_ROOT}/include)
 set(DD_LIB_NAME "datadog_profiling")
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-  set(DD_LIB_NAME "datadog_profling_ffi")
+  set(DD_LIB_NAME "${DD_LIB_NAME} datadog_profling_ffi")
 
   if(CMAKE_BUILD_TYPE STREQUAL "Release")
   find_library(
       Datadog_LIBRARY
-      NAMES datadog_profiling_ffi
+      NAMES ${DD_LIB_NAME}
       HINTS ${Datadog_ROOT}/release/static)
   else()
   find_library(
       Datadog_LIBRARY
-      NAMES datadog_profiling_ffi
+      NAMES ${DD_LIB_NAME}
       HINTS ${Datadog_ROOT}/debug/static)
   endif()
+  get_filename_component(DD_LIB_NAME ${Datadog_LIBRARY} NAME_WE)
+  message(STATUS "Datadog library name: ${DD_LIB_NAME}")
 else()
   find_library(
     Datadog_LIBRARY

--- a/cmake/DatadogConfig.cmake.in
+++ b/cmake/DatadogConfig.cmake.in
@@ -14,19 +14,22 @@ find_path(Datadog_INCLUDE_DIR datadog/profiling.h HINTS ${Datadog_ROOT}/include)
 set(DD_LIB_NAME "datadog_profiling")
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
-  set(DD_LIB_NAME "${DD_LIB_NAME} datadog_profling_ffi")
+  # Prefer static linking over dynamic unless specified
+  set(LINK_TYPE "static")
+  string(TOLOWER ${VCRUNTIME_LINK_TYPE} LINK_TYPE)
 
-  if(CMAKE_BUILD_TYPE STREQUAL "Release")
+  set(BUILD_TYPE "release")
+  string(TOLOWER ${CMAKE_BUILD_TYPE} BUILD_TYPE)
+
   find_library(
       Datadog_LIBRARY
-      NAMES ${DD_LIB_NAME}
-      HINTS ${Datadog_ROOT}/release/static)
-  else()
-  find_library(
-      Datadog_LIBRARY
-      NAMES ${DD_LIB_NAME}
-      HINTS ${Datadog_ROOT}/debug/static)
-  endif()
+      # Windows artifacts publish the library as datadog_profiling_ffi
+      # in {build_type}/{link_type} directory
+      NAMES ${DD_LIB_NAME} datadog_profiling_ffi
+      HINTS ${Datadog_ROOT}/lib ${Datadog_ROOT}/${BULID_TYPE}/${LINK_TYPE})
+
+  # It could be either datadog_profiling or datadog_profiling_ffi, set it to the
+  # one that is found
   get_filename_component(DD_LIB_NAME ${Datadog_LIBRARY} NAME_WE)
   message(STATUS "Datadog library name: ${DD_LIB_NAME}")
 else()

--- a/cmake/DatadogConfig.cmake.in
+++ b/cmake/DatadogConfig.cmake.in
@@ -30,7 +30,7 @@ if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
       # Windows artifacts publish the library as datadog_profiling_ffi
       # in {build_type}/{link_type} directory
       NAMES ${DD_LIB_NAME} datadog_profiling_ffi
-      HINTS ${Datadog_ROOT}/lib ${Datadog_ROOT}/${BULID_TYPE}/${LINK_TYPE})
+      HINTS ${Datadog_ROOT}/lib ${Datadog_ROOT}/${BUILD_TYPE}/${LINK_TYPE})
 
   # It could be either datadog_profiling or datadog_profiling_ffi, set it to the
   # one that is found

--- a/cmake/DatadogConfig.cmake.in
+++ b/cmake/DatadogConfig.cmake.in
@@ -11,10 +11,28 @@ endif()
 
 find_path(Datadog_INCLUDE_DIR datadog/profiling.h HINTS ${Datadog_ROOT}/include)
 
-find_library(
-  Datadog_LIBRARY
-  NAMES datadog_profiling
-  HINTS ${Datadog_ROOT}/lib)
+set(DD_LIB_NAME "datadog_profiling")
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+  set(DD_LIB_NAME "datadog_profling_ffi")
+
+  if(CMAKE_BUILD_TYPE STREQUAL "Release")
+  find_library(
+      Datadog_LIBRARY
+      NAMES datadog_profiling_ffi
+      HINTS ${Datadog_ROOT}/release/static)
+  else()
+  find_library(
+      Datadog_LIBRARY
+      NAMES datadog_profiling_ffi
+      HINTS ${Datadog_ROOT}/debug/static)
+  endif()
+else()
+  find_library(
+    Datadog_LIBRARY
+    NAMES ${DD_LIB_NAME}
+    HINTS ${Datadog_ROOT}/lib)
+endif()
 
 find_package_handle_standard_args(Datadog DEFAULT_MSG Datadog_LIBRARY
                                   Datadog_INCLUDE_DIR)
@@ -24,15 +42,15 @@ if(Datadog_FOUND)
   set(Datadog_LIBRARIES ${Datadog_LIBRARY} "@Datadog_LIBRARIES@")
   mark_as_advanced(Datadog_ROOT Datadog_LIBRARY Datadog_INCLUDE_DIR)
 
-  add_library(datadog_profiling INTERFACE)
-  target_include_directories(datadog_profiling
+  add_library(${DD_LIB_NAME} INTERFACE)
+  target_include_directories(${DD_LIB_NAME}
                              INTERFACE ${Datadog_INCLUDE_DIRS})
-  target_link_libraries(datadog_profiling INTERFACE ${Datadog_LIBRARIES})
-  target_compile_features(datadog_profiling INTERFACE c_std_11)
+  target_link_libraries(${DD_LIB_NAME} INTERFACE ${Datadog_LIBRARIES})
+  target_compile_features(${DD_LIB_NAME} INTERFACE c_std_11)
 
   if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     target_link_libraries(
-      datadog_profiling
+      ${DD_LIB_NAME}
       INTERFACE NtDll
                 UserEnv
                 Bcrypt
@@ -45,7 +63,7 @@ if(Datadog_FOUND)
                 PowrProf)
   endif()
 
-  add_library(Datadog::Profiling ALIAS datadog_profiling)
+  add_library(Datadog::Profiling ALIAS ${DD_LIB_NAME})
 else()
   set(Datadog_ROOT
       ""

--- a/cmake/DatadogConfig.cmake.in
+++ b/cmake/DatadogConfig.cmake.in
@@ -16,10 +16,14 @@ set(DD_LIB_NAME "datadog_profiling")
 if(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
   # Prefer static linking over dynamic unless specified
   set(LINK_TYPE "static")
-  string(TOLOWER ${VCRUNTIME_LINK_TYPE} LINK_TYPE)
+  if (DEFINED VCRUNTIME_LINK_TYPE)
+    string(TOLOWER ${VCRUNTIME_LINK_TYPE} LINK_TYPE)
+  endif()
 
   set(BUILD_TYPE "release")
-  string(TOLOWER ${CMAKE_BUILD_TYPE} BUILD_TYPE)
+  if (DEFINED CMAKE_BUILD_TYPE)
+    string(TOLOWER ${CMAKE_BUILD_TYPE} BUILD_TYPE)
+  endif()
 
   find_library(
       Datadog_LIBRARY


### PR DESCRIPTION
# What does this PR do?

Updates cmake config to be used with cmake builds. dd-trace-py would like to use this. See pending PR which basically hard-coded this change https://github.com/DataDog/dd-trace-py/pull/12073/files#diff-26c9bef493aa48c10dd1e6cc3b1f87e8ac4b9c0034a66ad3d6228d8f0be5e655R120-R166

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
