### PR TITLE
Enhance logging and add fork handling for sessions

### DIFF
--- a/crashtracker/src/lib.rs
+++ b/crashtracker/src/lib.rs
@@ -64,8 +64,8 @@ pub use crash_info::*;
 
 #[cfg(all(unix, feature = "receiver"))]
 pub use receiver::{
-    async_receiver_entry_point_unix_socket, receiver_entry_point_stdin,
-    receiver_entry_point_unix_socket,
+    async_receiver_entry_point_unix_listener, async_receiver_entry_point_unix_socket,
+    get_receiver_unix_socket, receiver_entry_point_stdin, receiver_entry_point_unix_socket,
 };
 
 #[cfg(all(unix, any(feature = "collector", feature = "receiver")))]

--- a/crashtracker/src/receiver/mod.rs
+++ b/crashtracker/src/receiver/mod.rs
@@ -4,8 +4,8 @@
 
 mod entry_points;
 pub use entry_points::{
-    async_receiver_entry_point_unix_socket, receiver_entry_point_stdin,
-    receiver_entry_point_unix_socket,
+    async_receiver_entry_point_unix_listener, async_receiver_entry_point_unix_socket,
+    get_receiver_unix_socket, receiver_entry_point_stdin, receiver_entry_point_unix_socket,
 };
 mod receive_report;
 

--- a/remote-config/src/fetch/multitarget.rs
+++ b/remote-config/src/fetch/multitarget.rs
@@ -167,44 +167,46 @@ where
         // "goto" like handling to drop the known_service borrow and be able to change services
         'service_handling: {
             'drop_service: {
-                let known_service = services.get_mut(target).unwrap();
-                known_service.refcount = if known_service.refcount == 1 {
-                    known_service.runtimes.remove(runtime_id);
-                    let mut status = known_service.status.lock().unwrap();
-                    *status = match *status {
-                        KnownTargetStatus::Pending => KnownTargetStatus::Alive, // not really
-                        KnownTargetStatus::Alive => {
-                            KnownTargetStatus::RemoveAt(Instant::now() + Duration::from_secs(3666))
-                        }
-                        KnownTargetStatus::RemoveAt(_) | KnownTargetStatus::Removing(_) => {
-                            unreachable!()
-                        }
-                    };
-                    // We've marked it Alive so that the Pending check in start_fetcher() will fail
-                    if matches!(*status, KnownTargetStatus::Alive) {
-                        break 'drop_service;
-                    }
-                    0
-                } else {
-                    if *known_service.fetcher.runtime_id.lock().unwrap() == runtime_id {
-                        'changed_rt_id: {
-                            for (id, runtime) in self.runtimes.lock().unwrap().iter() {
-                                if runtime.targets.len() == 1
-                                    && runtime.targets.contains_key(target)
-                                {
-                                    *known_service.fetcher.runtime_id.lock().unwrap() =
-                                        id.to_string();
-                                    break 'changed_rt_id;
-                                }
+                if let Some(known_service) = services.get_mut(target) {
+                    known_service.refcount = if known_service.refcount == 1 {
+                        known_service.runtimes.remove(runtime_id);
+                        let mut status = known_service.status.lock().unwrap();
+                        *status = match *status {
+                            KnownTargetStatus::Pending => KnownTargetStatus::Alive, // not really
+                            KnownTargetStatus::Alive => KnownTargetStatus::RemoveAt(
+                                Instant::now() + Duration::from_secs(3666),
+                            ),
+                            KnownTargetStatus::RemoveAt(_) | KnownTargetStatus::Removing(_) => {
+                                unreachable!()
                             }
-                            known_service.synthetic_id = true;
-                            *known_service.fetcher.runtime_id.lock().unwrap() =
-                                Self::generate_synthetic_id();
+                        };
+                        // We've marked it Alive so that the Pending check in start_fetcher() will
+                        // fail
+                        if matches!(*status, KnownTargetStatus::Alive) {
+                            break 'drop_service;
                         }
-                    }
-                    known_service.refcount - 1
-                };
-                break 'service_handling;
+                        0
+                    } else {
+                        if *known_service.fetcher.runtime_id.lock().unwrap() == runtime_id {
+                            'changed_rt_id: {
+                                for (id, runtime) in self.runtimes.lock().unwrap().iter() {
+                                    if runtime.targets.len() == 1
+                                        && runtime.targets.contains_key(target)
+                                    {
+                                        *known_service.fetcher.runtime_id.lock().unwrap() =
+                                            id.to_string();
+                                        break 'changed_rt_id;
+                                    }
+                                }
+                                known_service.synthetic_id = true;
+                                *known_service.fetcher.runtime_id.lock().unwrap() =
+                                    Self::generate_synthetic_id();
+                            }
+                        }
+                        known_service.refcount - 1
+                    };
+                    break 'service_handling;
+                }
             }
             trace!("Remove {target:?} from services map while in pending state");
             services.remove(target);
@@ -309,14 +311,15 @@ where
                 match info.targets.entry(target.clone()) {
                     Entry::Occupied(mut e) => *e.get_mut() += 1,
                     Entry::Vacant(e) => {
-                        // it's the second usage here
                         if let Some(primary_target) = primary_target {
                             let mut services = self.services.lock().unwrap();
-                            let known_target = services.get_mut(&primary_target).unwrap();
-                            if !known_target.synthetic_id {
-                                known_target.synthetic_id = true;
-                                *known_target.fetcher.runtime_id.lock().unwrap() =
-                                    Self::generate_synthetic_id();
+                            if let Some(known_target) = services.get_mut(&primary_target) {
+                                // it's the second usage here
+                                if !known_target.synthetic_id {
+                                    known_target.synthetic_id = true;
+                                    *known_target.fetcher.runtime_id.lock().unwrap() =
+                                        Self::generate_synthetic_id();
+                                }
                             }
                         }
                         e.insert(1);

--- a/sidecar-ffi/src/lib.rs
+++ b/sidecar-ffi/src/lib.rs
@@ -538,6 +538,7 @@ pub unsafe extern "C" fn ddog_sidecar_session_set_config(
     remote_config_products_count: usize,
     remote_config_capabilities: *const RemoteConfigCapabilities,
     remote_config_capabilities_count: usize,
+    is_fork: bool,
 ) -> MaybeError {
     #[cfg(unix)]
     let remote_config_notify_target = libc::getpid();
@@ -580,6 +581,7 @@ pub unsafe extern "C" fn ddog_sidecar_session_set_config(
             .as_slice()
             .to_vec(),
         },
+        is_fork
     ));
 
     MaybeError::None

--- a/sidecar-ffi/tests/sidecar.rs
+++ b/sidecar-ffi/tests/sidecar.rs
@@ -105,6 +105,7 @@ fn test_ddog_sidecar_register_app() {
             0,
             null(),
             0,
+            false,
         )
         .unwrap_none();
 
@@ -160,6 +161,7 @@ fn test_ddog_sidecar_register_app() {
             0,
             null(),
             0,
+            false,
         )
         .unwrap_none();
 

--- a/sidecar/src/entry.rs
+++ b/sidecar/src/entry.rs
@@ -73,11 +73,17 @@ where
     #[cfg(unix)]
     tokio::spawn(async move {
         let socket_path = crashtracker_unix_socket_path();
-        let _ = datadog_crashtracker::async_receiver_entry_point_unix_socket(
-            socket_path.to_str().unwrap_or_default(),
-            false,
-        )
-        .await;
+        match datadog_crashtracker::get_receiver_unix_socket(socket_path.to_str().unwrap_or_default()) {
+            Ok(listener) =>
+                loop {
+                    if let Err(e) =
+                        datadog_crashtracker::async_receiver_entry_point_unix_listener(&listener).await
+                    {
+                        tracing::warn!("Got error while receiving crash report: {e}");
+                    }
+                },
+            Err(e) => tracing::error!("Failed setting up the crashtracker listener: {e}"),
+        }
     });
 
     // Init. Early, before we start listening.

--- a/sidecar/src/entry.rs
+++ b/sidecar/src/entry.rs
@@ -73,15 +73,16 @@ where
     #[cfg(unix)]
     tokio::spawn(async move {
         let socket_path = crashtracker_unix_socket_path();
-        match datadog_crashtracker::get_receiver_unix_socket(socket_path.to_str().unwrap_or_default()) {
-            Ok(listener) =>
-                loop {
-                    if let Err(e) =
-                        datadog_crashtracker::async_receiver_entry_point_unix_listener(&listener).await
-                    {
-                        tracing::warn!("Got error while receiving crash report: {e}");
-                    }
-                },
+        match datadog_crashtracker::get_receiver_unix_socket(
+            socket_path.to_str().unwrap_or_default(),
+        ) {
+            Ok(listener) => loop {
+                if let Err(e) =
+                    datadog_crashtracker::async_receiver_entry_point_unix_listener(&listener).await
+                {
+                    tracing::warn!("Got error while receiving crash report: {e}");
+                }
+            },
             Err(e) => tracing::error!("Failed setting up the crashtracker listener: {e}"),
         }
     });

--- a/sidecar/src/log.rs
+++ b/sidecar/src/log.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 use std::hash::Hash;
 use std::ops::{DerefMut, Sub};
 use std::path::PathBuf;
-use std::sync::{Mutex, RwLock};
+use std::sync::{Mutex, OnceLock, RwLock};
 use std::time::{Duration, Instant, SystemTime};
 use std::{env, io};
 use tracing::level_filters::LevelFilter;
@@ -365,7 +365,8 @@ lazy_static! {
     pub static ref MULTI_LOG_FILTER: MultiEnvFilter = MultiEnvFilter::default();
     pub static ref MULTI_LOG_WRITER: MultiWriter = MultiWriter::default();
 }
-static mut PERMANENT_MIN_LOG_LEVEL: Option<TemporarilyRetainedMapGuard<String, EnvFilter>> = None;
+static PERMANENT_MIN_LOG_LEVEL: OnceLock<TemporarilyRetainedMapGuard<String, EnvFilter>> =
+    OnceLock::new();
 
 pub(crate) fn enable_logging() -> anyhow::Result<()> {
     tracing_subscriber::registry()
@@ -385,9 +386,7 @@ pub(crate) fn enable_logging() -> anyhow::Result<()> {
     let config = config::Config::get();
     if !config.log_level.is_empty() {
         let filter = MULTI_LOG_FILTER.add(config.log_level.clone());
-        unsafe {
-            PERMANENT_MIN_LOG_LEVEL.replace(filter);
-        } // SAFETY: initialized once
+        _ = PERMANENT_MIN_LOG_LEVEL.set(filter);
     }
     MULTI_LOG_WRITER.add(config.log_method); // same than MULTI_LOG_FILTER
 

--- a/sidecar/src/log.rs
+++ b/sidecar/src/log.rs
@@ -385,7 +385,9 @@ pub(crate) fn enable_logging() -> anyhow::Result<()> {
     let config = config::Config::get();
     if !config.log_level.is_empty() {
         let filter = MULTI_LOG_FILTER.add(config.log_level.clone());
-        unsafe { PERMANENT_MIN_LOG_LEVEL.replace(filter); } // SAFETY: initialized once
+        unsafe {
+            PERMANENT_MIN_LOG_LEVEL.replace(filter);
+        } // SAFETY: initialized once
     }
     MULTI_LOG_WRITER.add(config.log_method); // same than MULTI_LOG_FILTER
 

--- a/sidecar/src/service/blocking.rs
+++ b/sidecar/src/service/blocking.rs
@@ -209,6 +209,7 @@ pub fn set_session_config(
     #[cfg(windows)] remote_config_notify_function: *mut libc::c_void,
     session_id: String,
     config: &SessionConfig,
+    is_fork: bool,
 ) -> io::Result<()> {
     #[cfg(unix)]
     let remote_config_notify_target = pid;
@@ -219,6 +220,7 @@ pub fn set_session_config(
         session_id,
         remote_config_notify_target,
         config: config.clone(),
+        is_fork,
     })
 }
 

--- a/sidecar/src/service/sidecar_interface.rs
+++ b/sidecar/src/service/sidecar_interface.rs
@@ -72,6 +72,7 @@ pub trait SidecarInterface {
         session_id: String,
         remote_config_notify_target: RemoteConfigNotifyTarget,
         config: SessionConfig,
+        is_fork: bool,
     );
 
     /// Shuts down a runtime.

--- a/sidecar/src/service/tracing/trace_flusher.rs
+++ b/sidecar/src/service/tracing/trace_flusher.rs
@@ -255,7 +255,7 @@ impl TraceFlusher {
                         Err(e) => error!("Error receiving agent configuration: {e:?}"),
                     }
                 }
-                info!("Successfully flushed traces to {}", endpoint.url);
+                info!("Successfully flushed traces to {endpoint:?}");
             }
             Err(e) => {
                 error!("Error sending trace: {e:?}");

--- a/tinybytes/src/bytes_string.rs
+++ b/tinybytes/src/bytes_string.rs
@@ -4,9 +4,10 @@
 use crate::Bytes;
 #[cfg(feature = "serde")]
 use serde::ser::{Serialize, Serializer};
+use std::fmt::{Debug, Formatter};
 use std::{borrow::Borrow, hash, str::Utf8Error};
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct BytesString {
     bytes: Bytes,
 }
@@ -154,6 +155,12 @@ impl hash::Hash for BytesString {
     #[inline]
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         self.as_str().hash(state);
+    }
+}
+
+impl Debug for BytesString {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.serialize_str(self.as_str())
     }
 }
 


### PR DESCRIPTION
- This includes back-propagating crashtracker logs (i.e. doing the main crashtracker accept+dispatch loop directly in the sidecar).
- Relaxes .unwrap() calls with `if let` to avoid spurious panics.
- forked processes have the same session id than their parent. Do not reset the primary session on fork.