### PR TITLE
Prepare for 16.0.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "build_common"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "cbindgen",
  "serde",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "builder"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "data-pipeline"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "data-pipeline-ffi"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "build_common",
  "data-pipeline",
@@ -1336,7 +1336,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-alloc"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "allocator-api2",
  "bolero",
@@ -1346,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-crashtracker"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-crashtracker-ffi"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1388,7 +1388,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-ddsketch"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "prost 0.11.9",
  "prost-build 0.11.9",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "anyhow",
  "bitmaps",
@@ -1543,7 +1543,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-ffi"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-replayer"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1727,7 +1727,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-mini-agent"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1749,7 +1749,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-normalization"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-obfuscation"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1778,7 +1778,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-protobuf"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "prost 0.11.9",
  "prost-build 0.11.9",
@@ -1791,7 +1791,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-utils"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "anyhow",
  "bolero",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "anyhow",
  "cc",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon-ffi"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "anyhow",
  "bolero",
@@ -1881,7 +1881,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1907,7 +1907,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry-ffi"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "build_common",
  "ddcommon",
@@ -2051,7 +2051,7 @@ dependencies = [
 
 [[package]]
 name = "dogstatsd"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "datadog-protos",
  "ddsketch-agent",
@@ -2076,7 +2076,7 @@ dependencies = [
 
 [[package]]
 name = "dogstatsd-client"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "anyhow",
  "cadence",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "symbolizer-ffi"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "blazesym-c",
  "build_common",
@@ -5669,7 +5669,7 @@ dependencies = [
 
 [[package]]
 name = "tinybytes"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "once_cell",
  "pretty_assertions",
@@ -5941,7 +5941,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "15.0.0"
+version = "16.0.0"
 dependencies = [
  "lazy_static",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.78.0"
 edition = "2021"
-version = "15.0.0"
+version = "16.0.0"
 license = "Apache-2.0"
 
 [profile.dev]


### PR DESCRIPTION
# What does this PR do?
* Bump workspace version to 16.0.0

# Motivation

The major version increase is necessary because of some breaking changes in the crashtracker APIs.
