### PR TITLE
[library-configuration] Expose config file path for wasm dependencies

### DIFF
--- a/library-config-ffi/src/lib.rs
+++ b/library-config-ffi/src/lib.rs
@@ -141,7 +141,7 @@ pub extern "C" fn ddog_library_configurator_get(
 pub extern "C" fn ddog_library_config_name_to_env(name: LibraryConfigName) -> ffi::CStr<'static> {
     use LibraryConfigName::*;
     ffi::CStr::from_std(match name {
-        DdTraceApmEnabled => ddcommon::cstr!("DD_TRACE_ENABLED"),
+        DdApmTracingEnabled => ddcommon::cstr!("DD_APM_TRACING_ENABLED"),
         DdRuntimeMetricsEnabled => ddcommon::cstr!("DD_RUNTIME_METRICS_ENABLED"),
         DdLogsInjection => ddcommon::cstr!("DD_LOGS_INJECTION"),
         DdProfilingEnabled => ddcommon::cstr!("DD_PROFILING_ENABLED"),

--- a/library-config/src/lib.rs
+++ b/library-config/src/lib.rs
@@ -254,7 +254,7 @@ impl ProcessInfo {
 #[allow(clippy::enum_variant_names)]
 pub enum LibraryConfigName {
     // Phase 1: product enablement
-    DdTraceApmEnabled,
+    DdApmTracingEnabled,
     DdRuntimeMetricsEnabled,
     DdLogsInjection,
     DdProfilingEnabled,
@@ -276,7 +276,7 @@ impl LibraryConfigName {
     pub fn to_str(&self) -> &'static str {
         use LibraryConfigName::*;
         match self {
-            DdTraceApmEnabled => "DD_TRACE_ENABLED",
+            DdApmTracingEnabled => "DD_APM_TRACING_ENABLED",
             DdRuntimeMetricsEnabled => "DD_RUNTIME_METRICS_ENABLED",
             DdLogsInjection => "DD_LOGS_INJECTION",
             DdProfilingEnabled => "DD_PROFILING_ENABLED",
@@ -748,7 +748,7 @@ mod tests {
         test_config(
             b"
 apm_configuration_default:
-  DD_TRACE_APM_ENABLED: true
+  DD_APM_TRACING_ENABLED: true
   DD_RUNTIME_METRICS_ENABLED: true
   DD_LOGS_INJECTION: true
   DD_PROFILING_ENABLED: true
@@ -762,7 +762,7 @@ apm_configuration_default:
             b"",
             vec![
                 LibraryConfig {
-                    name: DdTraceApmEnabled,
+                    name: DdApmTracingEnabled,
                     value: "true".to_owned(),
                     source: LocalStableConfig,
                     config_id: None,
@@ -834,7 +834,7 @@ apm_configuration_default:
             b"
 config_id: abc
 apm_configuration_default:
-  DD_TRACE_APM_ENABLED: true
+  DD_APM_TRACING_ENABLED: true
   DD_RUNTIME_METRICS_ENABLED: true
   DD_LOGS_INJECTION: true
   DD_PROFILING_ENABLED: true
@@ -847,7 +847,7 @@ apm_configuration_default:
     ",
             vec![
                 LibraryConfig {
-                    name: DdTraceApmEnabled,
+                    name: DdApmTracingEnabled,
                     value: "true".to_owned(),
                     source: FleetStableConfig,
                     config_id: Some("abc".to_owned()),
@@ -918,20 +918,20 @@ apm_configuration_default:
         test_config(
             b"
 apm_configuration_default:
-  DD_TRACE_APM_ENABLED: true
+  DD_APM_TRACING_ENABLED: true
   DD_RUNTIME_METRICS_ENABLED: true
   DD_PROFILING_ENABLED: true
         ",
             b"
 config_id: abc
 apm_configuration_default:
-  DD_TRACE_APM_ENABLED: true
+  DD_APM_TRACING_ENABLED: true
   DD_LOGS_INJECTION: true
   DD_PROFILING_ENABLED: false
 ",
             vec![
                 LibraryConfig {
-                    name: DdTraceApmEnabled,
+                    name: DdApmTracingEnabled,
                     value: "true".to_owned(),
                     source: FleetStableConfig,
                     config_id: Some("abc".to_owned()),


### PR DESCRIPTION
# What does this PR do?

* Add Target enum with platform detection
* expose path dependending on target for wasm intergation

# Motivation

The crate library-config fails to compile on WASM due to missing const definitions.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
