### PR TITLE
[PROF-11306] Package libdatadog v16.0.1 for Ruby

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -29,7 +29,7 @@ Note: No Ruby needed to run this! It all runs inside docker :)
 Note: Publishing new releases to rubygems.org can only be done by Datadog employees.
 
 1. [ ] Locate the new libdatadog release on GitHub: <https://github.com/datadog/libdatadog/releases>
-2. [ ] Update the `LIB_VERSION_TO_PACKAGE` and `LIB_GITHUB_RELEASES` sections of the `Rakefile` with the new version
+2. [ ] Update the `LIB_GITHUB_RELEASES` section of the `Rakefile` with the hashes from the new version
 3. [ ] Update the <lib/libdatadog/version.rb> file with the `LIB_VERSION` and `VERSION` to use
 4. [ ] Commit change, open PR, get it merged
 5. [ ] Release by running `docker-compose run push_to_rubygems`.

--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -11,7 +11,9 @@ require "rubygems/package"
 
 RSpec::Core::RakeTask.new(:spec)
 
-LIB_VERSION_TO_PACKAGE = "14.3.1"
+# Note: When packaging rc releases and the like, you may need to set this differently from LIB_VERSION
+LIB_VERSION_TO_PACKAGE = Libdatadog::LIB_VERSION
+
 unless LIB_VERSION_TO_PACKAGE.start_with?(Libdatadog::LIB_VERSION)
   raise "`LIB_VERSION_TO_PACKAGE` setting in <Rakefile> (#{LIB_VERSION_TO_PACKAGE}) does not match " \
     "`LIB_VERSION` setting in <lib/libdatadog/version.rb> (#{Libdatadog::LIB_VERSION})"
@@ -20,22 +22,22 @@ end
 LIB_GITHUB_RELEASES = [
   {
     file: "libdatadog-aarch64-alpine-linux-musl.tar.gz",
-    sha256: "57f83aff275628bb1af89c22bb4bd696726daf2a9e09b6cd0d966b29e65a7ad6",
+    sha256: "54416e4078fa9d923869ecae1a7b32e0c9ae0a47ab8c999812bb3b69cffb85bd",
     ruby_platform: "aarch64-linux-musl"
   },
   {
     file: "libdatadog-aarch64-unknown-linux-gnu.tar.gz",
-    sha256: "36db8d50ccabb71571158ea13835c0f1d05d30b32135385f97c16343cfb6ddd4",
+    sha256: "ad16283494d565a1877c76d4a8765f789ec2acb70b0597b4efe6e7a20e8b4f97",
     ruby_platform: "aarch64-linux"
   },
   {
     file: "libdatadog-x86_64-alpine-linux-musl.tar.gz",
-    sha256: "2f61fd21cf2f8147743e414b4a8c77250a17be3aecc42a69ffe54f0a603d5c92",
+    sha256: "384a50bb5013f6098b37da650f0fe9aa7c11f44780da971f8a4a35d2e342f00b",
     ruby_platform: "x86_64-linux-musl"
   },
   {
     file: "libdatadog-x86_64-unknown-linux-gnu.tar.gz",
-    sha256: "f01f05600591063eba4faf388f54c155ab4e6302e5776c7855e3734955f7daf7",
+    sha256: "6cea4ef4ecd4f40c1c69118bc1bb842c20782b710b838df3917d02eea7575a4e",
     ruby_platform: "x86_64-linux"
   }
 ]

--- a/ruby/lib/libdatadog/version.rb
+++ b/ruby/lib/libdatadog/version.rb
@@ -2,7 +2,7 @@
 
 module Libdatadog
   # Current libdatadog version
-  LIB_VERSION = "14.3.1"
+  LIB_VERSION = "16.0.1"
 
   GEM_MAJOR_VERSION = "1"
   GEM_MINOR_VERSION = "0"


### PR DESCRIPTION
# What does this PR do?

This PR includes the changes documented in the "Releasing a new version to rubygems.org" part of the README:
https://github.com/datadog/libdatadog/tree/main/ruby#releasing-a-new-version-to-rubygemsorg

# Motivation

Enable Ruby to use libdatadog v16.0.1. Of particular interest, this includes improvements to crashtracking and the managed string table needed by https://github.com/DataDog/dd-trace-rb/pull/4331 .

# Additional Notes

N/A

# How to test the change?

I've tested this release locally using the changes in https://github.com/DataDog/dd-trace-rb/pull/4353 .

As a reminder, new libdatadog releases don't get automatically picked up by dd-trace-rb, so the PR that bumps the Ruby profiler will also test this release against all supported Ruby versions.