### PR TITLE
[library-config] Skip error on unknown config key

### DIFF
--- a/library-config/src/lib.rs
+++ b/library-config/src/lib.rs
@@ -875,10 +875,10 @@ apm_configuration_default:
   DD_APPSEC_ENABLED: true
   DD_IAST_ENABLED: true
   DD_DYNAMIC_INSTRUMENTATION_ENABLED: true
+  # extra keys should be skipped without errors
+  FOO_BAR: quoicoubeh
   DD_DATA_JOBS_ENABLED: true
   DD_APPSEC_SCA_ENABLED: true
-  # extra keys should be skipped without errors
-  FOO_BAR: hqecuh
 wtf:
 - 1
     ",

--- a/library-config/src/lib.rs
+++ b/library-config/src/lib.rs
@@ -634,7 +634,7 @@ impl Configurator {
             mem::take(&mut stable_config.apm_configuration_default)
                 .0
                 // TODO(paullgdc): use Box<[I]>::into_iter when we can use rust 1.80
-                .to_vec()
+                .into_vec()
                 .into_iter()
                 .map(|(k, v)| {
                     (


### PR DESCRIPTION
# What does this PR do?

* Add custom deserializer for the configuration map to not error on unknown keys

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
