### PR TITLE
Stabilize benchmarks using opt-level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,12 @@ opt-level = "s"            # optimize for size
 [profile.release.package.datadog-serverless-trace-mini-agent]
 strip = true
 
+[profile.bench]
+codegen-units = 1
+debug = false
+incremental = false
+opt-level = 3
+
 # https://camshaft.github.io/bolero/library-installation.html
 [profile.fuzz]
 inherits = "dev"


### PR DESCRIPTION
# What does this PR do?

Changes the `opt-level` of the `bench` profile to get more stable benchmark results.

# Motivation

The benchmark results are sensitive to strange things like changing the version number of the main project. This has been consistently repeated in a test PR #874. As to the reason why, I can only speculate that optimizing for size can change the placement of code and or fields in unexpected ways. This behavior goes away with the settings in this PR.

# Additional Notes

Nope

# How to test the change?

Was validate in PR #878 
