### PR TITLE
fix: skip serialization of optional properties in a span link

### DIFF
--- a/tinybytes/src/bytes_string.rs
+++ b/tinybytes/src/bytes_string.rs
@@ -114,6 +114,11 @@ impl BytesString {
     pub fn copy_to_string(&self) -> String {
         self.as_str().to_string()
     }
+
+    /// Returns `true` if the underlying bytes are empty.
+    pub fn is_empty(&self) -> bool {
+        self.bytes.is_empty()
+    }
 }
 
 impl Default for BytesString {

--- a/trace-utils/src/span/v04/span.rs
+++ b/trace-utils/src/span/v04/span.rs
@@ -78,8 +78,11 @@ pub struct SpanLink {
     pub trace_id: u64,
     pub trace_id_high: u64,
     pub span_id: u64,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub attributes: HashMap<BytesString, BytesString>,
+    #[serde(skip_serializing_if = "BytesString::is_empty")]
     pub tracestate: BytesString,
+    #[serde(skip_serializing_if = "is_default")]
     pub flags: u64,
 }
 


### PR DESCRIPTION
# What does this PR do?

tracestate, attributes and flags are optional. Following the existing pattern, when these have a default value, serialization ignores them.

> [!IMPORTANT]  
>Ideally, we should have them optional marked in the models itself, so we can get all the typeness but for now following the existing approach.

# Motivation

Failing .NET tests

<img width="1067" alt="image" src="https://github.com/user-attachments/assets/5059393f-ed7c-40fa-a7d1-3b66f28b4431" />

# How to test the change?

Use local agent to check the serialized payload.

eg

```
[
    [
        {
            "service": "data-pipeline-test",
            "name": "test-name-1",
            "resource": "test-resource-2",
            "type": "",
            "trace_id": 1,
            "span_id": 1,
            "start": 1739884373314738000,
            "duration": 11000000,
            "metrics": {
                "_dd.measured": 1.0,
                "_sampling_priority_v1": 1.0
            },
            "span_links": [
                {
                    "trace_id": 1,
                    "trace_id_high": 0,
                    "span_id": 0
                }
            ]
        },
....
```
