### PR TITLE
fix: skip serialization of span type when empty

### DIFF
--- a/trace-utils/src/span/v04/span.rs
+++ b/trace-utils/src/span/v04/span.rs
@@ -54,6 +54,7 @@ pub struct Span {
     pub service: BytesString,
     pub name: BytesString,
     pub resource: BytesString,
+    #[serde(skip_serializing_if = "BytesString::is_empty")]
     pub r#type: BytesString,
     pub trace_id: u64,
     pub span_id: u64,


### PR DESCRIPTION
# What does this PR do?

Followup of https://github.com/DataDog/libdatadog/pull/885

# Motivation

Similar problem as the mentioned PR that type is considered optional but data pipeline doesn't.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

using the local agent

```
....
        {
            "service": "data-pipeline-test",
            "name": "test-name-1",
            "resource": "test-resource-2",
            "trace_id": 1,
            "span_id": 1,
            "start": 1739891409688549000,
            "duration": 11000000,
            "metrics": {
                "_sampling_priority_v1": 1.0,
                "_dd.measured": 1.0
            }
        }
    ]
]
```
