### PR TITLE
Fix possible deadlock with remote configuration expiring during insertion

### DIFF
--- a/ddtelemetry/src/metrics.rs
+++ b/ddtelemetry/src/metrics.rs
@@ -63,7 +63,7 @@ pub struct MetricBuckets {
     distributions: HashMap<BucketKey, DDSketch>,
 }
 
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct MetricBucketStats {
     pub buckets: u32,
     pub series: u32,

--- a/ddtelemetry/src/worker/mod.rs
+++ b/ddtelemetry/src/worker/mod.rs
@@ -127,7 +127,7 @@ pub struct TelemetryWorker {
     data: TelemetryWorkerData,
 }
 
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct TelemetryWorkerStats {
     pub dependencies_stored: u32,
     pub dependencies_unflushed: u32,

--- a/remote-config/src/fetch/fetcher.rs
+++ b/remote-config/src/fetch/fetcher.rs
@@ -83,7 +83,7 @@ pub struct ConfigFetcherState<S> {
     pub expire_unused_files: bool,
 }
 
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct ConfigFetcherStateStats {
     pub active_files: u32,
 }

--- a/remote-config/src/fetch/multitarget.rs
+++ b/remote-config/src/fetch/multitarget.rs
@@ -54,7 +54,7 @@ where
     fetcher_semaphore: Semaphore,
 }
 
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct MultiTargetStats {
     known_runtimes: u32,
     starting_fetchers: u32,

--- a/remote-config/src/fetch/shared.rs
+++ b/remote-config/src/fetch/shared.rs
@@ -140,7 +140,7 @@ where
     run_id: Arc<RunnersGeneration>,
 }
 
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 pub struct RefcountingStorageStats {
     pub inactive_files: u32,
     pub fetcher: ConfigFetcherStateStats,

--- a/sidecar/src/entry.rs
+++ b/sidecar/src/entry.rs
@@ -93,7 +93,8 @@ where
     let server = SidecarServer::default();
     let (shutdown_complete_tx, shutdown_complete_rx) = mpsc::channel::<()>(1);
 
-    let watchdog_handle = Watchdog::from_receiver(shutdown_complete_rx).spawn_watchdog();
+    let watchdog_handle =
+        Watchdog::from_receiver(shutdown_complete_rx).spawn_watchdog(server.clone());
     let telemetry_handle = self_telemetry(server.clone(), watchdog_handle);
 
     listener(Box::new({

--- a/sidecar/src/log.rs
+++ b/sidecar/src/log.rs
@@ -66,7 +66,7 @@ unsafe impl<K, V> Sync for TemporarilyRetainedMap<K, V> where
 {
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct TemporarilyRetainedMapStats {
     pub elements: u32,
     pub live_counters: u32,

--- a/sidecar/src/service/debugger_diagnostics_bookkeeper.rs
+++ b/sidecar/src/service/debugger_diagnostics_bookkeeper.rs
@@ -136,7 +136,7 @@ impl Drop for DebuggerDiagnosticsBookkeeper {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct DebuggerDiagnosticsBookkeeperStats {
     runtime_ids: u32,
     total_probes: u32,

--- a/sidecar/src/service/session_info.rs
+++ b/sidecar/src/service/session_info.rs
@@ -272,14 +272,16 @@ impl SessionInfo {
             }
         }
 
-        let invariants = self.get_remote_config_invariants();
-        let version = invariants
-            .as_ref()
-            .map(|i| i.tracer_version.as_str())
-            .unwrap_or("0.0.0");
         if let Some(runtime) = self.lock_runtimes().get(runtime_id) {
             if let Some(app) = runtime.lock_applications().get_mut(&queue_id) {
-                let (tags, new_tags) = app.get_debugger_tags(&version, runtime_id);
+                let (tags, new_tags) = {
+                    let invariants = self.get_remote_config_invariants();
+                    let version = invariants
+                        .as_ref()
+                        .map(|i| i.tracer_version.as_str())
+                        .unwrap_or("0.0.0");
+                    app.get_debugger_tags(&version, runtime_id)
+                };
                 let sender = match debugger_type {
                     DebuggerType::Diagnostics => app.debugger_diagnostics_payload_sender.clone(),
                     DebuggerType::Logs => app.debugger_logs_payload_sender.clone(),

--- a/sidecar/src/service/sidecar_server.rs
+++ b/sidecar/src/service/sidecar_server.rs
@@ -63,8 +63,8 @@ fn no_response() -> NoResponse {
     future::ready(())
 }
 
-#[derive(Serialize, Deserialize)]
-struct SidecarStats {
+#[derive(Debug, Serialize, Deserialize)]
+pub struct SidecarStats {
     trace_flusher: TraceFlusherStats,
     sessions: u32,
     session_counter_size: u32,
@@ -306,7 +306,7 @@ impl SidecarServer {
         }
     }
 
-    async fn compute_stats(&self) -> SidecarStats {
+    pub async fn compute_stats(&self) -> SidecarStats {
         let mut telemetry_stats_errors = 0;
         let telemetry_stats = join_all({
             let sessions = self.lock_sessions();

--- a/sidecar/src/service/sidecar_server.rs
+++ b/sidecar/src/service/sidecar_server.rs
@@ -943,25 +943,24 @@ impl SidecarInterface for SidecarServer {
         let notify_target = RemoteConfigNotifyTarget {
             pid: session.pid.load(Ordering::Relaxed),
         };
+        let invariants = session
+            .get_remote_config_invariants()
+            .as_ref()
+            .expect("Expecting remote config invariants to be set early")
+            .clone();
         let runtime_info = session.get_runtime(&instance_id.runtime_id);
         let mut applications = runtime_info.lock_applications();
         let app = applications.entry(queue_id).or_default();
-        app.remote_config_guard = Some(
-            self.remote_configs.add_runtime(
-                session
-                    .get_remote_config_invariants()
-                    .as_ref()
-                    .expect("Expecting remote config invariants to be set early")
-                    .clone(),
-                *session.remote_config_interval.lock().unwrap(),
-                instance_id.runtime_id,
-                notify_target,
-                env_name.clone(),
-                service_name,
-                app_version.clone(),
-                global_tags.clone(),
-            ),
-        );
+        app.remote_config_guard = Some(self.remote_configs.add_runtime(
+            invariants,
+            *session.remote_config_interval.lock().unwrap(),
+            instance_id.runtime_id,
+            notify_target,
+            env_name.clone(),
+            service_name,
+            app_version.clone(),
+            global_tags.clone(),
+        ));
         app.set_metadata(env_name, app_version, global_tags);
 
         no_response()

--- a/sidecar/src/service/telemetry/enqueued_telemetry_stats.rs
+++ b/sidecar/src/service/telemetry/enqueued_telemetry_stats.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use std::iter::Sum;
 use std::ops::Add;
 
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Serialize, Deserialize)]
 /// `EnqueuedTelemetryStats`contains the count of stored and unflushed dependencies, configurations,
 /// and integrations. It also keeps track of the count of metrics, points, actions, and computed
 /// dependencies.

--- a/sidecar/src/service/tracing/trace_flusher.rs
+++ b/sidecar/src/service/tracing/trace_flusher.rs
@@ -30,7 +30,7 @@ const DEFAULT_MIN_FORCE_DROP_SIZE_BYTES: u32 = 10_000_000;
 /// `TraceFlusherStats` holds stats of the trace flusher like the count of allocated shared memory
 /// for agent config, agent config writers, last used entries in agent configs, and the size of send
 /// data.
-#[derive(Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct TraceFlusherStats {
     pub(crate) agent_config_allocated_shm: u32,
     pub(crate) agent_config_writers: u32,

--- a/sidecar/src/watchdog.rs
+++ b/sidecar/src/watchdog.rs
@@ -12,6 +12,7 @@ use std::{
     time::Duration,
 };
 
+use crate::service::SidecarServer;
 use tokio::{select, sync::mpsc::Receiver};
 use tracing::error;
 
@@ -42,7 +43,7 @@ impl Watchdog {
         }
     }
 
-    pub fn spawn_watchdog(mut self) -> WatchdogHandle {
+    pub fn spawn_watchdog(mut self, server: SidecarServer) -> WatchdogHandle {
         let mem_usage_bytes = Arc::new(AtomicUsize::new(0));
         let handle_mem_usage_bytes = mem_usage_bytes.clone();
 
@@ -98,6 +99,9 @@ impl Watchdog {
                                 std::thread::sleep(Duration::from_secs(5));
                                 std::process::exit(1);
                             });
+
+                            error!("Watchdog memory exceeded: Sidecar using more than {} bytes. Exiting.", self.max_memory_usage_bytes);
+                            error!("Memory statistics: {:?}", server.compute_stats().await);
                             return
                         }
 


### PR DESCRIPTION
In this case the dead handler (internally holding a lock to the service map) attempting to remove (needs to acquire the configurations map) while add_runtime (which holds a lock to the configurations map) is called (needs to acquire the services map).

Also doing a trivial re-order in session_info to not retain remote config invariants across runtimes and application locks.

And add a couple memory statistics on OOM kill for users to report.