### PR TITLE
ekump/APMSP-1756 add trace exporter integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,6 +1313,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_json",
+ "tempfile",
  "tinybytes",
  "tokio",
  "tokio-util",
@@ -1812,6 +1813,7 @@ dependencies = [
  "testcontainers",
  "tinybytes",
  "tokio",
+ "urlencoding",
 ]
 
 [[package]]
@@ -6164,6 +6166,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "ustr"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,6 +1297,7 @@ dependencies = [
  "arc-swap",
  "bytes",
  "criterion",
+ "data-pipeline",
  "datadog-ddsketch",
  "datadog-trace-protobuf",
  "datadog-trace-utils",

--- a/data-pipeline/Cargo.toml
+++ b/data-pipeline/Cargo.toml
@@ -41,8 +41,12 @@ path = "benches/main.rs"
 
 [dev-dependencies]
 criterion = "0.5.1"
+data-pipeline = { path = ".", features = ["test-utils"] }
 datadog-trace-utils = { path = "../trace-utils", features = ["test-utils"] }
 httpmock = "0.7.0"
 rand = "0.8.5"
 regex = "1.5"
 tokio = {version = "1.23", features = ["rt", "time", "test-util"], default-features = false}
+
+[features]
+test-utils = []

--- a/data-pipeline/Cargo.toml
+++ b/data-pipeline/Cargo.toml
@@ -46,6 +46,7 @@ datadog-trace-utils = { path = "../trace-utils", features = ["test-utils"] }
 httpmock = "0.7.0"
 rand = "0.8.5"
 regex = "1.5"
+tempfile = "3.3.0"
 tokio = {version = "1.23", features = ["rt", "time", "test-util"], default-features = false}
 
 [features]

--- a/data-pipeline/src/trace_exporter/mod.rs
+++ b/data-pipeline/src/trace_exporter/mod.rs
@@ -84,6 +84,16 @@ impl TraceExporterOutputFormat {
             },
         )
     }
+
+    #[cfg(feature = "test-utils")]
+    // This function is only intended for testing purposes so we don't need to go to all the trouble
+    // of breaking the uri down and parsing it as rigorously as we would if we were using it in
+    // production code.
+    fn add_query(&self, url: &Uri, query: &str) -> Uri {
+        let url = format!("{}?{}", url, query);
+
+        Uri::from_str(&url).expect("Failed to create Uri from string")
+    }
 }
 
 /// Add a path to the URL.
@@ -96,11 +106,10 @@ fn add_path(url: &Uri, path: &str) -> Uri {
     let p_and_q = url.path_and_query();
     let new_p_and_q = match p_and_q {
         Some(pq) => {
-            let mut p = pq.path().to_string();
-            if p.ends_with('/') {
-                p.pop();
-            }
+            let p = pq.path();
+            let mut p = p.strip_suffix('/').unwrap_or(p).to_owned();
             p.push_str(path);
+
             PathAndQuery::from_str(p.as_str())
         }
         None => PathAndQuery::from_str(path),
@@ -253,6 +262,8 @@ pub struct TraceExporter {
     agent_info: AgentInfoArc,
     previous_info_state: ArcSwapOption<String>,
     telemetry: Option<TelemetryClient>,
+    #[cfg(feature = "test-utils")]
+    query_params: Option<String>,
 }
 
 impl TraceExporter {
@@ -279,7 +290,6 @@ impl TraceExporter {
                     error::AgentErrorKind::EmptyResponse,
                 ));
             }
-
             Ok(AgentResponse::from(res))
         })
     }
@@ -640,7 +650,7 @@ impl TraceExporter {
                 let chunks = traces.len();
                 let payload_len = payload.len();
                 let endpoint = Endpoint {
-                    url: self.output_format.add_path(&self.endpoint.url),
+                    url: self.get_agent_url(),
                     ..self.endpoint.clone()
                 };
                 let mut headers: HashMap<&str, String> = header_tags.into();
@@ -683,7 +693,6 @@ impl TraceExporter {
                                     return Err(TraceExporterError::from(err));
                                 }
                             };
-
                             if status.is_success() {
                                 self.emit_metric(
                                     HealthMetric::Count(
@@ -742,6 +751,18 @@ impl TraceExporter {
             TraceExporterOutputFormat::V07 => todo!("We don't support translating to v07 yet"),
         }
     }
+
+    fn get_agent_url(&self) -> Uri {
+        #[cfg(feature = "test-utils")]
+        {
+            if let Some(query) = &self.query_params {
+                let url = self.output_format.add_path(&self.endpoint.url);
+                return self.output_format.add_query(&url, query);
+            }
+        }
+
+        self.output_format.add_path(&self.endpoint.url)
+    }
 }
 
 const DEFAULT_AGENT_URL: &str = "http://127.0.0.1:8126";
@@ -771,7 +792,9 @@ pub struct TraceExporterBuilder {
     dogstatsd_url: Option<String>,
     client_computed_stats: bool,
     client_computed_top_level: bool,
-
+    #[cfg(feature = "test-utils")]
+    /// not supported in production, but useful for interacting with the test-agent
+    query_params: Option<String>,
     // Stats specific fields
     /// A Some value enables stats-computation, None if it is disabled
     stats_bucket_size: Option<Duration>,
@@ -926,6 +949,14 @@ impl TraceExporterBuilder {
         self
     }
 
+    #[cfg(feature = "test-utils")]
+    /// Set query parameters to be used in the URL when communicating with the test-agent. This is
+    /// not supported in production as the real agent doesn't accept query params.
+    pub fn set_query_params(mut self, query_params: &str) -> Self {
+        self.query_params = Some(query_params.to_owned());
+        self
+    }
+
     #[allow(missing_docs)]
     pub fn build(self) -> Result<TraceExporter, TraceExporterError> {
         let runtime = tokio::runtime::Builder::new_current_thread()
@@ -1014,6 +1045,8 @@ impl TraceExporterBuilder {
             agent_info,
             previous_info_state: ArcSwapOption::new(None),
             telemetry,
+            #[cfg(feature = "test-utils")]
+            query_params: self.query_params,
         })
     }
 }

--- a/data-pipeline/src/trace_exporter/mod.rs
+++ b/data-pipeline/src/trace_exporter/mod.rs
@@ -290,6 +290,7 @@ impl TraceExporter {
                     error::AgentErrorKind::EmptyResponse,
                 ));
             }
+
             Ok(AgentResponse::from(res))
         })
     }
@@ -693,6 +694,7 @@ impl TraceExporter {
                                     return Err(TraceExporterError::from(err));
                                 }
                             };
+
                             if status.is_success() {
                                 self.emit_metric(
                                     HealthMetric::Count(

--- a/data-pipeline/tests/snapshots/compare_v04_trace_snapshot_test.json
+++ b/data-pipeline/tests/snapshots/compare_v04_trace_snapshot_test.json
@@ -1,0 +1,61 @@
+[
+  [
+    {
+      "service": "test-service",
+      "name": "test_name",
+      "resource": "test-resource",
+      "trace_id": 1234,
+      "span_id": 12342,
+      "parent_id": 12341,
+      "start": 1,
+      "duration": 5,
+      "meta": {
+        "env": "test-env",
+        "service": "test-service",
+        "runtime-id": "test-runtime-id-value"
+      },
+      "metrics": {
+        "_dd_metric1": 1.0,
+        "_dd_metric2": 2.0
+      }
+    },
+    {
+      "service": "test-service",
+      "name": "test_name",
+      "resource": "test-resource",
+      "trace_id": 1234,
+      "span_id": 12343,
+      "parent_id": 12341,
+      "start": 1,
+      "duration": 5,
+      "meta": {
+        "env": "test-env",
+        "runtime-id": "test-runtime-id-value",
+        "service": "test-service"
+      },
+      "metrics": {}
+    },
+    {
+      "service": "test-service",
+      "name": "test_name",
+      "resource": "test-resource",
+      "trace_id": 1234,
+      "span_id": 12341,
+      "parent_id": 0,
+      "start": 0,
+      "duration": 5,
+      "meta": {
+        "_dd.origin": "cloudfunction",
+        "env": "test-env",
+        "service": "test-service",
+        "runtime-id": "test-runtime-id-value",
+        "origin": "cloudfunction",
+        "functionname": "dummy_function_name"
+      },
+      "metrics": {
+        "_top_level": 1.0
+      },
+      "type": "web"
+    }
+  ]
+]

--- a/data-pipeline/tests/snapshots/compare_v04_trace_snapshot_test.json
+++ b/data-pipeline/tests/snapshots/compare_v04_trace_snapshot_test.json
@@ -32,8 +32,7 @@
         "env": "test-env",
         "runtime-id": "test-runtime-id-value",
         "service": "test-service"
-      },
-      "metrics": {}
+      }
     },
     {
       "service": "test-service",

--- a/data-pipeline/tests/test_trace_exporter.rs
+++ b/data-pipeline/tests/test_trace_exporter.rs
@@ -1,0 +1,139 @@
+// Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+#[cfg(test)]
+mod tracing_integration_tests {
+    use data_pipeline::trace_exporter::TraceExporter;
+    use datadog_trace_utils::test_utils::create_test_json_span;
+    use datadog_trace_utils::test_utils::datadog_test_agent::DatadogTestAgent;
+    use serde_json::json;
+    #[cfg(target_os = "linux")]
+    use std::fs::Permissions;
+    #[cfg(target_os = "linux")]
+    use std::os::unix::fs::PermissionsExt;
+    use tinybytes::Bytes;
+    use tokio::task;
+
+    fn get_v04_trace_snapshot_test_payload() -> Bytes {
+        let mut span_1 = create_test_json_span(1234, 12342, 12341, 1, false);
+
+        span_1["metrics"] = json!({
+            "_dd_metric1": 1.0,
+            "_dd_metric2": 2.0
+        });
+
+        let span_2 = create_test_json_span(1234, 12343, 12341, 1, false);
+        let mut root_span = create_test_json_span(1234, 12341, 0, 0, true);
+        root_span["type"] = json!("web".to_owned());
+
+        let encoded_data = rmp_serde::to_vec_named(&vec![vec![span_1, span_2, root_span]]).unwrap();
+
+        tinybytes::Bytes::from(encoded_data)
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn compare_v04_trace_snapshot_test() {
+        let relative_snapshot_path = "data-pipeline/tests/snapshots/";
+        let test_agent = DatadogTestAgent::new(Some(relative_snapshot_path), None).await;
+        let url = test_agent.get_base_uri().await;
+        let rate_param = "{\"service:test,env:test_env\": 0.5, \"service:test2,env:prod\": 0.2}";
+        test_agent
+            .start_session("compare_v04_trace_snapshot_test", Some(rate_param))
+            .await;
+
+        let task_result = task::spawn_blocking(move || {
+            let trace_exporter = TraceExporter::builder()
+                .set_url(url.to_string().as_ref())
+                .set_language("test-lang")
+                .set_language_version("2.0")
+                .set_language_interpreter_vendor("vendor")
+                .set_language_interpreter("interpreter")
+                .set_tracer_version("1.0")
+                .set_env("test_env")
+                .set_service("test")
+                .set_query_params("test_session_token=compare_v04_trace_snapshot_test")
+                .build()
+                .expect("Unable to build TraceExporter");
+
+            let data = get_v04_trace_snapshot_test_payload();
+            let response = trace_exporter.send(data, 1);
+            let expected_response = format!("{{\"rate_by_service\": {}}}", rate_param);
+
+            assert!(response.is_ok());
+            assert_eq!(response.unwrap().body, expected_response)
+        })
+        .await;
+
+        assert!(task_result.is_ok());
+
+        test_agent
+            .assert_snapshot("compare_v04_trace_snapshot_test")
+            .await;
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    // Validate that we can correctly send traces to the agent via UDS
+    async fn uds_snapshot_test() {
+        let relative_snapshot_path = "data-pipeline/tests/snapshots/";
+
+        // Create a temporary directory for the socket to be mounted in the test agent container
+        let socket_dir = tempfile::Builder::new()
+            .prefix("dd-trace-test-")
+            .tempdir()
+            .expect("Failed to create temporary directory");
+
+        std::fs::set_permissions(socket_dir.path(), Permissions::from_mode(0o755))
+            .expect("Failed to set directory permissions");
+
+        let absolute_socket_dir_path = socket_dir
+            .path()
+            .to_str()
+            .expect("Failed to convert path to string")
+            .to_owned();
+
+        let absolute_socket_path = socket_dir.path().join("apm.socket");
+        let url = format!("unix://{}", absolute_socket_path.display());
+
+        let test_agent = DatadogTestAgent::new(
+            Some(relative_snapshot_path),
+            Some(&absolute_socket_dir_path),
+        )
+        .await;
+
+        let rate_param = "{\"service:test,env:test_env\": 0.5, \"service:test2,env:prod\": 0.2}";
+        test_agent
+            .start_session("compare_v04_trace_snapshot_test", Some(rate_param))
+            .await;
+
+        let task_result = task::spawn_blocking(move || {
+            let trace_exporter = TraceExporter::builder()
+                .set_url(url.to_string().as_ref())
+                .set_language("test-lang")
+                .set_language_version("2.0")
+                .set_language_interpreter_vendor("vendor")
+                .set_language_interpreter("interpreter")
+                .set_tracer_version("1.0")
+                .set_env("test_env")
+                .set_service("test")
+                .set_query_params("test_session_token=compare_v04_trace_snapshot_test")
+                .build()
+                .expect("Unable to build TraceExporter");
+
+            let data = get_v04_trace_snapshot_test_payload();
+            let response = trace_exporter.send(data, 1);
+            let expected_response = format!("{{\"rate_by_service\": {}}}", rate_param);
+
+            assert!(response.is_ok());
+            assert_eq!(response.unwrap().body, expected_response)
+        })
+        .await;
+
+        assert!(task_result.is_ok());
+
+        test_agent
+            .assert_snapshot("compare_v04_trace_snapshot_test")
+            .await;
+    }
+}

--- a/dogstatsd-client/src/lib.rs
+++ b/dogstatsd-client/src/lib.rs
@@ -91,7 +91,7 @@ impl Client {
     /// version of DogStatsDAction. See the docs for DogStatsDActionOwned for details.
     pub fn send_owned(&self, actions: Vec<DogStatsDActionOwned>) {
         let client_opt = match self.get_or_init_client() {
-            Ok(guard) => guard,
+            Ok(client) => client,
             Err(e) => {
                 error!("Failed to get client: {}", e);
                 return;
@@ -130,7 +130,7 @@ impl Client {
         actions: Vec<DogStatsDAction<'a, T, V>>,
     ) {
         let client_opt = match self.get_or_init_client() {
-            Ok(guard) => guard,
+            Ok(client) => client,
             Err(e) => {
                 error!("Failed to get client: {}", e);
                 return;

--- a/trace-mini-agent/src/trace_processor.rs
+++ b/trace-mini-agent/src/trace_processor.rs
@@ -194,7 +194,7 @@ mod tests {
 
         let start = get_current_timestamp_nanos();
 
-        let json_span = create_test_json_span(11, 222, 333, start);
+        let json_span = create_test_json_span(11, 222, 333, start, false);
 
         let bytes = rmp_serde::to_vec(&vec![vec![json_span]]).unwrap();
         let request = Request::builder()

--- a/trace-utils/Cargo.toml
+++ b/trace-utils/Cargo.toml
@@ -41,6 +41,7 @@ cargo_metadata = { version = "0.18.1", optional = true }
 # Dependency of cargo metadata, but 0.1.8 requires too new of a rust version.
 cargo-platform = { version = "=0.1.7", optional = true }
 tinybytes =  { path = "../tinybytes", features = ["bytes_string", "serialization"] }
+urlencoding = { version="2.1.3", optional= true }
 
 [dev-dependencies]
 bolero = "0.10.1"
@@ -54,5 +55,5 @@ tempfile = "3.3.0"
 
 [features]
 default = ["proxy"]
-test-utils = ["httpmock", "testcontainers", "cargo_metadata", "cargo-platform"]
+test-utils = ["httpmock", "testcontainers", "cargo_metadata", "cargo-platform", "urlencoding"]
 proxy = ["hyper-proxy"]

--- a/trace-utils/src/msgpack_decoder/v04/mod.rs
+++ b/trace-utils/src/msgpack_decoder/v04/mod.rs
@@ -166,7 +166,7 @@ mod tests {
 
     #[test]
     fn test_decoder_read_null_string_success() {
-        let mut span = create_test_json_span(1, 2, 0, 0);
+        let mut span = create_test_json_span(1, 2, 0, 0, false);
         span["name"] = json!(null);
         let mut encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
         encoded_data.extend_from_slice(&[0, 0, 0, 0]); // some garbage, to be ignored
@@ -181,7 +181,7 @@ mod tests {
 
     #[test]
     fn test_decoder_read_number_success() {
-        let span = create_test_json_span(1, 2, 0, 0);
+        let span = create_test_json_span(1, 2, 0, 0, false);
         let mut encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
         encoded_data.extend_from_slice(&[0, 0, 0, 0]); // some garbage, to be ignored
         let (decoded_traces, _) =
@@ -195,7 +195,7 @@ mod tests {
 
     #[test]
     fn test_decoder_read_null_number_success() {
-        let mut span = create_test_json_span(1, 2, 0, 0);
+        let mut span = create_test_json_span(1, 2, 0, 0, false);
         span["trace_id"] = json!(null);
         let mut encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
         encoded_data.extend_from_slice(&[0, 0, 0, 0]); // some garbage, to be ignored
@@ -210,7 +210,7 @@ mod tests {
 
     #[test]
     fn test_decoder_meta_struct_null_map_success() {
-        let mut span = create_test_json_span(1, 2, 0, 0);
+        let mut span = create_test_json_span(1, 2, 0, 0, false);
         span["meta_struct"] = json!(null);
 
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
@@ -231,7 +231,7 @@ mod tests {
             generate_meta_struct_element(1),
         ]);
 
-        let mut span = create_test_json_span(1, 2, 0, 0);
+        let mut span = create_test_json_span(1, 2, 0, 0, false);
         span["meta_struct"] = json!(expected_meta_struct.clone());
 
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
@@ -255,7 +255,7 @@ mod tests {
         let expected_meta_struct: HashMap<String, Vec<u8>> =
             (0..20).map(generate_meta_struct_element).collect();
 
-        let mut span = create_test_json_span(1, 2, 0, 0);
+        let mut span = create_test_json_span(1, 2, 0, 0, false);
         span["meta_struct"] = json!(expected_meta_struct.clone());
 
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
@@ -281,7 +281,7 @@ mod tests {
             ("key2".to_string(), "value2".to_string()),
         ]);
 
-        let mut span = create_test_json_span(1, 2, 0, 0);
+        let mut span = create_test_json_span(1, 2, 0, 0, false);
         span["meta"] = json!(expected_meta.clone());
 
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
@@ -302,7 +302,7 @@ mod tests {
 
     #[test]
     fn test_decoder_meta_null_map_success() {
-        let mut span = create_test_json_span(1, 2, 0, 0);
+        let mut span = create_test_json_span(1, 2, 0, 0, false);
         span["meta"] = json!(null);
 
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
@@ -327,7 +327,7 @@ mod tests {
             })
             .collect();
 
-        let mut span = create_test_json_span(1, 2, 0, 0);
+        let mut span = create_test_json_span(1, 2, 0, 0, false);
         span["meta"] = json!(expected_meta.clone());
 
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
@@ -350,7 +350,7 @@ mod tests {
     fn test_decoder_metrics_fixed_map_success() {
         let expected_metrics = HashMap::from([("metric1", 1.23), ("metric2", 4.56)]);
 
-        let mut span = create_test_json_span(1, 2, 0, 0);
+        let mut span = create_test_json_span(1, 2, 0, 0, false);
         span["metrics"] = json!(expected_metrics.clone());
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
         let (decoded_traces, _) =
@@ -374,7 +374,7 @@ mod tests {
             .map(|i| (format!("metric{}", i), i as f64))
             .collect();
 
-        let mut span = create_test_json_span(1, 2, 0, 0);
+        let mut span = create_test_json_span(1, 2, 0, 0, false);
         span["metrics"] = json!(expected_metrics.clone());
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
         let (decoded_traces, _) =
@@ -394,7 +394,7 @@ mod tests {
 
     #[test]
     fn test_decoder_metrics_null_success() {
-        let mut span = create_test_json_span(1, 2, 0, 0);
+        let mut span = create_test_json_span(1, 2, 0, 0, false);
         span["metrics"] = json!(null);
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
         let (decoded_traces, _) =
@@ -420,7 +420,7 @@ mod tests {
             "flags": 0b101
         });
 
-        let mut span = create_test_json_span(1, 2, 0, 0);
+        let mut span = create_test_json_span(1, 2, 0, 0, false);
         span["span_links"] = json!([expected_span_link]);
 
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
@@ -467,7 +467,7 @@ mod tests {
 
     #[test]
     fn test_decoder_null_span_link_success() {
-        let mut span = create_test_json_span(1, 2, 0, 0);
+        let mut span = create_test_json_span(1, 2, 0, 0, false);
         span["span_links"] = json!(null);
 
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();

--- a/trace-utils/src/msgpack_decoder/v04/span.rs
+++ b/trace-utils/src/msgpack_decoder/v04/span.rs
@@ -46,7 +46,7 @@ pub fn decode_span(buffer: &mut Bytes) -> Result<SpanBytes, DecodeError> {
 fn fill_span(span: &mut SpanBytes, buf: &mut Bytes) -> Result<(), DecodeError> {
     let key = read_string_ref(unsafe { buf.as_mut_slice() })?
         .parse::<SpanKey>()
-        .map_err(|_| DecodeError::InvalidFormat("Invalid span key".to_owned()))?;
+        .map_err(|e| DecodeError::InvalidFormat(e.message))?;
 
     match key {
         SpanKey::Service => span.service = read_nullable_string_bytes(buf)?,

--- a/trace-utils/src/test_utils/datadog_test_agent.rs
+++ b/trace-utils/src/test_utils/datadog_test_agent.rs
@@ -22,6 +22,9 @@ const TEST_AGENT_READY_MSG: &str =
     "INFO:ddapm_test_agent.agent:Trace request stall seconds setting set to 0.0.";
 
 const TEST_AGENT_PORT: u16 = 8126;
+const SAMPLE_RATE_QUERY_PARAM_KEY: &str = "agent_sample_rate_by_service";
+const SESSION_TEST_TOKEN_QUERY_PARAM_KEY: &str = "test_session_token";
+const SESSION_START_ENDPOINT: &str = "test/session/start";
 
 #[derive(Debug)]
 struct DatadogTestAgentContainer {
@@ -76,6 +79,7 @@ impl DatadogTestAgentContainer {
                 "DD_APM_RECEIVER_SOCKET".to_string(),
                 "/tmp/ddsockets/apm.socket".to_owned(),
             );
+
             mounts.push(
                 Mount::bind_mount(absolute_socket_path, "/tmp/ddsockets")
                     .with_access_mode(AccessMode::ReadWrite),
@@ -231,6 +235,45 @@ impl DatadogTestAgent {
         Uri::from_str(&uri_string).expect("Invalid URI")
     }
 
+    async fn get_uri_for_endpoint_and_params(
+        &self,
+        endpoint: &str,
+        query_params: HashMap<&str, &str>,
+    ) -> Uri {
+        let base_uri = self.get_base_uri().await;
+        let mut parts = base_uri.into_parts();
+
+        let query_string = if !query_params.is_empty() {
+            let query = query_params
+                .iter()
+                .map(|(k, v)| format!("{}={}", urlencoding::encode(k), urlencoding::encode(v)))
+                .collect::<Vec<_>>()
+                .join("&");
+            format!("?{}", query)
+        } else {
+            String::new()
+        };
+
+        parts.path_and_query = Some(
+            format!("/{}{}", endpoint.trim_start_matches('/'), query_string)
+                .parse()
+                .expect("Invalid path and query"),
+        );
+
+        Uri::from_parts(parts).expect("Invalid URI")
+    }
+
+    /// Returns the URI for the Datadog Test Agent's base URL and port.
+    /// The docker-image dynamically assigns what port the test-agent's 8126 port is forwarded to.
+    ///
+    /// # Returns
+    ///
+    /// A `Uri` object representing the URI of the specified endpoint.
+    pub async fn get_base_uri(&self) -> Uri {
+        let base_uri_string = self.get_base_uri_string().await;
+        Uri::from_str(&base_uri_string).expect("Invalid URI")
+    }
+
     /// Asserts that the snapshot for a given token matches the expected snapshot. This should be
     /// called after sending data to the test-agent with the same token.
     ///
@@ -256,6 +299,65 @@ impl DatadogTestAgent {
             status_code, 200,
             "Expected status 200, but got {}. Response body: {}",
             status_code, body_string
+        );
+    }
+    /// Starts a new session with the Datadog Test Agent using the provided session token and
+    /// optional sampling rates. This should be called before sending data to the test-agent to
+    /// configure the session parameters. Please refer to
+    /// https://github.com/DataDog/dd-apm-test-agent for more details on sessions.
+    ///
+    /// # Arguments
+    ///
+    /// * `session_token` - A string slice that holds the session token for identifying this test
+    ///   session.
+    /// * `agent_sample_rates_by_service` - An optional string slice that holds JSON-formatted
+    ///   sampling rates by service. The format should be a JSON object mapping service and
+    ///   environment pairs to sampling rates. Example: `{"service:test,env:test_env": 0.5,
+    ///   "service:test2,env:prod": 0.2}`
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```no_run
+    /// use datadog_trace_utils::test_utils::datadog_test_agent::DatadogTestAgent;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let test_agent = DatadogTestAgent::new(Some("relative/path/to/snapshot"), None).await;
+    ///     let session_token = "test_session_token";
+    ///     let sample_rates = "{\"service:test,env:test_env\": 0.5, \"service:test2,env:prod\": 0.2}";
+    ///
+    ///     test_agent
+    ///         .start_session(session_token, Some(sample_rates))
+    ///         .await;
+    /// }
+    /// ```
+    pub async fn start_session(
+        &self,
+        session_token: &str,
+        agent_sample_rates_by_service: Option<&str>,
+    ) {
+        let client = Client::new();
+
+        let mut query_params_map = HashMap::new();
+        query_params_map.insert(SESSION_TEST_TOKEN_QUERY_PARAM_KEY, session_token);
+        if let Some(agent_sample_rates_by_service) = agent_sample_rates_by_service {
+            query_params_map.insert(SAMPLE_RATE_QUERY_PARAM_KEY, agent_sample_rates_by_service);
+        }
+
+        let uri = self
+            .get_uri_for_endpoint_and_params(SESSION_START_ENDPOINT, query_params_map)
+            .await;
+
+        let res = client.get(uri).await.expect("Request failed");
+
+        assert_eq!(
+            res.status(),
+            200,
+            "Expected status 200 for test agent {}, but got {}",
+            SESSION_START_ENDPOINT,
+            res.status()
         );
     }
 }

--- a/trace-utils/src/test_utils/mod.rs
+++ b/trace-utils/src/test_utils/mod.rs
@@ -217,8 +217,9 @@ pub fn create_test_json_span(
     span_id: u64,
     parent_id: u64,
     start: i64,
+    is_top_level: bool,
 ) -> serde_json::Value {
-    json!(
+    let mut span = json!(
         {
             "trace_id": trace_id,
             "span_id": span_id,
@@ -237,7 +238,32 @@ pub fn create_test_json_span(
             "metrics": {},
             "meta_struct": {},
         }
-    )
+    );
+
+    if is_top_level {
+        let additional_meta = json!(
+            {
+                "functionname": "dummy_function_name",
+                "_dd.origin": "cloudfunction",
+                "origin": "cloudfunction",
+            }
+        );
+        span.get_mut("meta")
+            .unwrap()
+            .as_object_mut()
+            .unwrap()
+            .extend(additional_meta.as_object().unwrap().clone());
+
+        span["type"] = json!("serverless");
+
+        span["metrics"] = json!(
+            {
+                "_top_level": 1.0,
+            }
+        );
+    }
+
+    span
 }
 
 /// This is a helper function for observing if a httpmock object has been "hit" the expected number

--- a/trace-utils/tests/snapshots/compare_v04_trace_snapshot_test.json
+++ b/trace-utils/tests/snapshots/compare_v04_trace_snapshot_test.json
@@ -32,8 +32,7 @@
         "env": "test-env",
         "runtime-id": "test-runtime-id-value",
         "service": "test-service"
-      },
-      "metrics": {}
+      }
     },
     {
       "service": "test-service",

--- a/trace-utils/tests/test_send_data.rs
+++ b/trace-utils/tests/test_send_data.rs
@@ -4,13 +4,11 @@
 #[cfg(test)]
 mod tracing_integration_tests {
     use datadog_trace_utils::send_data::SendData;
+    use datadog_trace_utils::test_utils::create_test_json_span;
     use datadog_trace_utils::test_utils::datadog_test_agent::DatadogTestAgent;
-    use datadog_trace_utils::test_utils::{
-        create_test_json_span, create_test_no_alloc_span, create_test_span,
-    };
     use datadog_trace_utils::trace_utils::TracerHeaderTags;
     use datadog_trace_utils::tracer_payload::{
-        DefaultTraceChunkProcessor, TraceEncoding, TracerPayloadCollection, TracerPayloadParams,
+        DefaultTraceChunkProcessor, TraceEncoding, TracerPayloadParams,
     };
     #[cfg(target_os = "linux")]
     use ddcommon::connector::uds::socket_path_to_uri;
@@ -22,7 +20,6 @@ mod tracing_integration_tests {
     use std::fs::Permissions;
     #[cfg(target_os = "linux")]
     use std::os::unix::fs::PermissionsExt;
-    use tinybytes::BytesString;
 
     #[cfg_attr(miri, ignore)]
     #[tokio::test]

--- a/trace-utils/tests/test_send_data.rs
+++ b/trace-utils/tests/test_send_data.rs
@@ -4,8 +4,10 @@
 #[cfg(test)]
 mod tracing_integration_tests {
     use datadog_trace_utils::send_data::SendData;
-    use datadog_trace_utils::test_utils::create_test_no_alloc_span;
     use datadog_trace_utils::test_utils::datadog_test_agent::DatadogTestAgent;
+    use datadog_trace_utils::test_utils::{
+        create_test_json_span, create_test_no_alloc_span, create_test_span,
+    };
     use datadog_trace_utils::trace_utils::TracerHeaderTags;
     use datadog_trace_utils::tracer_payload::{
         DefaultTraceChunkProcessor, TraceEncoding, TracerPayloadCollection, TracerPayloadParams,
@@ -15,6 +17,7 @@ mod tracing_integration_tests {
     use ddcommon::Endpoint;
     #[cfg(target_os = "linux")]
     use hyper::Uri;
+    use serde_json::json;
     #[cfg(target_os = "linux")]
     use std::fs::Permissions;
     #[cfg(target_os = "linux")]
@@ -23,8 +26,6 @@ mod tracing_integration_tests {
 
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
-    // TODO: APMSP-1779 - This test should call tracer_payload::TracerPayloadParams::try_into()
-    // instead of calling TracerPayloadCollection::V04 directly
     async fn compare_v04_trace_snapshot_test() {
         let relative_snapshot_path = "trace-utils/tests/snapshots/";
         let test_agent = DatadogTestAgent::new(Some(relative_snapshot_path), None).await;
@@ -44,29 +45,32 @@ mod tracing_integration_tests {
                 .get_uri_for_endpoint("v0.4/traces", Some("compare_v04_trace_snapshot_test"))
                 .await,
         );
-        let mut span_1 = create_test_no_alloc_span(1234, 12342, 12341, 1, false);
-        span_1.metrics.insert(
-            BytesString::from_slice("_dd_metric1".as_ref()).unwrap(),
-            1.0,
-        );
-        span_1.metrics.insert(
-            BytesString::from_slice("_dd_metric2".as_ref()).unwrap(),
-            2.0,
-        );
 
-        let span_2 = create_test_no_alloc_span(1234, 12343, 12341, 1, false);
+        let mut span_1 = create_test_json_span(1234, 12342, 12341, 1, false);
+        span_1["metrics"] = json!({
+            "_dd_metric1": 1.0,
+            "_dd_metric2": 2.0
+        });
 
-        let mut root_span = create_test_no_alloc_span(1234, 12341, 0, 0, true);
-        root_span.r#type = BytesString::from_slice("web".as_ref()).unwrap();
+        let span_2 = create_test_json_span(1234, 12343, 12341, 1, false);
+        let mut root_span = create_test_json_span(1234, 12341, 0, 0, true);
+        root_span["type"] = json!("web".to_owned());
 
-        let trace = vec![span_1, span_2, root_span];
+        let encoded_data = rmp_serde::to_vec_named(&vec![vec![span_1, span_2, root_span]]).unwrap();
 
-        let data = SendData::new(
-            300,
-            TracerPayloadCollection::V04(vec![trace.clone()]),
-            header_tags,
-            &endpoint,
-        );
+        let data = tinybytes::Bytes::from(encoded_data);
+
+        let payload_collection = TracerPayloadParams::new(
+            data,
+            &header_tags,
+            &mut DefaultTraceChunkProcessor,
+            false,
+            TraceEncoding::V04,
+        )
+        .try_into()
+        .expect("unable to convert TracerPayloadParams to TracerPayloadCollection");
+
+        let data = SendData::new(300, payload_collection, header_tags, &endpoint);
 
         let _result = data.send().await;
 
@@ -119,8 +123,6 @@ mod tracing_integration_tests {
     #[tokio::test]
     #[cfg(target_os = "linux")]
     // Validate that we can correctly send traces to the agent via UDS
-    // TODO: APMSP-1779 - This test should call tracer_payload::TracerPayloadParams::try_into()
-    // instead of calling TracerPayloadCollection::V04 directly
     async fn uds_snapshot_test() {
         let relative_snapshot_path = "trace-utils/tests/snapshots/";
 
@@ -180,29 +182,31 @@ mod tracing_integration_tests {
             ..Default::default()
         };
 
-        let mut span_1 = create_test_no_alloc_span(1234, 12342, 12341, 1, false);
-        span_1.metrics.insert(
-            BytesString::from_slice("_dd_metric1".as_ref()).unwrap(),
-            1.0,
-        );
-        span_1.metrics.insert(
-            BytesString::from_slice("_dd_metric2".as_ref()).unwrap(),
-            2.0,
-        );
+        let mut span_1 = create_test_json_span(1234, 12342, 12341, 1, false);
+        span_1["metrics"] = json!({
+            "_dd_metric1": 1.0,
+            "_dd_metric2": 2.0
+        });
 
-        let span_2 = create_test_no_alloc_span(1234, 12343, 12341, 1, false);
+        let span_2 = create_test_json_span(1234, 12343, 12341, 1, false);
+        let mut root_span = create_test_json_span(1234, 12341, 0, 0, true);
+        root_span["type"] = json!("web".to_owned());
 
-        let mut root_span = create_test_no_alloc_span(1234, 12341, 0, 0, true);
-        root_span.r#type = BytesString::from_slice("web".as_ref()).unwrap();
+        let encoded_data = rmp_serde::to_vec_named(&vec![vec![span_1, span_2, root_span]]).unwrap();
 
-        let trace = vec![span_1, span_2, root_span];
+        let data = tinybytes::Bytes::from(encoded_data);
 
-        let data = SendData::new(
-            300,
-            TracerPayloadCollection::V04(vec![trace.clone()]),
-            header_tags,
-            &endpoint,
-        );
+        let payload_collection = TracerPayloadParams::new(
+            data,
+            &header_tags,
+            &mut DefaultTraceChunkProcessor,
+            false,
+            TraceEncoding::V04,
+        )
+        .try_into()
+        .expect("unable to convert TracerPayloadParams to TracerPayloadCollection");
+
+        let data = SendData::new(300, payload_collection, header_tags, &endpoint);
 
         let _result = data.send().await;
 


### PR DESCRIPTION
# What does this PR do?

- Add initial integration tests for the `DataPipeline::TraceExporter`. These tests closely resemble existing tests for the `TraceUtils::SendData`, but flow through the exporter. The `SendData` tests are still necessary as there are places in libdatadog (like the Sidecar) that currently bypass the exporter. Identical snapshot tests have been added for http and UDS. 
- Update `test_send_data` to cover the payload collection construction steps.
- Add a test-only feature to gate adding query params to the agent's trace endpoint URI.
- Minor tweak to v0.4 msgpack span decoding error handling to include invalid keys in the message. 

# How to test the change?

Integration tests are included by default when running `cargo nextest run` locally. UDS related tests run on linux only and can be run locally on macOS [via docker](https://github.com/DataDog/dd-apm-test-agent).
