### PR TITLE
feat: add dev container for consistent development environment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/rust
+{
+    "name": "Rust",
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+
+    // Allow access to host machine
+    "runArgs": ["--network=host"],
+
+    // Use 'mounts' to make the cargo cache persistent in a Docker Volume.
+    "mounts": [
+        {
+            "source": "devcontainer-cargo-cache-${devcontainerId}",
+            "target": "/usr/local/cargo",
+            "type": "volume"
+        }
+    ],
+
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    "features": {
+        "ghcr.io/devcontainers/features/rust:1": {},
+        "ghcr.io/devcontainers-extra/features/cmake:1": {}
+    },
+
+    // Use 'postCreateCommand' to run commands after the container is created.
+    "postCreateCommand": "cargo install cbindgen",
+
+    // Configure tool-specific properties.
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "rust-lang.rust-analyzer",
+                "vadimcn.vscode-lldb"
+            ]
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -69,13 +69,26 @@ The simplest way to install [cargo-nextest][nt] is to use `cargo install` like t
 cargo install --locked 'cargo-nextest@0.9.85'
 ```
 
+#### Dev Containers
+
+##### Prerequisites
+
+- Install the [Dev Containers Extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) in VS Code.
+
+##### Steps
+
+1. Open a local VS Code window on the cloned repository.
+2. Open the command palette (`Ctrl+Shift+P` or `Cmd+Shift+P` on macOS) and select **"Dev Containers: Reopen in Container"**.
+3. Choose the **Rust Container**.
+4. VS Code will open a new window connected to the selected container.
+
 #### Docker container
 A dockerfile is provided to run tests in a Ubuntu linux environment. This is particularly useful for running and debugging linux-only tests on macOS.
 
 To build the docker image, from the root directory of the libdatadog project run
 ```bash
 docker build -f local-linux.Dockerfile -t libdatadog-linux .
-``` 
+```
 
 To start the docker container, you can run
 ```bash
@@ -88,6 +101,7 @@ This will:
 1. Mount a named volume `cargo-cache` to cache the cargo dependencies at ~/.cargo. This is helpful to avoid re-downloading dependencies every time you start the container, but isn't absolutely necessary.
 
 The `$CARGO_TARGET_DIR` environment variable is set to `/libdatadog/docker-linux-target` in the container, so cargo will use the target directory in the mounted volume to avoid conflicts with the host's default target directory of `libdatadog/target`.
+
 #### Skipping tracing integration tests
 
 Tracing integration tests require docker to be installed and running. If you don't have docker installed or you want to skip these tests, you can run:


### PR DESCRIPTION
# What does this PR do?

- ensures consistent development setup
- includes necessary dependencies and configurations
- allows step-in for things like how container id is generated since the whole workspace is inside a container

I went with minimal setup and targeting only one OS, but this can be extended with multiple container (debian, alpine etc)

# Motivation

I have been using it locally by keeping in my stashes, but this is general problem since we are all (or almost) on osx and want to test and debug how the libraries behave on linux. 

# Additional Notes

none.

# How to test the change?

Follow the readme.
