### PR TITLE
Handle EINTR in blocking ipc sender

### DIFF
--- a/ipc/src/platform/unix/channel.rs
+++ b/ipc/src/platform/unix/channel.rs
@@ -105,7 +105,7 @@ impl Write for Channel {
                     Ok(n) => {
                         buf = &buf[n..];
                         break;
-                    },
+                    }
                     Err(ref e) if e.kind() == ErrorKind::Interrupted => { /* retry */ }
                     Err(e) => {
                         self.metadata.reenqueue_for_sending(handles);

--- a/ipc/src/platform/unix/channel/async_channel.rs
+++ b/ipc/src/platform/unix/channel/async_channel.rs
@@ -135,3 +135,9 @@ impl AsyncRead for AsyncChannel {
         }
     }
 }
+
+impl AsyncChannel {
+    pub fn handle(&self) -> i32 {
+        self.inner.as_raw_fd()
+    }
+}

--- a/ipc/src/platform/windows/channel/async_channel.rs
+++ b/ipc/src/platform/windows/channel/async_channel.rs
@@ -36,10 +36,10 @@ pub struct AsyncChannel {
 }
 
 macro_rules! use_inner {
-    ($base:expr, $method:ident($($args:expr),+)) => {
+    ($base:expr, $method:ident($($args:expr),*)) => {
         match $base.inner {
-            NamedPipe::Client(ref client) => client.$method($($args),+),
-            NamedPipe::Server(ref server) => server.$method($($args),+),
+            NamedPipe::Client(ref client) => client.$method($($args),*),
+            NamedPipe::Server(ref server) => server.$method($($args),*),
         }
     }
 }
@@ -60,6 +60,10 @@ impl AsyncChannel {
 
     pub fn try_write(&self, buf: &[u8]) -> io::Result<usize> {
         use_inner!(self, try_write(buf))
+    }
+
+    pub fn handle(&self) -> i32 {
+        use_inner!(self, as_raw_handle()) as i32
     }
 }
 

--- a/ipc/src/sequential.rs
+++ b/ipc/src/sequential.rs
@@ -5,7 +5,7 @@ use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-
+use std::fmt::Debug;
 use futures::{ready, Future, Stream};
 use tarpc::server::{Channel, InFlightRequest, Requests, Serve};
 
@@ -24,7 +24,7 @@ pub fn execute_sequential<C, S>(
 where
     C: Channel,
     S: Serve<C::Req, Resp = C::Resp> + Send + 'static,
-    C::Req: Send + 'static,
+    C::Req: Send + Debug + 'static,
     C::Resp: Send + 'static,
     S::Fut: Send,
 {
@@ -60,7 +60,7 @@ where
 impl<C, S> Future for SequentialExecutor<C, S>
 where
     C: Channel + 'static,
-    C::Req: Send + 'static,
+    C::Req: Send + Debug + 'static,
     C::Resp: Send + 'static,
     S: Serve<C::Req, Resp = C::Resp> + Send + 'static + Clone,
     S::Fut: Send,

--- a/ipc/src/sequential.rs
+++ b/ipc/src/sequential.rs
@@ -1,12 +1,12 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+use futures::{ready, Future, Stream};
+use std::fmt::Debug;
 use std::{
     pin::Pin,
     task::{Context, Poll},
 };
-use std::fmt::Debug;
-use futures::{ready, Future, Stream};
 use tarpc::server::{Channel, InFlightRequest, Requests, Serve};
 
 #[allow(type_alias_bounds)]

--- a/ipc/tarpc/tarpc/src/server.rs
+++ b/ipc/tarpc/tarpc/src/server.rs
@@ -23,8 +23,8 @@ use futures::{
 };
 use in_flight_requests::{AlreadyExistsError, InFlightRequests};
 use pin_project::pin_project;
-use std::{error::Error, fmt, marker::PhantomData, pin::Pin};
 use std::fmt::Debug;
+use std::{error::Error, fmt, marker::PhantomData, pin::Pin};
 use tracing::{info_span, instrument::Instrument, Span};
 
 mod in_flight_requests;
@@ -837,9 +837,9 @@ mod tests {
         Future,
     };
     use futures_test::task::noop_context;
-    use std::{pin::Pin, task::Poll};
+    use std::{fmt::Debug, pin::Pin, task::Poll};
 
-    fn test_channel<Req, Resp>() -> (
+    fn test_channel<Req: Debug, Resp>() -> (
         Pin<Box<BaseChannel<Req, Resp, UnboundedChannel<ClientMessage<Req>, Response<Resp>>>>>,
         UnboundedChannel<Response<Resp>, ClientMessage<Req>>,
     ) {
@@ -847,7 +847,7 @@ mod tests {
         (Box::pin(BaseChannel::new(Config::default(), rx)), tx)
     }
 
-    fn test_requests<Req, Resp>() -> (
+    fn test_requests<Req: Debug, Resp>() -> (
         Pin<
             Box<
                 Requests<
@@ -864,7 +864,7 @@ mod tests {
         )
     }
 
-    fn test_bounded_requests<Req, Resp>(
+    fn test_bounded_requests<Req: Debug, Resp>(
         capacity: usize,
     ) -> (
         Pin<
@@ -884,7 +884,7 @@ mod tests {
         (Box::pin(BaseChannel::new(config, rx).requests()), tx)
     }
 
-    fn fake_request<Req>(req: Req) -> ClientMessage<Req> {
+    fn fake_request<Req: Debug>(req: Req) -> ClientMessage<Req> {
         ClientMessage::Request(Request {
             context: context::current(),
             id: 0,

--- a/ipc/tarpc/tarpc/src/server/in_flight_requests.rs
+++ b/ipc/tarpc/tarpc/src/server/in_flight_requests.rs
@@ -74,7 +74,7 @@ impl InFlightRequests {
             self.request_data.compact(0.1);
             abort_handle.abort();
             self.deadlines.remove(&deadline_key);
-            tracing::info!("ReceiveCancel");
+            tracing::info!("ReceiveCancel for request {request_id}");
             true
         } else {
             false
@@ -109,7 +109,7 @@ impl InFlightRequests {
                 let _entered = span.enter();
                 self.request_data.compact(0.1);
                 abort_handle.abort();
-                tracing::error!("DeadlineExceeded");
+                tracing::error!("DeadlineExceeded for request {}", expired.get_ref());
             }
             Some(expired.into_inner())
         })

--- a/ipc/tarpc/tarpc/src/server/incoming.rs
+++ b/ipc/tarpc/tarpc/src/server/incoming.rs
@@ -2,11 +2,11 @@ use super::{
     limits::{channels_per_key::MaxChannelsPerKey, requests_per_channel::MaxRequestsPerChannel},
     Channel,
 };
-use futures::prelude::*;
-use std::{fmt, hash::Hash};
-use std::fmt::Debug;
 #[cfg(feature = "tokio1")]
 use super::{tokio::TokioServerExecutor, Serve};
+use futures::prelude::*;
+use std::fmt::Debug;
+use std::{fmt, hash::Hash};
 
 /// An extension trait for [streams](futures::prelude::Stream) of [`Channels`](Channel).
 pub trait Incoming<C>

--- a/ipc/tarpc/tarpc/src/server/incoming.rs
+++ b/ipc/tarpc/tarpc/src/server/incoming.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use futures::prelude::*;
 use std::{fmt, hash::Hash};
-
+use std::fmt::Debug;
 #[cfg(feature = "tokio1")]
 use super::{tokio::TokioServerExecutor, Serve};
 
@@ -13,6 +13,7 @@ pub trait Incoming<C>
 where
     Self: Sized + Stream<Item = C>,
     C: Channel,
+    C::Req: Debug,
 {
     /// Enforces channel per-key limits.
     fn max_channels_per_key<K, KF>(self, n: u32, keymaker: KF) -> MaxChannelsPerKey<Self, K, KF>
@@ -45,5 +46,6 @@ impl<S, C> Incoming<C> for S
 where
     S: Sized + Stream<Item = C>,
     C: Channel,
+    C::Req: Debug,
 {
 }

--- a/ipc/tarpc/tarpc/src/server/tokio.rs
+++ b/ipc/tarpc/tarpc/src/server/tokio.rs
@@ -1,7 +1,7 @@
-use std::fmt::Debug;
 use super::{Channel, Requests, Serve};
 use futures::{prelude::*, ready, task::*};
 use pin_project::pin_project;
+use std::fmt::Debug;
 use std::pin::Pin;
 
 /// A future that drives the server by [spawning](tokio::spawn) a [`TokioChannelExecutor`](TokioChannelExecutor)

--- a/ipc/tarpc/tarpc/src/server/tokio.rs
+++ b/ipc/tarpc/tarpc/src/server/tokio.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use super::{Channel, Requests, Serve};
 use futures::{prelude::*, ready, task::*};
 use pin_project::pin_project;
@@ -50,7 +51,7 @@ impl<T, S> TokioChannelExecutor<T, S> {
 impl<C> Requests<C>
 where
     C: Channel,
-    C::Req: Send + 'static,
+    C::Req: Send + Debug + 'static,
     C::Resp: Send + 'static,
 {
     /// Executes all requests using the given service function. Requests are handled concurrently
@@ -67,7 +68,7 @@ impl<St, C, Se> Future for TokioServerExecutor<St, Se>
 where
     St: Sized + Stream<Item = C>,
     C: Channel + Send + 'static,
-    C::Req: Send + 'static,
+    C::Req: Send + Debug + 'static,
     C::Resp: Send + 'static,
     Se: Serve<C::Req, Resp = C::Resp> + Send + 'static + Clone,
     Se::Fut: Send,
@@ -86,7 +87,7 @@ where
 impl<C, S> Future for TokioChannelExecutor<Requests<C>, S>
 where
     C: Channel + 'static,
-    C::Req: Send + 'static,
+    C::Req: Send + Debug + 'static,
     C::Resp: Send + 'static,
     S: Serve<C::Req, Resp = C::Resp> + Send + 'static + Clone,
     S::Fut: Send,

--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -68,7 +68,7 @@ console-subscriber = { version = "0.1", optional = true }
 libc = { version = "0.2" }
 
 # watchdog and self telemetry
-memory-stats = { version = "1.0.0" }
+memory-stats = { version = "1.2.0", features = ["always_use_statm"] }
 
 [dependencies.windows]
 features = [

--- a/sidecar/src/service/sidecar_server.rs
+++ b/sidecar/src/service/sidecar_server.rs
@@ -133,6 +133,7 @@ impl SidecarServer {
     /// * `async_channel`: An `AsyncChannel` that represents the connection to the client.
     #[cfg_attr(not(windows), allow(unused_mut))]
     pub async fn accept_connection(mut self, async_channel: AsyncChannel) {
+        let handle = async_channel.handle();
         #[cfg(windows)]
         {
             self.process_handle = async_channel
@@ -164,7 +165,7 @@ impl SidecarServer {
         ));
 
         if let Err(e) = executor.await {
-            warn!("Error from executor: {e:?}");
+            warn!("Error from executor for handle {handle}: {e:?}");
         }
 
         self.process_interceptor_response(session_interceptor.await)
@@ -804,6 +805,7 @@ impl SidecarInterface for SidecarServer {
         _len: usize,
         headers: SerializedTracerHeaderTags,
     ) -> Self::SendTraceV04ShmFut {
+        
         if let Some(endpoint) = self
             .get_session(&instance_id.session_id)
             .get_trace_config()
@@ -819,6 +821,8 @@ impl SidecarInterface for SidecarServer {
                     Err(e) => error!("Failed mapping shared trace data memory: {}", e),
                 }
             });
+        } else {
+            warn!("Received trace data ({handle:?}) for missing session {}", instance_id.session_id);
         }
 
         no_response()
@@ -843,6 +847,8 @@ impl SidecarInterface for SidecarServer {
                 let bytes = tinybytes::Bytes::from(data);
                 self.send_trace_v04(&headers, bytes, &endpoint);
             });
+        } else {
+            warn!("Received trace data for missing session {}", instance_id.session_id);
         }
 
         no_response()

--- a/sidecar/src/service/sidecar_server.rs
+++ b/sidecar/src/service/sidecar_server.rs
@@ -805,7 +805,6 @@ impl SidecarInterface for SidecarServer {
         _len: usize,
         headers: SerializedTracerHeaderTags,
     ) -> Self::SendTraceV04ShmFut {
-        
         if let Some(endpoint) = self
             .get_session(&instance_id.session_id)
             .get_trace_config()
@@ -822,7 +821,10 @@ impl SidecarInterface for SidecarServer {
                 }
             });
         } else {
-            warn!("Received trace data ({handle:?}) for missing session {}", instance_id.session_id);
+            warn!(
+                "Received trace data ({handle:?}) for missing session {}",
+                instance_id.session_id
+            );
         }
 
         no_response()
@@ -848,7 +850,10 @@ impl SidecarInterface for SidecarServer {
                 self.send_trace_v04(&headers, bytes, &endpoint);
             });
         } else {
-            warn!("Received trace data for missing session {}", instance_id.session_id);
+            warn!(
+                "Received trace data for missing session {}",
+                instance_id.session_id
+            );
         }
 
         no_response()


### PR DESCRIPTION
Without this change file descriptions were not sent when send_with_fd was interrupted by a signal, causing the connection to become broken.

Also use statm for memory tracking in sidecar (we don't need full accuracy for the watchdog).