### PR TITLE
ci: add serverless as code owners for dogstatsd

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,3 +24,4 @@ sidecar                 @Datadog/libdatadog-php @Datadog/libdatadog-apm
 sidecar-ffi             @Datadog/libdatadog-php @Datadog/libdatadog-apm
 data-pipeline*/         @Datadog/libdatadog-apm
 ddsketch                @Datadog/libdatadog-apm @Datadog/libdatadog-telemetry
+dogstatsd/              @Datadog/serverless


### PR DESCRIPTION
# What does this PR do?

Adds serverless as a code owner for dogstatsd

# Motivation

AJ asked me to do this.

# Additional Notes

Probably should have done this while they still had a PR open, so we can see that it works.

