### PR TITLE
feat: Impl eq for replacerule so we can parse a yaml file

### DIFF
--- a/trace-obfuscation/src/replacer.rs
+++ b/trace-obfuscation/src/replacer.rs
@@ -12,7 +12,13 @@ struct RawReplaceRule {
     repl: String,
 }
 
-#[derive(Debug)]
+impl PartialEq for ReplaceRule {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name && self.repl == other.repl && self.re.as_str() == other.re.as_str()
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct ReplaceRule {
     // name specifies the name of the tag that the replace rule addresses. However,
     // some exceptions apply such as:


### PR DESCRIPTION
# What does this PR do?
We support `datadog.yaml` alongside environment variables. PartialEq allows figment to compare config instances

# Motivation
Fixes a yaml parsing issue with datadog.yaml

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
