### PR TITLE
[PROF-11405] Replace managed string storage Rc with Arc

### DIFF
--- a/profiling-ffi/src/string_storage.rs
+++ b/profiling-ffi/src/string_storage.rs
@@ -8,7 +8,7 @@ use ddcommon_ffi::{CharSlice, Error, MaybeError, Slice, StringWrapperResult};
 use libc::c_void;
 use std::mem::MaybeUninit;
 use std::num::NonZeroU32;
-use std::rc::Rc;
+use std::sync::Arc;
 use std::sync::Mutex;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -27,9 +27,9 @@ pub struct ManagedStringId {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub struct ManagedStringStorage {
-    // This may be null, but if not it will point to a valid InternalManagedStringStorage.
-    inner: *const c_void, /* Actually Mutex<InternalManagedStringStorage> but we're making it
-                           * opaque for cbindgen */
+    // This may be null, but if not it will point to a valid InternalManagedStringStorage,
+    // wrapped as needed for correct concurrency. This type is made opaque for cbindgen.
+    inner: *const c_void,
 }
 
 #[allow(dead_code)]
@@ -46,7 +46,7 @@ pub extern "C" fn ddog_prof_ManagedStringStorage_new() -> ManagedStringStorageNe
     let storage = InternalManagedStringStorage::new();
 
     ManagedStringStorageNewResult::Ok(ManagedStringStorage {
-        inner: Rc::into_raw(Rc::new(Mutex::new(storage))) as *const c_void,
+        inner: Arc::into_raw(Arc::new(Mutex::new(storage))) as *const c_void,
     })
 }
 
@@ -255,7 +255,7 @@ pub unsafe fn get_inner_string_storage(
     // (E.g. we use this flag to know if we need to increment the refcount for the copy we create
     // or not).
     for_use: bool,
-) -> anyhow::Result<Rc<Mutex<InternalManagedStringStorage>>> {
+) -> anyhow::Result<Arc<Mutex<InternalManagedStringStorage>>> {
     if storage.inner.is_null() {
         anyhow::bail!("storage inner pointer is null");
     }
@@ -263,14 +263,14 @@ pub unsafe fn get_inner_string_storage(
     let storage_ptr = storage.inner;
 
     if for_use {
-        // By incrementing strong count here we ensure that the returned Rc represents a "clone" of
+        // By incrementing strong count here we ensure that the returned Arc represents a "clone" of
         // the original and will thus not trigger a drop of the underlying data when out of
-        // scope. NOTE: We can't simply do Rc::from_raw(storage_ptr).clone() because when we
-        // return, the Rc created through `Rc::from_raw` would go out of scope and decrement
+        // scope. NOTE: We can't simply do Arc::from_raw(storage_ptr).clone() because when we
+        // return, the Arc created through `Arc::from_raw` would go out of scope and decrement
         // strong count.
-        Rc::increment_strong_count(storage_ptr);
+        Arc::increment_strong_count(storage_ptr);
     }
-    Ok(Rc::from_raw(
+    Ok(Arc::from_raw(
         storage_ptr as *const Mutex<InternalManagedStringStorage>,
     ))
 }

--- a/profiling/src/collections/string_storage.rs
+++ b/profiling/src/collections/string_storage.rs
@@ -53,6 +53,9 @@ struct InternalCachedProfileId {
     id: u32,
 }
 
+// Enable Mutex<ManagedStringStorage> to be Send
+unsafe impl Send for ManagedStringStorage {}
+
 impl From<&CachedProfileId> for InternalCachedProfileId {
     fn from(cached: &CachedProfileId) -> Self {
         InternalCachedProfileId { id: cached.id }

--- a/profiling/src/internal/profile/mod.rs
+++ b/profiling/src/internal/profile/mod.rs
@@ -17,7 +17,7 @@ use crate::serializer::CompressedProtobufSerializer;
 use anyhow::Context;
 use std::borrow::Cow;
 use std::collections::HashMap;
-use std::rc::Rc;
+use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::{Duration, SystemTime};
 
@@ -42,7 +42,7 @@ pub struct Profile {
     stack_traces: FxIndexSet<StackTrace>,
     start_time: SystemTime,
     strings: StringTable,
-    string_storage: Option<Rc<Mutex<ManagedStringStorage>>>,
+    string_storage: Option<Arc<Mutex<ManagedStringStorage>>>,
     string_storage_cached_profile_id: Option<CachedProfileId>,
     timestamp_key: StringId,
     upscaling_rules: UpscalingRules,
@@ -246,7 +246,7 @@ impl Profile {
         start_time: SystemTime,
         sample_types: &[api::ValueType],
         period: Option<api::Period>,
-        string_storage: Rc<Mutex<ManagedStringStorage>>,
+        string_storage: Arc<Mutex<ManagedStringStorage>>,
     ) -> Self {
         Self::new_internal(
             Self::backup_period(period),
@@ -589,7 +589,7 @@ impl Profile {
         owned_period: Option<owned_types::Period>,
         owned_sample_types: Option<Box<[owned_types::ValueType]>>,
         start_time: SystemTime,
-        string_storage: Option<Rc<Mutex<ManagedStringStorage>>>,
+        string_storage: Option<Arc<Mutex<ManagedStringStorage>>>,
     ) -> Self {
         let mut profile = Self {
             owned_period,
@@ -2344,7 +2344,7 @@ mod api_tests {
 
     #[test]
     fn test_regression_managed_string_table_correctly_maps_ids() {
-        let storage = Rc::new(Mutex::new(ManagedStringStorage::new()));
+        let storage = Arc::new(Mutex::new(ManagedStringStorage::new()));
         let hello_id: u32;
         let world_id: u32;
 


### PR DESCRIPTION
# What does this PR do?

This PR replaces the [`Rc`](https://doc.rust-lang.org/std/rc/struct.Rc.html) being used to wrap the managed string storage with an [`Arc`](https://doc.rust-lang.org/std/sync/struct.Arc.html).

As @danielsn pointed out, having `Rc<Mutex>` is suspicious, and he was right: this `Rc` can and will be accessed concurrently by users of libdatadog and thus it needs to be an `Arc`, as otherwise the `Rc`'s internal counter is subject to racy reads an writes.

# Motivation

Make managed string storage production-ready.

# Additional Notes

We probably got "lucky" with this not causing visible issues so far because there's not a lot of concurrency going on with this type.

# How to test the change?

The existing tests validate the API continues to work with this change.
