### PR TITLE
perf(profiling): don't unnecessarily copy sample values

### DIFF
--- a/profiling-ffi/src/profiles.rs
+++ b/profiling-ffi/src/profiles.rs
@@ -382,7 +382,7 @@ impl<'a> TryFrom<Sample<'a>> for api::Sample<'a> {
             locations.push(location.try_into()?)
         }
 
-        let values: Vec<i64> = sample.values.into_slice().to_vec();
+        let values = sample.values.into_slice();
 
         let mut labels: Vec<api::Label> = Vec::with_capacity(sample.labels.len());
         for label in sample.labels.as_slice().iter() {
@@ -397,11 +397,11 @@ impl<'a> TryFrom<Sample<'a>> for api::Sample<'a> {
     }
 }
 
-impl From<Sample<'_>> for api::StringIdSample {
-    fn from(sample: Sample<'_>) -> Self {
+impl<'a> From<Sample<'a>> for api::StringIdSample<'a> {
+    fn from(sample: Sample<'a>) -> Self {
         Self {
             locations: sample.locations.as_slice().iter().map(Into::into).collect(),
-            values: sample.values.into_slice().to_vec(),
+            values: sample.values.into_slice(),
             labels: sample.labels.as_slice().iter().map(Into::into).collect(),
         }
     }

--- a/profiling-replayer/src/replayer.rs
+++ b/profiling-replayer/src/replayer.rs
@@ -235,7 +235,7 @@ impl<'pprof> Replayer<'pprof> {
                 timestamp,
                 api::Sample {
                     locations: Self::sample_locations(profile_index, sample)?,
-                    values: sample.values.clone(),
+                    values: &(sample.values),
                     labels,
                 },
             ));

--- a/profiling/examples/profiles.rs
+++ b/profiling/examples/profiles.rs
@@ -43,7 +43,7 @@ fn main() {
                 ..Default::default()
             },
         ],
-        values: vec![1, 10000],
+        values: &[1, 10000],
         labels: vec![],
     };
 

--- a/profiling/src/api.rs
+++ b/profiling/src/api.rs
@@ -172,7 +172,7 @@ pub struct Sample<'a> {
     /// When aggregating multiple samples into a single sample, the
     /// result has a list of values that is the element-wise sum of the
     /// lists of the originals.
-    pub values: Vec<i64>,
+    pub values: &'a [i64],
 
     /// label includes additional context for this sample. It can include
     /// things like a thread id, allocation size, etc
@@ -181,9 +181,9 @@ pub struct Sample<'a> {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 // Same as Sample, but using StringIds
-pub struct StringIdSample {
+pub struct StringIdSample<'a> {
     pub locations: Vec<StringIdLocation>,
-    pub values: Vec<i64>,
+    pub values: &'a [i64],
     pub labels: Vec<StringIdLabel>,
 }
 
@@ -425,7 +425,7 @@ impl<'a> TryFrom<&'a pprof::Profile> for Profile<'a> {
             }
             let sample = Sample {
                 locations,
-                values: sample.values.clone(),
+                values: &sample.values,
                 labels,
             };
             samples.push(sample);

--- a/profiling/src/internal/observation/timestamped_observations.rs
+++ b/profiling/src/internal/observation/timestamped_observations.rs
@@ -46,7 +46,7 @@ impl TimestampedObservations {
         }
     }
 
-    pub fn add(&mut self, sample: Sample, ts: Timestamp, values: Vec<i64>) -> anyhow::Result<()> {
+    pub fn add(&mut self, sample: Sample, ts: Timestamp, values: &[i64]) -> anyhow::Result<()> {
         // We explicitly turn the data into a stream of bytes, feeding it to the compressor.
         // @ivoanjo: I played with introducing a structure to serialize it all-at-once, but it seems
         // to be a lot of boilerplate (of which cost I'm not sure) to basically do the same

--- a/profiling/src/internal/profile/fuzz_tests.rs
+++ b/profiling/src/internal/profile/fuzz_tests.rs
@@ -212,7 +212,7 @@ impl<'a> From<&'a Sample> for api::Sample<'a> {
     fn from(value: &'a Sample) -> Self {
         Self {
             locations: value.locations.iter().map(api::Location::from).collect(),
-            values: value.values.clone(),
+            values: &value.values,
             labels: value.labels.iter().map(api::Label::from).collect(),
         }
     }

--- a/profiling/src/internal/profile/mod.rs
+++ b/profiling/src/internal/profile/mod.rs
@@ -152,7 +152,7 @@ impl Profile {
 
     fn add_sample_internal(
         &mut self,
-        values: Vec<i64>,
+        values: &[i64],
         labels: Vec<LabelId>,
         locations: Vec<LocationId>,
         timestamp: Option<Timestamp>,
@@ -803,7 +803,7 @@ mod api_tests {
             .add_sample(
                 api::Sample {
                     locations,
-                    values: vec![1, 10000],
+                    values: &[1, 10000],
                     labels: vec![],
                 },
                 None,
@@ -852,7 +852,7 @@ mod api_tests {
             ..Default::default()
         }];
 
-        let values: Vec<i64> = vec![1];
+        let values = &[1];
         let labels = vec![api::Label {
             key: "pid",
             num: 101,
@@ -861,13 +861,13 @@ mod api_tests {
 
         let main_sample = api::Sample {
             locations: main_locations,
-            values: values.clone(),
+            values,
             labels: labels.clone(),
         };
 
         let test_sample = api::Sample {
             locations: test_locations,
-            values: values.clone(),
+            values,
             labels: labels.clone(),
         };
 
@@ -1086,7 +1086,7 @@ mod api_tests {
 
         let sample = api::Sample {
             locations: vec![],
-            values: vec![1, 10000],
+            values: &[1, 10000],
             labels: vec![id_label],
         };
 
@@ -1125,13 +1125,13 @@ mod api_tests {
 
         let sample1 = api::Sample {
             locations: vec![],
-            values: vec![1, 10000],
+            values: &[1, 10000],
             labels: vec![id_label, other_label],
         };
 
         let sample2 = api::Sample {
             locations: vec![],
-            values: vec![1, 10000],
+            values: &[1, 10000],
             labels: vec![id2_label, other_label],
         };
 
@@ -1275,7 +1275,7 @@ mod api_tests {
 
         let sample = api::Sample {
             locations: vec![],
-            values: vec![10000],
+            values: &[10000],
             labels,
         };
 
@@ -1300,7 +1300,7 @@ mod api_tests {
 
         let sample1 = api::Sample {
             locations: vec![],
-            values: vec![1, 10000],
+            values: &[1, 10000],
             labels: vec![id_label],
         };
 
@@ -1340,7 +1340,7 @@ mod api_tests {
 
         let sample1 = api::Sample {
             locations: vec![],
-            values: vec![0, 10000, 42],
+            values: &[0, 10000, 42],
             labels: vec![],
         };
 
@@ -1368,7 +1368,7 @@ mod api_tests {
 
         let sample1 = api::Sample {
             locations: vec![],
-            values: vec![1, 10000, 42],
+            values: &[1, 10000, 42],
             labels: vec![],
         };
 
@@ -1396,7 +1396,7 @@ mod api_tests {
 
         let sample1 = api::Sample {
             locations: vec![],
-            values: vec![1, 16, 29],
+            values: &[1, 16, 29],
             labels: vec![],
         };
 
@@ -1428,7 +1428,7 @@ mod api_tests {
 
         let sample1 = api::Sample {
             locations: vec![],
-            values: vec![1, 16, 29],
+            values: &[1, 16, 29],
             labels: vec![],
         };
 
@@ -1460,7 +1460,7 @@ mod api_tests {
 
         let sample1 = api::Sample {
             locations: vec![],
-            values: vec![1, 16, 0],
+            values: &[1, 16, 0],
             labels: vec![],
         };
 
@@ -1492,7 +1492,7 @@ mod api_tests {
 
         let sample1 = api::Sample {
             locations: vec![],
-            values: vec![1, 16, 0],
+            values: &[1, 16, 0],
             labels: vec![],
         };
 
@@ -1539,7 +1539,7 @@ mod api_tests {
 
         let sample1 = api::Sample {
             locations: vec![],
-            values: vec![1, 10000, 21],
+            values: &[1, 10000, 21],
             labels: vec![],
         };
 
@@ -1562,7 +1562,7 @@ mod api_tests {
 
         let sample2 = api::Sample {
             locations: main_locations,
-            values: vec![5, 24, 99],
+            values: &[5, 24, 99],
             labels: vec![],
         };
 
@@ -1596,7 +1596,7 @@ mod api_tests {
 
         let sample1 = api::Sample {
             locations: vec![],
-            values: vec![1, 10000, 21],
+            values: &[1, 10000, 21],
             labels: vec![],
         };
 
@@ -1618,7 +1618,7 @@ mod api_tests {
 
         let sample2 = api::Sample {
             locations: main_locations,
-            values: vec![5, 24, 99],
+            values: &[5, 24, 99],
             labels: vec![],
         };
 
@@ -1663,7 +1663,7 @@ mod api_tests {
 
         let sample1 = api::Sample {
             locations: vec![],
-            values: vec![1, 10000, 42],
+            values: &[1, 10000, 42],
             labels: vec![id_label],
         };
 
@@ -1719,7 +1719,7 @@ mod api_tests {
 
         let sample1 = api::Sample {
             locations: vec![],
-            values: vec![1, 10000, 42],
+            values: &[1, 10000, 42],
             labels: vec![id_label],
         };
 
@@ -1754,7 +1754,7 @@ mod api_tests {
 
         let sample1 = api::Sample {
             locations: vec![],
-            values: vec![1, 10000, 42],
+            values: &[1, 10000, 42],
             labels: vec![id_label],
         };
 
@@ -1776,7 +1776,7 @@ mod api_tests {
 
         let sample2 = api::Sample {
             locations: main_locations,
-            values: vec![5, 24, 99],
+            values: &[5, 24, 99],
             labels: vec![],
         };
 
@@ -1818,7 +1818,7 @@ mod api_tests {
 
         let sample1 = api::Sample {
             locations: vec![],
-            values: vec![1, 10000, 42],
+            values: &[1, 10000, 42],
             labels: vec![id_label, id_no_match_label],
         };
 
@@ -1847,7 +1847,7 @@ mod api_tests {
 
         let sample2 = api::Sample {
             locations: main_locations,
-            values: vec![5, 24, 99],
+            values: &[5, 24, 99],
             labels: vec![id_no_match_label, id_label2],
         };
 
@@ -1900,7 +1900,7 @@ mod api_tests {
 
         let sample1 = api::Sample {
             locations: vec![],
-            values: vec![1, 10000, 42],
+            values: &[1, 10000, 42],
             labels: vec![id_label],
         };
 
@@ -1936,7 +1936,7 @@ mod api_tests {
 
         let sample1 = api::Sample {
             locations: vec![],
-            values: vec![1, 10000, 42],
+            values: &[1, 10000, 42],
             labels: vec![id_label],
         };
 
@@ -2208,7 +2208,7 @@ mod api_tests {
 
         let sample1 = api::Sample {
             locations: vec![],
-            values: vec![1, 10000, 42],
+            values: &[1, 10000, 42],
             labels: vec![id_label],
         };
 
@@ -2270,13 +2270,13 @@ mod api_tests {
 
         let sample1 = api::Sample {
             locations: vec![],
-            values: vec![1, 10000],
+            values: &[1, 10000],
             labels: vec![id_label],
         };
 
         let sample2 = api::Sample {
             locations: vec![],
-            values: vec![1, 10000],
+            values: &[1, 10000],
             labels: vec![id2_label],
         };
 
@@ -2369,7 +2369,7 @@ mod api_tests {
 
         let sample = api::StringIdSample {
             locations: vec![location],
-            values: vec![1],
+            values: &[1],
             labels: vec![],
         };
 

--- a/profiling/tests/wordpress.rs
+++ b/profiling/tests/wordpress.rs
@@ -98,7 +98,7 @@ fn wordpress() {
             /* 8 */ php_location("<?php", "/var/www/html/public/wp-blog-header.php", 13),
             /* 9 */ php_location("<?php", "/var/www/html/public/index.php", 17),
         ],
-        values: vec![1, 6925169, 5340670],
+        values: &[1, 6925169, 5340670],
         labels: vec![],
     };
 
@@ -185,7 +185,7 @@ fn wordpress() {
             /* 8 */ php_location("<?php", "/var/www/html/public/wp-blog-header.php", 13),
             /* 9 */ php_location("<?php", "/var/www/html/public/index.php", 17),
         ],
-        values: vec![1, 10097441, 8518865],
+        values: &[1, 10097441, 8518865],
         labels: vec![],
     };
     let actual_sample1 = api.samples.get(1).unwrap();


### PR DESCRIPTION
# What does this PR do?

Uses a slice instead of a Vec to avoid unnecessary allocations and copies

# Motivation

Fewer allocations are better.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
