### PR TITLE
[profiling] Reduce copying and allocation in exporter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1556,6 +1556,7 @@ dependencies = [
  "ddcommon",
  "ddcommon-ffi",
  "ddtelemetry-ffi",
+ "function_name",
  "futures",
  "hyper 0.14.31",
  "libc",

--- a/ddcommon-ffi/src/handle.rs
+++ b/ddcommon-ffi/src/handle.rs
@@ -1,6 +1,8 @@
 // Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+use std::ptr::null_mut;
+
 use anyhow::Context;
 
 /// Represents an object that should only be referred to by its handle.
@@ -9,6 +11,12 @@ use anyhow::Context;
 pub struct Handle<T> {
     // This may be null, but if not it will point to a valid <T>.
     inner: *mut T,
+}
+
+impl<T> Handle<T> {
+    pub fn empty() -> Self {
+        Self { inner: null_mut() }
+    }
 }
 
 pub trait ToInner<T> {

--- a/ddcommon-ffi/src/result.rs
+++ b/ddcommon-ffi/src/result.rs
@@ -40,6 +40,14 @@ impl<T> Result<T> {
             Self::Err(err) => panic!("{err}"),
         }
     }
+
+    pub fn unwrap_err(self) -> Error {
+        match self {
+            #[allow(clippy::panic)]
+            Self::Ok(_) => panic!("Expected error, got value"),
+            Self::Err(err) => err,
+        }
+    }
 }
 
 impl<T> From<anyhow::Result<T>> for Result<T> {

--- a/ddcommon-ffi/src/result.rs
+++ b/ddcommon-ffi/src/result.rs
@@ -15,6 +15,20 @@ pub enum VoidResult {
     Err(Error),
 }
 
+impl VoidResult {
+    pub fn unwrap(self) {
+        assert!(matches!(self, Self::Ok(_)));
+    }
+
+    pub fn unwrap_err(self) -> Error {
+        match self {
+            #[allow(clippy::panic)]
+            Self::Ok(_) => panic!("Expected error, got value"),
+            Self::Err(err) => err,
+        }
+    }
+}
+
 impl From<anyhow::Result<()>> for VoidResult {
     fn from(value: anyhow::Result<()>) -> Self {
         match value {

--- a/examples/ffi/exporter.cpp
+++ b/examples/ffi/exporter.cpp
@@ -150,7 +150,7 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
-  auto &request = build_result.ok;
+  auto request = &build_result.ok;
 
   ddog_CancellationToken *cancel = ddog_CancellationToken_new();
   ddog_CancellationToken *cancel_for_background_thread = ddog_CancellationToken_clone(cancel);
@@ -174,17 +174,16 @@ int main(int argc, char *argv[]) {
   trigger_cancel_if_request_takes_too_long_thread.detach();
 
   int exit_code = 0;
-  ddog_prof_Exporter_SendResult send_result = ddog_prof_Exporter_send(exporter, request, cancel);
-  if (send_result.tag == DDOG_PROF_EXPORTER_SEND_RESULT_ERR) {
+  auto send_result = ddog_prof_Exporter_send(exporter, request, cancel);
+  if (send_result.tag == DDOG_PROF_RESULT_HTTP_STATUS_ERR_HTTP_STATUS) {
     print_error("Failed to send profile: ", send_result.err);
     exit_code = 1;
     ddog_Error_drop(&send_result.err);
   } else {
-    printf("Response code: %d\n", send_result.http_response.code);
+    printf("Response code: %d\n", send_result.ok.code);
   }
 
-  ddog_prof_Exporter_Request_drop(&request);
-
+  ddog_prof_Exporter_Request_drop(request);
   ddog_prof_Exporter_drop(exporter);
   ddog_CancellationToken_drop(cancel);
   return exit_code;

--- a/examples/ffi/exporter.cpp
+++ b/examples/ffi/exporter.cpp
@@ -139,12 +139,12 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
-  ddog_prof_Exporter_Request_BuildResult build_result = ddog_prof_Exporter_Request_build(
+  auto build_result = ddog_prof_Exporter_Request_build(
       exporter, encoded_profile, files_to_compress_and_export, files_to_export_unmodified, nullptr,
       &internal_metadata_example, &info_example);
   ddog_prof_EncodedProfile_drop(encoded_profile);
 
-  if (build_result.tag == DDOG_PROF_EXPORTER_REQUEST_BUILD_RESULT_ERR) {
+  if (build_result.tag == DDOG_PROF_RESULT_HANDLE_REQUEST_ERR_HANDLE_REQUEST) {
     print_error("Failed to build request: ", build_result.err);
     ddog_Error_drop(&build_result.err);
     return 1;
@@ -174,7 +174,7 @@ int main(int argc, char *argv[]) {
   trigger_cancel_if_request_takes_too_long_thread.detach();
 
   int exit_code = 0;
-  ddog_prof_Exporter_SendResult send_result = ddog_prof_Exporter_send(exporter, &request, cancel);
+  ddog_prof_Exporter_SendResult send_result = ddog_prof_Exporter_send(exporter, request, cancel);
   if (send_result.tag == DDOG_PROF_EXPORTER_SEND_RESULT_ERR) {
     print_error("Failed to send profile: ", send_result.err);
     exit_code = 1;

--- a/examples/ffi/exporter.cpp
+++ b/examples/ffi/exporter.cpp
@@ -109,18 +109,18 @@ int main(int argc, char *argv[]) {
     return 1;
   }
 
-  ddog_prof_Exporter_NewResult exporter_new_result = ddog_prof_Exporter_new(
+  auto exporter_new_result = ddog_prof_Exporter_new(
       DDOG_CHARSLICE_C_BARE("exporter-example"), DDOG_CHARSLICE_C_BARE("1.2.3"),
       DDOG_CHARSLICE_C_BARE("native"), &tags, endpoint);
   ddog_Vec_Tag_drop(tags);
 
-  if (exporter_new_result.tag == DDOG_PROF_EXPORTER_NEW_RESULT_ERR) {
+  if (exporter_new_result.tag == DDOG_PROF_PROFILE_EXPORTER_RESULT_ERR_HANDLE_PROFILE_EXPORTER) {
     print_error("Failed to create exporter: ", exporter_new_result.err);
     ddog_Error_drop(&exporter_new_result.err);
     return 1;
   }
 
-  auto exporter = exporter_new_result.ok;
+  auto exporter = &exporter_new_result.ok;
 
   auto files_to_compress_and_export = ddog_prof_Exporter_Slice_File_empty();
   auto files_to_export_unmodified = ddog_prof_Exporter_Slice_File_empty();
@@ -133,9 +133,9 @@ int main(int argc, char *argv[]) {
                             "\"platform\": {\"kernel\": \"Darwin Kernel 22.5.0\"}}");
 
   auto res = ddog_prof_Exporter_set_timeout(exporter, 30000);
-  if (res.tag == DDOG_PROF_OPTION_ERROR_SOME_ERROR) {
-    print_error("Failed to set the timeout", res.some);
-    ddog_Error_drop(&res.some);
+  if (res.tag == DDOG_PROF_VOID_RESULT_ERR) {
+    print_error("Failed to set the timeout", res.err);
+    ddog_Error_drop(&res.err);
     return 1;
   }
 
@@ -144,7 +144,7 @@ int main(int argc, char *argv[]) {
       &internal_metadata_example, &info_example);
   ddog_prof_EncodedProfile_drop(encoded_profile);
 
-  if (build_result.tag == DDOG_PROF_RESULT_HANDLE_REQUEST_ERR_HANDLE_REQUEST) {
+  if (build_result.tag == DDOG_PROF_REQUEST_RESULT_ERR_HANDLE_REQUEST) {
     print_error("Failed to build request: ", build_result.err);
     ddog_Error_drop(&build_result.err);
     return 1;

--- a/examples/ffi/exporter.cpp
+++ b/examples/ffi/exporter.cpp
@@ -38,8 +38,7 @@ int main(int argc, char *argv[]) {
 
   const ddog_prof_Slice_ValueType sample_types = {&wall_time, 1};
   const ddog_prof_Period period = {wall_time, 60};
-  ddog_prof_Profile_NewResult profile_new_result =
-      ddog_prof_Profile_new(sample_types, &period, nullptr);
+  ddog_prof_Profile_NewResult profile_new_result = ddog_prof_Profile_new(sample_types, &period);
   if (profile_new_result.tag != DDOG_PROF_PROFILE_NEW_RESULT_OK) {
     print_error("Failed to make new profile: ", profile_new_result.err);
     ddog_Error_drop(&profile_new_result.err);

--- a/examples/ffi/exporter.cpp
+++ b/examples/ffi/exporter.cpp
@@ -161,7 +161,7 @@ int main(int argc, char *argv[]) {
   //
   // If the request is faster than the sleep time, no cancellation takes place.
   std::thread trigger_cancel_if_request_takes_too_long_thread(
-      [](ddog_prof_Handle_TokioCancellationToken cancel_for_background_thread) {
+      [](ddog_prof_CancellationToken cancel_for_background_thread) {
         int timeout_ms = 5000;
         std::this_thread::sleep_for(std::chrono::milliseconds(timeout_ms));
         printf("Request took longer than %d ms, triggering asynchronous "

--- a/examples/ffi/profiles.c
+++ b/examples/ffi/profiles.c
@@ -14,7 +14,7 @@ int main(void) {
   const ddog_prof_Slice_ValueType sample_types = {&wall_time, 1};
   const ddog_prof_Period period = {wall_time, 60};
 
-  ddog_prof_Profile_NewResult new_result = ddog_prof_Profile_new(sample_types, &period, NULL);
+  ddog_prof_Profile_NewResult new_result = ddog_prof_Profile_new(sample_types, &period);
   if (new_result.tag != DDOG_PROF_PROFILE_NEW_RESULT_OK) {
     ddog_CharSlice message = ddog_Error_message(&new_result.err);
     fprintf(stderr, "%.*s", (int)message.len, message.ptr);
@@ -58,7 +58,7 @@ int main(void) {
   //   printf("Press any key to reset and drop...");
   //   getchar();
 
-  ddog_prof_Profile_Result reset_result = ddog_prof_Profile_reset(profile, NULL);
+  ddog_prof_Profile_Result reset_result = ddog_prof_Profile_reset(profile);
   if (reset_result.tag != DDOG_PROF_PROFILE_RESULT_OK) {
     ddog_CharSlice message = ddog_Error_message(&reset_result.err);
     fprintf(stderr, "%.*s", (int)message.len, message.ptr);

--- a/profiling-ffi/Cargo.toml
+++ b/profiling-ffi/Cargo.toml
@@ -48,3 +48,4 @@ symbolic-demangle = { version = "12.8.0", default-features = false, features = [
 symbolic-common = "12.8.0"
 data-pipeline-ffi = { path = "../data-pipeline-ffi", default-features = false, optional = true }
 datadog-library-config-ffi = {  path = "../library-config-ffi", default-features = false, optional = true }
+function_name = "0.3.0"

--- a/profiling-ffi/cbindgen.toml
+++ b/profiling-ffi/cbindgen.toml
@@ -50,6 +50,18 @@ renaming_overrides_prefixing = true
 "StringWrapper" = "ddog_StringWrapper"
 "StringWrapperResult" = "ddog_StringWrapperResult"
 
+"HandleProfileExporter" = "ddog_prof_ProfileExporter"
+"Handle_ProfileExporter" = "ddog_prof_ProfileExporter"
+"Result_HandleProfileExporter" = "ddog_prof_ProfileExporter_Result"
+
+"HandleRequest" = "ddog_prof_Request"
+"Handle_Request" = "ddog_prof_Request"
+"Result_HandleRequest" = "ddog_prof_Request_Result"
+
+"HandleEncodedProfile" = "ddog_prof_EncodedProfile"
+"Handle_EncodedProfile" = "ddog_prof_EncodedProfile"
+"Result_HandleEncodedProfile" = "ddog_prof_EncodedProfile_Result"
+
 [export.mangle]
 rename_types = "PascalCase"
 

--- a/profiling-ffi/cbindgen.toml
+++ b/profiling-ffi/cbindgen.toml
@@ -66,6 +66,7 @@ renaming_overrides_prefixing = true
 "Result_HandleEncodedProfile" = "ddog_prof_EncodedProfile_Result"
 
 "CancellationToken" = "struct ddog_prof_OpaqueCancellationToken"
+"Handle_TokioCancellationToken" = "ddog_prof_CancellationToken"
 
 [export.mangle]
 rename_types = "PascalCase"

--- a/profiling-ffi/cbindgen.toml
+++ b/profiling-ffi/cbindgen.toml
@@ -15,13 +15,16 @@ no_includes = true
 sys_includes = ["stdbool.h", "stddef.h", "stdint.h"]
 includes = ["common.h"]
 
+after_includes = """
+struct TokioCancellationToken;
+"""
+
 [export]
 prefix = "ddog_prof_"
 renaming_overrides_prefixing = true
 
 [export.rename]
 "ByteSlice" = "ddog_ByteSlice"
-"CancellationToken" = "ddog_CancellationToken"
 "CharSlice" = "ddog_CharSlice"
 "Endpoint" = "ddog_Endpoint"
 "Error" = "ddog_Error"
@@ -61,6 +64,8 @@ renaming_overrides_prefixing = true
 "HandleEncodedProfile" = "ddog_prof_EncodedProfile"
 "Handle_EncodedProfile" = "ddog_prof_EncodedProfile"
 "Result_HandleEncodedProfile" = "ddog_prof_EncodedProfile_Result"
+
+"CancellationToken" = "struct ddog_prof_OpaqueCancellationToken"
 
 [export.mangle]
 rename_types = "PascalCase"

--- a/profiling-ffi/src/exporter.rs
+++ b/profiling-ffi/src/exporter.rs
@@ -369,7 +369,9 @@ pub unsafe extern "C" fn ddog_CancellationToken_cancel(
 /// The `token` can be null, but non-null values must be created by the Rust
 /// Global allocator and must have not been dropped already.
 #[no_mangle]
-pub unsafe extern "C" fn ddog_CancellationToken_drop(mut token: *mut Handle<TokioCancellationToken>) {
+pub unsafe extern "C" fn ddog_CancellationToken_drop(
+    mut token: *mut Handle<TokioCancellationToken>,
+) {
     drop(token.take())
 }
 

--- a/profiling-ffi/src/exporter.rs
+++ b/profiling-ffi/src/exporter.rs
@@ -491,14 +491,30 @@ mod tests {
 
         assert_eq!(parsed_event_json["attachments"], json!(["profile.pprof"]));
         assert_eq!(parsed_event_json["endpoint_counts"], json!(null));
-        assert_eq!(
-            parsed_event_json["start"],
-            json!("1970-01-01T00:00:12.000000034Z")
-        );
-        assert_eq!(
-            parsed_event_json["end"],
-            json!("1970-01-01T00:00:56.000000078Z")
-        );
+        #[cfg(not(windows))]
+        {
+            assert_eq!(
+                parsed_event_json["start"],
+                json!("1970-01-01T00:00:12.000000034Z")
+            );
+            assert_eq!(
+                parsed_event_json["end"],
+                json!("1970-01-01T00:00:56.000000078Z")
+            );
+        }
+        // Windows is less accurate on timestamps
+        #[cfg(windows)]
+        {
+            assert_eq!(
+                parsed_event_json["start"],
+                json!("1970-01-01T00:00:12.000000000Z")
+            );
+            assert_eq!(
+                parsed_event_json["end"],
+                json!("1970-01-01T00:00:56.000000000Z")
+            );
+        }
+
         assert_eq!(parsed_event_json["family"], json!("native"));
         assert_eq!(
             parsed_event_json["internal"],

--- a/profiling-ffi/src/exporter.rs
+++ b/profiling-ffi/src/exporter.rs
@@ -255,16 +255,16 @@ impl From<RequestBuildResult> for Result<Box<Request>, String> {
 /// "RFC: Pprof System Info Support".
 ///
 /// # Safety
-/// The `exporter`, `optional_additional_stats`, and `optional_endpoint_stats` args should be
-/// valid objects created by this module.
-/// NULL is allowed for `optional_additional_tags`, `optional_endpoints_stats`,
+/// The `exporter`, `profile`, `optional_additional_stats`, and `optional_endpoint_stats` args
+/// should be valid objects created by this module.
+/// NULL is allowed for `profile`, `optional_additional_tags`, `optional_endpoints_stats`,
 /// `optional_internal_metadata_json` and `optional_info_json`.
 /// Consumes the `SerializedProfile`
 #[no_mangle]
 #[must_use]
 pub unsafe extern "C" fn ddog_prof_Exporter_Request_build(
     exporter: Option<&mut ProfileExporter>,
-    profile: *mut Handle<EncodedProfile>,
+    profile: Option<&mut Handle<EncodedProfile>>,
     files_to_compress_and_export: Slice<File>,
     files_to_export_unmodified: Slice<File>,
     optional_additional_tags: Option<&ddcommon_ffi::Vec<Tag>>,
@@ -289,13 +289,13 @@ pub unsafe extern "C" fn ddog_prof_Exporter_Request_build(
                 Err(err) => return RequestBuildResult::Err(err.into()),
             };
 
-            if profile.is_null() {
-                return RequestBuildResult::Err(anyhow::anyhow!("profile pointer was null").into());
-            }
-
-            let profile = match (*profile).take() {
-                Ok(p) => *p,
-                Err(e) => return RequestBuildResult::Err(e.into()),
+            let profile = if let Some(profile) = profile {
+                match profile.take() {
+                    Ok(p) => Some(*p),
+                    Err(e) => return RequestBuildResult::Err(e.into()),
+                }
+            } else {
+                None
             };
 
             match exporter.build(
@@ -591,7 +591,7 @@ mod tests {
         let build_result = unsafe {
             ddog_prof_Exporter_Request_build(
                 Some(exporter.as_mut()),
-                profile,
+                Some(profile),
                 Slice::empty(),
                 Slice::empty(),
                 None,
@@ -661,7 +661,7 @@ mod tests {
         let build_result = unsafe {
             ddog_prof_Exporter_Request_build(
                 Some(exporter.as_mut()),
-                profile,
+                Some(profile),
                 Slice::empty(),
                 Slice::empty(),
                 None,
@@ -715,7 +715,7 @@ mod tests {
         let build_result = unsafe {
             ddog_prof_Exporter_Request_build(
                 Some(exporter.as_mut()),
-                profile,
+                Some(profile),
                 Slice::empty(),
                 Slice::empty(),
                 None,
@@ -793,7 +793,7 @@ mod tests {
         let build_result = unsafe {
             ddog_prof_Exporter_Request_build(
                 Some(exporter.as_mut()),
-                profile,
+                Some(profile),
                 Slice::empty(),
                 Slice::empty(),
                 None,
@@ -867,7 +867,7 @@ mod tests {
         let build_result = unsafe {
             ddog_prof_Exporter_Request_build(
                 Some(exporter.as_mut()),
-                profile,
+                Some(profile),
                 Slice::empty(),
                 Slice::empty(),
                 None,
@@ -891,7 +891,7 @@ mod tests {
         let build_result = unsafe {
             ddog_prof_Exporter_Request_build(
                 None, // No exporter, will fail
-                profile,
+                Some(profile),
                 Slice::empty(),
                 Slice::empty(),
                 None,

--- a/profiling-ffi/src/profiles.rs
+++ b/profiling-ffi/src/profiles.rs
@@ -707,7 +707,7 @@ unsafe fn add_upscaling_rule(
 
 /// # Safety
 /// Only pass a reference to a valid `ddog_prof_EncodedProfile`, or null. A
-/// valid reference also means that it hasn't already been dropped (do not
+/// valid reference also means that it hasn't already been dropped or exported (do not
 /// call this twice on the same object).
 #[no_mangle]
 pub unsafe extern "C" fn ddog_prof_EncodedProfile_drop(

--- a/profiling-ffi/src/profiles.rs
+++ b/profiling-ffi/src/profiles.rs
@@ -728,7 +728,7 @@ pub unsafe extern "C" fn ddog_prof_EncodedProfile_drop(
 #[no_mangle]
 #[must_use]
 #[named]
-pub unsafe extern "C" fn ddog_prof_EncodedProfile_get_pprof_bytes<'a>(
+pub unsafe extern "C" fn ddog_prof_EncodedProfile_bytes<'a>(
     mut encoded_profile: *mut Handle<internal::EncodedProfile>,
 ) -> ddcommon_ffi::Result<ByteSlice<'a>> {
     wrap_with_ffi_result!({

--- a/profiling-replayer/src/main.rs
+++ b/profiling-replayer/src/main.rs
@@ -163,11 +163,9 @@ fn main() -> anyhow::Result<()> {
 
     let mut replayer = Replayer::try_from(&pprof)?;
 
-    let mut outprof = datadog_profiling::internal::Profile::new(
-        replayer.start_time,
-        &replayer.sample_types,
-        replayer.period,
-    );
+    let mut outprof =
+        datadog_profiling::internal::Profile::new(&replayer.sample_types, replayer.period)
+            .with_start_time(replayer.start_time)?;
 
     // Before benchmarking, let's calculate some statistics.
     // No point doing that if there aren't at least 4 samples though.

--- a/profiling/examples/profiles.rs
+++ b/profiling/examples/profiles.rs
@@ -5,7 +5,6 @@ use datadog_profiling::api;
 use datadog_profiling::internal::Profile;
 use std::io::Write;
 use std::process::exit;
-use std::time::SystemTime;
 
 // Keep this in-sync with profiles.c
 fn main() {
@@ -48,7 +47,7 @@ fn main() {
     };
 
     // Intentionally use the current time.
-    let mut profile = Profile::new(SystemTime::now(), &sample_types, Some(period));
+    let mut profile = Profile::new(&sample_types, Some(period));
 
     match profile.add_sample(sample, None) {
         Ok(_) => {}

--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -10,8 +10,9 @@ use lz4_flex::frame::FrameEncoder;
 use serde_json::json;
 use std::borrow::Cow;
 use std::fmt::Debug;
+use std::future;
 use std::io::{Cursor, Write};
-use std::{future, iter};
+use std::ops::Not;
 use tokio::runtime::Runtime;
 use tokio_util::sync::CancellationToken;
 
@@ -152,7 +153,7 @@ impl ProfileExporter {
 
     #[allow(clippy::too_many_arguments)]
     /// Build a Request object representing the profile information provided.
-    /// 
+    ///
     /// Consumes the `EncodedProfile`, which is unavailable for use after.
     ///
     /// For details on the `internal_metadata` parameter, please reference the Datadog-internal
@@ -164,7 +165,7 @@ impl ProfileExporter {
     /// "RFC: Pprof System Info Support".
     pub fn build(
         &self,
-        profile: EncodedProfile,
+        mut profile: Option<EncodedProfile>,
         files_to_compress_and_export: &[File],
         files_to_export_unmodified: &[File],
         additional_tags: Option<&Vec<Tag>>,
@@ -217,20 +218,30 @@ impl ProfileExporter {
             .iter()
             .chain(files_to_export_unmodified.iter())
             .map(|file| file.name.to_owned())
-            .chain(iter::once("profile.pprof".to_string()))
+            .chain(profile.as_ref().map(|_| "profile.pprof".to_string()))
             .collect();
 
-        let endpoint_counts = if profile.endpoints_stats.is_empty() {
-            None
-        } else {
-            Some(profile.endpoints_stats)
-        };
+        let endpoint_counts = profile
+            .as_ref()
+            .map(|p| &p.endpoints_stats)
+            .and_then(|es| es.is_empty().not().then_some(es));
+
+        let start = profile.as_ref().map(|p| {
+            DateTime::<Utc>::from(p.start)
+                .format("%Y-%m-%dT%H:%M:%S%.9fZ")
+                .to_string()
+        });
+        let end = profile.as_ref().map(|p| {
+            DateTime::<Utc>::from(p.end)
+                .format("%Y-%m-%dT%H:%M:%S%.9fZ")
+                .to_string()
+        });
 
         let event = json!({
             "attachments": attachments,
             "tags_profiler": tags_profiler,
-            "start": DateTime::<Utc>::from(profile.start).format("%Y-%m-%dT%H:%M:%S%.9fZ").to_string(),
-            "end": DateTime::<Utc>::from(profile.end).format("%Y-%m-%dT%H:%M:%S%.9fZ").to_string(),
+            "start": start,
+            "end": end,
             "family": self.family.as_ref(),
             "version": "4",
             "endpoint_counts" : endpoint_counts,
@@ -277,12 +288,15 @@ impl ProfileExporter {
              */
             form.add_reader_file(file.name, Cursor::new(encoded), file.name)
         }
-        // Add the actual pprof
-        form.add_reader_file(
-            "profile.pprof",
-            Cursor::new(profile.buffer),
-            "profile.pprof",
-        );
+
+        if let Some(profile) = &mut profile {
+            // Add the actual pprof
+            form.add_reader_file(
+                "profile.pprof",
+                Cursor::new(std::mem::take(&mut profile.buffer)),
+                "profile.pprof",
+            );
+        }
 
         let builder = self
             .endpoint

--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -153,7 +153,7 @@ impl ProfileExporter {
     #[allow(clippy::too_many_arguments)]
     /// Build a Request object representing the profile information provided.
     /// 
-    /// Consumes the `EncodedProfile`
+    /// Consumes the `EncodedProfile`, which is unavailable for use after.
     ///
     /// For details on the `internal_metadata` parameter, please reference the Datadog-internal
     /// "RFC: Attaching internal metadata to pprof profiles".

--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -152,6 +152,8 @@ impl ProfileExporter {
 
     #[allow(clippy::too_many_arguments)]
     /// Build a Request object representing the profile information provided.
+    /// 
+    /// Consumes the `EncodedProfile`
     ///
     /// For details on the `internal_metadata` parameter, please reference the Datadog-internal
     /// "RFC: Attaching internal metadata to pprof profiles".

--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -152,7 +152,7 @@ impl ProfileExporter {
 
     #[allow(clippy::too_many_arguments)]
     /// Build a Request object representing the profile information provided.
-    /// 
+    ///
     /// Consumes the `EncodedProfile`, which is unavailable for use after.
     ///
     /// For details on the `internal_metadata` parameter, please reference the Datadog-internal

--- a/profiling/src/internal/profile/fuzz_tests.rs
+++ b/profiling/src/internal/profile/fuzz_tests.rs
@@ -424,7 +424,7 @@ fn fuzz_failure_001() {
             },
         ],
     };
-    let mut expected_profile = Profile::new(SystemTime::now(), &sample_types, None);
+    let mut expected_profile = Profile::new(&sample_types, None);
     let mut samples_with_timestamps = Vec::new();
     let mut samples_without_timestamps: HashMap<(&[Location], &[Label]), Vec<i64>> = HashMap::new();
 
@@ -462,7 +462,7 @@ fn test_fuzz_add_sample() {
                 .iter()
                 .map(api::ValueType::from)
                 .collect();
-            let mut expected_profile = Profile::new(SystemTime::now(), &sample_types, None);
+            let mut expected_profile = Profile::new(&sample_types, None);
             let mut samples_with_timestamps = Vec::new();
             let mut samples_without_timestamps: HashMap<(&[Location], &[Label]), Vec<i64>> =
                 HashMap::new();
@@ -511,7 +511,7 @@ fn fuzz_add_sample_with_fixed_sample_length() {
         })
         .for_each(|(sample_types, samples)| {
             let api_sample_types: Vec<_> = sample_types.iter().map(api::ValueType::from).collect();
-            let mut profile = Profile::new(SystemTime::now(), &api_sample_types, None);
+            let mut profile = Profile::new(&api_sample_types, None);
             let mut samples_with_timestamps = Vec::new();
             let mut samples_without_timestamps: HashMap<(&[Location], &[Label]), Vec<i64>> =
                 HashMap::new();
@@ -558,7 +558,7 @@ fn fuzz_add_endpoint() {
     bolero::check!()
         .with_type::<Vec<(u64, String)>>()
         .for_each(|endpoints| {
-            let mut profile = Profile::new(SystemTime::now(), &[], None);
+            let mut profile = Profile::new(&[], None);
             for (local_root_span_id, endpoint) in endpoints {
                 profile
                     .add_endpoint(*local_root_span_id, endpoint.into())
@@ -573,7 +573,7 @@ fn fuzz_add_endpoint_count() {
     bolero::check!()
         .with_type::<Vec<(String, i64)>>()
         .for_each(|endpoint_counts| {
-            let mut profile = Profile::new(SystemTime::now(), &[], None);
+            let mut profile = Profile::new(&[], None);
             for (endpoint, count) in endpoint_counts {
                 profile
                     .add_endpoint_count(endpoint.into(), *count)
@@ -610,7 +610,7 @@ fn fuzz_api_function_calls() {
         })
         .for_each(|(sample_types, operations)| {
             let api_sample_types: Vec<_> = sample_types.iter().map(api::ValueType::from).collect();
-            let mut profile = Profile::new(SystemTime::now(), &api_sample_types, None);
+            let mut profile = Profile::new(&api_sample_types, None);
             let mut samples_with_timestamps: Vec<&Sample> = Vec::new();
             let mut samples_without_timestamps: HashMap<(&[Location], &[Label]), Vec<i64>> =
                 HashMap::new();

--- a/profiling/src/internal/profile/mod.rs
+++ b/profiling/src/internal/profile/mod.rs
@@ -259,22 +259,16 @@ impl Profile {
     ///
     /// All other fields are default.
     #[inline]
-    pub fn new(
-        start_time: SystemTime,
-        sample_types: &[api::ValueType],
-        period: Option<api::Period>,
-    ) -> Self {
+    pub fn new(sample_types: &[api::ValueType], period: Option<api::Period>) -> Self {
         Self::new_internal(
             Self::backup_period(period),
             Self::backup_sample_types(sample_types),
-            start_time,
             None,
         )
     }
 
     #[inline]
     pub fn with_string_storage(
-        start_time: SystemTime,
         sample_types: &[api::ValueType],
         period: Option<api::Period>,
         string_storage: Arc<Mutex<ManagedStringStorage>>,
@@ -282,7 +276,6 @@ impl Profile {
         Self::new_internal(
             Self::backup_period(period),
             Self::backup_sample_types(sample_types),
-            start_time,
             Some(string_storage),
         )
     }
@@ -290,14 +283,10 @@ impl Profile {
     /// Resets all data except the sample types and period.
     /// Returns the previous Profile on success.
     #[inline]
-    pub fn reset_and_return_previous(
-        &mut self,
-        start_time: Option<SystemTime>,
-    ) -> anyhow::Result<Profile> {
+    pub fn reset_and_return_previous(&mut self) -> anyhow::Result<Profile> {
         let mut profile = Profile::new_internal(
             self.owned_period.take(),
             self.owned_sample_types.take(),
-            start_time.unwrap_or_else(SystemTime::now),
             self.string_storage.clone(),
         );
 
@@ -419,6 +408,16 @@ impl Profile {
             buffer: encoder.finish()?,
             endpoints_stats,
         })
+    }
+
+    pub fn set_start_time(&mut self, start_time: SystemTime) -> anyhow::Result<()> {
+        self.start_time = start_time;
+        Ok(())
+    }
+
+    pub fn with_start_time(mut self, start_time: SystemTime) -> anyhow::Result<Self> {
+        self.set_start_time(start_time)?;
+        Ok(self)
     }
 
     /// In incident 35390 (JIRA PROF-11456) we observed invalid location_ids being present in
@@ -658,9 +657,9 @@ impl Profile {
     fn new_internal(
         owned_period: Option<owned_types::Period>,
         owned_sample_types: Option<Box<[owned_types::ValueType]>>,
-        start_time: SystemTime,
         string_storage: Option<Arc<Mutex<ManagedStringStorage>>>,
     ) -> Self {
+        let start_time = SystemTime::now();
         let mut profile = Self {
             owned_period,
             owned_sample_types,
@@ -818,7 +817,7 @@ mod api_tests {
     #[test]
     fn interning() {
         let sample_types = [api::ValueType::new("samples", "count")];
-        let mut profiles = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profiles = Profile::new(&sample_types, None);
 
         let expected_id = StringId::from_offset(profiles.interned_strings_count());
 
@@ -866,7 +865,7 @@ mod api_tests {
             },
         ];
 
-        let mut profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile = Profile::new(&sample_types, None);
         assert_eq!(profile.only_for_testing_num_aggregated_samples(), 0);
 
         profile
@@ -947,7 +946,7 @@ mod api_tests {
             labels,
         };
 
-        let mut profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile = Profile::new(&sample_types, None);
         assert_eq!(profile.only_for_testing_num_aggregated_samples(), 0);
 
         profile
@@ -1087,7 +1086,7 @@ mod api_tests {
         assert!(profile.endpoints.stats.is_empty());
 
         let prev = profile
-            .reset_and_return_previous(None)
+            .reset_and_return_previous()
             .expect("reset to succeed");
 
         // These should all be empty now
@@ -1118,10 +1117,10 @@ mod api_tests {
             r#type: sample_types[0],
             value: 10_000_000,
         };
-        let mut profile = Profile::new(SystemTime::now(), &sample_types, Some(period));
+        let mut profile = Profile::new(&sample_types, Some(period));
 
         let prev = profile
-            .reset_and_return_previous(None)
+            .reset_and_return_previous()
             .expect("reset to succeed");
 
         // Resolve the string values to check that they match (their string
@@ -1145,7 +1144,7 @@ mod api_tests {
     fn adding_local_root_span_id_with_string_value_fails() {
         let sample_types = [api::ValueType::new("wall-time", "nanoseconds")];
 
-        let mut profile: Profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile: Profile = Profile::new(&sample_types, None);
 
         let id_label = api::Label {
             key: "local root span id",
@@ -1170,7 +1169,7 @@ mod api_tests {
             api::ValueType::new("wall-time", "nanoseconds"),
         ];
 
-        let mut profile: Profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile: Profile = Profile::new(&sample_types, None);
 
         let id_label = api::Label {
             key: "local root span id",
@@ -1280,7 +1279,7 @@ mod api_tests {
             api::ValueType::new("wall-time", "nanoseconds"),
         ];
 
-        let profile: Profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let profile: Profile = Profile::new(&sample_types, None);
 
         let encoded_profile = profile
             .serialize_into_compressed_pprof(None, None)
@@ -1297,7 +1296,7 @@ mod api_tests {
             api::ValueType::new("wall-time", "nanoseconds"),
         ];
 
-        let mut profile: Profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile: Profile = Profile::new(&sample_types, None);
 
         let one_endpoint = "my endpoint";
         profile.add_endpoint_count(Cow::from(one_endpoint), 1)?;
@@ -1326,7 +1325,7 @@ mod api_tests {
     fn local_root_span_id_label_cannot_occur_more_than_once() {
         let sample_types = [api::ValueType::new("wall-time", "nanoseconds")];
 
-        let mut profile: Profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile: Profile = Profile::new(&sample_types, None);
 
         let labels = vec![
             api::Label {
@@ -1359,7 +1358,7 @@ mod api_tests {
             api::ValueType::new("wall-time", "nanoseconds"),
         ];
 
-        let mut profile: Profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile: Profile = Profile::new(&sample_types, None);
 
         let id_label = api::Label {
             key: "my label",
@@ -1406,7 +1405,7 @@ mod api_tests {
     fn test_upscaling_by_value_a_zero_value() {
         let sample_types = create_samples_types();
 
-        let mut profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile = Profile::new(&sample_types, None);
 
         let sample1 = api::Sample {
             locations: vec![],
@@ -1434,7 +1433,7 @@ mod api_tests {
     fn test_upscaling_by_value_on_one_value() {
         let sample_types = create_samples_types();
 
-        let mut profile: Profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile: Profile = Profile::new(&sample_types, None);
 
         let sample1 = api::Sample {
             locations: vec![],
@@ -1462,7 +1461,7 @@ mod api_tests {
     fn test_upscaling_by_value_on_one_value_with_poisson() {
         let sample_types = create_samples_types();
 
-        let mut profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile = Profile::new(&sample_types, None);
 
         let sample1 = api::Sample {
             locations: vec![],
@@ -1494,7 +1493,7 @@ mod api_tests {
     fn test_upscaling_by_value_on_one_value_with_poisson_count() {
         let sample_types = create_samples_types();
 
-        let mut profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile = Profile::new(&sample_types, None);
 
         let sample1 = api::Sample {
             locations: vec![],
@@ -1526,7 +1525,7 @@ mod api_tests {
     fn test_upscaling_by_value_on_zero_value_with_poisson() {
         let sample_types = create_samples_types();
 
-        let mut profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile = Profile::new(&sample_types, None);
 
         let sample1 = api::Sample {
             locations: vec![],
@@ -1558,7 +1557,7 @@ mod api_tests {
     fn test_cannot_add_a_rule_with_invalid_poisson_info() {
         let sample_types = create_samples_types();
 
-        let mut profile: Profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile: Profile = Profile::new(&sample_types, None);
 
         let sample1 = api::Sample {
             locations: vec![],
@@ -1605,7 +1604,7 @@ mod api_tests {
     fn test_upscaling_by_value_on_two_values() {
         let sample_types = create_samples_types();
 
-        let mut profile: Profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile: Profile = Profile::new(&sample_types, None);
 
         let sample1 = api::Sample {
             locations: vec![],
@@ -1662,7 +1661,7 @@ mod api_tests {
     fn test_upscaling_by_value_on_two_value_with_two_rules() {
         let sample_types = create_samples_types();
 
-        let mut profile: Profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile: Profile = Profile::new(&sample_types, None);
 
         let sample1 = api::Sample {
             locations: vec![],
@@ -1727,7 +1726,7 @@ mod api_tests {
     fn test_no_upscaling_by_label_if_no_match() {
         let sample_types = create_samples_types();
 
-        let mut profile: Profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile: Profile = Profile::new(&sample_types, None);
 
         let id_label = create_label("my_label", Some("coco"));
 
@@ -1783,7 +1782,7 @@ mod api_tests {
     fn test_upscaling_by_label_on_one_value() {
         let sample_types = create_samples_types();
 
-        let mut profile: Profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile: Profile = Profile::new(&sample_types, None);
 
         let id_label = create_label("my label", Some("coco"));
 
@@ -1818,7 +1817,7 @@ mod api_tests {
     fn test_upscaling_by_label_on_only_sample_out_of_two() {
         let sample_types = create_samples_types();
 
-        let mut profile: Profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile: Profile = Profile::new(&sample_types, None);
 
         let id_label = create_label("my label", Some("coco"));
 
@@ -1880,7 +1879,7 @@ mod api_tests {
     fn test_upscaling_by_label_with_two_different_rules_on_two_different_sample() {
         let sample_types = create_samples_types();
 
-        let mut profile: Profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile: Profile = Profile::new(&sample_types, None);
 
         let id_no_match_label = create_label("another label", Some("do not care"));
 
@@ -1964,7 +1963,7 @@ mod api_tests {
     fn test_upscaling_by_label_on_two_values() {
         let sample_types = create_samples_types();
 
-        let mut profile: Profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile: Profile = Profile::new(&sample_types, None);
 
         let id_label = create_label("my label", Some("coco"));
 
@@ -2000,7 +1999,7 @@ mod api_tests {
     fn test_upscaling_by_value_and_by_label_different_values() {
         let sample_types = create_samples_types();
 
-        let mut profile: Profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile: Profile = Profile::new(&sample_types, None);
 
         let id_label = create_label("my label", Some("coco"));
 
@@ -2043,7 +2042,7 @@ mod api_tests {
     fn test_add_same_byvalue_rule_twice() {
         let sample_types = create_samples_types();
 
-        let mut profile: Profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile: Profile = Profile::new(&sample_types, None);
 
         // adding same offsets
         let upscaling_info = UpscalingInfo::Proportional { scale: 2.0 };
@@ -2080,7 +2079,7 @@ mod api_tests {
     fn test_add_two_bylabel_rules_with_overlap_on_values() {
         let sample_types = create_samples_types();
 
-        let mut profile: Profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile: Profile = Profile::new(&sample_types, None);
 
         // adding same offsets
         let mut value_offsets: Vec<usize> = vec![0, 2];
@@ -2130,7 +2129,7 @@ mod api_tests {
     fn test_fail_if_bylabel_rule_and_by_value_rule_with_overlap_on_values() {
         let sample_types = create_samples_types();
 
-        let mut profile: Profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile: Profile = Profile::new(&sample_types, None);
 
         // adding same offsets
         let mut value_offsets: Vec<usize> = vec![0, 2];
@@ -2184,7 +2183,7 @@ mod api_tests {
     fn test_add_rule_with_offset_out_of_bound() {
         let sample_types = create_samples_types();
 
-        let mut profile: Profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile: Profile = Profile::new(&sample_types, None);
 
         // adding same offsets
         let by_value_offsets: Vec<usize> = vec![0, 4];
@@ -2203,7 +2202,7 @@ mod api_tests {
     fn test_add_rule_with_offset_out_of_bound_poisson_function() {
         let sample_types = create_samples_types();
 
-        let mut profile: Profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile: Profile = Profile::new(&sample_types, None);
 
         // adding same offsets
         let by_value_offsets: Vec<usize> = vec![0, 4];
@@ -2226,7 +2225,7 @@ mod api_tests {
     fn test_add_rule_with_offset_out_of_bound_poisson_function2() {
         let sample_types = create_samples_types();
 
-        let mut profile: Profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile: Profile = Profile::new(&sample_types, None);
 
         // adding same offsets
         let by_value_offsets: Vec<usize> = vec![0, 4];
@@ -2249,7 +2248,7 @@ mod api_tests {
     fn test_add_rule_with_offset_out_of_bound_poisson_function3() {
         let sample_types = create_samples_types();
 
-        let mut profile: Profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile: Profile = Profile::new(&sample_types, None);
 
         // adding same offsets
         let by_value_offsets: Vec<usize> = vec![0, 4];
@@ -2272,7 +2271,7 @@ mod api_tests {
     fn test_fails_when_adding_byvalue_rule_colliding_on_offset_with_existing_bylabel_rule() {
         let sample_types = create_samples_types();
 
-        let mut profile: Profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile: Profile = Profile::new(&sample_types, None);
 
         let id_label = create_label("my label", Some("coco"));
 
@@ -2318,7 +2317,7 @@ mod api_tests {
             },
         ];
 
-        let mut profile = Profile::new(SystemTime::now(), &sample_types, None);
+        let mut profile = Profile::new(&sample_types, None);
 
         let id_label = api::Label {
             key: "local root span id",
@@ -2425,8 +2424,7 @@ mod api_tests {
         }
 
         let sample_types = [api::ValueType::new("samples", "count")];
-        let mut profile =
-            Profile::with_string_storage(SystemTime::now(), &sample_types, None, storage.clone());
+        let mut profile = Profile::with_string_storage(&sample_types, None, storage.clone());
 
         let location = api::StringIdLocation {
             function: api::StringIdFunction {
@@ -2447,7 +2445,7 @@ mod api_tests {
         profile.add_string_id_sample(sample.clone(), None).unwrap();
 
         let pprof_first_profile =
-            pprof::roundtrip_to_pprof(profile.reset_and_return_previous(None).unwrap()).unwrap();
+            pprof::roundtrip_to_pprof(profile.reset_and_return_previous().unwrap()).unwrap();
 
         assert!(pprof_first_profile
             .string_table

--- a/profiling/src/internal/profile/mod.rs
+++ b/profiling/src/internal/profile/mod.rs
@@ -55,6 +55,38 @@ pub struct EncodedProfile {
     pub endpoints_stats: ProfiledEndpointsStats,
 }
 
+impl EncodedProfile {
+    pub fn test_instance() -> anyhow::Result<Self> {
+        use std::io::Read;
+
+        fn open<P: AsRef<std::path::Path>>(path: P) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+            let mut file = std::fs::File::open(path)?;
+            let metadata = file.metadata()?;
+            let mut buffer = Vec::with_capacity(metadata.len() as usize);
+            file.read_to_end(&mut buffer)?;
+
+            Ok(buffer)
+        }
+
+        let small_pprof_name = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/profile.pprof");
+        let buffer = open(small_pprof_name).expect("to open file and read its bytes");
+
+        let start = SystemTime::UNIX_EPOCH
+            .checked_add(Duration::from_nanos(12000000034))
+            .unwrap();
+        let end = SystemTime::UNIX_EPOCH
+            .checked_add(Duration::from_nanos(56000000078))
+            .unwrap();
+        let endpoints_stats = ProfiledEndpointsStats::default();
+        Ok(EncodedProfile {
+            start,
+            end,
+            buffer,
+            endpoints_stats,
+        })
+    }
+}
+
 /// Public API
 impl Profile {
     /// Add the endpoint data to the endpoint mappings.

--- a/profiling/src/internal/profile/mod.rs
+++ b/profiling/src/internal/profile/mod.rs
@@ -69,7 +69,7 @@ impl EncodedProfile {
         }
 
         let small_pprof_name = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/profile.pprof");
-        let buffer = open(small_pprof_name).expect("to open file and read its bytes");
+        let buffer = open(small_pprof_name).map_err(|e| anyhow::anyhow!("{e}"))?;
 
         let start = SystemTime::UNIX_EPOCH
             .checked_add(Duration::from_nanos(12000000034))

--- a/profiling/src/internal/profile/mod.rs
+++ b/profiling/src/internal/profile/mod.rs
@@ -73,10 +73,10 @@ impl EncodedProfile {
 
         let start = SystemTime::UNIX_EPOCH
             .checked_add(Duration::from_nanos(12000000034))
-            .unwrap();
+            .context("Translating time failed")?;
         let end = SystemTime::UNIX_EPOCH
             .checked_add(Duration::from_nanos(56000000078))
-            .unwrap();
+            .context("Translating time failed")?;
         let endpoints_stats = ProfiledEndpointsStats::default();
         Ok(EncodedProfile {
             start,

--- a/profiling/src/internal/profile/mod.rs
+++ b/profiling/src/internal/profile/mod.rs
@@ -70,7 +70,6 @@ impl EncodedProfile {
 
         let small_pprof_name = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/profile.pprof");
         let buffer = open(small_pprof_name).map_err(|e| anyhow::anyhow!("{e}"))?;
-
         let start = SystemTime::UNIX_EPOCH
             .checked_add(Duration::from_nanos(12000000034))
             .context("Translating time failed")?;

--- a/profiling/tests/form.rs
+++ b/profiling/tests/form.rs
@@ -9,7 +9,7 @@ fn multipart(
     internal_metadata: Option<serde_json::Value>,
     info: Option<serde_json::Value>,
 ) -> Request {
-    let profile = EncodedProfile::test_instance().expect("To get a profile");
+    let profile = Some(EncodedProfile::test_instance().expect("To get a profile"));
 
     let files_to_compress_and_export = &[];
     let files_to_export_unmodified = &[];

--- a/profiling/tests/form.rs
+++ b/profiling/tests/form.rs
@@ -1,50 +1,27 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use datadog_profiling::exporter::{File, ProfileExporter, Request};
-use std::error::Error;
-use std::io::Read;
-use std::ops::Sub;
-use std::path::Path;
-
-fn open<P: AsRef<Path>>(path: P) -> Result<Vec<u8>, Box<dyn Error>> {
-    let mut file = std::fs::File::open(path)?;
-    let metadata = file.metadata()?;
-    let mut buffer = Vec::with_capacity(metadata.len() as usize);
-    file.read_to_end(&mut buffer)?;
-
-    Ok(buffer)
-}
+use datadog_profiling::exporter::{ProfileExporter, Request};
+use datadog_profiling::internal::EncodedProfile;
 
 fn multipart(
     exporter: &mut ProfileExporter,
     internal_metadata: Option<serde_json::Value>,
     info: Option<serde_json::Value>,
 ) -> Request {
-    let small_pprof_name = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/profile.pprof");
-    let buffer = open(small_pprof_name).expect("to open file and read its bytes");
+    let profile = EncodedProfile::test_instance().expect("To get a profile");
 
-    let files_to_compress_and_export: &[File] = &[File {
-        name: "profile.pprof",
-        bytes: buffer.as_slice(),
-    }];
-
+    let files_to_compress_and_export = &[];
     let files_to_export_unmodified = &[];
-
-    let now = chrono::Utc::now();
-    let start = now.sub(chrono::Duration::seconds(60));
-    let end = now;
 
     let timeout: u64 = 10_000;
     exporter.set_timeout(timeout);
 
     let request = exporter
         .build(
-            start,
-            end,
+            profile,
             files_to_compress_and_export,
             files_to_export_unmodified,
-            None,
             None,
             internal_metadata,
             info,
@@ -126,7 +103,6 @@ mod tests {
         );
 
         let parsed_event_json = parsed_event_json(request);
-
         assert_eq!(parsed_event_json["attachments"], json!(["profile.pprof"]));
         assert_eq!(parsed_event_json["endpoint_counts"], json!(null));
         assert_eq!(parsed_event_json["family"], json!("php"));

--- a/profiling/tests/form.rs
+++ b/profiling/tests/form.rs
@@ -9,7 +9,7 @@ fn multipart(
     internal_metadata: Option<serde_json::Value>,
     info: Option<serde_json::Value>,
 ) -> Request {
-    let profile = Some(EncodedProfile::test_instance().expect("To get a profile"));
+    let profile = EncodedProfile::test_instance().expect("To get a profile");
 
     let files_to_compress_and_export = &[];
     let files_to_export_unmodified = &[];


### PR DESCRIPTION
# What does this PR do?

Passes the `EncodedProfile` as a Rust object, rather than forcing it through the C-FFI straw.

# Motivation

We ended up having to make a new `Vec` and copy the bytes from the pprof in, even though they were already there.  This saves the allocation and copy (which can be several MB).

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Existing tests