### PR TITLE
refactor(trace-utils): make flate2 and and hyper-proxy dependencies optionnal 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1796,7 +1796,6 @@ dependencies = [
  "httpmock",
  "hyper 0.14.31",
  "hyper-proxy",
- "hyper-rustls 0.27.3",
  "log",
  "prost 0.11.9",
  "rand",

--- a/trace-mini-agent/Cargo.toml
+++ b/trace-mini-agent/Cargo.toml
@@ -20,7 +20,7 @@ serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0"
 ddcommon = { path = "../ddcommon" }
 datadog-trace-protobuf = { path = "../trace-protobuf" }
-datadog-trace-utils = { path = "../trace-utils", features = ["proxy"] }
+datadog-trace-utils = { path = "../trace-utils", features = ["mini_agent"] }
 datadog-trace-normalization = { path = "../trace-normalization" }
 datadog-trace-obfuscation = { path = "../trace-obfuscation" }
 

--- a/trace-utils/Cargo.toml
+++ b/trace-utils/Cargo.toml
@@ -24,7 +24,7 @@ prost = "0.11.6"
 rmp-serde = "1.1.1"
 log = "0.4"
 serde_json = "1.0"
-flate2 = "1.0"
+flate2 = { version = "1.0", optional = true }
 futures = { version = "0.3", default-features = false }
 ddcommon = { path = "../ddcommon", features = ["use_webpki_roots"] }
 datadog-trace-protobuf = { path = "../trace-protobuf" }
@@ -55,7 +55,7 @@ datadog-trace-utils = { path = ".", features = ["test-utils"] }
 tempfile = "3.3.0"
 
 [features]
-default = ["proxy"]
+mini_agent = ["proxy", "compression"]
 test-utils = ["httpmock", "testcontainers", "cargo_metadata", "cargo-platform", "urlencoding"]
 proxy = ["hyper-proxy"]
-compression = ["zstd"]
+compression = ["zstd", "flate2"]

--- a/trace-utils/Cargo.toml
+++ b/trace-utils/Cargo.toml
@@ -16,46 +16,66 @@ path = "benches/main.rs"
 
 [dependencies]
 anyhow = "1.0"
-hyper = { version = "0.14", features = ["client", "server", "runtime", "backports", "deprecated"] }
-hyper-proxy = { version = "0.9.1", default-features = false, features = ["rustls"], optional = true }
-hyper-rustls = {version = "0.27", default-features = false, features = ["native-tokio", "http1", "tls12"]}
+hyper = { version = "0.14", features = [
+    "client",
+    "tcp",
+    "backports",
+    "deprecated",
+] }
 serde = { version = "1.0.145", features = ["derive"] }
 prost = "0.11.6"
 rmp-serde = "1.1.1"
 log = "0.4"
 serde_json = "1.0"
-flate2 = { version = "1.0", optional = true }
 futures = { version = "0.3", default-features = false }
-ddcommon = { path = "../ddcommon", features = ["use_webpki_roots"] }
+ddcommon = { path = "../ddcommon" }
 datadog-trace-protobuf = { path = "../trace-protobuf" }
 datadog-trace-normalization = { path = "../trace-normalization" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 rand = "0.8.5"
 bytes = "1.6.0"
-# This should only be used for testing. It isn't under dev-dependencies because test-utils can't be under #[cfg(test)].
-httpmock = { version = "0.7.0", optional = true}
 rmpv = { version = "1.3.0", default-features = false }
 rmp = { version = "0.8.14", default-features = false }
-testcontainers = { version = "0.17.0", optional = true }
+tinybytes = { path = "../tinybytes", features = [
+    "bytes_string",
+    "serialization",
+] }
+
+# Proxy feature
+hyper-proxy = { version = "0.9.1", default-features = false, features = [
+    "rustls",
+], optional = true }
+
+# Compression feature
+flate2 = { version = "1.0", optional = true }
+zstd = { version = "0.13.3", default-features = false, optional = true }
+
+# test-utils feature
 cargo_metadata = { version = "0.18.1", optional = true }
 # Dependency of cargo metadata, but 0.1.8 requires too new of a rust version.
 cargo-platform = { version = "=0.1.7", optional = true }
-tinybytes =  { path = "../tinybytes", features = ["bytes_string", "serialization"] }
-urlencoding = { version="2.1.3", optional= true }
-zstd = { version = "0.13.3", default-features = false, optional = true }
+testcontainers = { version = "0.17.0", optional = true }
+httpmock = { version = "0.7.0", optional = true }
+urlencoding = { version = "2.1.3", optional = true }
 
 [dev-dependencies]
 bolero = "0.10.1"
 bolero-generator = "0.10.2"
 criterion = "0.5.1"
-httpmock = { version = "0.7.0"}
+httpmock = { version = "0.7.0" }
 serde_json = "1.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 datadog-trace-utils = { path = ".", features = ["test-utils"] }
 tempfile = "3.3.0"
 
 [features]
-mini_agent = ["proxy", "compression"]
-test-utils = ["httpmock", "testcontainers", "cargo_metadata", "cargo-platform", "urlencoding"]
+mini_agent = ["proxy", "compression", "ddcommon/use_webpki_roots"]
+test-utils = [
+    "httpmock",
+    "testcontainers",
+    "cargo_metadata",
+    "cargo-platform",
+    "urlencoding",
+]
 proxy = ["hyper-proxy"]
 compression = ["zstd", "flate2"]

--- a/trace-utils/src/send_with_retry/mod.rs
+++ b/trace-utils/src/send_with_retry/mod.rs
@@ -10,7 +10,6 @@ pub use retry_strategy::{RetryBackoffType, RetryStrategy};
 use bytes::Bytes;
 use ddcommon::{connector, Endpoint, HttpRequestBuilder};
 use hyper::{Body, Client, Method, Response};
-use hyper_proxy::{Intercept, Proxy, ProxyConnector};
 use std::{collections::HashMap, time::Duration};
 
 pub type Attempts = u32;
@@ -85,6 +84,9 @@ impl std::error::Error for RequestError {}
 /// it is used as the uri of the proxy. The request is executed with a timeout of
 /// [`Endpoint::timeout_ms`].
 ///
+/// # Arguments
+/// http_proxy will be ignored if hte crate is not compiled with the `proxy` feature
+
 /// # Returns
 ///
 /// Return a [`SendWithRetryResult`] containing the response and the number of attempts or an error
@@ -173,22 +175,32 @@ async fn send_request(
 ) -> Result<Response<Body>, RequestError> {
     let req = req.body(Body::from(payload)).or(Err(RequestError::Build))?;
 
+    #[cfg(feature = "proxy")]
     #[allow(clippy::unwrap_used)]
-    match tokio::time::timeout(
-        timeout,
+    let req_future = {
         if let Some(proxy) = http_proxy {
-            let proxy = Proxy::new(Intercept::Https, proxy.parse().unwrap());
+            let proxy =
+                hyper_proxy::Proxy::new(hyper_proxy::Intercept::Https, proxy.parse().unwrap());
             let proxy_connector =
-                ProxyConnector::from_proxy(connector::Connector::default(), proxy).unwrap();
+                hyper_proxy::ProxyConnector::from_proxy(connector::Connector::default(), proxy)
+                    .unwrap();
             Client::builder().build(proxy_connector).request(req)
         } else {
             Client::builder()
                 .build(connector::Connector::default())
                 .request(req)
-        },
-    )
-    .await
-    {
+        }
+    };
+
+    #[cfg(not(feature = "proxy"))]
+    let req_future = {
+        let _ = http_proxy;
+        Client::builder()
+            .build(connector::Connector::default())
+            .request(req)
+    };
+
+    match tokio::time::timeout(timeout, req_future).await {
         Ok(resp) => match resp {
             Ok(body) => Ok(body),
             Err(e) => {

--- a/trace-utils/src/send_with_retry/mod.rs
+++ b/trace-utils/src/send_with_retry/mod.rs
@@ -86,7 +86,7 @@ impl std::error::Error for RequestError {}
 ///
 /// # Arguments
 /// http_proxy will be ignored if hte crate is not compiled with the `proxy` feature
-
+///
 /// # Returns
 ///
 /// Return a [`SendWithRetryResult`] containing the response and the number of attempts or an error

--- a/trace-utils/src/stats_utils.rs
+++ b/trace-utils/src/stats_utils.rs
@@ -1,82 +1,89 @@
 // Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use flate2::{write::GzEncoder, Compression};
-use hyper::body::HttpBody;
-use hyper::{body::Buf, Body, Client, Method, Request, StatusCode};
-use log::debug;
-use std::io::Write;
+#[cfg(feature = "mini_agent")]
+pub use mini_agent::*;
 
-use datadog_trace_protobuf::pb;
-use ddcommon::connector::Connector;
-use ddcommon::Endpoint;
+#[cfg(feature = "mini_agent")]
+mod mini_agent {
+    use hyper::body::HttpBody;
+    use hyper::{body::Buf, Body, Client, Method, Request, StatusCode};
+    use log::debug;
+    use std::io::Write;
 
-pub async fn get_stats_from_request_body(body: Body) -> anyhow::Result<pb::ClientStatsPayload> {
-    let buffer = body.collect().await?.aggregate();
+    use datadog_trace_protobuf::pb;
+    use ddcommon::connector::Connector;
+    use ddcommon::Endpoint;
 
-    let client_stats_payload: pb::ClientStatsPayload = match rmp_serde::from_read(buffer.reader()) {
-        Ok(res) => res,
-        Err(err) => {
-            anyhow::bail!("Error deserializing stats from request body: {err}")
+    pub async fn get_stats_from_request_body(body: Body) -> anyhow::Result<pb::ClientStatsPayload> {
+        let buffer = body.collect().await?.aggregate();
+
+        let client_stats_payload: pb::ClientStatsPayload =
+            match rmp_serde::from_read(buffer.reader()) {
+                Ok(res) => res,
+                Err(err) => {
+                    anyhow::bail!("Error deserializing stats from request body: {err}")
+                }
+            };
+
+        if client_stats_payload.stats.is_empty() {
+            debug!("Empty trace stats payload received, but this is okay");
         }
-    };
-
-    if client_stats_payload.stats.is_empty() {
-        debug!("Empty trace stats payload received, but this is okay");
+        Ok(client_stats_payload)
     }
-    Ok(client_stats_payload)
-}
 
-pub fn construct_stats_payload(stats: Vec<pb::ClientStatsPayload>) -> pb::StatsPayload {
-    pb::StatsPayload {
-        agent_hostname: "".to_string(),
-        agent_env: "".to_string(),
-        stats,
-        agent_version: "".to_string(),
-        client_computed: true,
-        split_payload: false,
+    pub fn construct_stats_payload(stats: Vec<pb::ClientStatsPayload>) -> pb::StatsPayload {
+        pb::StatsPayload {
+            agent_hostname: "".to_string(),
+            agent_env: "".to_string(),
+            stats,
+            agent_version: "".to_string(),
+            client_computed: true,
+            split_payload: false,
+        }
     }
-}
 
-pub fn serialize_stats_payload(payload: pb::StatsPayload) -> anyhow::Result<Vec<u8>> {
-    let msgpack = rmp_serde::to_vec_named(&payload)?;
-    let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
-    encoder.write_all(&msgpack)?;
-    match encoder.finish() {
-        Ok(res) => Ok(res),
-        Err(e) => anyhow::bail!("Error serializing stats payload: {e}"),
+    pub fn serialize_stats_payload(payload: pb::StatsPayload) -> anyhow::Result<Vec<u8>> {
+        let msgpack = rmp_serde::to_vec_named(&payload)?;
+        let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+        encoder.write_all(&msgpack)?;
+        match encoder.finish() {
+            Ok(res) => Ok(res),
+            Err(e) => anyhow::bail!("Error serializing stats payload: {e}"),
+        }
     }
-}
 
-pub async fn send_stats_payload(
-    data: Vec<u8>,
-    target: &Endpoint,
-    api_key: &str,
-) -> anyhow::Result<()> {
-    let req = Request::builder()
-        .method(Method::POST)
-        .uri(target.url.clone())
-        .header("Content-Type", "application/msgpack")
-        .header("Content-Encoding", "gzip")
-        .header("DD-API-KEY", api_key)
-        .body(Body::from(data.clone()))?;
+    pub async fn send_stats_payload(
+        data: Vec<u8>,
+        target: &Endpoint,
+        api_key: &str,
+    ) -> anyhow::Result<()> {
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri(target.url.clone())
+            .header("Content-Type", "application/msgpack")
+            .header("Content-Encoding", "gzip")
+            .header("DD-API-KEY", api_key)
+            .body(Body::from(data.clone()))?;
 
-    let client: Client<_, hyper::Body> = Client::builder().build(Connector::default());
-    match client.request(req).await {
-        Ok(response) => {
-            if response.status() != StatusCode::ACCEPTED {
-                let body_bytes = response.into_body().collect().await?.to_bytes();
-                let response_body = String::from_utf8(body_bytes.to_vec()).unwrap_or_default();
-                anyhow::bail!("Server did not accept trace stats: {response_body}");
+        let client: Client<_, hyper::Body> = Client::builder().build(Connector::default());
+        match client.request(req).await {
+            Ok(response) => {
+                if response.status() != StatusCode::ACCEPTED {
+                    let body_bytes = response.into_body().collect().await?.to_bytes();
+                    let response_body = String::from_utf8(body_bytes.to_vec()).unwrap_or_default();
+                    anyhow::bail!("Server did not accept trace stats: {response_body}");
+                }
+                Ok(())
             }
-            Ok(())
+            Err(e) => anyhow::bail!("Failed to send trace stats: {e}"),
         }
-        Err(e) => anyhow::bail!("Failed to send trace stats: {e}"),
     }
 }
 
 #[cfg(test)]
-mod tests {
+#[cfg(feature = "mini_agent")]
+mod mini_agent_tests {
     use crate::stats_utils;
     use datadog_trace_protobuf::pb::{
         ClientGroupedStats, ClientStatsBucket, ClientStatsPayload, Trilean::NotSet,


### PR DESCRIPTION
# What does this PR do?

* Add a new feature "mini_agent" on trace_utils and do not use it bydefault. This is going to be used to progressively separate code used by only the mini agent from common code=
* Hide flate2 usage under the compression flag
* Hide hyper-proxy dependency under the proxy feature flag

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
