### PR TITLE
Push retry strategy into client

### DIFF
--- a/dogstatsd/src/datadog.rs
+++ b/dogstatsd/src/datadog.rs
@@ -261,7 +261,7 @@ impl DdApi {
                         return Ok(resp);
                     }
                     match retry_strategy {
-                         RetryStrategy::LienarBackoff(max_attempts, _)
+                         RetryStrategy::LinearBackoff(max_attempts, _)
                         | RetryStrategy::Immediate(max_attempts)
                             if attempts >= max_attempts =>
                         {

--- a/dogstatsd/src/datadog.rs
+++ b/dogstatsd/src/datadog.rs
@@ -166,12 +166,7 @@ impl DdApi {
         let safe_body = serde_json::to_vec(&series)
             .map_err(|e| ShippingError::Payload(format!("Failed to serialize series: {e}")))?;
         debug!("Sending body: {:?}", &series);
-        self.ship_data(
-            url,
-            safe_body,
-            "application/json",
-        )
-        .await
+        self.ship_data(url, safe_body, "application/json").await
     }
 
     pub async fn ship_distributions(
@@ -183,12 +178,8 @@ impl DdApi {
             .write_to_bytes()
             .map_err(|e| ShippingError::Payload(format!("Failed to serialize series: {e}")))?;
         debug!("Sending distributions: {:?}", &sketches);
-        self.ship_data(
-            url,
-            safe_body,
-            "application/x-protobuf",
-        )
-        .await
+        self.ship_data(url, safe_body, "application/x-protobuf")
+            .await
         // TODO maybe go to coded output stream if we incrementally
         // add sketch payloads to the buffer
         // something like this, but fix the utf-8 encoding issue

--- a/dogstatsd/src/datadog.rs
+++ b/dogstatsd/src/datadog.rs
@@ -255,7 +255,10 @@ impl DdApi {
                     match resp {
                         Ok(resp) if resp.status().is_success() => return Ok(resp),
                         Ok(resp) => {
-                            debug!("Statsd non-success status code but OK response: {:?}", resp.status());
+                            debug!(
+                                "Statsd non-success status code but OK response: {:?}",
+                                resp.status()
+                            );
                             return Ok(resp);
                         }
                         Err(resp) => {

--- a/dogstatsd/src/datadog.rs
+++ b/dogstatsd/src/datadog.rs
@@ -261,8 +261,7 @@ impl DdApi {
                         return Ok(resp);
                     }
                     match retry_strategy {
-                        RetryStrategy::ExponentialBackoff(max_attempts, _)
-                        | RetryStrategy::LienarBackoff(max_attempts, _)
+                         RetryStrategy::LienarBackoff(max_attempts, _)
                         | RetryStrategy::Immediate(max_attempts)
                             if attempts >= max_attempts =>
                         {
@@ -271,8 +270,7 @@ impl DdApi {
                                 "Failed to send request after {max_attempts}".to_string(),
                             ));
                         }
-                        RetryStrategy::ExponentialBackoff(_, delay)
-                        | RetryStrategy::LienarBackoff(_, delay) => {
+                        RetryStrategy::LinearBackoff(_, delay) => {
                             tokio::time::sleep(Duration::from_secs(delay)).await;
                         }
                         _ => {}
@@ -292,8 +290,7 @@ impl DdApi {
 #[derive(Debug, Clone)]
 pub enum RetryStrategy {
     Immediate(u64),               // attempts
-    ExponentialBackoff(u64, u64), // attempts, delay
-    LienarBackoff(u64, u64),      // attempts, delay
+    LinearBackoff(u64, u64),      // attempts, delay
 }
 
 fn build_client(https_proxy: Option<String>, timeout: Duration) -> Result<Client, reqwest::Error> {

--- a/dogstatsd/src/datadog.rs
+++ b/dogstatsd/src/datadog.rs
@@ -261,7 +261,7 @@ impl DdApi {
                         return Ok(resp);
                     }
                     match retry_strategy {
-                         RetryStrategy::LinearBackoff(max_attempts, _)
+                        RetryStrategy::LinearBackoff(max_attempts, _)
                         | RetryStrategy::Immediate(max_attempts)
                             if attempts >= max_attempts =>
                         {
@@ -289,8 +289,8 @@ impl DdApi {
 
 #[derive(Debug, Clone)]
 pub enum RetryStrategy {
-    Immediate(u64),               // attempts
-    LinearBackoff(u64, u64),      // attempts, delay
+    Immediate(u64),          // attempts
+    LinearBackoff(u64, u64), // attempts, delay
 }
 
 fn build_client(https_proxy: Option<String>, timeout: Duration) -> Result<Client, reqwest::Error> {

--- a/dogstatsd/src/datadog.rs
+++ b/dogstatsd/src/datadog.rs
@@ -254,9 +254,8 @@ impl DdApi {
                     let resp = builder.send().await;
                     match resp {
                         Ok(resp) if resp.status().is_success() => return Ok(resp),
-                        // TODO what if it's okay and there status code is somehow not success?
                         Ok(resp) => {
-                            debug!("Non-success status code: {:?}", resp.status());
+                            debug!("Statsd non-success status code but OK response: {:?}", resp.status());
                             return Ok(resp);
                         }
                         Err(resp) => {

--- a/dogstatsd/src/datadog.rs
+++ b/dogstatsd/src/datadog.rs
@@ -380,7 +380,6 @@ impl Series {
 #[cfg(test)]
 mod test {
     use super::*;
-    
 
     #[test]
     fn override_can_be_empty() {

--- a/dogstatsd/src/flusher.rs
+++ b/dogstatsd/src/flusher.rs
@@ -3,7 +3,7 @@
 
 use crate::aggregator::Aggregator;
 use crate::datadog::{self};
-use datadog::{DdApi, RetryStrategy, MetricsIntakeUrlPrefix};
+use datadog::{DdApi, MetricsIntakeUrlPrefix, RetryStrategy};
 use reqwest::{Response, StatusCode};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;

--- a/dogstatsd/src/flusher.rs
+++ b/dogstatsd/src/flusher.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::aggregator::Aggregator;
-use crate::datadog::{self};
-use datadog::{DdApi, MetricsIntakeUrlPrefix, RetryStrategy};
+use crate::datadog::{DdApi, MetricsIntakeUrlPrefix, RetryStrategy};
 use reqwest::{Response, StatusCode};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;

--- a/dogstatsd/src/flusher.rs
+++ b/dogstatsd/src/flusher.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::aggregator::Aggregator;
-use crate::datadog;
-use datadog::{DdApi, MetricsIntakeUrlPrefix};
+use crate::datadog::{self};
+use datadog::{DdApi, RetryStrategy, MetricsIntakeUrlPrefix};
 use reqwest::{Response, StatusCode};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -20,6 +20,7 @@ pub struct FlusherConfig {
     pub metrics_intake_url_prefix: MetricsIntakeUrlPrefix,
     pub https_proxy: Option<String>,
     pub timeout: Duration,
+    pub retry_strategy: RetryStrategy,
 }
 
 #[allow(clippy::await_holding_lock)]
@@ -30,6 +31,7 @@ impl Flusher {
             config.metrics_intake_url_prefix,
             config.https_proxy,
             config.timeout,
+            config.retry_strategy,
         );
         Flusher {
             dd_api,

--- a/dogstatsd/tests/integration_test.rs
+++ b/dogstatsd/tests/integration_test.rs
@@ -21,6 +21,8 @@ use tokio_util::sync::CancellationToken;
 #[cfg(not(miri))]
 #[tokio::test]
 async fn dogstatsd_server_ships_series() {
+    use dogstatsd::datadog::RetryStrategy;
+
     let mut mock_server = Server::new_async().await;
 
     let mock = mock_server
@@ -51,6 +53,7 @@ async fn dogstatsd_server_ships_series() {
         .expect("failed to create URL"),
         https_proxy: None,
         timeout: std::time::Duration::from_secs(5),
+        retry_strategy: RetryStrategy::Immediate(3),
     });
 
     let server_address = "127.0.0.1:18125";

--- a/dogstatsd/tests/integration_test.rs
+++ b/dogstatsd/tests/integration_test.rs
@@ -101,3 +101,113 @@ async fn start_dogstatsd(metrics_aggr: &Arc<Mutex<MetricsAggregator>>) -> Cancel
 
     dogstatsd_cancel_token
 }
+
+#[cfg(test)]
+#[cfg(not(miri))]
+#[tokio::test]
+async fn test_send_with_retry_immediate_failure() {
+    use dogstatsd::datadog::{DdApi, DdDdUrl, RetryStrategy};
+    use dogstatsd::metric::{parse, SortedTags};
+
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("POST", "/api/v2/series")
+        .with_status(500)
+        .with_body("Internal Server Error")
+        .expect(3)
+        .create_async()
+        .await;
+
+    let retry_strategy = RetryStrategy::Immediate(3);
+    let dd_api = DdApi::new(
+        "test_key".to_string(),
+        MetricsIntakeUrlPrefix::new(
+            None,
+            MetricsIntakeUrlPrefixOverride::maybe_new(
+                None,
+                Some(DdDdUrl::new(server.url()).expect("failed to create URL")),
+            ),
+        )
+        .expect("failed to create URL"),
+        None,
+        Duration::from_secs(1),
+        retry_strategy.clone(),
+    );
+
+    // Create a series using the Aggregator
+    let mut aggregator = MetricsAggregator::new(SortedTags::parse("test:value").unwrap(), 1)
+        .expect("failed to create aggregator");
+    let metric = parse("test:1|c").expect("failed to parse metric");
+    aggregator.insert(metric).expect("failed to insert metric");
+    let series = aggregator.to_series();
+
+    let result = dd_api.ship_series(&series).await;
+
+    // The result should be an error since we got a 500 response
+    assert!(result.is_err());
+
+    // Verify that the mock was called exactly 3 times
+    mock.assert_async().await;
+}
+
+#[cfg(test)]
+#[cfg(not(miri))]
+#[tokio::test]
+async fn test_send_with_retry_linear_backoff_success() {
+    use dogstatsd::datadog::{DdApi, DdDdUrl, RetryStrategy};
+    use dogstatsd::metric::{parse, SortedTags};
+
+    let mut server = Server::new_async().await;
+    let mock = server
+        .mock("POST", "/api/v2/series")
+        .with_status(500)
+        .with_body("Internal Server Error")
+        .expect(1)
+        .create_async()
+        .await;
+
+    let success_mock = server
+        .mock("POST", "/api/v2/series")
+        .with_status(200)
+        .with_body("Success")
+        .expect(1)
+        .create_async()
+        .await;
+
+    let retry_strategy = RetryStrategy::LinearBackoff(3, 1); // 3 attempts, 1ms delay
+    let dd_api = DdApi::new(
+        "test_key".to_string(),
+        MetricsIntakeUrlPrefix::new(
+            None,
+            MetricsIntakeUrlPrefixOverride::maybe_new(
+                None,
+                Some(DdDdUrl::new(server.url()).expect("failed to create URL")),
+            ),
+        )
+        .expect("failed to create URL"),
+        None,
+        Duration::from_secs(1),
+        retry_strategy.clone(),
+    );
+
+    // Create a series using the Aggregator
+    let mut aggregator = MetricsAggregator::new(SortedTags::parse("test:value").unwrap(), 1)
+        .expect("failed to create aggregator");
+    let metric = parse("test:1|c").expect("failed to parse metric");
+    aggregator.insert(metric).expect("failed to insert metric");
+    let series = aggregator.to_series();
+
+    let result = dd_api.ship_series(&series).await;
+
+    // The result should be Ok since we got a 200 response on retry
+    assert!(result.is_ok());
+    if let Ok(response) = result {
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+    } else {
+        panic!("Expected Ok result");
+    }
+
+    // Verify that both mocks were called exactly once
+    mock.assert_async().await;
+    success_mock.assert_async().await;
+}

--- a/serverless/src/main.rs
+++ b/serverless/src/main.rs
@@ -26,7 +26,7 @@ use datadog_trace_mini_agent::{
 use dogstatsd::{
     aggregator::Aggregator as MetricsAggregator,
     constants::CONTEXTS,
-    datadog::{MetricsIntakeUrlPrefix, Site, RetryStrategy},
+    datadog::{MetricsIntakeUrlPrefix, RetryStrategy, Site},
     dogstatsd::{DogStatsD, DogStatsDConfig},
     flusher::{Flusher, FlusherConfig},
 };

--- a/serverless/src/main.rs
+++ b/serverless/src/main.rs
@@ -26,7 +26,7 @@ use datadog_trace_mini_agent::{
 use dogstatsd::{
     aggregator::Aggregator as MetricsAggregator,
     constants::CONTEXTS,
-    datadog::{MetricsIntakeUrlPrefix, Site},
+    datadog::{MetricsIntakeUrlPrefix, Site, RetryStrategy},
     dogstatsd::{DogStatsD, DogStatsDConfig},
     flusher::{Flusher, FlusherConfig},
 };
@@ -184,6 +184,7 @@ async fn start_dogstatsd(
                 .expect("Failed to create intake URL prefix"),
                 https_proxy,
                 timeout: DOGSTATSD_TIMEOUT_DURATION,
+                retry_strategy: RetryStrategy::LinearBackoff(3, 1),
             });
             Some(metrics_flusher)
         }


### PR DESCRIPTION
# What does this PR do?
The original idea was to make retries happen from the users of this lib, but now that we've added compression this adds the overhead of re-compressing the request on each retry. This PR changes the behavior to retry in the request client instead.

# Motivation
Saves CPU time
