### PR TITLE
Fix hyper development dependencies in trace-utils.

### DIFF
--- a/trace-utils/Cargo.toml
+++ b/trace-utils/Cargo.toml
@@ -71,6 +71,8 @@ tempfile = "3.3.0"
 [features]
 mini_agent = ["proxy", "compression", "ddcommon/use_webpki_roots"]
 test-utils = [
+    "hyper/server",
+    "hyper/runtime",
     "httpmock",
     "testcontainers",
     "cargo_metadata",


### PR DESCRIPTION
# What does this PR do?

Issuing cargo test without specifying any dependecies on trace-utils crate failed due to some needed hyper features.
