### PR TITLE
[dogstatsd] optimize `parse` function in `SortedTags`

### DIFF
--- a/dogstatsd/src/constants.rs
+++ b/dogstatsd/src/constants.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// The maximum tags that a `Metric` may hold.
-pub const MAX_TAGS: usize = 32;
+pub const MAX_TAGS: usize = 100;
 
 pub const CONTEXTS: usize = 10_240;
 

--- a/dogstatsd/src/metric.rs
+++ b/dogstatsd/src/metric.rs
@@ -71,12 +71,8 @@ impl SortedTags {
     }
 
     pub fn parse(tags_section: &str) -> Result<SortedTags, ParseError> {
-        let count = tags_section.bytes().filter(|&b| b == b',').count();
-        if count > constants::MAX_TAGS {
-            return Err(ParseError::Raw(format!("Too many tags, more than {count}")));
-        }
-
-        let mut parsed_tags = Vec::with_capacity(count + 1);
+        let total_tags = tags_section.bytes().filter(|&b| b == b',').count() + 1;
+        let mut parsed_tags = Vec::with_capacity(total_tags);
 
         for part in tags_section.split(',').filter(|s| !s.is_empty()) {
             if let Some(i) = part.find(':') {
@@ -89,6 +85,13 @@ impl SortedTags {
         }
 
         parsed_tags.dedup();
+        if parsed_tags.len() > constants::MAX_TAGS {
+            return Err(ParseError::Raw(format!(
+                "Too many tags, more than {c}",
+                c = constants::MAX_TAGS
+            )));
+        }
+
         parsed_tags.sort_unstable();
         Ok(SortedTags {
             values: parsed_tags,
@@ -555,15 +558,13 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn parse_too_many_tags() {
-        // 33
-        assert_eq!(parse("foo:1|g|#a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3").unwrap_err(),
-                   ParseError::Raw("Too many tags, more than 32".to_string()));
-
-        // 32
-        assert!(parse("foo:1|g|#a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2").is_ok());
-
-        // 31
-        assert!(parse("foo:1|g|#a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1").is_ok());
+        // 101
+        assert_eq!(
+            parse(
+                "foo:1|g|#a:1,b:2,c:3,d:4,e:5,f:6,g:7,h:8,i:9,j:10,k:11,l:12,m:13,n:14,o:15,p:16,q:17,r:18,s:19,t:20,u:21,v:22,w:23,x:24,y:25,z:26,aa:27,ab:28,ac:29,ad:30,ae:31,af:32,ag:33,ah:34,ai:35,aj:36,ak:37,al:38,am:39,an:40,ao:41,ap:42,aq:43,ar:44,as:45,at:46,au:47,av:48,aw:49,ax:50,ay:51,az:52,ba:53,bb:54,bc:55,bd:56,be:57,bf:58,bg:59,bh:60,bi:61,bj:62,bk:63,bl:64,bm:65,bn:66,bo:67,bp:68,bq:69,br:70,bs:71,bt:72,bu:73,bv:74,bw:75,bx:76,by:77,bz:78,ca:79,cb:80,cc:81,cd:82,ce:83,cf:84,cg:85,ch:86,ci:87,cj:88,ck:89,cl:90,cm:91,cn:92,co:93,cp:94,cq:95,cr:96,cs:97,ct:98,cu:99,cv:100,cw:101"
+            ).unwrap_err(),
+            ParseError::Raw("Too many tags, more than 100".to_string())
+        );
 
         // 30
         assert!(parse("foo:1|g|#a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3,a:1,b:2,c:3").is_ok());


### PR DESCRIPTION
# What does this PR do?

Optimizes how `parse` is implemented.

# Motivation

Previously, the vector allocation would be undefined, from data that can be counted beforehand.
This reduces allocations and conditions on the loop.

# Additional Notes

- Saves around 2-3ms.
- Dedup doesnt work, we are not fixing that here.
- Changes MAX_TAGS to `100`, as per our internal docs – needs to be re-reviewed in a future PR tho.

# How to test the change?

Tested manually on a project using this method.
