### PR TITLE
Aj/disable gitlab dogstatsd

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,10 @@ include:
   - local: .gitlab/benchmarks.yml
 
 trigger_internal_build:
+  rules:
+    - changes:
+        - ./dogstatsd/**
+      when: never
   variables:
     LIBDATADOG_COMMIT_BRANCH: $CI_COMMIT_BRANCH
     LIBDATADOG_COMMIT_SHA: $CI_COMMIT_SHA

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,9 +10,10 @@ include:
 
 trigger_internal_build:
   rules:
-    - changes:
-        - ./dogstatsd/**
-      when: never
+    if: true
+      - changes:
+          - ./dogstatsd/**
+        when: never
   variables:
     LIBDATADOG_COMMIT_BRANCH: $CI_COMMIT_BRANCH
     LIBDATADOG_COMMIT_SHA: $CI_COMMIT_SHA
@@ -44,9 +45,10 @@ report_failure:
 report_gitlab_CI_status:
   tags: ["arch:amd64"]
   rules:
-    - changes:
-        - ./dogstatsd/**
-      when: never
+    if: true
+      - changes:
+          - ./dogstatsd/**
+        when: never
     - when: always
   stage: .post
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,10 +10,10 @@ include:
 
 trigger_internal_build:
   rules:
-    if: true
-      - changes:
-          - ./dogstatsd/**
-        when: never
+    - if: true
+      changes:
+        - ./dogstatsd/**
+      when: never
   variables:
     LIBDATADOG_COMMIT_BRANCH: $CI_COMMIT_BRANCH
     LIBDATADOG_COMMIT_SHA: $CI_COMMIT_SHA
@@ -45,10 +45,10 @@ report_failure:
 report_gitlab_CI_status:
   tags: ["arch:amd64"]
   rules:
-    if: true
-      - changes:
-          - ./dogstatsd/**
-        when: never
+    - if: true
+      changes:
+        - ./dogstatsd/**
+      when: never
     - when: always
   stage: .post
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,7 +43,11 @@ report_failure:
 # Final job that will show in github statuses
 report_gitlab_CI_status:
   tags: ["arch:amd64"]
-  when: always
+  rules:
+    - changes:
+        - ./dogstatsd/**
+      when: never
+    - when: always
   stage: .post
   script:
     - "echo TIP: If you see this failing, something else in the GitLab pipeline failed. Follow the link to the pipeline and check for other things that failed prior to this step."


### PR DESCRIPTION
# What does this PR do?
These crazy long waits for mac builds are irrelevant because this specific crate is only used in Lambda and azure container apps linux today

# Motivation
1+ hr wait for mac time

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
