### PR TITLE
perf(profiling): always be serializing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,7 +1522,7 @@ dependencies = [
  "futures",
  "futures-core",
  "futures-util",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.31",
@@ -2533,9 +2533,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "hdrhistogram"
@@ -3094,7 +3097,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.1",
+ "hashbrown 0.15.2",
  "serde",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,7 +724,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_urlencoded",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tokio-util",
  "tower-service",
@@ -823,7 +823,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -1012,7 +1012,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "rand",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -1533,10 +1533,11 @@ dependencies = [
  "mime",
  "mime_guess",
  "percent-encoding",
- "prost 0.12.6",
+ "prost 0.13.5",
  "rustc-hash 1.1.0",
  "serde",
  "serde_json",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-util",
 ]
@@ -1581,7 +1582,7 @@ version = "0.1.0"
 source = "git+https://github.com/DataDog/saluki/?rev=c89b58e5784b985819baf11f13f7d35876741222#c89b58e5784b985819baf11f13f7d35876741222"
 dependencies = [
  "bytes",
- "prost 0.13.3",
+ "prost 0.13.5",
  "protobuf",
  "protobuf-codegen",
  "tonic 0.12.3",
@@ -2052,7 +2053,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tokio-util",
  "tracing",
@@ -3678,7 +3679,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "rand",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tokio-stream",
 ]
@@ -3693,7 +3694,7 @@ dependencies = [
  "lazy_static",
  "opentelemetry",
  "opentelemetry-semantic-conventions",
- "thiserror",
+ "thiserror 1.0.68",
  "thrift",
  "tokio",
 ]
@@ -4112,12 +4113,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.3"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive 0.13.3",
+ "prost-derive 0.13.5",
 ]
 
 [[package]]
@@ -4156,7 +4157,7 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease 0.2.25",
- "prost 0.13.3",
+ "prost 0.13.5",
  "prost-types 0.13.3",
  "regex",
  "syn 2.0.87",
@@ -4191,9 +4192,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.3"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
  "itertools 0.13.0",
@@ -4217,7 +4218,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
 dependencies = [
- "prost 0.13.3",
+ "prost 0.13.5",
 ]
 
 [[package]]
@@ -4229,7 +4230,7 @@ dependencies = [
  "bytes",
  "once_cell",
  "protobuf-support",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -4244,7 +4245,7 @@ dependencies = [
  "protobuf-parse",
  "regex",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -4259,7 +4260,7 @@ dependencies = [
  "protobuf",
  "protobuf-support",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.68",
  "which",
 ]
 
@@ -4269,7 +4270,7 @@ version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b088fd20b938a875ea00843b6faf48579462630015c3788d397ad6a786663252"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -4348,7 +4349,7 @@ dependencies = [
  "rustc-hash 2.0.0",
  "rustls 0.23.18",
  "socket2",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tracing",
 ]
@@ -4365,7 +4366,7 @@ dependencies = [
  "rustc-hash 2.0.0",
  "rustls 0.23.18",
  "slab",
- "thiserror",
+ "thiserror 1.0.68",
  "tinyvec",
  "tracing",
 ]
@@ -4469,7 +4470,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -4813,7 +4814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a15e661f0f9dac21f3494fe5d23a6338c0ac116a2d22c2b63010acd89467ffe"
 dependencies = [
  "byteorder",
- "thiserror",
+ "thiserror 1.0.68",
  "twox-hash",
 ]
 
@@ -5456,7 +5457,7 @@ dependencies = [
  "serde_bytes",
  "static_assertions",
  "tarpc-plugins",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tokio-serde",
  "tokio-util",
@@ -5564,7 +5565,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -5577,7 +5578,16 @@ version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.68",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -5585,6 +5595,17 @@ name = "thiserror-impl"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5914,7 +5935,7 @@ dependencies = [
  "http-body-util",
  "percent-encoding",
  "pin-project",
- "prost 0.13.3",
+ "prost 0.13.5",
  "tokio-stream",
  "tower-layer",
  "tower-service",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1572,7 +1572,7 @@ dependencies = [
  "anyhow",
  "clap",
  "datadog-profiling",
- "prost 0.12.6",
+ "prost 0.13.5",
  "sysinfo",
 ]
 
@@ -4106,16 +4106,6 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
-dependencies = [
- "bytes",
- "prost-derive 0.12.6",
-]
-
-[[package]]
-name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
@@ -4178,19 +4168,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
-dependencies = [
- "anyhow",
- "itertools 0.12.1",
- "proc-macro2",
- "quote",
- "syn 2.0.87",
 ]
 
 [[package]]

--- a/profiling-replayer/Cargo.toml
+++ b/profiling-replayer/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 anyhow = "1.0"
 clap = { version = "4.3.21", features = ["cargo", "color", "derive"] }
 datadog-profiling = { path = "../profiling"}
-prost = "0.12"
+prost = "0.13"
 sysinfo = {version = "0.29.8", default-features = false}
 
 [[bin]]

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -28,7 +28,7 @@ derivative = "2.2.0"
 futures = { version = "0.3", default-features = false }
 futures-core = {version = "0.3.0", default-features = false}
 futures-util = {version = "0.3.0", default-features = false}
-hashbrown = { version = "0.14", default-features = false, features = ["allocator-api2"] }
+hashbrown = { version = "0.15.2", default-features = false, features = ["allocator-api2"] }
 http = "0.2"
 http-body = "0.4"
 hyper = {version = "0.14", features = ["client", "backports", "deprecated"], default-features = false}

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -39,10 +39,11 @@ lz4_flex = { version = "0.9", default-features = false, features = ["std", "safe
 mime = "0.3.16"
 mime_guess = {version = "2.0", default-features = false}
 percent-encoding = "2.1"
-prost = "0.12"
+prost = "0.13.5"
 rustc-hash = { version = "1.1", default-features = false }
 serde = {version = "1.0", features = ["derive"]}
 serde_json = {version = "1.0"}
+thiserror = "2"
 tokio = {version = "1.23", features = ["rt", "macros"]}
 tokio-util = "0.7.1"
 byteorder = { version = "1.5", features = ["std"] }

--- a/profiling/src/internal/function.rs
+++ b/profiling/src/internal/function.rs
@@ -34,7 +34,7 @@ impl PprofItem for Function {
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 #[repr(transparent)]
-pub struct FunctionId(NonZeroU32);
+pub struct FunctionId(pub(crate) NonZeroU32);
 
 impl Id for FunctionId {
     type RawId = u64;

--- a/profiling/src/internal/location.rs
+++ b/profiling/src/internal/location.rs
@@ -39,7 +39,7 @@ impl PprofItem for Location {
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 #[repr(transparent)]
-pub struct LocationId(NonZeroU32);
+pub struct LocationId(pub(crate) NonZeroU32);
 
 impl Id for LocationId {
     type RawId = u64;

--- a/profiling/src/internal/mapping.rs
+++ b/profiling/src/internal/mapping.rs
@@ -48,7 +48,7 @@ impl PprofItem for Mapping {
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 #[repr(transparent)]
-pub struct MappingId(NonZeroU32);
+pub struct MappingId(pub(crate) NonZeroU32);
 
 impl Id for MappingId {
     type RawId = u64;

--- a/profiling/src/internal/stack_trace.rs
+++ b/profiling/src/internal/stack_trace.rs
@@ -7,7 +7,7 @@ use super::*;
 pub struct StackTrace {
     /// The ids recorded here correspond to a Profile.location.id.
     /// The leaf is at location_id[0].
-    pub locations: Vec<LocationId>,
+    pub locations: Vec<Option<LocationId>>,
 }
 
 impl Item for StackTrace {

--- a/profiling/src/pprof/encodable.rs
+++ b/profiling/src/pprof/encodable.rs
@@ -136,7 +136,7 @@ unsafe fn encode_varint_with_tag_with_zero_opt(tag: u32, value: u64, buf: &mut V
 
 #[inline]
 fn encoded_len_u64_with_zero_opt(tag: u32, num: u64) -> usize {
-    0 + if num != 0 {
+    if num != 0 {
         encoded_len_u64_without_zero_opt(tag, num)
     } else {
         0
@@ -150,7 +150,7 @@ fn encoded_len_u64_without_zero_opt(tag: u32, num: u64) -> usize {
 
 #[inline]
 fn encoded_len_i64_with_zero_opt(tag: u32, num: i64) -> usize {
-    0 + if num != 0 {
+    if num != 0 {
         encoded_len_i64_without_zero_opt(tag, num)
     } else {
         0
@@ -234,8 +234,8 @@ impl LenEncodable for Mapping {
             // tag 5 (filename) was already encoded
             encode_varint_with_tag_with_zero_opt(6u32, self.build_id as u64, buf);
             let end = buf.len() as u32;
-            let range = Range { start, end };
-            range
+
+            Range { start, end }
         }
     }
 }
@@ -268,8 +268,8 @@ impl LenEncodable for Function {
             encode_varint_with_tag_with_zero_opt(5u32, self.start_line as u64, buf);
 
             let end = buf.len() as u32;
-            let range = Range { start, end };
-            range
+
+            Range { start, end }
         }
     }
 }
@@ -287,8 +287,7 @@ impl LenEncodable for Location {
             tag + len_prefix + item
         };
 
-        let len = id + mapping_id + address + line;
-        len
+        id + mapping_id + address + line
     }
 
     unsafe fn encode(&self, buf: &mut Vec<u8>) -> Range<u32> {
@@ -310,8 +309,8 @@ impl LenEncodable for Location {
             encode_varint_with_tag_with_zero_opt(3u32, self.address, buf);
 
             let end = buf.len() as u32;
-            let range = Range { start, end };
-            range
+
+            Range { start, end }
         }
     }
 }

--- a/profiling/src/pprof/encodable.rs
+++ b/profiling/src/pprof/encodable.rs
@@ -54,6 +54,10 @@ pub fn try_encode_with_tag(
     let encoded_len = encodable.encoded_len();
     let required =
         encoding::key_len(tag) + encoding::encoded_len_varint(encoded_len as u64) + encoded_len;
+
+    // Overflow: since all of our individual Mapping, Function, and Location
+    // messages are bounded in size, required will always be "small." So a
+    // buf.len() + required will not overflow usize, not even on 32-bit.
     if buf.len() + required > PROTOBUF_MAX_MESSAGE_BYTES {
         let len = buf.len();
         Err(EncodeError::TooLarge { len, required })

--- a/profiling/src/pprof/encodable.rs
+++ b/profiling/src/pprof/encodable.rs
@@ -1,0 +1,507 @@
+// Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+use super::proto::{Function, Line};
+use prost::encoding::{WireType, MAX_TAG, MIN_TAG};
+use prost::*;
+use std::ops::Range;
+
+/// Represents something that converts to the in-wire LEN type.
+pub trait LenEncodable {
+    fn encoded_len(&self) -> usize;
+
+    /// Encodes the value into the in-wire protobuf format. Returns the range
+    /// of bytes which could be used to deduplicate two values of the same
+    /// message type (e.g., excludes the Mapping.id field in Mapping).
+    ///
+    /// # Safety
+    /// The buffer needs to have at least [Self::encoded_len] free bytes, and
+    /// the message being encoded needs to match this number of bytes as well.
+    unsafe fn encode(&self, buf: &mut Vec<u8>) -> Range<u32>;
+}
+
+/// Encodes the value into the in-wire protobuf format, including the tag and
+/// length prefix.
+///
+/// # Safety
+/// There must be space for the tag, length delimiter, and the message.
+#[cfg_attr(debug_assertions, track_caller)]
+pub unsafe fn encode_with_tag_unchecked(
+    encodable: &impl LenEncodable,
+    tag: u32,
+    encoded_len: usize,
+    buf: &mut Vec<u8>,
+) -> Range<u32> {
+    debug_assert!(encoded_len == encodable.encoded_len());
+    encode_key(tag, WireType::LengthDelimited, buf);
+    encode_varint(encoded_len as u64, buf);
+    encodable.encode(buf)
+}
+
+/// Encodes the value into the in-wire protobuf format, including the tag and
+/// length prefix. This uses [Vec::try_reserve] to ensure there's enough
+/// memory for the message.
+///
+/// Returns the range of bytes which could be used to deduplicate two values
+/// of the same message type (e.g., excludes the Mapping.id field in Mapping).
+#[inline]
+pub fn try_encode_with_tag(
+    encodable: &impl LenEncodable,
+    tag: u32,
+    buf: &mut Vec<u8>,
+) -> Result<Range<u32>, EncodeError> {
+    let encoded_len = encodable.encoded_len();
+    let required =
+        encoding::key_len(tag) + encoding::encoded_len_varint(encoded_len as u64) + encoded_len;
+    if required > PROTOBUF_MAX_MESSAGE_BYTES {
+        Err(EncodeError::TooLarge { required })
+    } else if let Err(_err) = buf.try_reserve(required) {
+        Err(EncodeError::Oom {
+            required,
+            remaining: required,
+        })
+    } else {
+        // SAFETY: the proper number of bytes were reserved to encode the tag,
+        // length, and the message.
+        Ok(unsafe { encode_with_tag_unchecked(encodable, tag, encoded_len, buf) })
+    }
+}
+
+/// Represents a Mapping for pprof, with some fields omitted. We don't
+/// currently use those fields at all in our end-user APIs, so we omit them
+/// here to save space/bytes/cpu ops. Since they'd default to the zero repr
+/// anyway, they can just be omitted from the protobuf in-wire.
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
+pub struct Mapping {
+    pub id: u64,           // 1
+    pub memory_start: u64, // 2
+    pub memory_limit: u64, // 3
+    pub file_offset: u64,  // 4
+    pub filename: i64,     // 5
+    pub build_id: i64,     // 6
+}
+
+/// Represents a Location for pprof. This borrows the slice for the lines
+/// because it's not meant to be long-lived--you create one, serialize it,
+/// and throw the struct away.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct Location<'a> {
+    pub id: u64,           // 1
+    pub mapping_id: u64,   // 2
+    pub address: u64,      // 3
+    /// There should usually be exactly 1 line, but if there is more than one,
+    /// it should not allow for the whole Location to exceed 2 GiB in size.
+    pub lines: &'a [Line], // 4
+    pub is_folded: bool,   // 5
+}
+
+impl From<Mapping> for crate::pprof::proto::Mapping {
+    fn from(value: Mapping) -> Self {
+        Self {
+            id: value.id,
+            memory_start: value.memory_start,
+            memory_limit: value.memory_limit,
+            file_offset: value.file_offset,
+            filename: value.filename,
+            build_id: value.build_id,
+            has_functions: false,
+            has_filenames: false,
+            has_line_numbers: false,
+            has_inline_frames: false,
+        }
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum EncodeError {
+    #[error("protobuf messages need to fit in 2 GiB, asked for {required}")]
+    TooLarge { required: usize },
+
+    #[error("protobuf message needed {required} bytes, only {remaining} remaining")]
+    Oom { required: usize, remaining: usize },
+}
+
+/// Protobuf messages need to fit in 2 GiB, which is plenty for profiling.
+const PROTOBUF_MAX_MESSAGE_BYTES: usize = (u32::MAX as usize) - 1;
+
+///  # Safety
+/// The encoded_len must match the number of bytes needed to encode the value,
+/// and the buffer must have at least this number of bytes of unused capacity.
+#[inline]
+#[cfg_attr(debug_assertions, track_caller)]
+unsafe fn encode_varint_with_tag_with_zero_opt(tag: u32, value: u64, buf: &mut Vec<u8>) {
+    if value != 0 {
+        // SAFETY: guarded by function's safety conditions.
+        unsafe { encode_varint_with_tag(tag, value, buf) };
+    }
+}
+
+///  # Safety
+/// The encoded_len must match the number of bytes needed to encode the value,
+/// and the buffer must have at least this number of bytes of unused capacity.
+#[inline]
+#[cfg_attr(debug_assertions, track_caller)]
+unsafe fn encode_bool_with_tag(tag: u32, value: bool, buf: &mut Vec<u8>) {
+    // SAFETY: size is guarded above.
+    unsafe { encode_varint_with_tag_with_zero_opt(tag, value as u64, buf) };
+}
+
+#[inline]
+fn encoded_len_u64_with_zero_opt(tag: u32, num: u64) -> usize {
+    0 + if num != 0 {
+        encoded_len_u64_without_zero_opt(tag, num)
+    } else {
+        0
+    }
+}
+
+#[inline]
+fn encoded_len_u64_without_zero_opt(tag: u32, num: u64) -> usize {
+    encoding::uint64::encoded_len(tag, &num)
+}
+
+#[inline]
+fn encoded_len_i64_with_zero_opt(tag: u32, num: i64) -> usize {
+    0 + if num != 0 {
+        encoded_len_i64_without_zero_opt(tag, num)
+    } else {
+        0
+    }
+}
+
+#[inline]
+fn encoded_len_i64_without_zero_opt(tag: u32, num: i64) -> usize {
+    encoded_len_u64_without_zero_opt(tag, num as u64)
+}
+
+#[inline]
+fn encoded_len_bool_with_zero_opt(tag: u32, value: bool) -> usize {
+    0 + if value != false {
+        encoding::bool::encoded_len(tag, &value)
+    } else {
+        0
+    }
+}
+
+/// # Safety
+/// Assumes there is enough capacity to write the varint.
+#[inline]
+unsafe fn encode_varint(mut value: u64, buf: &mut Vec<u8>) {
+    loop {
+        if buf.len() == buf.capacity() {
+            // SAFETY: the try_reserve above prevents this branch.
+            unsafe { std::hint::unreachable_unchecked() }
+        }
+        buf.push(if value < 0x80 {
+            value as u8
+        } else {
+            ((value & 0x7F) | 0x80) as u8
+        });
+        if value < 0x80 {
+            break;
+        }
+        value >>= 7;
+    }
+}
+
+/// # Safety
+/// Assumes there is enough capacity to write the key.
+#[inline]
+#[cfg_attr(debug_assertions, track_caller)]
+unsafe fn encode_key(tag: u32, wire_type: WireType, buf: &mut Vec<u8>) {
+    debug_assert!((MIN_TAG..=MAX_TAG).contains(&tag));
+    let key = (tag << 3) | wire_type as u32;
+    // SAFETY: see function's safety conditions.
+    unsafe { encode_varint(u64::from(key), buf) };
+}
+
+///  # Safety
+/// The encoded_len must match the number of bytes needed to encode the value,
+/// and the buffer must have at least this number of bytes of unused capacity.
+#[cfg_attr(debug_assertions, track_caller)]
+unsafe fn encode_varint_with_tag(tag: u32, value: u64, buf: &mut Vec<u8>) {
+    debug_assert!(encoded_len_u64_without_zero_opt(tag, value) <= buf.capacity() - buf.len());
+    encode_key(tag, WireType::Varint, buf);
+    encode_varint(value, buf);
+}
+
+impl LenEncodable for Mapping {
+    fn encoded_len(&self) -> usize {
+        // Without zero-opt because it's inherently non-zero.
+        let id = encoded_len_u64_without_zero_opt(1u32, self.id);
+        let memory_start = encoded_len_u64_with_zero_opt(2u32, self.memory_start);
+        let memory_limit = encoded_len_u64_with_zero_opt(3u32, self.memory_limit);
+        let file_offset = encoded_len_u64_with_zero_opt(4u32, self.file_offset);
+        // Without zero-opt because we use it for a unique prefix.
+        let filename = encoded_len_i64_without_zero_opt(5u32, self.filename);
+        let build_id = encoded_len_i64_with_zero_opt(6u32, self.build_id);
+
+        id + memory_start + memory_limit + file_offset + filename + build_id
+    }
+
+    unsafe fn encode(&self, buf: &mut Vec<u8>) -> Range<u32> {
+        // The id comes off first so we can slice it off for byte comparisons.
+        // SAFETY: size is guarded above, and the given lens match the needed
+        // number of bytes.
+        unsafe {
+            encode_varint_with_tag(1u32, self.id, buf);
+            // For Mapping, we use filename (tag 5) as our unique prefix.
+            let start = buf.len() as u32;
+            encode_varint_with_tag(5u32, self.filename as u64, buf);
+
+            encode_varint_with_tag_with_zero_opt(2u32, self.memory_start, buf);
+            encode_varint_with_tag_with_zero_opt(3u32, self.memory_limit, buf);
+            encode_varint_with_tag_with_zero_opt(4u32, self.file_offset, buf);
+            // tag 5 (filename) was already encoded
+            encode_varint_with_tag_with_zero_opt(6u32, self.build_id as u64, buf);
+            let end = buf.len() as u32;
+            let range = Range { start, end };
+            range
+        }
+    }
+}
+
+impl LenEncodable for Function {
+    fn encoded_len(&self) -> usize {
+        // Without zero-opt because it's inherently non-zero.
+        let id = encoded_len_u64_without_zero_opt(1u32, self.id);
+        // Without zero-opt because we use it for a unique prefix.
+        let name = encoded_len_i64_without_zero_opt(2u32, self.name);
+        let system_name = encoded_len_i64_with_zero_opt(3u32, self.system_name);
+        let filename = encoded_len_i64_with_zero_opt(4u32, self.filename);
+        let start_line = encoded_len_i64_with_zero_opt(5u32, self.start_line);
+
+        id + name + system_name + filename + start_line
+    }
+
+    unsafe fn encode(&self, buf: &mut Vec<u8>) -> Range<u32> {
+        // The id comes off first so we can slice it off for byte comparisons.
+        // SAFETY: size is guarded above, and the given lens match the needed
+        // number of bytes.
+        unsafe {
+            encode_varint_with_tag(1u32, self.id, buf);
+
+            // For Function, we use name (tag 2) as our unique prefix.
+            let start = buf.len() as u32;
+            encode_varint_with_tag(2u32, self.name as u64, buf);
+            encode_varint_with_tag_with_zero_opt(3u32, self.system_name as u64, buf);
+            encode_varint_with_tag_with_zero_opt(4u32, self.filename as u64, buf);
+            encode_varint_with_tag_with_zero_opt(5u32, self.start_line as u64, buf);
+
+            let end = buf.len() as u32;
+            let range = Range { start, end };
+            range
+        }
+    }
+}
+
+impl<'a> LenEncodable for Location<'a> {
+    fn encoded_len(&self) -> usize {
+        debug_assert!(!self.lines.is_empty());
+        // Without zero-opt because it's inherently non-zero.
+        let id = encoded_len_u64_without_zero_opt(1u32, self.id);
+        let mapping_id = encoded_len_u64_with_zero_opt(2u32, self.mapping_id);
+        let address = encoded_len_u64_with_zero_opt(3u32, self.address);
+        let lines = self
+            .lines
+            .iter()
+            .map(|line| {
+                let item = Message::encoded_len(line);
+                let tag = encoding::key_len(4u32);
+                let len_prefix = encoding::encoded_len_varint(item as u64);
+                tag + len_prefix + item
+            })
+            .sum::<usize>();
+        let is_folded = encoded_len_bool_with_zero_opt(5u32, self.is_folded);
+
+        let len = id + mapping_id + address + lines + is_folded;
+        len
+    }
+
+    unsafe fn encode(&self, buf: &mut Vec<u8>) -> Range<u32> {
+        // The id comes off first so we can slice it off for byte comparisons.
+        // SAFETY: size is guarded above, and the given lens match the needed
+        // number of bytes.
+        unsafe {
+            encode_varint_with_tag(1u32, self.id, buf);
+
+            // For Location, we use lines (tag 4) as our unique prefix. This
+            // also means each Location needs 1 or more Lines.
+            let start = buf.len() as u32;
+
+            for line in self.lines.iter() {
+                encode_key(4u32, WireType::LengthDelimited, buf);
+                encode_varint(Message::encoded_len(line) as u64, buf);
+                // Can ignore errors, as we've reserved enough capacity prior.
+                _ = Message::encode(line, buf);
+            }
+            encode_varint_with_tag_with_zero_opt(2u32, self.mapping_id, buf);
+            encode_varint_with_tag_with_zero_opt(3u32, self.address, buf);
+            encode_bool_with_tag(5u32, self.is_folded, buf);
+
+            let end = buf.len() as u32;
+            let range = Range { start, end };
+            range
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mapping() {
+        let cases = [
+            Mapping {
+                id: 0,
+                memory_start: 0,
+                memory_limit: 0,
+                file_offset: 0,
+                filename: 0,
+                build_id: 0,
+            },
+            Mapping {
+                id: 11,
+                memory_start: 12,
+                memory_limit: 13,
+                file_offset: 14,
+                filename: 15,
+                build_id: 16,
+            },
+            Mapping {
+                id: u64::MAX,
+                memory_start: u64::MAX,
+                memory_limit: u64::MAX,
+                file_offset: u64::MAX,
+                filename: i64::MAX,
+                build_id: i64::MAX,
+            },
+        ];
+        for before in cases {
+            use crate::pprof::proto::Mapping as PprofMapping;
+            let required = {
+                let ddog = LenEncodable::encoded_len(&before);
+                let prost = Message::encoded_len(&(PprofMapping::from(before)));
+                // We skip the zero-encoding optimization for some items to
+                // ensure a unique prefix, so we should be equal or bigger
+                // than the prost version depending on the provided values,
+                // but we should never be smaller.
+                assert!(ddog >= prost);
+                ddog
+            };
+            let mut buf = Vec::with_capacity(required);
+            // SAFETY: correct size, plus buffer has reserved capacity.
+            let _range = unsafe { LenEncodable::encode(&before, &mut buf) };
+            // We exactly request the number of bytes, this should match.
+            let remaining = buf.capacity() - buf.len();
+            assert_eq!(
+                0, remaining,
+                "{remaining} bytes unused, encoded len may be too large or encoder may be wrong for {before:?}",
+            );
+
+            let after = PprofMapping::decode(buf.as_slice()).unwrap();
+            assert_eq!(before.id, after.id);
+            assert_eq!(before.memory_start, after.memory_start);
+            assert_eq!(before.memory_limit, after.memory_limit);
+            assert_eq!(before.file_offset, after.file_offset);
+            assert_eq!(before.filename, after.filename);
+            assert_eq!(before.build_id, after.build_id);
+        }
+    }
+
+    #[test]
+    fn test_function() {
+        let cases = [
+            Function {
+                id: 0,
+                name: 0,
+                system_name: 0,
+                filename: 0,
+                start_line: 0,
+            },
+            Function {
+                id: 11,
+                name: 12,
+                system_name: 13,
+                filename: 14,
+                start_line: 15,
+            },
+            Function {
+                id: 65536,
+                name: 32768,
+                system_name: 16384,
+                filename: 8192,
+                start_line: 4096,
+            },
+            Function {
+                id: u64::MAX,
+                name: i64::MAX,
+                system_name: i64::MAX,
+                filename: i64::MAX,
+                start_line: i64::MAX,
+            },
+        ];
+        for before in cases {
+            let required = {
+                let ddog = LenEncodable::encoded_len(&before);
+                let prost = Message::encoded_len(&before);
+                // We skip the zero-encoding optimization for some items to
+                // ensure a unique prefix, so we should be equal or bigger
+                // than the prost version depending on the provided values,
+                // but we should never be smaller.
+                assert!(ddog >= prost);
+                ddog
+            };
+            let mut buf = Vec::with_capacity(required);
+            // SAFETY: correct size, plus buffer has reserved capacity.
+            let _range = unsafe { LenEncodable::encode(&before, &mut buf) };
+            // We exactly request the number of bytes, this should match.
+            let remaining = buf.capacity() - buf.len();
+            assert_eq!(
+                0, remaining,
+                "{remaining} bytes unused, encoded len may be too large or encoder may be wrong for {before:?}",
+            );
+
+            let after = Function::decode(buf.as_slice()).unwrap();
+            assert_eq!(before, after);
+            // The implementation of Eq ignores the id field so we check it too.
+            assert_eq!(before.id, after.id);
+        }
+    }
+
+    #[test]
+    fn test_location() {
+        let before = Location {
+            id: 1,
+            mapping_id: 2,
+            address: 3,
+            lines: &[Line {
+                function_id: 4,
+                line: 5,
+            }],
+            is_folded: false,
+        };
+
+        let len = LenEncodable::encoded_len(&before);
+        let mut buf = Vec::with_capacity(len);
+
+        // SAFETY: correct size, plus buffer has reserved capacity.
+        let _range = unsafe { LenEncodable::encode(&before, &mut buf) };
+
+        // We exactly request the number of bytes, this should match.
+        let remaining = buf.capacity() - buf.len();
+        assert_eq!(
+            0, remaining,
+            "{remaining} bytes unused, encoded len may be too large or encoder may be wrong for {before:?}",
+        );
+
+        let after = crate::pprof::Location::decode(buf.as_slice()).unwrap();
+        // different reprs, have to go piece by piece.
+        assert_eq!(before.id, after.id);
+        assert_eq!(before.mapping_id, after.mapping_id);
+        assert_eq!(before.address, after.address);
+        assert_eq!(&before.lines, &after.lines);
+        assert_eq!(before.is_folded, after.is_folded);
+    }
+}

--- a/profiling/src/pprof/mod.rs
+++ b/profiling/src/pprof/mod.rs
@@ -2,12 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod proto;
-mod proto_map;
+pub mod proto_map;
 
 pub mod encodable;
 pub mod sliced_proto;
 pub use proto::*;
-pub use proto_map::*;
 
 #[cfg(test)]
 pub mod test_utils;

--- a/profiling/src/pprof/mod.rs
+++ b/profiling/src/pprof/mod.rs
@@ -2,11 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod proto;
+mod proto_map;
 
+pub mod encodable;
 pub mod sliced_proto;
 pub use proto::*;
+pub use proto_map::*;
 
 #[cfg(test)]
 pub mod test_utils;
+
 #[cfg(test)]
 pub use test_utils::*;

--- a/profiling/src/pprof/proto_map.rs
+++ b/profiling/src/pprof/proto_map.rs
@@ -31,14 +31,14 @@ pub trait Identifiable: LenEncodable {
 
 impl ProfileProtoMap {
     #[inline]
-    fn project(buf: &Vec<u8>, byte_range: ByteRange) -> &[u8] {
+    fn project(buf: &[u8], byte_range: ByteRange) -> &[u8] {
         let range = Range {
             start: byte_range.start as usize,
             end: byte_range.end as usize,
         };
         // SAFETY: the ByteRange's are not exposed, and we constructed them
         // in-range, and we never modify the existing bytes (only append).
-        unsafe { &buf.get_unchecked(range) }
+        unsafe { buf.get_unchecked(range) }
     }
 
     #[inline]

--- a/profiling/src/pprof/proto_map.rs
+++ b/profiling/src/pprof/proto_map.rs
@@ -1,0 +1,562 @@
+// Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+use super::encodable::{try_encode_with_tag, LenEncodable, Location, Mapping};
+use super::proto::Function;
+use hashbrown::HashTable;
+use rustc_hash::FxHasher;
+use std::hash::Hasher;
+use std::ops::Range;
+
+// This type exists because Range<u32> is not Copy.
+#[derive(Clone, Copy, Debug)]
+pub struct ByteRange {
+    pub start: u32,
+    pub end: u32,
+}
+
+pub struct ProfileProtoMap {
+    ht: HashTable<(ByteRange, u64)>,
+    buf: Vec<u8>,
+}
+
+trait Identifiable: LenEncodable {
+    fn id(&self) -> u64;
+
+    /// Return true if this should dedup to id=0. This is likely a performance
+    /// sensitive operation, make sure you branch on the most helpful field(s)
+    /// first.
+    fn is_zero_id(&self) -> bool;
+}
+
+impl ProfileProtoMap {
+    fn project(buf: &Vec<u8>, byte_range: ByteRange) -> &[u8] {
+        let range = Range {
+            start: byte_range.start as usize,
+            end: byte_range.end as usize,
+        };
+        &buf.as_slice()[range]
+    }
+
+    #[inline]
+    fn hash(bytes: &[u8]) -> u64 {
+        let mut hasher = FxHasher::default();
+        hasher.write(bytes);
+        hasher.finish()
+    }
+
+    fn insert_byte_range(&mut self, range: ByteRange, mut id: u64) -> (u64, bool) {
+        // We need an immutable reference to the buffer, and a mutable
+        // reference to the hash table, and that goes against borrow rules if
+        // we directly refer to self. So instead of using self references for
+        // both, steal the buffer and now that's a separate borrow.
+        // Put it back later, of course.
+        let mut buf = Vec::new();
+        core::mem::swap(&mut self.buf, &mut buf);
+
+        // These are the bytes of the item being added. We'll compare against
+        // this byte slice possibly many times.
+        let bytes = Self::project(&buf, range);
+        // The hash of the bytes of the item being added.
+        let hash = Self::hash(bytes);
+
+        // Find the hash table entry. If it doesn't exist, there's an
+        // AbsentEntry API to insert it.
+        let item = self.ht.find(hash, |(range, _id)| {
+            let bytes2 = Self::project(&buf, *range);
+            bytes.eq(bytes2)
+        });
+
+        let already_existed = item.is_some();
+        if let Some((_range, existing_id)) = item {
+            id = *existing_id;
+        } else {
+            _ = self.ht.insert_unique(hash, (range, id), |(range, _id)| {
+                let bytes = Self::project(&buf, *range);
+                Self::hash(bytes)
+            });
+        };
+
+        // Restore buffer before returning.
+        core::mem::swap(&mut self.buf, &mut buf);
+        (id, already_existed)
+    }
+
+    #[cfg_attr(debug_assertions, track_caller)]
+    fn insert_with_tag(&mut self, tag: u32, encodable: &impl Identifiable) -> (u64, bool) {
+        if encodable.is_zero_id() {
+            return (0, true);
+        }
+
+        // Items get pushed to the end, then deduplicated. If they already
+        // existed, then we can shrink back to this size. This means the
+        // buffer cannot have any other writes!
+        // todo: can we rewrite the code so this is structurally true?
+        let checkpoint = self.buf.len();
+        let id = encodable.id();
+
+        // SAFETY: the global allocator doesn't panic, and the other condition
+        // is a value over 2 GiB, which is not possible with a single Mapping,
+        // Function, and Location. Location is a bit trickier because it holds
+        // an array, but in practice it's usually 1:1 (one Line per Location),
+        // and we have a requirement on Location that it's not too big.
+        let range =
+            unsafe { try_encode_with_tag(encodable, tag, &mut self.buf).unwrap_unchecked() };
+        debug_assert!(range.end >= range.start);
+
+        let byte_range = ByteRange {
+            start: range.start,
+            end: range.end,
+        };
+
+        let (id, already_existed) = self.insert_byte_range(byte_range, id);
+        if already_existed {
+            // The len should be shrunk back down to the checkpoint, but the
+            // capacity should remain; this matches `truncate` exactly.
+            self.buf.truncate(checkpoint);
+        }
+        (id, already_existed)
+    }
+}
+
+impl ProfileProtoMap {
+    pub fn new() -> Self {
+        Self {
+            ht: HashTable::new(),
+            buf: Vec::new(),
+        }
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.ht.len()
+    }
+
+    #[inline]
+    pub fn clear(&mut self) -> Vec<u8> {
+        self.ht.clear();
+        core::mem::replace(&mut self.buf, Vec::new())
+    }
+}
+
+mod sealed {
+    use super::*;
+    pub trait Insert<T: Identifiable> {
+        fn insert(&mut self, value: &T) -> (u64, bool);
+    }
+}
+use sealed::Insert;
+
+impl Insert<Mapping> for ProfileProtoMap {
+    fn insert(&mut self, value: &Mapping) -> (u64, bool) {
+        self.insert_with_tag(3u32, value)
+    }
+}
+
+impl Insert<Location<'_>> for ProfileProtoMap {
+    fn insert(&mut self, value: &Location) -> (u64, bool) {
+        self.insert_with_tag(4u32, value)
+    }
+}
+
+impl Insert<Function> for ProfileProtoMap {
+    fn insert(&mut self, value: &Function) -> (u64, bool) {
+        self.insert_with_tag(5u32, value)
+    }
+}
+
+impl Identifiable for Mapping {
+    fn id(&self) -> u64 {
+        self.id
+    }
+
+    #[inline]
+    fn is_zero_id(&self) -> bool {
+        // In PHP, Python, and Ruby, these are all zero (they don't really use
+        // mappings except as required by APIs).
+        // .NET currently only sets filename.
+        // The native profiler uses all the fields.
+        // This implementation does a mix of branching and branch-free to try
+        // and have middle-ground performance for all languages.
+        let filename = self.filename;
+        let build_id = self.build_id;
+        let c = filename | build_id;
+        if c != 0 {
+            return false;
+        }
+
+        let memory_start = self.memory_start;
+        let memory_limit = self.memory_limit;
+        let file_offset = self.file_offset;
+        0 == (memory_start | memory_limit | file_offset)
+    }
+}
+
+impl Identifiable for Location<'_> {
+    fn id(&self) -> u64 {
+        self.id
+    }
+
+    fn is_zero_id(&self) -> bool {
+        // If there are lines, they need to be zero-reprs for the Location to
+        // also be zero.
+        for line in self.lines {
+            // I don't expect any profilers to set a zero value here, so pay
+            // for the branch; I expect this to basically always return false
+            // on the first loop.
+            if line.function_id != 0 {
+                return false;
+            }
+            if line.line != 0 {
+                return false;
+            }
+        }
+
+        // These members are not used by some of the profilers, so optimize
+        // for them all being zero by doing bitwise operations.
+        // If any bit is set in any of them, then it's not zero, so bitwise-or
+        // them all together.
+        let mapping_id = self.mapping_id;
+        let address = self.address;
+        let is_folded = self.is_folded as u64;
+        let c = mapping_id | address | is_folded;
+        c == 0
+    }
+}
+
+impl Identifiable for Function {
+    fn id(&self) -> u64 {
+        self.id
+    }
+
+    #[inline]
+    fn is_zero_id(&self) -> bool {
+        // I expect everyone to set a non-zero function name, as pprof tools
+        // seem to expect a name here and don't handle the missing case well
+        // (at least when I tried). This branch should be predictable.
+        if self.name != 0 {
+            return false;
+        }
+
+        // But I don't see the point in branching for any of these, if the
+        // function name was zero, I think the rest are probably zero as well.
+        let system_name = self.system_name;
+        let filename = self.filename;
+        let start_line = self.start_line;
+        0 == (system_name | filename | start_line)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pprof::Line;
+
+    #[test]
+    fn test_insert() {
+        let mut map = ProfileProtoMap::new();
+
+        // Adding the same items multiple times should result in the same ids.
+        let mut already_existed = false;
+        loop {
+            // Empty mapping, when excluding the ID.
+            let (id0, b0) = map.insert(&Mapping {
+                id: 1,
+                memory_start: 0,
+                memory_limit: 0,
+                file_offset: 0,
+                filename: 0,
+                build_id: 0,
+            });
+            assert_eq!(0, id0);
+            assert!(b0);
+
+            // Empty Function, when excluding the ID.
+            let (id0, b0) = map.insert(&Function {
+                id: 2,
+                name: 0,
+                system_name: 0,
+                filename: 0,
+                start_line: 0,
+            });
+            assert_eq!(0, id0);
+            assert!(b0);
+
+            // Empty Location, when excluding the ID.
+            let (id0, b0) = map.insert(&Location {
+                id: 1,
+                mapping_id: 0,
+                address: 0,
+                lines: &[],
+                is_folded: false,
+            });
+            assert_eq!(0, id0);
+            assert!(b0);
+
+            // Empty Location, when excluding the ID.
+            let (id0, b0) = map.insert(&Location {
+                id: 1,
+                mapping_id: 0,
+                address: 0,
+                lines: &[Line {
+                    function_id: 0,
+                    line: 0,
+                }],
+                is_folded: false,
+            });
+            assert_eq!(0, id0);
+            assert!(b0);
+
+            let (id1, b1) = map.insert(&Function {
+                id: 1,
+                name: 1,
+                system_name: 0,
+                filename: 0,
+                start_line: 0,
+            });
+            assert_eq!(1, id1);
+            assert_eq!(already_existed, b1);
+
+            let (id1, b1) = map.insert(&Function {
+                id: 2, // Same as 1 except for id, so it'll dedup.
+                name: 1,
+                system_name: 0,
+                filename: 0,
+                start_line: 0,
+            });
+            assert_eq!(1, id1);
+            assert_eq!(true, b1);
+
+            let (id2, b2) = map.insert(&Mapping {
+                id: 2,
+                memory_start: 0,
+                memory_limit: 0,
+                file_offset: 0,
+                filename: 2,
+                build_id: 0,
+            });
+            assert_eq!(2, id2);
+            assert_eq!(already_existed, b2);
+
+            let (id3, b3) = map.insert(&Location {
+                id: 3,
+                mapping_id: 0,
+                address: 0,
+                lines: &[Line {
+                    function_id: 1,
+                    line: 1,
+                }],
+                is_folded: false,
+            });
+            assert_eq!(3, id3);
+            assert_eq!(already_existed, b3);
+
+            let (id4, b4) = map.insert(&Function {
+                id: 4,
+                name: 4,
+                system_name: 0,
+                filename: 2,
+                start_line: 1,
+            });
+            assert_eq!(4, id4);
+            assert_eq!(already_existed, b4);
+
+            let (id5, b5) = map.insert(&Location {
+                id: 5,
+                mapping_id: 0,
+                address: 0,
+                lines: &[Line {
+                    function_id: 4,
+                    line: 2,
+                }],
+                is_folded: false,
+            });
+            assert_eq!(5, id5);
+            assert_eq!(already_existed, b5);
+
+            if !already_existed {
+                already_existed = true;
+            } else {
+                break;
+            }
+        }
+    }
+
+    #[test]
+    fn test_serialization() {
+        let mut map = ProfileProtoMap::new();
+        // Values were pulled from a PHP profile of the symfony/demo app,
+        // though mappings were dropped (all Mapping.id=1 which is an empty
+        // mapping, which we should avoid and use location.mapping_id=0).
+        let functions = [
+            Function {
+                id: 1,
+                name: 21,
+                ..Function::default()
+            },
+            Function {
+                id: 2,
+                name: 25,
+                ..Function::default()
+            },
+            Function {
+                id: 3,
+                name: 26,
+                ..Function::default()
+            },
+            Function {
+                id: 4,
+                name: 27,
+                filename: 24,
+                ..Function::default()
+            },
+            Function {
+                id: 5,
+                name: 48,
+                filename: 39,
+                ..Function::default()
+            },
+            Function {
+                id: 6,
+                name: 49,
+                filename: 30,
+                ..Function::default()
+            },
+            Function {
+                id: 7,
+                name: 27,
+                filename: 29,
+                ..Function::default()
+            },
+            Function {
+                id: 8,
+                name: 27,
+                filename: 28,
+                ..Function::default()
+            },
+            Function {
+                id: 9,
+                name: 63,
+                ..Function::default()
+            },
+            Function {
+                id: 10,
+                name: 27,
+                filename: 62,
+                ..Function::default()
+            },
+        ];
+        let locations = [
+            Location {
+                id: 1,
+                lines: &[Line {
+                    function_id: 1,
+                    line: 0,
+                }],
+                ..Location::default()
+            },
+            Location {
+                id: 2,
+                lines: &[Line {
+                    function_id: 2,
+                    line: 0,
+                }],
+                ..Location::default()
+            },
+            Location {
+                id: 3,
+                lines: &[Line {
+                    function_id: 3,
+                    line: 0,
+                }],
+                ..Location::default()
+            },
+            Location {
+                id: 4,
+                lines: &[Line {
+                    function_id: 4,
+                    line: 5,
+                }],
+                ..Location::default()
+            },
+            Location {
+                id: 5,
+                lines: &[Line {
+                    function_id: 5,
+                    line: 41,
+                }],
+                ..Location::default()
+            },
+            Location {
+                id: 6,
+                lines: &[Line {
+                    function_id: 6,
+                    line: 45,
+                }],
+                ..Location::default()
+            },
+            Location {
+                id: 7,
+                lines: &[Line {
+                    function_id: 7,
+                    line: 25,
+                }],
+                ..Location::default()
+            },
+            Location {
+                id: 8,
+                lines: &[Line {
+                    function_id: 8,
+                    line: 5,
+                }],
+                ..Location::default()
+            },
+            Location {
+                id: 9,
+                lines: &[Line {
+                    function_id: 9,
+                    line: 0,
+                }],
+                ..Location::default()
+            },
+            Location {
+                id: 10,
+                lines: &[Line {
+                    function_id: 10,
+                    line: 67,
+                }],
+                ..Location::default()
+            },
+        ];
+
+        // We don't _need_ to insert these in this order, but it practices a
+        // capability that we have with this structure that we didn't before.
+        for (function, location) in functions.iter().zip(locations.iter()) {
+            _ = map.insert(function);
+            _ = map.insert(location);
+        }
+
+        let buffer = map.clear();
+
+        use prost::Message;
+        let profile = crate::pprof::Profile::decode(buffer.as_slice()).unwrap();
+        assert_eq!(profile.locations.len(), locations.len());
+        assert_eq!(profile.functions.len(), functions.len());
+
+        for (pprof, encodable) in profile.functions.iter().zip(&functions) {
+            assert_eq!(pprof.id, encodable.id);
+            assert_eq!(pprof.name, encodable.name);
+            assert_eq!(pprof.system_name, encodable.system_name);
+            assert_eq!(pprof.filename, encodable.filename);
+            assert_eq!(pprof.start_line, encodable.start_line);
+        }
+
+        for (pprof, encodable) in profile.locations.iter().zip(&locations) {
+            assert_eq!(pprof.id, encodable.id);
+            assert_eq!(pprof.mapping_id, encodable.mapping_id);
+            assert_eq!(pprof.address, encodable.address);
+            assert_eq!(pprof.lines.as_slice(), encodable.lines);
+            assert_eq!(pprof.is_folded, encodable.is_folded);
+        }
+    }
+}

--- a/profiling/src/pprof/proto_map.rs
+++ b/profiling/src/pprof/proto_map.rs
@@ -101,7 +101,13 @@ impl ProfileProtoMap {
 
         // PANIC: the global allocator doesn't panic, and the other condition
         // is a value over 2 GiB
-        let range = try_encode_with_tag(encodable, tag, &mut self.buf).unwrap();
+        let range = match try_encode_with_tag(encodable, tag, &mut self.buf) {
+            Ok(range) => range,
+            Err(err) => {
+                self.buf.truncate(checkpoint);
+                panic!("failed inserting message with tag {tag}: {err}")
+            }
+        };
         debug_assert!(range.end >= range.start);
 
         let byte_range = ByteRange {

--- a/profiling/src/pprof/proto_map.rs
+++ b/profiling/src/pprof/proto_map.rs
@@ -38,7 +38,7 @@ impl ProfileProtoMap {
         };
         // SAFETY: the ByteRange's are not exposed, and we constructed them
         // in-range, and we never modify the existing bytes (only append).
-        unsafe { &buf.as_slice().get_unchecked(range) }
+        unsafe { &buf.get_unchecked(range) }
     }
 
     #[inline]

--- a/profiling/src/pprof/proto_map.rs
+++ b/profiling/src/pprof/proto_map.rs
@@ -120,22 +120,33 @@ impl ProfileProtoMap {
 }
 
 impl ProfileProtoMap {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             ht: HashTable::new(),
             buf: Vec::new(),
         }
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn len(&self) -> usize {
         self.ht.len()
+    }
+
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.ht.is_empty()
     }
 
     #[inline]
     pub fn clear(&mut self) -> Vec<u8> {
         self.ht.clear();
-        core::mem::replace(&mut self.buf, Vec::new())
+        core::mem::take(&mut self.buf)
+    }
+}
+
+impl Default for ProfileProtoMap {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -313,7 +324,7 @@ mod tests {
                 start_line: 0,
             });
             assert_eq!(1, id1);
-            assert_eq!(true, b1);
+            assert!(b1);
 
             let (id2, b2) = map.insert(&Mapping {
                 id: 2,

--- a/profiling/src/serializer/compressed_streaming_encoder.rs
+++ b/profiling/src/serializer/compressed_streaming_encoder.rs
@@ -27,6 +27,12 @@ impl CompressedProtobufSerializer {
         Ok(())
     }
 
+    /// Copy the buffer into the compressor. The caller must ensure that
+    /// buffer contains valid in-wire protobuf for pprof.
+    pub fn copy_buffer(&mut self, buf: &[u8]) -> std::io::Result<()> {
+        self.zipper.write_all(buf)
+    }
+
     /// Only meant for string table strings. This is essentially an
     /// implementation of [prost::Message::encode] but for any `AsRef<str>`,
     /// and specialized for handling the unlikely OOM conditions of writing


### PR DESCRIPTION
# What does this PR do?

Immediately serializes Mappings, Locations, and Functions to their in-wire protobuf format, and dedups based on that instead. See [Always Be Serializing](https://docs.google.com/document/d/1jWcVpdvo4bYErKdOdlWozckXEy3K_Tvd_i3CdDr7hVc/edit?usp=sharing).

# Motivation

- Writing them in-order can help with certain debugging scenarios.
- Saves space when a given language doesn't use certain fields.
- Might save CPU from fewer intermediate representations, but in-wire serialization is not trivial so we'll have to see how it shakes out.

# Additional Notes

I bounced ideas off @ivoanjo and he helped me refine the implementation. He also helped me test the performance.

I didn't delete the now-unused representations to keep the PR more focused, but there are some internal representations that could be removed if this merges.

# How to test the change?

The external APIs are the same. However, some fuzzer tests are failing. I _think_ this is an issue with the fuzzer harness/test, because they look fine when I manually serialize and unserialize the problematic cases. If pursued to production quality, we'd want to get to the root of this.
