### PR TITLE
chore: hyper 1.x migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -407,7 +407,7 @@ dependencies = [
  "rustversion",
  "serde",
  "sync_wrapper 0.1.2",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
 ]
@@ -443,12 +443,6 @@ dependencies = [
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -708,7 +702,7 @@ dependencies = [
  "home",
  "http 1.1.0",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper 1.6.0",
  "hyper-named-pipe",
  "hyper-rustls 0.26.0",
  "hyper-util",
@@ -1001,14 +995,14 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "common-multipart-rfc7578"
-version = "0.5.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22328b3864f1d8dbe7036f3f2fdfdcb1f367af43dca418943d396fbf8c4b8021"
+checksum = "f08d53b5e0c302c5830cfa7511ba0edc3f241c691a95c0d184dfb761e11a6cc2"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 0.2.12",
+ "http 1.1.0",
  "mime",
  "mime_guess",
  "rand",
@@ -1227,15 +1221,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ct-logs"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
-dependencies = [
- "sct",
-]
-
-[[package]]
 name = "current_platform"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1305,8 +1290,11 @@ dependencies = [
  "ddtelemetry",
  "dogstatsd-client",
  "either",
+ "http 1.1.0",
+ "http-body-util",
  "httpmock",
- "hyper 0.14.31",
+ "hyper 1.6.0",
+ "hyper-util",
  "log",
  "rand",
  "regex",
@@ -1354,8 +1342,7 @@ dependencies = [
  "chrono",
  "ddcommon",
  "ddtelemetry",
- "http 0.2.12",
- "hyper 0.14.31",
+ "http 1.1.0",
  "libc",
  "nix 0.27.1",
  "num-derive",
@@ -1382,7 +1369,6 @@ dependencies = [
  "ddcommon",
  "ddcommon-ffi",
  "function_name",
- "hyper 0.14.31",
  "libc",
  "symbolic-common",
  "symbolic-demangle",
@@ -1476,7 +1462,8 @@ dependencies = [
  "anyhow",
  "constcat",
  "ddcommon",
- "hyper 0.14.31",
+ "http-body-util",
+ "hyper 1.6.0",
  "percent-encoding",
  "regex",
  "regex-automata 0.4.8",
@@ -1523,9 +1510,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hashbrown 0.14.5",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.31",
+ "http 1.1.0",
+ "http-body-util",
+ "hyper 1.6.0",
  "hyper-multipart-rfc7578",
  "indexmap 2.6.0",
  "libc",
@@ -1555,7 +1542,8 @@ dependencies = [
  "ddcommon-ffi",
  "ddtelemetry-ffi",
  "futures",
- "hyper 0.14.31",
+ "http-body-util",
+ "hyper 1.6.0",
  "libc",
  "serde_json",
  "symbolic-common",
@@ -1600,8 +1588,10 @@ dependencies = [
  "ddcommon",
  "futures",
  "futures-util",
- "http 0.2.12",
- "hyper 0.14.31",
+ "http 1.1.0",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
  "manual_future",
  "serde",
  "serde_json",
@@ -1653,9 +1643,10 @@ dependencies = [
  "ddtelemetry",
  "dogstatsd-client",
  "futures",
- "http 0.2.12",
+ "http 1.1.0",
+ "http-body-util",
  "httpmock",
- "hyper 0.14.31",
+ "hyper 1.6.0",
  "libc",
  "manual_future",
  "memory-stats",
@@ -1698,7 +1689,7 @@ dependencies = [
  "ddtelemetry",
  "ddtelemetry-ffi",
  "dogstatsd-client",
- "hyper 0.14.31",
+ "http 1.1.0",
  "libc",
  "paste",
  "tempfile",
@@ -1724,13 +1715,16 @@ dependencies = [
  "datadog-trace-utils",
  "ddcommon",
  "duplicate",
- "hyper 0.14.31",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
  "rmp-serde",
  "serde",
  "serde_json",
  "serial_test",
  "tempfile",
  "tokio",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -1793,9 +1787,10 @@ dependencies = [
  "ddcommon",
  "flate2",
  "futures",
+ "http-body-util",
  "httpmock",
- "hyper 0.14.31",
- "hyper-proxy",
+ "hyper 1.6.0",
+ "hyper-http-proxy",
  "log",
  "prost 0.11.9",
  "rand",
@@ -1822,8 +1817,10 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "http 0.2.12",
- "hyper 0.14.31",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
  "hyper-rustls 0.27.3",
  "hyper-util",
  "indexmap 2.6.0",
@@ -1842,6 +1839,7 @@ dependencies = [
  "static_assertions",
  "tokio",
  "tokio-rustls 0.26.0",
+ "tower-service",
  "windows-sys 0.52.0",
 ]
 
@@ -1855,7 +1853,7 @@ dependencies = [
  "chrono",
  "crossbeam-queue",
  "ddcommon",
- "hyper 0.14.31",
+ "hyper 1.6.0",
  "serde",
 ]
 
@@ -1880,8 +1878,10 @@ dependencies = [
  "ddcommon",
  "futures",
  "hashbrown 0.14.5",
- "http 0.2.12",
- "hyper 0.14.31",
+ "http 1.1.0",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
  "serde",
  "serde_json",
  "sys-info",
@@ -2068,7 +2068,7 @@ dependencies = [
  "anyhow",
  "cadence",
  "ddcommon",
- "http 0.2.12",
+ "http 1.1.0",
  "serde",
  "tokio",
  "tracing",
@@ -2551,14 +2551,14 @@ dependencies = [
 
 [[package]]
 name = "headers"
-version = "0.3.9"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
 dependencies = [
  "base64 0.21.7",
  "bytes",
  "headers-core",
- "http 0.2.12",
+ "http 1.1.0",
  "httpdate",
  "mime",
  "sha1",
@@ -2566,11 +2566,11 @@ dependencies = [
 
 [[package]]
 name = "headers-core"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 0.2.12",
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -2740,9 +2740,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2760,16 +2760,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-multipart-rfc7578"
-version = "0.7.0"
+name = "hyper-http-proxy"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63ca8108ac0ae98d310d41cddb11c6b822e8aca865dbe421366934e6f7f72e10"
+checksum = "7ad4b0a1e37510028bc4ba81d0e38d239c39671b0f0ce9e02dfa93a8133f7c08"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "headers",
+ "http 1.1.0",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.3",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-multipart-rfc7578"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a60fb748074dd040c8d05d8a002725200fb594e0ffcfa0b83fb8f64616b50267"
 dependencies = [
  "bytes",
  "common-multipart-rfc7578",
  "futures-core",
- "http 0.2.12",
- "hyper 0.14.31",
+ "http 1.1.0",
+ "hyper 1.6.0",
 ]
 
 [[package]]
@@ -2779,48 +2799,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
 dependencies = [
  "hex",
- "hyper 1.5.0",
+ "hyper 1.6.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
  "tower-service",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "hyper-proxy"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca815a891b24fdfb243fa3239c86154392b0953ee584aa1a2a1f66d20cbe75cc"
-dependencies = [
- "bytes",
- "futures",
- "headers",
- "http 0.2.12",
- "hyper 0.14.31",
- "hyper-rustls 0.22.1",
- "rustls-native-certs 0.5.0",
- "tokio",
- "tokio-rustls 0.22.0",
- "tower-service",
- "webpki",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
-dependencies = [
- "ct-logs",
- "futures-util",
- "hyper 0.14.31",
- "log",
- "rustls 0.19.1",
- "rustls-native-certs 0.5.0",
- "tokio",
- "tokio-rustls 0.22.0",
- "webpki",
 ]
 
 [[package]]
@@ -2831,7 +2815,7 @@ checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.5.0",
+ "hyper 1.6.0",
  "hyper-util",
  "log",
  "rustls 0.22.4",
@@ -2850,7 +2834,7 @@ checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.5.0",
+ "hyper 1.6.0",
  "hyper-util",
  "rustls 0.23.18",
  "rustls-native-certs 0.8.0",
@@ -2884,7 +2868,7 @@ dependencies = [
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
- "hyper 1.5.0",
+ "hyper 1.6.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2900,7 +2884,7 @@ checksum = "acf569d43fa9848e510358c07b80f4adf34084ddc28c6a4a651ee8474c070dcc"
 dependencies = [
  "hex",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper 1.6.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -3478,7 +3462,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper 1.6.0",
  "hyper-util",
  "log",
  "rand",
@@ -4361,7 +4345,7 @@ checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
 dependencies = [
  "bytes",
  "rand",
- "ring 0.17.8",
+ "ring",
  "rustc-hash 2.0.0",
  "rustls 0.23.18",
  "slab",
@@ -4550,7 +4534,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper 1.6.0",
  "hyper-rustls 0.27.3",
  "hyper-util",
  "ipnet",
@@ -4581,21 +4565,6 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
@@ -4604,8 +4573,8 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "libc",
- "spin 0.9.8",
- "untrusted 0.9.0",
+ "spin",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -4683,25 +4652,12 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
-dependencies = [
- "base64 0.13.1",
- "log",
- "ring 0.16.20",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
- "ring 0.17.8",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -4716,23 +4672,11 @@ checksum = "9c9cc1d47e243d655ace55ed38201c19ae02c148ae56412ab8750e8f0166ab7f"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
- "ring 0.17.8",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
-dependencies = [
- "openssl-probe",
- "rustls 0.19.1",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -4783,9 +4727,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "aws-lc-rs",
- "ring 0.17.8",
+ "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -4870,16 +4814,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sct"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
-dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
-]
 
 [[package]]
 name = "security-framework"
@@ -5218,12 +5152,6 @@ dependencies = [
  "winapi 0.2.8",
  "windows",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -5753,17 +5681,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
-dependencies = [
- "rustls 0.19.1",
- "tokio",
- "webpki",
-]
-
-[[package]]
-name = "tokio-rustls"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
@@ -5894,7 +5811,7 @@ dependencies = [
  "prost 0.11.9",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5960,6 +5877,20 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 1.0.1",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -6136,12 +6067,6 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -6346,16 +6271,6 @@ checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.21.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
-dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1800,7 +1800,6 @@ dependencies = [
  "httpmock",
  "hyper 0.14.31",
  "hyper-proxy",
- "hyper-rustls 0.27.3",
  "log",
  "prost 0.11.9",
  "rand",

--- a/crashtracker-ffi/Cargo.toml
+++ b/crashtracker-ffi/Cargo.toml
@@ -28,7 +28,6 @@ anyhow = "1.0"
 datadog-crashtracker = { path = "../crashtracker" }
 ddcommon = { path = "../ddcommon" }
 ddcommon-ffi = { path = "../ddcommon-ffi", default-features = false }
-hyper = {version = "0.14", features = ["backports", "deprecated"], default-features = false}
 symbolic-demangle = { version = "12.8.0", default-features = false, features = ["rust", "cpp", "msvc"], optional = true }
 symbolic-common = { version = "12.8.0", default-features = false, optional = true }
 function_name = "0.3.0"

--- a/crashtracker/Cargo.toml
+++ b/crashtracker/Cargo.toml
@@ -33,8 +33,7 @@ backtrace = "0.3.74"
 chrono = {version = "0.4", default-features = false, features = ["std", "clock", "serde"]}
 ddcommon = {path = "../ddcommon"}
 ddtelemetry = {path = "../ddtelemetry"}
-http = "0.2"
-hyper = {version = "0.14", features = ["client", "backports", "deprecated"], default-features = false}
+http = "1.0"
 libc = "0.2"
 nix = { version = "0.27.1", features = ["poll", "signal", "socket"] }
 num-derive = "0.4.2"

--- a/data-pipeline/Cargo.toml
+++ b/data-pipeline/Cargo.toml
@@ -12,24 +12,34 @@ autobenches = false
 [dependencies]
 anyhow = { version = "1.0" }
 arc-swap = "1.7.1"
-hyper = {version = "0.14", features = ["client", "server", "runtime", "backports", "deprecated"], default-features = false}
+hyper = { version = "1.6", features = ["http1", "client"] }
+hyper-util = { version = "0.1", features = ["client", "client-legacy"] }
+http = "1.0"
+http-body-util = "0.1"
 log = "0.4"
 rmp-serde = "1.1.1"
 serde = "1.0.209"
 serde_json = "1.0.127"
 bytes = "1.4"
 either = "1.13.0"
-tokio = { version = "1.23", features = ["rt", "test-util", "time"], default-features = false }
+tokio = { version = "1.23", features = [
+    "rt",
+    "test-util",
+    "time",
+], default-features = false }
 
 ddcommon = { path = "../ddcommon" }
 ddtelemetry = { path = "../ddtelemetry" }
 datadog-trace-protobuf = { path = "../trace-protobuf" }
 datadog-trace-utils = { path = "../trace-utils" }
-datadog-ddsketch = { path = "../ddsketch"}
-dogstatsd-client = { path = "../dogstatsd-client"}
+datadog-ddsketch = { path = "../ddsketch" }
+dogstatsd-client = { path = "../dogstatsd-client" }
 uuid = { version = "1.10.0", features = ["v4"] }
 tokio-util = "0.7.11"
-tinybytes =  { path = "../tinybytes", features = ["bytes_string", "serialization"] }
+tinybytes = { path = "../tinybytes", features = [
+    "bytes_string",
+    "serialization",
+] }
 
 [lib]
 bench = false
@@ -47,7 +57,11 @@ httpmock = "0.7.0"
 rand = "0.8.5"
 regex = "1.5"
 tempfile = "3.3.0"
-tokio = {version = "1.23", features = ["rt", "time", "test-util"], default-features = false}
+tokio = { version = "1.23", features = [
+    "rt",
+    "time",
+    "test-util",
+], default-features = false }
 
 [features]
 test-utils = []

--- a/data-pipeline/src/agent_info/fetcher.rs
+++ b/data-pipeline/src/agent_info/fetcher.rs
@@ -6,8 +6,9 @@
 use super::{schema::AgentInfo, AgentInfoArc};
 use anyhow::{anyhow, Result};
 use arc_swap::ArcSwapOption;
-use ddcommon::{connector::Connector, Endpoint};
-use hyper::body::HttpBody;
+use ddcommon::hyper_migration;
+use ddcommon::Endpoint;
+use http_body_util::BodyExt;
 use hyper::{self, body::Buf, header::HeaderName};
 use log::{error, info};
 use std::sync::Arc;
@@ -38,8 +39,8 @@ pub async fn fetch_info_with_state(
     let req = info_endpoint
         .to_request_builder(concat!("Libdatadog/", env!("CARGO_PKG_VERSION")))?
         .method(hyper::Method::GET)
-        .body(hyper::Body::empty());
-    let client = hyper::Client::builder().build(Connector::default());
+        .body(hyper_migration::Body::empty());
+    let client = hyper_migration::new_default_client();
     let res = client.request(req?).await?;
     let new_state_hash = res
         .headers()

--- a/data-pipeline/src/telemetry/mod.rs
+++ b/data-pipeline/src/telemetry/mod.rs
@@ -260,6 +260,7 @@ impl TelemetryClient {
 
 #[cfg(test)]
 mod tests {
+    use ddcommon::hyper_migration;
     use httpmock::Method::POST;
     use httpmock::MockServer;
     use hyper::{Response, StatusCode};
@@ -564,7 +565,7 @@ mod tests {
     #[tokio::test]
     async fn telemetry_from_network_error_test() {
         // Create an hyper error by calling an undefined service
-        let hyper_error = hyper::Client::new()
+        let hyper_error = hyper_migration::new_default_client()
             .get(hyper::Uri::from_static("localhost:12345"))
             .await
             .unwrap_err();

--- a/data-pipeline/src/trace_exporter/error.rs
+++ b/data-pipeline/src/trace_exporter/error.rs
@@ -3,6 +3,7 @@
 
 use crate::telemetry::error::TelemetryError;
 use crate::trace_exporter::msgpack_decoder::decode::error::DecodeError;
+use ddcommon::hyper_migration;
 use hyper::http::StatusCode;
 use hyper::Error as HyperError;
 use rmp_serde::encode::Error as EncodeError;
@@ -74,18 +75,28 @@ pub enum NetworkErrorKind {
 #[derive(Debug)]
 pub struct NetworkError {
     kind: NetworkErrorKind,
-    source: HyperError,
+    source: anyhow::Error,
 }
 
 impl Error for NetworkError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
-        Some(&self.source)
+        self.source.chain().next()
     }
 }
 
 impl NetworkError {
-    fn new(kind: NetworkErrorKind, source: HyperError) -> Self {
-        Self { kind, source }
+    fn new_hyper(kind: NetworkErrorKind, source: HyperError) -> Self {
+        Self {
+            kind,
+            source: source.into(),
+        }
+    }
+
+    fn new_hyper_util(kind: NetworkErrorKind, source: hyper_util::client::legacy::Error) -> Self {
+        Self {
+            kind,
+            source: source.into(),
+        }
     }
 
     pub fn kind(&self) -> NetworkErrorKind {
@@ -160,24 +171,73 @@ impl From<hyper::http::uri::InvalidUri> for TraceExporterError {
     }
 }
 
+impl From<hyper_migration::Error> for TraceExporterError {
+    fn from(err: hyper_migration::Error) -> Self {
+        match err {
+            hyper_migration::Error::Hyper(e) => e.into(),
+            hyper_migration::Error::Other(e) => TraceExporterError::Network(NetworkError {
+                kind: NetworkErrorKind::Unknown,
+                source: e,
+            }),
+            hyper_migration::Error::Infallible(e) => match e {},
+        }
+    }
+}
+
+impl From<hyper_util::client::legacy::Error> for TraceExporterError {
+    fn from(err: hyper_util::client::legacy::Error) -> Self {
+        if err.is_connect() {
+            return TraceExporterError::Network(NetworkError::new_hyper_util(
+                NetworkErrorKind::ConnectionClosed,
+                err,
+            ));
+        }
+        if let Some(e) = err.source().and_then(|e| e.downcast_ref::<HyperError>()) {
+            if e.is_parse() {
+                return TraceExporterError::Network(NetworkError::new_hyper_util(
+                    NetworkErrorKind::Parse,
+                    err,
+                ));
+            } else if e.is_canceled() {
+                return TraceExporterError::Network(NetworkError::new_hyper_util(
+                    NetworkErrorKind::Canceled,
+                    err,
+                ));
+            } else if e.is_incomplete_message() || e.is_body_write_aborted() {
+                return TraceExporterError::Network(NetworkError::new_hyper_util(
+                    NetworkErrorKind::Body,
+                    err,
+                ));
+            } else if e.is_parse_status() {
+                return TraceExporterError::Network(NetworkError::new_hyper_util(
+                    NetworkErrorKind::WrongStatus,
+                    err,
+                ));
+            } else if e.is_timeout() {
+                return TraceExporterError::Network(NetworkError::new_hyper_util(
+                    NetworkErrorKind::TimedOut,
+                    err,
+                ));
+            }
+        }
+        TraceExporterError::Network(NetworkError::new_hyper_util(NetworkErrorKind::Unknown, err))
+    }
+}
+
 impl From<HyperError> for TraceExporterError {
     fn from(err: HyperError) -> Self {
         if err.is_parse() {
-            TraceExporterError::Network(NetworkError::new(NetworkErrorKind::Parse, err))
+            TraceExporterError::Network(NetworkError::new_hyper(NetworkErrorKind::Parse, err))
         } else if err.is_canceled() {
-            TraceExporterError::Network(NetworkError::new(NetworkErrorKind::Canceled, err))
-        } else if err.is_connect() {
-            TraceExporterError::Network(NetworkError::new(NetworkErrorKind::ConnectionClosed, err))
-        } else if err.is_parse_too_large() {
-            TraceExporterError::Network(NetworkError::new(NetworkErrorKind::MessageTooLarge, err))
+            TraceExporterError::Network(NetworkError::new_hyper(NetworkErrorKind::Canceled, err))
         } else if err.is_incomplete_message() || err.is_body_write_aborted() {
-            TraceExporterError::Network(NetworkError::new(NetworkErrorKind::Body, err))
+            TraceExporterError::Network(NetworkError::new_hyper(NetworkErrorKind::Body, err))
         } else if err.is_parse_status() {
-            TraceExporterError::Network(NetworkError::new(NetworkErrorKind::WrongStatus, err))
+            TraceExporterError::Network(NetworkError::new_hyper(NetworkErrorKind::WrongStatus, err))
         } else if err.is_timeout() {
-            TraceExporterError::Network(NetworkError::new(NetworkErrorKind::TimedOut, err))
+            TraceExporterError::Network(NetworkError::new_hyper(NetworkErrorKind::TimedOut, err))
         } else {
-            TraceExporterError::Network(NetworkError::new(NetworkErrorKind::Unknown, err))
+            TraceExporterError::Network(NetworkError::new_hyper(NetworkErrorKind::Unknown, err))
         }
     }
 }

--- a/ddcommon-ffi/Cargo.toml
+++ b/ddcommon-ffi/Cargo.toml
@@ -23,7 +23,7 @@ anyhow = "1.0"
 chrono = { version = "0.4.38", features = ["std"] }
 crossbeam-queue = "0.3.11"
 ddcommon = { path = "../ddcommon" }
-hyper = {version = "0.14", features = ["backports", "deprecated"], default-features = false}
+hyper = { version = "1.6", features = ["http1", "client"] }
 serde = "1.0"
 
 [dev-dependencies]

--- a/ddcommon/Cargo.toml
+++ b/ddcommon/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 
 [lib]
 crate-type = ["lib"]
-bench =false
+bench = false
 
 [dependencies]
 anyhow = "1.0"
@@ -18,24 +18,24 @@ futures = "0.3"
 futures-core = { version = "0.3.0", default-features = false }
 futures-util = { version = "0.3.0", default-features = false }
 hex = "0.4"
-http = "0.2"
-hyper = { version = "0.14", features = [
+hyper = { version = "1.6", features = ["http1", "client"] }
+hyper-util = { version = "0.1.10", features = [
     "http1",
     "client",
-    "tcp",
-    "stream",
-    "backports",
-    "deprecated"
-], default-features = false }
+    "client-legacy",
+] }
+http = "1.0"
+http-body = "1.0"
+http-body-util = "0.1"
+tower-service = "0.3"
 cc = "1.1.31"
-hyper-util = "0.1.3"
 log = { version = "0.4" }
 pin-project = "1"
 rand = "0.8.3"
 regex = "1.5"
 rmp = "0.8.14"
 rmp-serde = "1.3.0"
-rustls = { version = "0.23", default-features = false, optional = true}
+rustls = { version = "0.23", default-features = false, optional = true }
 rustls-native-certs = { version = "0.7", optional = true }
 tokio = { version = "1.23", features = ["rt", "macros"] }
 tokio-rustls = { version = "0.26", default-features = false, optional = true }
@@ -45,10 +45,7 @@ libc = "0.2"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.52"
-features = [
-    "Win32_Foundation",
-    "Win32_System_Performance",
-]
+features = ["Win32_Foundation", "Win32_System_Performance"]
 
 [target.'cfg(unix)'.dependencies]
 hyper-rustls = { version = "0.27", default-features = false, features = [
@@ -73,7 +70,7 @@ maplit = "1.0"
 
 [features]
 default = ["https"]
-https = ["tokio-rustls", "rustls", "hyper-rustls"]
+https = ["tokio-rustls", "rustls", "hyper-rustls", "rustls-native-certs"]
 use_webpki_roots = ["hyper-rustls/webpki-roots"]
 # Enable this feature to enable stubbing of cgroup
 # php directly import this crate and uses functions gated by this feature for their test

--- a/ddcommon/Cargo.toml
+++ b/ddcommon/Cargo.toml
@@ -36,10 +36,10 @@ rand = "0.8.3"
 regex = "1.5"
 rmp = "0.8.14"
 rmp-serde = "1.3.0"
-rustls = { version = "0.23", default-features = false }
-rustls-native-certs = { version = "0.7" }
+rustls = { version = "0.23", default-features = false, optional = true}
+rustls-native-certs = { version = "0.7", optional = true }
 tokio = { version = "1.23", features = ["rt", "macros"] }
-tokio-rustls = { version = "0.26", default-features = false }
+tokio-rustls = { version = "0.26", default-features = false, optional = true }
 serde = { version = "1.0", features = ["derive"] }
 static_assertions = "1.1.0"
 libc = "0.2"
@@ -57,7 +57,7 @@ hyper-rustls = { version = "0.27", default-features = false, features = [
     "http1",
     "tls12",
     "aws-lc-rs",
-] }
+], optional = true }
 memfd = { version = "0.6" }
 
 [target.'cfg(not(unix))'.dependencies]
@@ -66,14 +66,15 @@ hyper-rustls = { version = "0.27", default-features = false, features = [
     "http1",
     "tls12",
     "ring",
-] }
+], optional = true }
 
 [dev-dependencies]
 indexmap = "2.2"
 maplit = "1.0"
 
 [features]
-default = []
+default = ["https"]
+https = ["tokio-rustls", "rustls", "hyper-rustls"]
 use_webpki_roots = ["hyper-rustls/webpki-roots"]
 # Enable this feature to enable stubbing of cgroup
 # php directly import this crate and uses functions gated by this feature for their test

--- a/ddcommon/src/config.rs
+++ b/ddcommon/src/config.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod parse_env {
-    use http::Uri;
+    use hyper::Uri;
     use std::{env, str::FromStr, time::Duration};
 
     use crate::parse_uri;

--- a/ddcommon/src/connector/mod.rs
+++ b/ddcommon/src/connector/mod.rs
@@ -55,15 +55,15 @@ impl Connector {
         }
         #[cfg(not(feature = "https"))]
         {
-            Connector::Http(HttpConnector::new())
+            Connector::Http(connect::HttpConnector::new())
         }
     }
 
-    fn build_conn_stream<'a>(
+    fn build_conn_stream(
         &mut self,
         uri: hyper::Uri,
         require_tls: bool,
-    ) -> BoxFuture<'a, Result<ConnStream, ConnStreamError>> {
+    ) -> BoxFuture<'static, Result<ConnStream, ConnStreamError>> {
         match self {
             Self::Http(c) => {
                 if require_tls {

--- a/ddcommon/src/hyper_migration.rs
+++ b/ddcommon/src/hyper_migration.rs
@@ -59,14 +59,14 @@ impl fmt::Display for Error {
 
 impl std::error::Error for Error {}
 
-pub fn mock_reponse(
+pub fn mock_response(
     builder: http::response::Builder,
     body: hyper::body::Bytes,
 ) -> anyhow::Result<HttpResponse> {
     Ok(builder.body(Body::from_bytes(body))?)
 }
 
-pub fn empty_reponse(builder: http::response::Builder) -> anyhow::Result<HttpResponse> {
+pub fn empty_response(builder: http::response::Builder) -> anyhow::Result<HttpResponse> {
     Ok(builder.body(Body::empty())?)
 }
 

--- a/ddcommon/src/hyper_migration.rs
+++ b/ddcommon/src/hyper_migration.rs
@@ -1,0 +1,196 @@
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+use core::fmt;
+use std::{convert::Infallible, task::Poll};
+
+use crate::connector::{self, Connector};
+use http_body_util::BodyExt;
+use hyper::body::Incoming;
+use pin_project::pin_project;
+// Need aliases because cbindgen is not smart enough to figure type aliases
+use hyper::Request as HyperRequest;
+
+/// Create a new default configuration hyper client for fixed interval sending.
+///
+/// This client does not keep connections because otherwise we would get a pipe closed
+/// every second connection because of low keep alive in the agent.
+///
+/// This is on general not a problem if we use the client once every tens of seconds.
+pub fn new_client_periodic() -> HttpClient {
+    hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::default())
+        .pool_max_idle_per_host(0)
+        .build(Connector::new())
+}
+
+/// Create a new default configuration hyper client.
+///
+/// It will keep connections open for a longer time and reuse them.
+pub fn new_default_client() -> HttpClient {
+    hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::default())
+        .build(Connector::new())
+}
+
+pub type HttpResponse = hyper::Response<Body>;
+pub type HttpRequest = HyperRequest<Body>;
+pub type ClientError = hyper_util::client::legacy::Error;
+pub type ResponseFuture = hyper_util::client::legacy::ResponseFuture;
+
+pub fn into_response(response: hyper::Response<Incoming>) -> HttpResponse {
+    response.map(Body::Incoming)
+}
+
+#[derive(Debug)]
+pub enum Error {
+    Hyper(hyper::Error),
+    Other(anyhow::Error),
+    Infallible(Infallible),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Hyper(e) => write!(f, "hyper error: {}", e),
+            Error::Infallible(e) => match *e {},
+            Error::Other(e) => write!(f, "other error: {}", e),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+pub fn mock_reponse(
+    builder: http::response::Builder,
+    body: hyper::body::Bytes,
+) -> anyhow::Result<HttpResponse> {
+    Ok(builder.body(Body::from_bytes(body))?)
+}
+
+pub fn empty_reponse(builder: http::response::Builder) -> anyhow::Result<HttpResponse> {
+    Ok(builder.body(Body::empty())?)
+}
+
+#[pin_project(project=BodyProj)]
+#[derive(Debug)]
+pub enum Body {
+    Single(#[pin] http_body_util::Full<hyper::body::Bytes>),
+    Empty(#[pin] http_body_util::Empty<hyper::body::Bytes>),
+    Boxed(#[pin] http_body_util::combinators::BoxBody<hyper::body::Bytes, anyhow::Error>),
+    Channel(#[pin] tokio::sync::mpsc::Receiver<hyper::body::Bytes>),
+    Incoming(#[pin] hyper::body::Incoming),
+}
+
+pub struct Sender {
+    tx: tokio::sync::mpsc::Sender<hyper::body::Bytes>,
+}
+
+impl Sender {
+    pub async fn send_data(&self, data: hyper::body::Bytes) -> anyhow::Result<()> {
+        self.tx.send(data).await?;
+        Ok(())
+    }
+}
+
+impl Body {
+    pub fn empty() -> Self {
+        Body::Empty(http_body_util::Empty::new())
+    }
+
+    pub fn from_bytes(bytes: hyper::body::Bytes) -> Self {
+        Body::Single(http_body_util::Full::new(bytes))
+    }
+
+    pub fn boxed<
+        E: std::error::Error + Sync + Send + 'static,
+        T: hyper::body::Body<Data = hyper::body::Bytes, Error = E> + Sync + Send + 'static,
+    >(
+        body: T,
+    ) -> Self {
+        Body::Boxed(body.map_err(anyhow::Error::from).boxed())
+    }
+
+    pub fn channel() -> (Sender, Self) {
+        let (tx, rx) = tokio::sync::mpsc::channel(1);
+        (Sender { tx }, Body::Channel(rx))
+    }
+
+    pub fn incoming(incoming: Incoming) -> Self {
+        Body::Incoming(incoming)
+    }
+}
+
+impl Default for Body {
+    fn default() -> Self {
+        Body::empty()
+    }
+}
+
+impl From<&'static str> for Body {
+    fn from(s: &'static str) -> Self {
+        Body::from_bytes(hyper::body::Bytes::from_static(s.as_bytes()))
+    }
+}
+
+impl From<Vec<u8>> for Body {
+    fn from(s: Vec<u8>) -> Self {
+        Body::from_bytes(hyper::body::Bytes::from(s))
+    }
+}
+
+impl From<String> for Body {
+    fn from(s: String) -> Self {
+        Body::from_bytes(hyper::body::Bytes::from(s))
+    }
+}
+
+impl hyper::body::Body for Body {
+    type Data = hyper::body::Bytes;
+
+    type Error = Error;
+
+    fn poll_frame(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+        match self.project() {
+            BodyProj::Single(pin) => pin.poll_frame(cx).map_err(Error::Infallible),
+            BodyProj::Empty(pin) => pin.poll_frame(cx).map_err(Error::Infallible),
+            BodyProj::Boxed(pin) => pin.poll_frame(cx).map_err(Error::Other),
+            BodyProj::Channel(pin) => {
+                let data = match pin.get_mut().poll_recv(cx) {
+                    Poll::Ready(Some(data)) => data,
+                    Poll::Ready(None) => return Poll::Ready(None),
+                    Poll::Pending => return Poll::Pending,
+                };
+                Poll::Ready(Some(Ok(hyper::body::Frame::data(data))))
+            }
+            BodyProj::Incoming(pin) => pin.poll_frame(cx).map_err(Error::Hyper),
+        }
+    }
+
+    fn is_end_stream(&self) -> bool {
+        match self {
+            Body::Single(body) => body.is_end_stream(),
+            Body::Empty(body) => body.is_end_stream(),
+            Body::Boxed(body) => body.is_end_stream(),
+            Body::Channel(body) => body.is_closed(),
+            Body::Incoming(body) => body.is_end_stream(),
+        }
+    }
+
+    fn size_hint(&self) -> http_body::SizeHint {
+        match self {
+            Body::Single(body) => body.size_hint(),
+            Body::Empty(body) => body.size_hint(),
+            Body::Boxed(body) => body.size_hint(),
+            Body::Channel(_) => http_body::SizeHint::default(),
+            Body::Incoming(body) => body.size_hint(),
+        }
+    }
+}
+
+pub type HttpClient = hyper_util::client::legacy::Client<connector::Connector, Body>;
+
+pub fn client_builder() -> hyper_util::client::legacy::Builder {
+    hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::default())
+}

--- a/ddcommon/src/lib.rs
+++ b/ddcommon/src/lib.rs
@@ -21,6 +21,7 @@ pub mod entity_id;
 #[macro_use]
 pub mod cstr;
 pub mod config;
+pub mod hyper_migration;
 pub mod rate_limiter;
 pub mod tag;
 pub mod tracer_metadata;
@@ -103,8 +104,8 @@ pub mod header {
         HeaderName::from_static("x-datadog-test-session-token");
 }
 
-pub type HttpClient = hyper::Client<connector::Connector, hyper::Body>;
-pub type HttpResponse = hyper::Response<hyper::Body>;
+pub type HttpClient = hyper_migration::HttpClient;
+pub type HttpResponse = hyper_migration::HttpResponse;
 pub type HttpRequestBuilder = hyper::http::request::Builder;
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]

--- a/ddtelemetry/Cargo.toml
+++ b/ddtelemetry/Cargo.toml
@@ -19,8 +19,10 @@ ddcommon = { path = "../ddcommon" }
 datadog-ddsketch = { path = "../ddsketch" }
 base64 = "0.22"
 futures = { version = "0.3", default-features = false }
-http = "0.2"
-hyper = { version = "0.14", features = ["client", "backports", "deprecated"], default-features = false }
+hyper = { version = "1.6", features = ["http1", "client"] }
+hyper-util = { version = "0.1", features = ["http1", "client", "client-legacy"] }
+http-body-util = "0.1"
+http = "1.0"
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }

--- a/ddtelemetry/src/worker/http_client.rs
+++ b/ddtelemetry/src/worker/http_client.rs
@@ -92,7 +92,7 @@ impl HttpClient for MockClient {
                 writer.write_all(body.as_ref())?;
             }
 
-            hyper_migration::empty_reponse(hyper::Response::builder().status(202))
+            hyper_migration::empty_response(hyper::Response::builder().status(202))
         })
     }
 }

--- a/ddtelemetry/src/worker/http_client.rs
+++ b/ddtelemetry/src/worker/http_client.rs
@@ -1,10 +1,8 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use ddcommon::HttpRequestBuilder;
-use http::{Request, Response};
-use hyper::body::HttpBody;
-use hyper::Body;
+use ddcommon::{hyper_migration, HttpRequestBuilder};
+use http_body_util::BodyExt;
 use std::{
     fs::OpenOptions,
     future::Future,
@@ -25,10 +23,10 @@ pub mod header {
 }
 
 pub type ResponseFuture =
-    Pin<Box<dyn Future<Output = Result<Response<Body>, hyper::Error>> + Send>>;
+    Pin<Box<dyn Future<Output = Result<hyper_migration::HttpResponse, anyhow::Error>> + Send>>;
 
 pub trait HttpClient {
-    fn request(&self, req: Request<hyper::Body>) -> ResponseFuture;
+    fn request(&self, req: hyper_migration::HttpRequest) -> ResponseFuture;
 }
 
 pub fn request_builder(c: &Config) -> anyhow::Result<HttpRequestBuilder> {
@@ -60,9 +58,7 @@ pub fn from_config(c: &Config) -> Box<dyn HttpClient + Sync + Send> {
         Some(_) | None => {}
     };
     Box::new(HyperClient {
-        inner: hyper::Client::builder()
-            .pool_idle_timeout(std::time::Duration::from_secs(30))
-            .build(ddcommon::connector::Connector::default()),
+        inner: hyper_migration::new_client_periodic(),
     })
 }
 
@@ -71,8 +67,9 @@ pub struct HyperClient {
 }
 
 impl HttpClient for HyperClient {
-    fn request(&self, req: Request<hyper::Body>) -> ResponseFuture {
-        Box::pin(self.inner.request(req))
+    fn request(&self, req: hyper_migration::HttpRequest) -> ResponseFuture {
+        let resp = self.inner.request(req);
+        Box::pin(async { Ok(hyper_migration::into_response(resp.await?)) })
     }
 }
 
@@ -82,7 +79,7 @@ pub struct MockClient {
 }
 
 impl HttpClient for MockClient {
-    fn request(&self, req: Request<hyper::Body>) -> ResponseFuture {
+    fn request(&self, req: hyper_migration::HttpRequest) -> ResponseFuture {
         let s = self.clone();
         Box::pin(async move {
             let mut body = req.collect().await?.to_bytes().to_vec();
@@ -92,15 +89,10 @@ impl HttpClient for MockClient {
                 #[allow(clippy::expect_used)]
                 let mut writer = s.file.lock().expect("mutex poisoned");
 
-                #[allow(clippy::unwrap_used)]
-                writer.write_all(body.as_ref()).unwrap();
+                writer.write_all(body.as_ref())?;
             }
 
-            #[allow(clippy::unwrap_used)]
-            Ok(Response::builder()
-                .status(202)
-                .body(hyper::Body::empty())
-                .unwrap())
+            hyper_migration::empty_reponse(hyper::Response::builder().status(202))
         })
     }
 }
@@ -120,7 +112,7 @@ mod tests {
         };
         c.request(
             HttpRequestBuilder::new()
-                .body(hyper::Body::from("hello world\n"))
+                .body(hyper_migration::Body::from("hello world\n"))
                 .unwrap(),
         )
         .await

--- a/dogstatsd-client/Cargo.toml
+++ b/dogstatsd-client/Cargo.toml
@@ -15,7 +15,7 @@ cadence = "1.3.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 tracing = { version = "0.1", default-features = false }
 anyhow = { version = "1.0" }
-http = "0.2"
+http = "1.0"
 
 
 [dev-dependencies]

--- a/live-debugger/Cargo.toml
+++ b/live-debugger/Cargo.toml
@@ -7,7 +7,9 @@ version = "0.0.1"
 [dependencies]
 anyhow = "1.0"
 ddcommon = { path = "../ddcommon" }
-hyper = { version = "0.14", features = ["client", "backports", "deprecated"] }
+hyper = { version = "1.6", features = ["http1", "client"] }
+http-body-util = "0.1"
+
 regex = "1.9.3"
 percent-encoding = "2.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/profiling-ffi/Cargo.toml
+++ b/profiling-ffi/Cargo.toml
@@ -35,7 +35,8 @@ build_common = { path = "../build-common" }
 anyhow = "1.0"
 datadog-crashtracker-ffi = { path = "../crashtracker-ffi", default-features = false, optional = true}
 datadog-profiling = { path = "../profiling" }
-hyper = { version = "0.14", features = ["backports", "deprecated"], default-features = false }
+hyper = { version = "1.6", features = ["http1", "client"] }
+http-body-util = "0.1"
 ddcommon = { path = "../ddcommon"}
 ddcommon-ffi = { path = "../ddcommon-ffi", default-features = false }
 ddtelemetry-ffi = { path = "../ddtelemetry-ffi", default-features = false, optional = true, features = ["expanded_builder_macros"] }

--- a/profiling-ffi/src/exporter.rs
+++ b/profiling-ffi/src/exporter.rs
@@ -481,7 +481,7 @@ mod tests {
     use super::*;
     use ddcommon::tag;
     use ddcommon_ffi::Slice;
-    use hyper::body::HttpBody;
+    use http_body_util::BodyExt;
     use serde_json::json;
 
     fn profiling_library_name() -> CharSlice<'static> {

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -29,10 +29,10 @@ futures = { version = "0.3", default-features = false }
 futures-core = {version = "0.3.0", default-features = false}
 futures-util = {version = "0.3.0", default-features = false}
 hashbrown = { version = "0.14", default-features = false, features = ["allocator-api2"] }
-http = "0.2"
-http-body = "0.4"
-hyper = {version = "0.14", features = ["client", "backports", "deprecated"], default-features = false}
-hyper-multipart-rfc7578 = "0.7.0"
+http = "1.0"
+hyper = { version = "1.6", features = ["http1", "client"] }
+http-body-util = "0.1"
+hyper-multipart-rfc7578 = "0.9.0"
 indexmap = "2.2"
 libc = "0.2"
 lz4_flex = { version = "0.9", default-features = false, features = ["std", "safe-encode", "frame"] }

--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -15,7 +15,9 @@ use serde_json::json;
 use tokio::runtime::Runtime;
 use tokio_util::sync::CancellationToken;
 
-use ddcommon::{azure_app_services, connector, Endpoint, HttpClient, HttpResponse};
+use ddcommon::{
+    azure_app_services, connector, hyper_migration, Endpoint, HttpClient, HttpResponse,
+};
 
 pub mod config;
 mod errors;
@@ -57,11 +59,11 @@ pub struct File<'a> {
 #[derive(Debug)]
 pub struct Request {
     timeout: Option<std::time::Duration>,
-    req: hyper::Request<hyper::Body>,
+    req: hyper_migration::HttpRequest,
 }
 
-impl From<hyper::Request<hyper::Body>> for Request {
-    fn from(req: hyper::Request<hyper::Body>) -> Self {
+impl From<hyper_migration::HttpRequest> for Request {
+    fn from(req: hyper_migration::HttpRequest) -> Self {
         Self { req, timeout: None }
     }
 }
@@ -88,7 +90,7 @@ impl Request {
         self.req.headers()
     }
 
-    pub fn body(self) -> hyper::Body {
+    pub fn body(self) -> hyper_migration::Body {
         self.req.into_body()
     }
 
@@ -96,7 +98,7 @@ impl Request {
         self,
         client: &HttpClient,
         cancel: Option<&CancellationToken>,
-    ) -> anyhow::Result<hyper::Response<hyper::Body>> {
+    ) -> anyhow::Result<HttpResponse> {
         tokio::select! {
             _ = async { match cancel {
                     Some(cancellation_token) => cancellation_token.cancelled().await,
@@ -105,13 +107,16 @@ impl Request {
                 }}
             => Err(crate::exporter::errors::Error::UserRequestedCancellation.into()),
             result = async {
-                Ok(match self.timeout {
-                    Some(t) => tokio::time::timeout(t, client.request(self.req))
-                        .await
-                        .map_err(|_| crate::exporter::errors::Error::OperationTimedOut)?,
-                    None => client.request(self.req).await,
-                }?)}
-            => result,
+                match self.timeout {
+                    Some(t) => {
+                        let res = tokio::time::timeout(t, client.request(self.req)).await;
+                        res
+                            .map_err(|_| anyhow::Error::from(crate::exporter::errors::Error::OperationTimedOut))
+                    },
+                    None => Ok(client.request(self.req).await),
+                }
+            }
+            => Ok(hyper_migration::into_response(result??)),
         }
     }
 }
@@ -282,10 +287,11 @@ impl ProfileExporter {
                 self.profiling_library_version.as_ref(),
             );
 
-        Ok(
-            Request::from(form.set_body_convert::<hyper::Body, multipart::Body>(builder)?)
-                .with_timeout(std::time::Duration::from_millis(self.endpoint.timeout_ms)),
+        Ok(Request::from(
+            form.set_body::<multipart::Body>(builder)?
+                .map(hyper_migration::Body::boxed),
         )
+        .with_timeout(std::time::Duration::from_millis(self.endpoint.timeout_ms)))
     }
 
     pub fn send(
@@ -307,9 +313,7 @@ impl Exporter {
     /// Creates a new Exporter, initializing the TLS stack.
     pub fn new() -> anyhow::Result<Self> {
         // Set idle to 0, which prevents the pipe being broken every 2nd request
-        let client = hyper::Client::builder()
-            .pool_max_idle_per_host(0)
-            .build(connector::Connector::default());
+        let client = hyper_migration::new_client_periodic();
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()?;
@@ -323,12 +327,14 @@ impl Exporter {
         mut headers: hyper::header::HeaderMap,
         body: &[u8],
         timeout: std::time::Duration,
-    ) -> anyhow::Result<hyper::Response<hyper::Body>> {
+    ) -> anyhow::Result<hyper_migration::HttpResponse> {
         self.runtime.block_on(async {
             let mut request = hyper::Request::builder()
                 .method(http_method)
                 .uri(url)
-                .body(hyper::Body::from(Bytes::copy_from_slice(body)))?;
+                .body(hyper_migration::Body::from_bytes(Bytes::copy_from_slice(
+                    body,
+                )))?;
             std::mem::swap(request.headers_mut(), &mut headers);
 
             let request: Request = request.into();

--- a/profiling/tests/form.rs
+++ b/profiling/tests/form.rs
@@ -61,7 +61,7 @@ mod tests {
     use crate::multipart;
     use datadog_profiling::exporter::*;
     use ddcommon::tag;
-    use hyper::body::HttpBody;
+    use http_body_util::BodyExt;
     use serde_json::json;
 
     fn default_tags() -> Vec<Tag> {

--- a/remote-config/Cargo.toml
+++ b/remote-config/Cargo.toml
@@ -5,7 +5,7 @@ name = "datadog-remote-config"
 version = "0.0.1"
 
 [features]
-test = []
+test = ["hyper/server", "hyper-util"]
 
 [dependencies]
 anyhow = { version = "1.0" }
@@ -13,8 +13,9 @@ ddcommon = { path = "../ddcommon" }
 datadog-dynamic-configuration = { path = "../dynamic-configuration" }
 datadog-trace-protobuf = { path = "../trace-protobuf" }
 datadog-live-debugger = { path = "../live-debugger" }
-hyper = { version = "0.14", features = ["client", "backports", "deprecated"], default-features = false }
-http = "0.2"
+hyper = { version = "1.6", features = ["http1", "client"] }
+http-body-util = "0.1"
+http = "1.0"
 base64 = "0.22.1"
 sha2 = "0.10"
 uuid = { version = "1.7.0", features = ["v4"] }
@@ -27,8 +28,10 @@ tracing = { version = "0.1", default-features = false }
 serde = "1.0"
 serde_json = { version = "1.0", features = ["raw_value"] }
 
+# Test feature
+hyper-util = {version = "0.1", features = ["service"], optional = true}
+
 [dev-dependencies]
-hyper = { version = "0.14", features = ["client", "server", "backports", "deprecated"], default-features = false }
 futures = "0.3"
 
 [lib]

--- a/remote-config/src/fetch/fetcher.rs
+++ b/remote-config/src/fetch/fetcher.rs
@@ -665,9 +665,7 @@ pub mod tests {
     #[tokio::test]
     #[cfg_attr(miri, ignore)]
     async fn test_fetch_cache() {
-        eprintln!("before spawn");
         let server = RemoteConfigServer::spawn();
-        eprintln!("spawned");
 
         server.files.lock().unwrap().insert(
             get_path_first().clone(),

--- a/remote-config/src/fetch/test_server.rs
+++ b/remote-config/src/fetch/test_server.rs
@@ -18,11 +18,10 @@ use base64::Engine;
 use datadog_trace_protobuf::remoteconfig::{
     ClientGetConfigsRequest, ClientGetConfigsResponse, File,
 };
-use ddcommon::Endpoint;
-use http::{Request, Response};
-use hyper::body::HttpBody;
-use hyper::service::{make_service_fn, service_fn};
-use hyper::{Body, Server};
+use ddcommon::{hyper_migration, Endpoint};
+use http::Response;
+use http_body_util::BodyExt;
+use hyper::service::service_fn;
 use serde_json::value::to_raw_value;
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
@@ -37,13 +36,138 @@ pub struct RemoteConfigServer {
     pub last_request: Mutex<Option<ClientGetConfigsRequest>>,
     #[allow(clippy::type_complexity)]
     pub files: Mutex<HashMap<RemoteConfigPath, (Vec<Arc<Target>>, u64, String)>>,
-    pub next_response: Mutex<Option<Response<Body>>>,
+    pub next_response: Mutex<Option<Response<hyper_migration::Body>>>,
     pub endpoint: Endpoint,
     #[allow(dead_code)] // stops receiver on drop
-    shutdown_complete_tx: Sender<()>,
+    pub shutdown_complete_tx: Sender<()>,
 }
 
 impl RemoteConfigServer {
+    fn handle_request(
+        &self,
+        body_bytes: hyper::body::Bytes,
+    ) -> Result<Response<hyper_migration::Body>, Infallible> {
+        let request: ClientGetConfigsRequest =
+            serde_json::from_str(core::str::from_utf8(&body_bytes).unwrap()).unwrap();
+        let response = if let Some(response) = self.next_response.lock().unwrap().take() {
+            response
+        } else {
+            let known: HashMap<_, _> = request
+                .cached_target_files
+                .iter()
+                .map(|m| (m.path.clone(), m.hashes[0].hash.clone()))
+                .collect();
+            let files = self.files.lock().unwrap();
+            let applied_files: HashMap<_, _> = files
+                .iter()
+                .filter(|(_, (targets, _, _))| {
+                    let tracer = request
+                        .client
+                        .as_ref()
+                        .unwrap()
+                        .client_tracer
+                        .as_ref()
+                        .unwrap();
+                    targets.iter().any(|t| {
+                        t.service == tracer.service
+                            && t.env == tracer.env
+                            && t.app_version == tracer.app_version
+                    })
+                })
+                .collect();
+            let states = &request
+                .client
+                .as_ref()
+                .unwrap()
+                .state
+                .as_ref()
+                .unwrap()
+                .config_states;
+            if applied_files.len() == states.len()
+                && states.iter().all(|s| {
+                    for (p, (_, v, _)) in applied_files.iter() {
+                        if p.product.to_string() == s.product
+                            && p.config_id == s.id
+                            && *v == s.version
+                        {
+                            return true;
+                        }
+                    }
+                    false
+                })
+            {
+                Response::new(hyper_migration::Body::from("{}"))
+            } else {
+                let target_info: Vec<_> = applied_files
+                    .iter()
+                    .map(|(p, (_, v, file))| {
+                        (
+                            p.to_string(),
+                            format!("{:x}", Sha256::digest(file)),
+                            to_raw_value(v).unwrap(),
+                            file.clone(),
+                        )
+                    })
+                    .filter(|(p, hash, _, _)| {
+                        if let Some(existing) = known.get(p) {
+                            existing != hash
+                        } else {
+                            true
+                        }
+                    })
+                    .collect();
+                let targets = TargetsList {
+                    signatures: vec![],
+                    signed: TargetsData {
+                        _type: "",
+                        custom: TargetsCustom {
+                            agent_refresh_interval: Some(1000),
+                            opaque_backend_state: "some state",
+                        },
+                        expires: OffsetDateTime::from_unix_timestamp(253402300799).unwrap(),
+                        spec_version: "1.0.0",
+                        targets: target_info
+                            .iter()
+                            .map(|(p, hash, version, _)| {
+                                (
+                                    p.as_str(),
+                                    TargetData {
+                                        custom: HashMap::from([("v", &**version)]),
+                                        hashes: HashMap::from([("sha256", hash.as_str())]),
+                                        length: 0,
+                                    },
+                                )
+                            })
+                            .collect(),
+                        version: 1,
+                    },
+                };
+                let response = ClientGetConfigsResponse {
+                    roots: vec![], /* not checked */
+                    targets: base64::engine::general_purpose::STANDARD
+                        .encode(serde_json::to_vec(&targets).unwrap())
+                        .into_bytes(),
+                    target_files: target_info
+                        .iter()
+                        .map(|(p, _, _, file)| File {
+                            path: p.to_string(),
+                            raw: base64::engine::general_purpose::STANDARD
+                                .encode(file)
+                                .into_bytes(),
+                        })
+                        .collect(),
+                    client_configs: applied_files.keys().map(|k| k.to_string()).collect(),
+                };
+                Response::new(hyper_migration::Body::from(
+                    serde_json::to_vec(&response).unwrap(),
+                ))
+            }
+        };
+        *self.last_request.lock().unwrap() = Some(request);
+        eprintln!("reponse finished");
+        Ok(response)
+    }
+
     pub fn spawn() -> Arc<Self> {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
@@ -56,158 +180,33 @@ impl RemoteConfigServer {
             shutdown_complete_tx,
         });
         let this = server.clone();
+        let service = service_fn(move |req: hyper::Request<hyper::body::Incoming>| {
+            let this = this.clone();
+            async move {
+                eprintln!("new response");
+                let body_bytes = req.into_body().collect().await.unwrap().to_bytes();
+                this.handle_request(body_bytes)
+            }
+        });
         tokio::spawn(async move {
-            let service = make_service_fn(|_conn| {
-                let this = this.clone();
-                async move {
-                    Ok::<_, Infallible>(service_fn(move |req: Request<Body>| {
-                        let this = this.clone();
-                        async move {
-                            let body_bytes = req.into_body().collect().await.unwrap().to_bytes();
-                            let request: ClientGetConfigsRequest =
-                                serde_json::from_str(core::str::from_utf8(&body_bytes).unwrap())
-                                    .unwrap();
-                            let response =
-                                if let Some(response) = this.next_response.lock().unwrap().take() {
-                                    response
-                                } else {
-                                    let known: HashMap<_, _> = request
-                                        .cached_target_files
-                                        .iter()
-                                        .map(|m| (m.path.clone(), m.hashes[0].hash.clone()))
-                                        .collect();
-                                    let files = this.files.lock().unwrap();
-                                    let applied_files: HashMap<_, _> = files
-                                        .iter()
-                                        .filter(|(_, (targets, _, _))| {
-                                            let tracer = request
-                                                .client
-                                                .as_ref()
-                                                .unwrap()
-                                                .client_tracer
-                                                .as_ref()
-                                                .unwrap();
-                                            targets.iter().any(|t| {
-                                                t.service == tracer.service
-                                                    && t.env == tracer.env
-                                                    && t.app_version == tracer.app_version
-                                            })
-                                        })
-                                        .collect();
-                                    let states = &request
-                                        .client
-                                        .as_ref()
-                                        .unwrap()
-                                        .state
-                                        .as_ref()
-                                        .unwrap()
-                                        .config_states;
-                                    if applied_files.len() == states.len()
-                                        && states.iter().all(|s| {
-                                            for (p, (_, v, _)) in applied_files.iter() {
-                                                if p.product.to_string() == s.product
-                                                    && p.config_id == s.id
-                                                    && *v == s.version
-                                                {
-                                                    return true;
-                                                }
-                                            }
-                                            false
-                                        })
-                                    {
-                                        Response::new(Body::from("{}"))
-                                    } else {
-                                        let target_info: Vec<_> = applied_files
-                                            .iter()
-                                            .map(|(p, (_, v, file))| {
-                                                (
-                                                    p.to_string(),
-                                                    format!("{:x}", Sha256::digest(file)),
-                                                    to_raw_value(v).unwrap(),
-                                                    file.clone(),
-                                                )
-                                            })
-                                            .filter(|(p, hash, _, _)| {
-                                                if let Some(existing) = known.get(p) {
-                                                    existing != hash
-                                                } else {
-                                                    true
-                                                }
-                                            })
-                                            .collect();
-                                        let targets = TargetsList {
-                                            signatures: vec![],
-                                            signed: TargetsData {
-                                                _type: "",
-                                                custom: TargetsCustom {
-                                                    agent_refresh_interval: Some(1000),
-                                                    opaque_backend_state: "some state",
-                                                },
-                                                expires: OffsetDateTime::from_unix_timestamp(
-                                                    253402300799,
-                                                )
-                                                .unwrap(),
-                                                spec_version: "1.0.0",
-                                                targets: target_info
-                                                    .iter()
-                                                    .map(|(p, hash, version, _)| {
-                                                        (
-                                                            p.as_str(),
-                                                            TargetData {
-                                                                custom: HashMap::from([(
-                                                                    "v", &**version,
-                                                                )]),
-                                                                hashes: HashMap::from([(
-                                                                    "sha256",
-                                                                    hash.as_str(),
-                                                                )]),
-                                                                length: 0,
-                                                            },
-                                                        )
-                                                    })
-                                                    .collect(),
-                                                version: 1,
-                                            },
-                                        };
-                                        let response = ClientGetConfigsResponse {
-                                            roots: vec![], /* not checked */
-                                            targets: base64::engine::general_purpose::STANDARD
-                                                .encode(serde_json::to_vec(&targets).unwrap())
-                                                .into_bytes(),
-                                            target_files: target_info
-                                                .iter()
-                                                .map(|(p, _, _, file)| File {
-                                                    path: p.to_string(),
-                                                    raw: base64::engine::general_purpose::STANDARD
-                                                        .encode(file)
-                                                        .into_bytes(),
-                                                })
-                                                .collect(),
-                                            client_configs: applied_files
-                                                .keys()
-                                                .map(|k| k.to_string())
-                                                .collect(),
-                                        };
-                                        Response::new(Body::from(
-                                            serde_json::to_vec(&response).unwrap(),
-                                        ))
-                                    }
-                                };
-                            *this.last_request.lock().unwrap() = Some(request);
-                            Ok::<_, Infallible>(response)
-                        }
-                    }))
-                }
-            });
-            let server = Server::from_tcp(listener).unwrap().serve(service);
-
-            select! {
-                server_result = server => {
-                    if let Err(e) = server_result {
-                        eprintln!("server connection error: {}", e);
-                    }
-                },
-                _ = shutdown_complete_rx.recv() => {},
+            listener.set_nonblocking(true).unwrap();
+            let listener = tokio::net::TcpListener::from_std(listener).unwrap();
+            loop {
+                // let (stream, _) = listener.accept().await.unwrap();
+                let stream = select! {
+                    _ = shutdown_complete_rx.recv() => break,
+                    res = listener.accept()
+                    => {res.unwrap().0}
+                };
+                let service = service.clone();
+                eprintln!("new conn");
+                tokio::spawn(async move {
+                    eprintln!("new conn inside");
+                    hyper::server::conn::http1::Builder::new()
+                        .serve_connection(hyper_util::rt::tokio::TokioIo::new(stream), service)
+                        .await
+                        .unwrap();
+                });
             }
         });
         server

--- a/remote-config/src/fetch/test_server.rs
+++ b/remote-config/src/fetch/test_server.rs
@@ -39,7 +39,7 @@ pub struct RemoteConfigServer {
     pub next_response: Mutex<Option<Response<hyper_migration::Body>>>,
     pub endpoint: Endpoint,
     #[allow(dead_code)] // stops receiver on drop
-    pub shutdown_complete_tx: Sender<()>,
+    shutdown_complete_tx: Sender<()>,
 }
 
 impl RemoteConfigServer {
@@ -183,7 +183,6 @@ impl RemoteConfigServer {
         let service = service_fn(move |req: hyper::Request<hyper::body::Incoming>| {
             let this = this.clone();
             async move {
-                eprintln!("new response");
                 let body_bytes = req.into_body().collect().await.unwrap().to_bytes();
                 this.handle_request(body_bytes)
             }

--- a/sidecar-ffi/Cargo.toml
+++ b/sidecar-ffi/Cargo.toml
@@ -25,7 +25,7 @@ libc = "0.2"
 dogstatsd-client = { path = "../dogstatsd-client" }
 
 [dev-dependencies]
-hyper = { version = "0.14", features = ["backports", "deprecated"], default-features = false }
+http = "1.0"
 tempfile = { version = "3.3" }
 
 [lints.rust]

--- a/sidecar-ffi/tests/sidecar.rs
+++ b/sidecar-ffi/tests/sidecar.rs
@@ -87,7 +87,7 @@ fn test_ddog_sidecar_register_app() {
             &mut transport,
             "session_id".into(),
             &Endpoint {
-                url: hyper::Uri::from_static("http://localhost:8082/"),
+                url: http::Uri::from_static("http://localhost:8082/"),
                 ..Default::default()
             },
             &Endpoint::default(),
@@ -143,7 +143,7 @@ fn test_ddog_sidecar_register_app() {
             &mut transport,
             "session_id".into(),
             &Endpoint {
-                url: hyper::Uri::from_static("http://localhost:8083/"),
+                url: http::Uri::from_static("http://localhost:8083/"),
                 ..Default::default()
             },
             &Endpoint::default(),

--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -30,8 +30,9 @@ tinybytes = { path = "../tinybytes" }
 
 futures = { version = "0.3", default-features = false }
 manual_future = "0.1.1"
-http = "0.2"
-hyper = { version = "0.14", features = ["client", "backports", "deprecated"], default-features = false }
+http = "1.0"
+hyper = { version = "1.6", features = ["http1", "client"] }
+http-body-util = "0.1"
 
 datadog-ipc = { path = "../ipc", features = ["tiny-bytes"] }
 datadog-ipc-macros = { path = "../ipc/macros" }

--- a/sidecar/src/service/tracing/trace_flusher.rs
+++ b/sidecar/src/service/tracing/trace_flusher.rs
@@ -9,7 +9,7 @@ use datadog_trace_utils::trace_utils::SendData;
 use datadog_trace_utils::trace_utils::SendDataResult;
 use ddcommon::{Endpoint, MutexExt};
 use futures::future::join_all;
-use hyper::body::HttpBody;
+use http_body_util::BodyExt;
 use manual_future::{ManualFuture, ManualFutureCompleter};
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::Entry;

--- a/trace-mini-agent/Cargo.toml
+++ b/trace-mini-agent/Cargo.toml
@@ -12,7 +12,10 @@ bench = false
 
 [dependencies]
 anyhow = "1.0"
-hyper = { version = "0.14", default-features = false, features = ["server", "backports", "deprecated"] }
+hyper = { version = "1.6", features = ["http1", "client", "server"] }
+hyper-util = {version = "0.1", features = ["service"] }
+tower = { version = "0.5.2", features = ["util"]  }
+http-body-util = "0.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"]}
 async-trait = "0.1.64"
 tracing = { version = "0.1", default-features = false }

--- a/trace-mini-agent/src/env_verifier.rs
+++ b/trace-mini-agent/src/env_verifier.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use async_trait::async_trait;
-use hyper::body::HttpBody;
-use hyper::{Body, Client, Method, Request, Response};
+use ddcommon::hyper_migration;
+use http_body_util::BodyExt;
+use hyper::{Method, Request};
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::fs;
@@ -177,23 +178,24 @@ fn get_region_from_gcp_region_string(str: String) -> String {
 /// tests
 #[async_trait]
 pub(crate) trait GoogleMetadataClient {
-    async fn get_metadata(&self) -> anyhow::Result<Response<Body>>;
+    async fn get_metadata(&self) -> anyhow::Result<hyper_migration::HttpResponse>;
 }
+
 struct GoogleMetadataClientWrapper {}
 
 #[async_trait]
 impl GoogleMetadataClient for GoogleMetadataClientWrapper {
-    async fn get_metadata(&self) -> anyhow::Result<Response<Body>> {
+    async fn get_metadata(&self) -> anyhow::Result<hyper_migration::HttpResponse> {
         let req = Request::builder()
             .method(Method::POST)
             .uri(GCP_METADATA_URL)
             .header("Metadata-Flavor", "Google")
-            .body(Body::empty())
+            .body(hyper_migration::Body::empty())
             .map_err(|err| anyhow::anyhow!(err.to_string()))?;
 
-        let client = Client::new();
+        let client = hyper_migration::new_default_client();
         match client.request(req).await {
-            Ok(res) => Ok(res),
+            Ok(res) => Ok(hyper_migration::into_response(res)),
             Err(err) => anyhow::bail!(err.to_string()),
         }
     }
@@ -233,7 +235,7 @@ async fn ensure_gcp_function_environment(
     Ok(gcp_metadata)
 }
 
-async fn get_gcp_metadata_from_body(body: hyper::Body) -> anyhow::Result<GCPMetadata> {
+async fn get_gcp_metadata_from_body(body: hyper_migration::Body) -> anyhow::Result<GCPMetadata> {
     let bytes = body.collect().await?.to_bytes();
     let body_str = String::from_utf8(bytes.to_vec())?;
     let gcp_metadata: GCPMetadata = serde_json::from_str(&body_str)?;
@@ -331,7 +333,8 @@ async fn ensure_azure_function_environment(
 mod tests {
     use async_trait::async_trait;
     use datadog_trace_utils::trace_utils;
-    use hyper::{Body, Response, StatusCode};
+    use ddcommon::hyper_migration;
+    use hyper::{body::Bytes, Response, StatusCode};
     use serde_json::json;
     use serial_test::serial;
     use std::{fs, path::Path, time::Duration};
@@ -351,7 +354,7 @@ mod tests {
         struct MockGoogleMetadataClient {}
         #[async_trait]
         impl GoogleMetadataClient for MockGoogleMetadataClient {
-            async fn get_metadata(&self) -> anyhow::Result<Response<Body>> {
+            async fn get_metadata(&self) -> anyhow::Result<hyper_migration::HttpResponse> {
                 anyhow::bail!("Random Error")
             }
         }
@@ -371,11 +374,11 @@ mod tests {
         struct MockGoogleMetadataClient {}
         #[async_trait]
         impl GoogleMetadataClient for MockGoogleMetadataClient {
-            async fn get_metadata(&self) -> anyhow::Result<Response<Body>> {
-                Ok(Response::builder()
-                    .status(StatusCode::OK)
-                    .body(Body::empty())
-                    .unwrap())
+            async fn get_metadata(&self) -> anyhow::Result<hyper_migration::HttpResponse> {
+                Ok(
+                    hyper_migration::empty_reponse(Response::builder().status(StatusCode::OK))
+                        .unwrap(),
+                )
             }
         }
         let gmc =
@@ -394,12 +397,13 @@ mod tests {
         struct MockGoogleMetadataClient {}
         #[async_trait]
         impl GoogleMetadataClient for MockGoogleMetadataClient {
-            async fn get_metadata(&self) -> anyhow::Result<Response<Body>> {
-                Ok(Response::builder()
-                    .status(StatusCode::OK)
-                    .header("Server", "Metadata Server NOT for Serverless")
-                    .body(Body::empty())
-                    .unwrap())
+            async fn get_metadata(&self) -> anyhow::Result<hyper_migration::HttpResponse> {
+                Ok(hyper_migration::empty_reponse(
+                    Response::builder()
+                        .status(StatusCode::OK)
+                        .header("Server", "Metadata Server NOT for Serverless"),
+                )
+                .unwrap())
             }
         }
         let gmc =
@@ -418,11 +422,12 @@ mod tests {
         struct MockGoogleMetadataClient {}
         #[async_trait]
         impl GoogleMetadataClient for MockGoogleMetadataClient {
-            async fn get_metadata(&self) -> anyhow::Result<Response<Body>> {
-                Ok(Response::builder()
-                    .status(StatusCode::OK)
-                    .header("Server", "Metadata Server for Serverless")
-                    .body(Body::from(
+            async fn get_metadata(&self) -> anyhow::Result<hyper_migration::HttpResponse> {
+                Ok(hyper_migration::mock_reponse(
+                    Response::builder()
+                        .status(StatusCode::OK)
+                        .header("Server", "Metadata Server for Serverless"),
+                    Bytes::from(
                         json!({
                             "instance": {
                                 "region": "projects/123123/regions/us-east1",
@@ -432,8 +437,9 @@ mod tests {
                             }
                         })
                         .to_string(),
-                    ))
-                    .unwrap())
+                    ),
+                )
+                .unwrap())
             }
         }
         let gmc =
@@ -459,13 +465,13 @@ mod tests {
         struct MockGoogleMetadataClient {}
         #[async_trait]
         impl GoogleMetadataClient for MockGoogleMetadataClient {
-            async fn get_metadata(&self) -> anyhow::Result<Response<Body>> {
+            async fn get_metadata(&self) -> anyhow::Result<hyper_migration::HttpResponse> {
                 // Sleep for 5 seconds to let the timeout trigger
                 tokio::time::sleep(Duration::from_secs(5)).await;
-                Ok(Response::builder()
-                    .status(StatusCode::OK)
-                    .body(Body::empty())
-                    .unwrap())
+                Ok(
+                    hyper_migration::empty_reponse(Response::builder().status(StatusCode::OK))
+                        .unwrap(),
+                )
             }
         }
         let gmc =

--- a/trace-mini-agent/src/env_verifier.rs
+++ b/trace-mini-agent/src/env_verifier.rs
@@ -376,7 +376,7 @@ mod tests {
         impl GoogleMetadataClient for MockGoogleMetadataClient {
             async fn get_metadata(&self) -> anyhow::Result<hyper_migration::HttpResponse> {
                 Ok(
-                    hyper_migration::empty_reponse(Response::builder().status(StatusCode::OK))
+                    hyper_migration::empty_response(Response::builder().status(StatusCode::OK))
                         .unwrap(),
                 )
             }
@@ -398,7 +398,7 @@ mod tests {
         #[async_trait]
         impl GoogleMetadataClient for MockGoogleMetadataClient {
             async fn get_metadata(&self) -> anyhow::Result<hyper_migration::HttpResponse> {
-                Ok(hyper_migration::empty_reponse(
+                Ok(hyper_migration::empty_response(
                     Response::builder()
                         .status(StatusCode::OK)
                         .header("Server", "Metadata Server NOT for Serverless"),
@@ -423,7 +423,7 @@ mod tests {
         #[async_trait]
         impl GoogleMetadataClient for MockGoogleMetadataClient {
             async fn get_metadata(&self) -> anyhow::Result<hyper_migration::HttpResponse> {
-                Ok(hyper_migration::mock_reponse(
+                Ok(hyper_migration::mock_response(
                     Response::builder()
                         .status(StatusCode::OK)
                         .header("Server", "Metadata Server for Serverless"),
@@ -469,7 +469,7 @@ mod tests {
                 // Sleep for 5 seconds to let the timeout trigger
                 tokio::time::sleep(Duration::from_secs(5)).await;
                 Ok(
-                    hyper_migration::empty_reponse(Response::builder().status(StatusCode::OK))
+                    hyper_migration::empty_response(Response::builder().status(StatusCode::OK))
                         .unwrap(),
                 )
             }

--- a/trace-mini-agent/src/stats_processor.rs
+++ b/trace-mini-agent/src/stats_processor.rs
@@ -5,7 +5,8 @@ use std::sync::Arc;
 use std::time::UNIX_EPOCH;
 
 use async_trait::async_trait;
-use hyper::{http, Body, Request, Response, StatusCode};
+use ddcommon::hyper_migration;
+use hyper::{http, StatusCode};
 use tokio::sync::mpsc::Sender;
 use tracing::debug;
 
@@ -22,9 +23,9 @@ pub trait StatsProcessor {
     async fn process_stats(
         &self,
         config: Arc<Config>,
-        req: Request<Body>,
+        req: hyper_migration::HttpRequest,
         tx: Sender<pb::ClientStatsPayload>,
-    ) -> http::Result<Response<Body>>;
+    ) -> http::Result<hyper_migration::HttpResponse>;
 }
 
 #[derive(Clone)]
@@ -35,9 +36,9 @@ impl StatsProcessor for ServerlessStatsProcessor {
     async fn process_stats(
         &self,
         config: Arc<Config>,
-        req: Request<Body>,
+        req: hyper_migration::HttpRequest,
         tx: Sender<pb::ClientStatsPayload>,
-    ) -> http::Result<Response<Body>> {
+    ) -> http::Result<hyper_migration::HttpResponse> {
         debug!("Received trace stats to process");
         let (parts, body) = req.into_parts();
 

--- a/trace-utils/Cargo.toml
+++ b/trace-utils/Cargo.toml
@@ -39,9 +39,6 @@ tinybytes = { path = "../tinybytes", features = [
 ] }
 
 # Proxy feature
-# hyper-proxy = { version = "0.9.1", default-features = false, features = [
-#     "rustls",
-# ], optional = true }
 hyper-http-proxy = { version = "1.1.0", default-features = false, features = [
     "rustls-tls-webpki-roots",
 ], optional = true }

--- a/trace-utils/Cargo.toml
+++ b/trace-utils/Cargo.toml
@@ -18,7 +18,6 @@ path = "benches/main.rs"
 anyhow = "1.0"
 hyper = { version = "0.14", features = ["client", "server", "runtime", "backports", "deprecated"] }
 hyper-proxy = { version = "0.9.1", default-features = false, features = ["rustls"], optional = true }
-hyper-rustls = {version = "0.27", default-features = false, features = ["native-tokio", "http1", "tls12"]}
 serde = { version = "1.0.145", features = ["derive"] }
 prost = "0.11.6"
 rmp-serde = "1.1.1"

--- a/trace-utils/Cargo.toml
+++ b/trace-utils/Cargo.toml
@@ -16,12 +16,9 @@ path = "benches/main.rs"
 
 [dependencies]
 anyhow = "1.0"
-hyper = { version = "0.14", features = [
-    "client",
-    "tcp",
-    "backports",
-    "deprecated",
-] }
+hyper = { version = "1.6", features = ["http1", "client"] }
+http-body-util = "0.1"
+
 serde = { version = "1.0.145", features = ["derive"] }
 prost = "0.11.6"
 rmp-serde = "1.1.1"
@@ -42,8 +39,11 @@ tinybytes = { path = "../tinybytes", features = [
 ] }
 
 # Proxy feature
-hyper-proxy = { version = "0.9.1", default-features = false, features = [
-    "rustls",
+# hyper-proxy = { version = "0.9.1", default-features = false, features = [
+#     "rustls",
+# ], optional = true }
+hyper-http-proxy = { version = "1.1.0", default-features = false, features = [
+    "rustls-tls-webpki-roots",
 ], optional = true }
 
 # Compression feature
@@ -77,5 +77,5 @@ test-utils = [
     "cargo-platform",
     "urlencoding",
 ]
-proxy = ["hyper-proxy"]
+proxy = ["hyper-http-proxy"]
 compression = ["zstd", "flate2"]

--- a/trace-utils/src/send_data/send_data_result.rs
+++ b/trace-utils/src/send_data/send_data_result.rs
@@ -3,13 +3,13 @@
 
 use crate::send_with_retry::{SendWithRetryError, SendWithRetryResult};
 use anyhow::anyhow;
-use hyper::{Body, Response};
+use ddcommon::hyper_migration;
 use std::collections::HashMap;
 
 #[derive(Debug)]
 pub struct SendDataResult {
     /// Keeps track of the last request result.
-    pub last_result: anyhow::Result<Response<Body>>,
+    pub last_result: anyhow::Result<hyper_migration::HttpResponse>,
     /// Count metric for 'trace_api.requests'.
     pub requests_count: u64,
     /// Count metric for 'trace_api.responses'. Each key maps a different HTTP status code.

--- a/trace-utils/src/test_utils/datadog_test_agent.rs
+++ b/trace-utils/src/test_utils/datadog_test_agent.rs
@@ -7,8 +7,9 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use cargo_metadata::MetadataCommand;
-use hyper::body::HttpBody;
-use hyper::{Client, Uri};
+use ddcommon::hyper_migration;
+use http_body_util::BodyExt;
+use hyper::Uri;
 use testcontainers::core::AccessMode;
 use testcontainers::{
     core::{Mount, WaitFor},
@@ -281,7 +282,7 @@ impl DatadogTestAgent {
     ///
     /// * `snapshot_token` - A string slice that holds the snapshot token.
     pub async fn assert_snapshot(&self, snapshot_token: &str) {
-        let client = Client::new();
+        let client = hyper_migration::new_default_client();
         let uri = self
             .get_uri_for_endpoint("test/session/snapshot", Some(snapshot_token))
             .await;
@@ -338,7 +339,7 @@ impl DatadogTestAgent {
         session_token: &str,
         agent_sample_rates_by_service: Option<&str>,
     ) {
-        let client = Client::new();
+        let client = hyper_migration::new_default_client();
 
         let mut query_params_map = HashMap::new();
         query_params_map.insert(SESSION_TEST_TOKEN_QUERY_PARAM_KEY, session_token);


### PR DESCRIPTION
# What does this PR do?

Update all direct dependencies from hyper 0.14 to hyper 1.x

The path of migration is not always obvious:
* The hyper::Client struct was dropped
  *  Migration: use hyper_utils::client::legacy
* hyper::Body was dropped in favor of a trait that people are free to implement
  * Migration: This one is hard to fix. hyper::Body was a unifying struct over multiple behaviors (incoming and outgoing requests) (empty body, single body, streaming body)
    To match the previous behaviour I implemented hyper_migration::Body, an enum abstracting over all listed uses cases.
    This type is used everywhere to unify the Body types used in libdatadog
* hyper::Server was dropped in favor of a simpler, connection oriented server 
  * Migration: implement the accept spawn responder task loop ourselves. This is one of the things where I am the less sure we keep previous behaviour. Looking at hyper 0.14 code I don't think we are missing any part with the current migrated code in the mini-agent but without integration tests it's hard to be sure.
* Because of the migration, hyper_util::Error is less descriptive than hyper::Error, which makes migration of the TraceExporterError not easy. We try to unwrap and find the source error as much as we can to preserve the behavior, and use anyhow to store the source error
* hyper_proxy use in trace-util for the mini-agent has not migrated to hyper 1 (and is in general not maintained)
  * Migration: Use `hyper-http-proxy` a fork that did the update. We could also vendor the code because it's pretty small


We're not completely free of hyper 0.14 though sadly because httpmock, a dev-dependency of the data-pipeline crate has not migrated yet to hyper 1.


# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
