### PR TITLE
perf(profiling)!: remove Function.start_line

### DIFF
--- a/profiling-ffi/src/profiles.rs
+++ b/profiling-ffi/src/profiles.rs
@@ -164,9 +164,6 @@ pub struct Function<'a> {
     /// Source file containing the function.
     pub filename: CharSlice<'a>,
     pub filename_id: ManagedStringId,
-
-    /// Line number in source file.
-    pub start_line: i64,
 }
 
 #[repr(C)]
@@ -286,7 +283,6 @@ impl<'a> TryFrom<&'a Function<'a>> for api::Function<'a> {
             name,
             system_name,
             filename,
-            start_line: function.start_line,
         })
     }
 }
@@ -297,7 +293,6 @@ impl<'a> From<&'a Function<'a>> for api::StringIdFunction {
             name: function.name_id,
             system_name: function.system_name_id,
             filename: function.filename_id,
-            start_line: function.start_line,
         }
     }
 }
@@ -907,7 +902,6 @@ mod tests {
                     system_name_id: ManagedStringId { value: 0 },
                     filename: "index.php".into(),
                     filename_id: ManagedStringId { value: 0 },
-                    start_line: 0,
                 },
                 ..Default::default()
             }];
@@ -972,7 +966,6 @@ mod tests {
                 system_name_id: ManagedStringId { value: 0 },
                 filename: "index.php".into(),
                 filename_id: ManagedStringId { value: 0 },
-                start_line: 0,
             },
             ..Default::default()
         }];
@@ -985,7 +978,6 @@ mod tests {
                 system_name_id: ManagedStringId { value: 0 },
                 filename: "index.php".into(),
                 filename_id: ManagedStringId { value: 0 },
-                start_line: 3,
             },
             line: 4,
             ..Default::default()

--- a/profiling-replayer/src/replayer.rs
+++ b/profiling-replayer/src/replayer.rs
@@ -206,7 +206,6 @@ impl<'pprof> Replayer<'pprof> {
             name: profile_index.get_string(function.name)?,
             system_name: profile_index.get_string(function.system_name)?,
             filename: profile_index.get_string(function.filename)?,
-            start_line: function.start_line,
         })
     }
 

--- a/profiling/src/api.rs
+++ b/profiling/src/api.rs
@@ -78,9 +78,6 @@ pub struct Function<'a> {
 
     /// Source file containing the function.
     pub filename: &'a str,
-
-    /// Line number in source file.
-    pub start_line: i64,
 }
 
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq)]
@@ -89,7 +86,6 @@ pub struct StringIdFunction {
     pub name: ManagedStringId,
     pub system_name: ManagedStringId,
     pub filename: ManagedStringId,
-    pub start_line: i64,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -326,7 +322,6 @@ fn function_fetch(pprof: &pprof::Profile, id: u64) -> anyhow::Result<Function> {
             name: string_table_fetch(pprof, function.name)?,
             system_name: string_table_fetch(pprof, function.system_name)?,
             filename: string_table_fetch(pprof, function.filename)?,
-            start_line: function.start_line,
         }),
         None => anyhow::bail!("Function {id} was not found."),
     }

--- a/profiling/src/internal/function.rs
+++ b/profiling/src/internal/function.rs
@@ -11,7 +11,6 @@ pub struct Function {
     pub name: StringId,
     pub system_name: StringId,
     pub filename: StringId,
-    pub start_line: i64,
 }
 
 impl Item for Function {
@@ -27,7 +26,6 @@ impl PprofItem for Function {
             name: self.name.to_raw_id(),
             system_name: self.system_name.to_raw_id(),
             filename: self.filename.to_raw_id(),
-            start_line: self.start_line,
         }
     }
 }

--- a/profiling/src/internal/profile/fuzz_tests.rs
+++ b/profiling/src/internal/profile/fuzz_tests.rs
@@ -16,18 +16,14 @@ pub struct Function {
 
     /// Source file containing the function.
     pub filename: Box<str>,
-
-    /// Line number in source file.
-    pub start_line: i64,
 }
 
 impl Function {
-    pub fn new(name: Box<str>, system_name: Box<str>, filename: Box<str>, start_line: i64) -> Self {
+    pub fn new(name: Box<str>, system_name: Box<str>, filename: Box<str>) -> Self {
         Self {
             name,
             system_name,
             filename,
-            start_line,
         }
     }
 }
@@ -38,7 +34,6 @@ impl<'a> From<&'a Function> for api::Function<'a> {
             name: &value.name,
             system_name: &value.system_name,
             filename: &value.filename,
-            start_line: value.start_line,
         }
     }
 }
@@ -306,7 +301,6 @@ fn assert_samples_eq(
                     .into_boxed_str(),
                 profile.string_table_fetch_owned(function.system_name),
                 profile.string_table_fetch_owned(function.filename),
-                function.start_line,
             );
             let owned_location =
                 Location::new(owned_mapping, owned_function, location.address, line.line);

--- a/profiling/src/internal/profile/mod.rs
+++ b/profiling/src/internal/profile/mod.rs
@@ -416,12 +416,10 @@ impl Profile {
         let system_name = self.intern(function.system_name);
         let filename = self.intern(function.filename);
 
-        let start_line = function.start_line;
         self.functions.dedup(Function {
             name,
             system_name,
             filename,
-            start_line,
         })
     }
 
@@ -433,12 +431,10 @@ impl Profile {
         let system_name = self.resolve(function.system_name)?;
         let filename = self.resolve(function.filename)?;
 
-        let start_line = function.start_line;
         Ok(self.functions.dedup(Function {
             name,
             system_name,
             filename,
-            start_line,
         }))
     }
 
@@ -823,7 +819,6 @@ mod api_tests {
                     name: "phpinfo",
                     system_name: "phpinfo",
                     filename: "index.php",
-                    start_line: 0,
                 },
                 ..Default::default()
             },
@@ -866,7 +861,6 @@ mod api_tests {
                 name: "{main}",
                 system_name: "{main}",
                 filename: "index.php",
-                ..Default::default()
             },
             ..Default::default()
         }];
@@ -876,7 +870,6 @@ mod api_tests {
                 name: "test",
                 system_name: "test",
                 filename: "index.php",
-                start_line: 3,
             },
             ..Default::default()
         }];
@@ -886,7 +879,6 @@ mod api_tests {
                 name: "test",
                 system_name: "test",
                 filename: "index.php",
-                start_line: 4,
             },
             ..Default::default()
         }];
@@ -944,8 +936,8 @@ mod api_tests {
 
         assert_eq!(profile.samples.len(), 3);
         assert_eq!(profile.mappings.len(), 1);
-        assert_eq!(profile.locations.len(), 3);
-        assert_eq!(profile.functions.len(), 3);
+        assert_eq!(profile.locations.len(), 2); // one of them dedups
+        assert_eq!(profile.functions.len(), 2);
 
         for (index, mapping) in profile.mappings.iter().enumerate() {
             assert_eq!((index + 1) as u64, mapping.id);
@@ -1593,7 +1585,6 @@ mod api_tests {
                 name: "{main}",
                 system_name: "{main}",
                 filename: "index.php",
-                start_line: 0,
             },
             address: 0,
             line: 0,
@@ -1650,7 +1641,6 @@ mod api_tests {
                 name: "{main}",
                 system_name: "{main}",
                 filename: "index.php",
-                start_line: 0,
             },
             ..Default::default()
         }];
@@ -1808,7 +1798,6 @@ mod api_tests {
                 name: "{main}",
                 system_name: "{main}",
                 filename: "index.php",
-                start_line: 0,
             },
             ..Default::default()
         }];
@@ -1872,7 +1861,6 @@ mod api_tests {
                 name: "{main}",
                 system_name: "{main}",
                 filename: "index.php",
-                start_line: 0,
             },
             ..Default::default()
         }];

--- a/profiling/src/pprof/proto.rs
+++ b/profiling/src/pprof/proto.rs
@@ -163,9 +163,12 @@ pub struct Function {
     #[prost(int64, tag = "3")]
     pub system_name: i64, // Index into string table
     #[prost(int64, tag = "4")]
-    pub filename: i64, // Index into string table
-    #[prost(int64, tag = "5")]
-    pub start_line: i64, // Index into string table
+    pub filename: i64, /* Index into string table */
+
+                       /* We derive no value from this line, so our APIs and reprs omit it.
+                        * We comment it out here to also not waste time serializing it.
+                        * #[prost(int64, tag = "5")]
+                        *pub start_line: i64, // Index into string table */
 }
 
 #[cfg(test)]
@@ -214,7 +217,6 @@ mod tests {
             name: 4,
             system_name: 4,
             filename: 5,
-            start_line: 0,
         };
 
         let test_function = Function {
@@ -222,7 +224,6 @@ mod tests {
             name: 6,
             system_name: 6,
             filename: 5,
-            start_line: 3,
         };
 
         let main_line = Line {

--- a/profiling/tests/wordpress.rs
+++ b/profiling/tests/wordpress.rs
@@ -18,7 +18,6 @@ fn php_location<'a>(name: &'a str, filename: &'a str, line: i64) -> api::Locatio
             name,
             system_name: "",
             filename,
-            start_line: 0,
         },
         line,
     }


### PR DESCRIPTION
# What does this PR do?

This removes `start_line` from all the different profile representations. This is a compatibility break, albeit probably a small one because most profilers did not use this field before.

# Motivation

This saves memory and a small number of CPU cycles. There is no business value for this field right now, with none planned, so let's claim this back.

# Additional Notes

It doesn't impact the in-wire size except for .NET, which was previously setting this field.

# How to test the change?

Remove `start_line` from your structs if needed, then test as normal. You will have to update tests if you have functions which differed only in their `start_line`, but otherwise no other changes should be necessary. 