### PR TITLE
test: ignore some slow tests on miri, speed up one test

### DIFF
--- a/dogstatsd/src/metric.rs
+++ b/dogstatsd/src/metric.rs
@@ -583,6 +583,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn parse_tag_no_value() {
         let result = parse("datadog.tracer.flush_triggered:1|c|#lang:go,lang_version:go1.22.10,_dd.origin:lambda,runtime-id:d66f501c-d09b-4d0d-970f-515235c4eb56,v1.65.1,service:aws.lambda,reason:scheduled");
         assert!(result.is_ok());
@@ -596,6 +597,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn parse_tag_multi_column() {
         let result = parse("datadog.tracer.flush_triggered:1|c|#lang:go:and:something:else");
         assert!(result.is_ok());
@@ -606,6 +608,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn parse_tracer_metric() {
         let input = "datadog.tracer.flush_duration:0.785551|ms|#lang:go,lang_version:go1.23.2,env:redacted_env,_dd.origin:lambda,runtime-id:redacted_runtime,tracer_version:v1.70.1,service:redacted_service,env:redacted_env,service:redacted_service,version:redacted_version";
         let expected_error = "ms".to_string();
@@ -617,6 +620,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn parse_metric_timestamp() {
         // Important to test that we round down to the nearest 10 seconds
         // for our buckets
@@ -626,6 +630,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn parse_metric_no_timestamp() {
         // *wince* this could be a race condition
         // we round the timestamp down to a 10s bucket and I want to test now

--- a/live-debugger/src/expr_eval.rs
+++ b/live-debugger/src/expr_eval.rs
@@ -620,7 +620,7 @@ mod tests {
     use std::collections::HashMap;
 
     struct EvalCtx<'e> {
-        variables: &'e HashMap<String, Val>,
+        variables: &'e HashMap<&'e str, Val>,
     }
 
     #[derive(Clone, PartialEq)]
@@ -863,32 +863,32 @@ mod tests {
     #[test]
     fn test_eval() {
         let vars = HashMap::from([
-            ("var".to_string(), Val::Str("bar".to_string())),
+            ("var", Val::Str("bar".to_string())),
             (
-                "vec".to_string(),
+                "vec",
                 Val::Vec(vec![Val::Num(10.), Val::Num(11.), Val::Num(12.)]),
             ),
             (
-                "vecvec".to_string(),
+                "vecvec",
                 Val::Vec(vec![
                     Val::Vec(vec![Val::Num(10.), Val::Num(11.)]),
                     Val::Vec(vec![Val::Num(12.)]),
                 ]),
             ),
-            ("empty".to_string(), Val::Str("".to_string())),
-            ("emptyvec".to_string(), Val::Vec(vec![])),
-            ("null".to_string(), Val::Null),
-            ("zero".to_string(), Val::Num(0.)),
-            ("two".to_string(), Val::Num(2.)),
+            ("empty", Val::Str("".to_string())),
+            ("emptyvec", Val::Vec(vec![])),
+            ("null", Val::Null),
+            ("zero", Val::Num(0.)),
+            ("two", Val::Num(2.)),
             (
-                "objA".to_string(),
+                "objA",
                 Val::Obj(OrdMap(HashMap::from([(
                     "class".to_string(),
                     Val::Str("A".to_string()),
                 )]))),
             ),
             (
-                "objB".to_string(),
+                "objB",
                 Val::Obj(OrdMap(HashMap::from([(
                     "class".to_string(),
                     Val::Str("B".to_string()),

--- a/sidecar/src/log.rs
+++ b/sidecar/src/log.rs
@@ -496,6 +496,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_logs_created_counter() {
         enable_logging().ok();
 
@@ -517,6 +518,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_multi_env_filter() {
         let filter = MultiEnvFilter::default();
         filter.add("warn".to_string());

--- a/trace-obfuscation/src/obfuscate.rs
+++ b/trace-obfuscation/src/obfuscate.rs
@@ -80,6 +80,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_replace_span_tags() {
         let mut span = test_utils::create_test_span(111, 222, 0, 1, true);
         span.meta

--- a/trace-obfuscation/src/replacer.rs
+++ b/trace-obfuscation/src/replacer.rs
@@ -251,6 +251,7 @@ mod tests {
         ]
     )]
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_name() {
         let parsed_rules = replacer::parse_rules_from_string(rules);
 
@@ -281,6 +282,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_replace_rule_eq() {
         let rule1 = replacer::ReplaceRule {
             name: "http.url".to_string(),
@@ -298,6 +300,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_replace_rule_neq() {
         let rule1 = replacer::ReplaceRule {
             name: "http.url".to_string(),


### PR DESCRIPTION
# What does this PR do?

This skips some slow tests on miri.

It also converts a test to use `&str` instead of `String` to speed up the miri run for that test (rather than skipping it).

# Motivation

The miri job is slow again.

# Additional Notes

It's still a bit slow after making this change, but it shaved off a few minutes and these were the "SLOW" tests.

# How to test the change?

Just regular test commands are fine.