### PR TITLE
Avoid struct<Generic = ()> in cbindgen-read definitions

### DIFF
--- a/ipc/src/rate_limiter.rs
+++ b/ipc/src/rate_limiter.rs
@@ -21,7 +21,7 @@ struct ShmLimiterData<'a, Inner> {
     _phantom: PhantomData<&'a ShmLimiterMemory<Inner>>,
 }
 
-pub struct ShmLimiterMemory<Inner = ()> {
+pub struct ShmLimiterMemory<Inner> {
     mem: Arc<RwLock<MappedMem<NamedShmHandle>>>,
     last_size: AtomicU32,
     _phantom: PhantomData<Inner>,
@@ -195,7 +195,7 @@ impl<Inner> ShmLimiterMemory<Inner> {
     }
 }
 
-pub struct ShmLimiter<Inner = ()> {
+pub struct ShmLimiter<Inner> {
     idx: u32,
     memory: ShmLimiterMemory<Inner>,
 }
@@ -295,7 +295,7 @@ impl<Inner> Drop for ShmLimiter<Inner> {
 
 pub enum AnyLimiter {
     Local(LocalLimiter),
-    Shm(ShmLimiter),
+    Shm(ShmLimiter<()>),
 }
 
 impl AnyLimiter {

--- a/sidecar/src/shm_remote_config.rs
+++ b/sidecar/src/shm_remote_config.rs
@@ -127,7 +127,7 @@ struct ConfigFileStorage {
 
 struct StoredShmFile {
     handle: Mutex<NamedShmHandle>,
-    limiter: Option<ShmLimiter>,
+    limiter: Option<ShmLimiter<()>>,
     refcount: FileRefcountData,
 }
 

--- a/sidecar/src/tracer.rs
+++ b/sidecar/src/tracer.rs
@@ -10,9 +10,9 @@ use std::ffi::CString;
 use std::str::FromStr;
 use std::sync::{Mutex, OnceLock};
 
-static SHM_LIMITER: OnceLock<Mutex<ShmLimiterMemory>> = OnceLock::new();
+static SHM_LIMITER: OnceLock<Mutex<ShmLimiterMemory<()>>> = OnceLock::new();
 
-pub fn get_shm_limiter() -> &'static Mutex<ShmLimiterMemory> {
+pub fn get_shm_limiter() -> &'static Mutex<ShmLimiterMemory<()>> {
     #[allow(clippy::unwrap_used)]
     SHM_LIMITER.get_or_init(|| Mutex::new(ShmLimiterMemory::create(shm_limiter_path()).unwrap()))
 }


### PR DESCRIPTION
Works around https://github.com/mozilla/cbindgen/issues/993 in cbindgen 0.27+