### PR TITLE
[PROF-11524] Bump libdatadog version to 17.0.0 in preparation for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "build_common"
-version = "16.0.3"
+version = "17.0.0"
 dependencies = [
  "cbindgen",
  "serde",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "builder"
-version = "16.0.3"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1291,7 +1291,7 @@ dependencies = [
 
 [[package]]
 name = "data-pipeline"
-version = "16.0.3"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "data-pipeline-ffi"
-version = "16.0.3"
+version = "17.0.0"
 dependencies = [
  "build_common",
  "data-pipeline",
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-alloc"
-version = "16.0.3"
+version = "17.0.0"
 dependencies = [
  "allocator-api2",
  "bolero",
@@ -1345,7 +1345,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-crashtracker"
-version = "16.0.3"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -1374,7 +1374,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-crashtracker-ffi"
-version = "16.0.3"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-ddsketch"
-version = "16.0.3"
+version = "17.0.0"
 dependencies = [
  "prost 0.11.9",
  "prost-build 0.11.9",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling"
-version = "16.0.3"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "bitmaps",
@@ -1543,7 +1543,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-ffi"
-version = "16.0.3"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-replayer"
-version = "16.0.3"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1714,7 +1714,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-mini-agent"
-version = "16.0.3"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1736,7 +1736,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-normalization"
-version = "16.0.3"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1747,7 +1747,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-obfuscation"
-version = "16.0.3"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-protobuf"
-version = "16.0.3"
+version = "17.0.0"
 dependencies = [
  "prost 0.11.9",
  "prost-build 0.11.9",
@@ -1778,7 +1778,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-utils"
-version = "16.0.3"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "bolero",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon"
-version = "16.0.3"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "cc",
@@ -1847,7 +1847,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon-ffi"
-version = "16.0.3"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "bolero",
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry"
-version = "16.0.3"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1894,7 +1894,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry-ffi"
-version = "16.0.3"
+version = "17.0.0"
 dependencies = [
  "build_common",
  "ddcommon",
@@ -2038,7 +2038,7 @@ dependencies = [
 
 [[package]]
 name = "dogstatsd"
-version = "16.0.3"
+version = "17.0.0"
 dependencies = [
  "datadog-protos",
  "ddsketch-agent",
@@ -2063,7 +2063,7 @@ dependencies = [
 
 [[package]]
 name = "dogstatsd-client"
-version = "16.0.3"
+version = "17.0.0"
 dependencies = [
  "anyhow",
  "cadence",
@@ -5339,7 +5339,7 @@ dependencies = [
 
 [[package]]
 name = "symbolizer-ffi"
-version = "16.0.3"
+version = "17.0.0"
 dependencies = [
  "blazesym-c",
  "build_common",
@@ -5665,7 +5665,7 @@ dependencies = [
 
 [[package]]
 name = "tinybytes"
-version = "16.0.3"
+version = "17.0.0"
 dependencies = [
  "once_cell",
  "pretty_assertions",
@@ -5937,7 +5937,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "16.0.3"
+version = "17.0.0"
 dependencies = [
  "regex",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.78.0"
 edition = "2021"
-version = "16.0.3"
+version = "17.0.0"
 license = "Apache-2.0"
 
 [profile.dev]


### PR DESCRIPTION
# What does this PR do?

This PR bumps the libdatadog version to 17.0.0 in preparation for release.

We're going from 16.x to 17.0.0 because of a number of small backwards-incompatible changes, including https://github.com/DataDog/libdatadog/pull/948 .

# Motivation

Release libdatadog 17.0.0.

# Additional Notes

I'm opening this PR before https://github.com/DataDog/libdatadog/pull/913 and https://github.com/DataDog/libdatadog/pull/948 are merged in but I'll wait for both of them to hit `main` before merging this.

# How to test the change?

I've tested the libdatadog 17 release locally using the Ruby profiler test suite.