### PR TITLE
feat(profiling): add runtime_platform tag automatically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,6 +1565,7 @@ dependencies = [
  "rustc-hash 1.1.0",
  "serde",
  "serde_json",
+ "target-triple",
  "tokio",
  "tokio-util",
 ]
@@ -5492,9 +5493,9 @@ dependencies = [
 
 [[package]]
 name = "target-triple"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a4d50cdb458045afc8131fd91b64904da29548bcb63c7236e0844936c13078"
+checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
 
 [[package]]
 name = "tarpc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,6 +1061,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "constcat"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1522,6 +1542,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "chrono",
+ "const_format",
  "criterion",
  "datadog-alloc",
  "ddcommon",
@@ -1827,6 +1848,7 @@ version = "16.0.3"
 dependencies = [
  "anyhow",
  "cc",
+ "const_format",
  "futures",
  "futures-core",
  "futures-util",
@@ -3913,16 +3935,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
 name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"

--- a/ddcommon/Cargo.toml
+++ b/ddcommon/Cargo.toml
@@ -42,6 +42,7 @@ tokio-rustls = { version = "0.26", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 static_assertions = "1.1.0"
 libc = "0.2"
+const_format = "0.2.34"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.52"

--- a/ddcommon/src/lib.rs
+++ b/ddcommon/src/lib.rs
@@ -107,6 +107,9 @@ pub type HttpClient = hyper::Client<connector::Connector, hyper::Body>;
 pub type HttpResponse = hyper::Response<hyper::Body>;
 pub type HttpRequestBuilder = hyper::http::request::Builder;
 
+// Used by tag! macro
+pub use const_format;
+
 #[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
 pub struct Endpoint {
     #[serde(serialize_with = "serialize_uri", deserialize_with = "deserialize_uri")]

--- a/ddcommon/src/tag.rs
+++ b/ddcommon/src/tag.rs
@@ -37,7 +37,7 @@ impl Tag {
 /// all tag validation is currently done client-side). If the key or value
 /// aren't known at compile-time, then use [Tag::new].
 // todo: what's a good way to keep these in-sync with Tag::from_value?
-// This can be a little more strict because it's compitle-time evaluated.
+// This can be a little more strict because it's compile-time evaluated.
 // https://docs.datadoghq.com/getting_started/tagging/#define-tags
 #[macro_export]
 macro_rules! tag {
@@ -48,7 +48,7 @@ macro_rules! tag {
         //       which checks that the whole thing doesn't end with a colon.
         $crate::tag::const_assert!(!$val.is_empty());
 
-        const COMBINED: &'static str = concat!($key, ":", $val);
+        const COMBINED: &'static str = $crate::const_format::concatcp!($key, ":", $val);
 
         // Tags must start with a letter. This is more restrictive than is
         // required (could be a unicode alphabetic char) and can be lifted

--- a/profiling-ffi/src/exporter.rs
+++ b/profiling-ffi/src/exporter.rs
@@ -622,7 +622,6 @@ mod tests {
         );
         assert_eq!(parsed_event_json["family"], json!("native"));
         assert_eq!(parsed_event_json["internal"], json!({}));
-        assert_eq!(parsed_event_json["tags_profiler"], json!(""));
         assert_eq!(parsed_event_json["version"], json!("4"));
 
         // TODO: Assert on contents of attachments, as well as on the headers/configuration for the

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -46,6 +46,7 @@ serde_json = {version = "1.0"}
 tokio = {version = "1.23", features = ["rt", "macros"]}
 tokio-util = "0.7.1"
 byteorder = { version = "1.5", features = ["std"] }
+const_format = "0.2.34"
 
 [dev-dependencies]
 bolero = "0.10.1"

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -20,8 +20,10 @@ harness = false
 [dependencies]
 anyhow = "1.0"
 bitmaps = "3.2.0"
+byteorder = { version = "1.5", features = ["std"] }
 bytes = "1.1"
 chrono = {version = "0.4", default-features = false, features = ["std", "clock"]}
+const_format = "0.2.34"
 datadog-alloc = {path = "../alloc"}
 ddcommon = {path = "../ddcommon"}
 derivative = "2.2.0"
@@ -43,10 +45,9 @@ prost = "0.12"
 rustc-hash = { version = "1.1", default-features = false }
 serde = {version = "1.0", features = ["derive"]}
 serde_json = {version = "1.0"}
+target-triple = "0.1.4"
 tokio = {version = "1.23", features = ["rt", "macros"]}
 tokio-util = "0.7.1"
-byteorder = { version = "1.5", features = ["std"] }
-const_format = "0.2.34"
 
 [dev-dependencies]
 bolero = "0.10.1"

--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -151,20 +151,14 @@ impl ProfileExporter {
         })
     }
 
-    #[cfg(target_env = "musl")]
-    fn runtime_platform_tag(&self) -> Tag {
-        tag!(
-            "runtime_platform",
-            concatcp!(std::env::consts::ARCH, "-", std::env::consts::OS, "-musl")
-        )
-    }
+    const RUNTIME_INFO: &'static str = if cfg!(target_env = "musl") {
+        concatcp!(std::env::consts::ARCH, "-", std::env::consts::OS, "-musl")
+    } else {
+        concatcp!(std::env::consts::ARCH, "-", std::env::consts::OS)
+    };
 
-    #[cfg(not(target_env = "musl"))]
     fn runtime_platform_tag(&self) -> Tag {
-        tag!(
-            "runtime_platform",
-            concatcp!(std::env::consts::ARCH, "-", std::env::consts::OS)
-        )
+        tag!("runtime_platform", ProfileExporter::RUNTIME_INFO)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -158,6 +158,7 @@ impl ProfileExporter {
     /// The target triple. This is a string like:
     ///  - aarch64-apple-darwin
     ///  - x86_64-unknown-linux-gnu
+    ///
     /// The name is which is a misnomer, it traditionally had 3 pieces, but
     /// it's commonly 4+ fragments today.
     const TARGET_TRIPLE: &'static str = target_triple::TARGET;

--- a/profiling/tests/form.rs
+++ b/profiling/tests/form.rs
@@ -131,9 +131,22 @@ mod tests {
         assert_eq!(parsed_event_json["endpoint_counts"], json!(null));
         assert_eq!(parsed_event_json["family"], json!("php"));
         assert_eq!(parsed_event_json["internal"], json!({}));
-        assert_eq!(
-            parsed_event_json["tags_profiler"],
-            json!("service:php,host:bits")
+        let tags_profiler = parsed_event_json["tags_profiler"]
+            .as_str()
+            .unwrap()
+            .split(',')
+            .collect::<Vec<_>>();
+        assert!(tags_profiler.contains(&"service:php"));
+        assert!(tags_profiler.contains(&"host:bits"));
+        let runtime_platform = tags_profiler
+            .iter()
+            .find(|tag| tag.starts_with("runtime_platform:"))
+            .expect("runtime_platform tag should exist");
+        assert!(
+            runtime_platform.starts_with(&format!("runtime_platform:{}", std::env::consts::ARCH)),
+            "expected platform tag to start with runtime_platform:{} but got '{}'",
+            std::env::consts::ARCH,
+            runtime_platform
         );
         assert_eq!(parsed_event_json["version"], json!("4"));
     }


### PR DESCRIPTION
# What does this PR do?

This PR adds the `runtime_platform` tag as per [Profiler common tags](https://docs.google.com/spreadsheets/d/1LOGMf4c4Avbtn36uZ2SWvhIGKRPLM1BoWkUP4JYj7hA/edit?gid=0#gid=0). It uses the target triple, which is a bit different from what Ruby did before, but close enough.


# Motivation

Up until now, only Ruby was reporting this tag, but in incident 35390 it would've been useful to have this information, and it seems easy enough to add.

# Additional Notes

We should probably talk to the Datadog platform team to figure out if there's a "standard" or "approved" tag name, but this one is already in use so let's not block on that. We can migrate later as needed.

# How to test the change?

I've added test coverage for this feature. I've also tested it with the Ruby profiler.
