### PR TITLE
ci: use a larger github runner for miri

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   run-miri:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     env:
       CARGO_TERM_COLOR: always
       PROPTEST_CASES: 1
@@ -21,7 +21,7 @@ jobs:
       run: chmod +x ./scripts/install-protoc.sh && ./scripts/install-protoc.sh $HOME
     - uses: taiki-e/install-action@v2
       with: 
-        tool: nextest@0.9.81
+        tool: nextest@0.9.92
     - run: MIRIFLAGS="-Zmiri-disable-isolation" cargo miri nextest run
     # We need to disable isolation because 
     # "unsupported operation: `clock_gettime` with `REALTIME` clocks not available when isolation is enabled" 


### PR DESCRIPTION
# What does this PR do?

This uses a larger runner size for the miri job on GitHub Actions.

It also updates nextest from 0.9.81 to 0.9.92. There were some notes in some of the changelogs that seemed like they might be interesting to have.

# Motivation

The miri job is up to 20 minutes, trying to bring it back down.

# Additional Notes

I do not know if we have access to these runners.

# How to test the change?

Nothing to do, this is a CI change only,.
