### PR TITLE
ci: use parallel jobs for Miri

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -2,15 +2,12 @@ name: Miri test
 on:
   push:
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
-  run-miri:
+  build-miri:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        partition: [1, 2, 3, 4]
-    env:
-      CARGO_TERM_COLOR: always
-      PROPTEST_CASES: 1
     steps:
       - uses: actions/checkout@v4
       - name: Set up Rust
@@ -25,6 +22,32 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: nextest@0.9.92
-      - run: MIRIFLAGS="-Zmiri-disable-isolation" cargo miri nextest run --partition count:${{ matrix.partition }}/4
+      - run: cargo nextest archive --archive-file nextest-archive.tar.zst
+      - name: Upload archive to workflow
+        uses: actions/upload-artifact@v4
+        with:
+          name: nextest-archive
+          path: nextest-archive.tar.zst
+
+  run-miri:
+    runs-on: ubuntu-latest
+    needs: build-miri
+    strategy:
+      matrix:
+        partition: [1, 2, 3, 4]
+    env:
+      PROPTEST_CASES: 1
+    steps:
+      - uses: actions/checkout@v4
+      # Cargo nextest's run phase does not require Cargo, but ~/.cargo/bin is
+      # required by the install action.
+      - run: mkdir -p ~/.cargo/bin
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@0.9.92
+      - run: |
+          MIRIFLAGS="-Zmiri-disable-isolation" ~/.cargo/bin/cargo-nextest miri nextest run \
+            --archive-file nextest-archive.tar.zst \
+            --partition count:${{ matrix.partition }}/4
       # We need to disable isolation because
       # "unsupported operation: `clock_gettime` with `REALTIME` clocks not available when isolation is enabled"

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -2,12 +2,15 @@ name: Miri test
 on:
   push:
 
-env:
-  CARGO_TERM_COLOR: always
-
 jobs:
-  build-miri:
+  run-miri:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        partition: [1, 2, 3, 4]
+    env:
+      CARGO_TERM_COLOR: always
+      PROPTEST_CASES: 1
     steps:
       - uses: actions/checkout@v4
       - name: Set up Rust
@@ -22,32 +25,6 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: nextest@0.9.92
-      - run: cargo nextest archive --archive-file nextest-archive.tar.zst
-      - name: Upload archive to workflow
-        uses: actions/upload-artifact@v4
-        with:
-          name: nextest-archive
-          path: nextest-archive.tar.zst
-
-  run-miri:
-    runs-on: ubuntu-latest
-    needs: build-miri
-    strategy:
-      matrix:
-        partition: [1, 2, 3, 4]
-    env:
-      PROPTEST_CASES: 1
-    steps:
-      - uses: actions/checkout@v4
-      # Cargo nextest's run phase does not require Cargo, but ~/.cargo/bin is
-      # required by the install action.
-      - run: mkdir -p ~/.cargo/bin
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: nextest@0.9.92
-      - run: |
-          MIRIFLAGS="-Zmiri-disable-isolation" ~/.cargo/bin/cargo-nextest miri nextest run \
-            --archive-file nextest-archive.tar.zst \
-            --partition count:${{ matrix.partition }}/4
+      - run: MIRIFLAGS="-Zmiri-disable-isolation" cargo miri nextest run --partition count:${{ matrix.partition }}/4
       # We need to disable isolation because
       # "unsupported operation: `clock_gettime` with `REALTIME` clocks not available when isolation is enabled"

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        partition: [1, 2, 3, 4]
+        partition: [1, 2, 3, 4, 5]
     env:
       CARGO_TERM_COLOR: always
       PROPTEST_CASES: 1
@@ -25,6 +25,6 @@ jobs:
       - uses: taiki-e/install-action@v2
         with:
           tool: nextest@0.9.92
-      - run: MIRIFLAGS="-Zmiri-disable-isolation" cargo miri nextest run --partition count:${{ matrix.partition }}/4
+      - run: MIRIFLAGS="-Zmiri-disable-isolation" cargo miri nextest run --partition count:${{ matrix.partition }}/5
       # We need to disable isolation because
       # "unsupported operation: `clock_gettime` with `REALTIME` clocks not available when isolation is enabled"

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -34,20 +34,23 @@ jobs:
     needs: build-miri
     strategy:
       matrix:
-        partition: [1, 2, 3, 4]
+        partition: [1, 2, 3, 4, 5]
     env:
       PROPTEST_CASES: 1
     steps:
       - uses: actions/checkout@v4
-      # Cargo nextest's run phase does not require Cargo, but ~/.cargo/bin is
-      # required by the install action.
-      - run: mkdir -p ~/.cargo/bin
+      - name: Set up Rust
+        run: |
+          set -e
+          rustup set profile minimal
+          rustup toolchain install nightly-2024-12-16 --component miri
+          rustup default nightly-2024-12-16
       - uses: taiki-e/install-action@v2
         with:
           tool: nextest@0.9.92
       - run: |
-          MIRIFLAGS="-Zmiri-disable-isolation" ~/.cargo/bin/cargo-nextest miri nextest run \
+          MIRIFLAGS="-Zmiri-disable-isolation" cargo miri nextest run \
             --archive-file nextest-archive.tar.zst \
-            --partition count:${{ matrix.partition }}/4
+            --partition count:${{ matrix.partition }}/5
       # We need to disable isolation because
       # "unsupported operation: `clock_gettime` with `REALTIME` clocks not available when isolation is enabled"

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -5,23 +5,26 @@ on:
 jobs:
   run-miri:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        partition: [1, 2, 3, 4]
     env:
       CARGO_TERM_COLOR: always
       PROPTEST_CASES: 1
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Rust
-      run: |
-        set -e
-        rustup set profile minimal
-        rustup toolchain install nightly-2024-12-16 --component miri
-        rustup default nightly-2024-12-16
-    - name: Install Protoc Binary
-      shell: bash
-      run: chmod +x ./scripts/install-protoc.sh && ./scripts/install-protoc.sh $HOME
-    - uses: taiki-e/install-action@v2
-      with: 
-        tool: nextest@0.9.81
-    - run: MIRIFLAGS="-Zmiri-disable-isolation" cargo miri nextest run
-    # We need to disable isolation because 
-    # "unsupported operation: `clock_gettime` with `REALTIME` clocks not available when isolation is enabled" 
+      - uses: actions/checkout@v4
+      - name: Set up Rust
+        run: |
+          set -e
+          rustup set profile minimal
+          rustup toolchain install nightly-2024-12-16 --component miri
+          rustup default nightly-2024-12-16
+      - name: Install Protoc Binary
+        shell: bash
+        run: chmod +x ./scripts/install-protoc.sh && ./scripts/install-protoc.sh $HOME
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: nextest@0.9.92
+      - run: MIRIFLAGS="-Zmiri-disable-isolation" cargo miri nextest run --partition count:${{ matrix.partition }}/4
+      # We need to disable isolation because
+      # "unsupported operation: `clock_gettime` with `REALTIME` clocks not available when isolation is enabled"

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -34,23 +34,20 @@ jobs:
     needs: build-miri
     strategy:
       matrix:
-        partition: [1, 2, 3, 4, 5]
+        partition: [1, 2, 3, 4]
     env:
       PROPTEST_CASES: 1
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Rust
-        run: |
-          set -e
-          rustup set profile minimal
-          rustup toolchain install nightly-2024-12-16 --component miri
-          rustup default nightly-2024-12-16
+      # Cargo nextest's run phase does not require Cargo, but ~/.cargo/bin is
+      # required by the install action.
+      - run: mkdir -p ~/.cargo/bin
       - uses: taiki-e/install-action@v2
         with:
           tool: nextest@0.9.92
       - run: |
-          MIRIFLAGS="-Zmiri-disable-isolation" cargo miri nextest run \
+          MIRIFLAGS="-Zmiri-disable-isolation" ~/.cargo/bin/cargo-nextest miri nextest run \
             --archive-file nextest-archive.tar.zst \
-            --partition count:${{ matrix.partition }}/5
+            --partition count:${{ matrix.partition }}/4
       # We need to disable isolation because
       # "unsupported operation: `clock_gettime` with `REALTIME` clocks not available when isolation is enabled"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3913,16 +3913,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
 name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plotters"


### PR DESCRIPTION
# What does this PR do?

This updates nextest to the latest version in the miri job and runs the miri tests in parallel, currently with 4 jobs.

It also updates the lock file which... I'm not sure how it ever got out of order to begin with.

# Motivation

The Miri job is up to 20+ minutes even after I skipped a handful of slow tests in a previous PR.

With this, it now takes ~7-8 minutes, which is better more in line with other jobs.

# Additional Notes

I tried using a larger runner in #955, that didn't work because it would have taken longer than 16 minutes just to get the runner. I don't know if this is because we aren't approved for them, or there aren't enough provisioned. Regardless, the net effect is it is too slow. Just use standard runners but more of them.

This PR is a bit wasteful in the sense that we rebuild everything in every job. I tried to split it into build + run jobs but `cargo miri nextest run` doesn't seem to support the archive needed to support that, so for now we'll just spend some extra CPU to reduce wall time.

There are also Code Vulnerability warnings, but this PR hasn't change the state of anything. We should fix that, but please don't block my PR on this. This is already a few steps removed from what I am trying to do, no more yak shaving please!

# How to test the change?

This is a CI only change, nothing else to test.