### PR TITLE
[NO-TICKET] Include libdatadog profiling crate version when reporting profiles

### DIFF
--- a/profiling-ffi/src/exporter.rs
+++ b/profiling-ffi/src/exporter.rs
@@ -621,7 +621,10 @@ mod tests {
             json!("1970-01-01T00:00:56.000000078Z")
         );
         assert_eq!(parsed_event_json["family"], json!("native"));
-        assert_eq!(parsed_event_json["internal"], json!({}));
+        assert_eq!(
+            parsed_event_json["internal"],
+            json!({"libdatadog_version": env!("CARGO_PKG_VERSION")})
+        );
         assert_eq!(parsed_event_json["tags_profiler"], json!(""));
         assert_eq!(parsed_event_json["version"], json!("4"));
 
@@ -699,7 +702,8 @@ mod tests {
             json!({
                 "no_signals_workaround_enabled": "true",
                 "execution_trace_enabled": "false",
-                "extra object": {"key": [1, 2, true]}
+                "extra object": {"key": [1, 2, true]},
+                "libdatadog_version": env!("CARGO_PKG_VERSION"),
             })
         );
     }

--- a/profiling/src/exporter/mod.rs
+++ b/profiling/src/exporter/mod.rs
@@ -219,6 +219,9 @@ impl ProfileExporter {
             .map(|file| file.name.to_owned())
             .collect();
 
+        let mut internal: serde_json::value::Value = internal_metadata.unwrap_or_else(|| json!({}));
+        internal["libdatadog_version"] = json!(env!("CARGO_PKG_VERSION"));
+
         let event = json!({
             "attachments": attachments,
             "tags_profiler": tags_profiler,
@@ -227,7 +230,7 @@ impl ProfileExporter {
             "family": self.family.as_ref(),
             "version": "4",
             "endpoint_counts" : endpoint_counts,
-            "internal": internal_metadata.unwrap_or_else(|| json!({})),
+            "internal": internal,
             "info": info.unwrap_or_else(|| json!({})),
         })
         .to_string();

--- a/profiling/tests/form.rs
+++ b/profiling/tests/form.rs
@@ -130,7 +130,10 @@ mod tests {
         assert_eq!(parsed_event_json["attachments"], json!(["profile.pprof"]));
         assert_eq!(parsed_event_json["endpoint_counts"], json!(null));
         assert_eq!(parsed_event_json["family"], json!("php"));
-        assert_eq!(parsed_event_json["internal"], json!({}));
+        assert_eq!(
+            parsed_event_json["internal"],
+            json!({"libdatadog_version": env!("CARGO_PKG_VERSION")})
+        );
         assert_eq!(
             parsed_event_json["tags_profiler"],
             json!("service:php,host:bits")
@@ -159,7 +162,8 @@ mod tests {
         let internal_metadata = json!({
             "no_signals_workaround_enabled": "true",
             "execution_trace_enabled": "false",
-            "extra object": {"key": [1, 2, true]}
+            "extra object": {"key": [1, 2, true]},
+            "libdatadog_version": env!("CARGO_PKG_VERSION"),
         });
         let request = multipart(&mut exporter, Some(internal_metadata.clone()), None);
         let parsed_event_json = parsed_event_json(request);


### PR DESCRIPTION
# What does this PR do?

This PR tweaks the `internal` metadata section that gets reported along with every profile to include the libdatadog profiling crate version (which matches the libdatadog version currently).

# Motivation

In incident 35390 I had to manually check which libdatadog version a given profiler version was reporting and I missed having a nice unified way to figure this out.

# Additional Notes

Arguably this could go in the `info` version instead, but I decided to keep it as internal info for now, and we can always change it later.

# How to test the change?

I've updated the unit tests and also validated this works with the Ruby profiler.