### PR TITLE
fix(profiling): label handling and fuzzing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -721,7 +721,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "serde_urlencoded",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tokio-util",
  "tower-service",
@@ -820,7 +820,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -1009,7 +1009,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "rand 0.8.5",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -1555,6 +1555,7 @@ dependencies = [
  "serde",
  "serde_json",
  "target-triple",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-util",
 ]
@@ -1581,6 +1582,7 @@ dependencies = [
  "symbolic-common",
  "symbolic-demangle",
  "symbolizer-ffi",
+ "thiserror 2.0.12",
  "tokio-util",
 ]
 
@@ -2086,7 +2088,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tokio-util",
  "tracing",
@@ -3319,7 +3321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3719,7 +3721,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "rand 0.8.5",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tokio-stream",
 ]
@@ -3734,7 +3736,7 @@ dependencies = [
  "lazy_static",
  "opentelemetry",
  "opentelemetry-semantic-conventions",
- "thiserror",
+ "thiserror 1.0.68",
  "thrift",
  "tokio",
 ]
@@ -4275,7 +4277,7 @@ dependencies = [
  "bytes",
  "once_cell",
  "protobuf-support",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -4290,7 +4292,7 @@ dependencies = [
  "protobuf-parse",
  "regex",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -4305,7 +4307,7 @@ dependencies = [
  "protobuf",
  "protobuf-support",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.68",
  "which",
 ]
 
@@ -4315,7 +4317,7 @@ version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b088fd20b938a875ea00843b6faf48579462630015c3788d397ad6a786663252"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -4394,7 +4396,7 @@ dependencies = [
  "rustc-hash 2.0.0",
  "rustls 0.23.18",
  "socket2",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tracing",
 ]
@@ -4411,7 +4413,7 @@ dependencies = [
  "rustc-hash 2.0.0",
  "rustls 0.23.18",
  "slab",
- "thiserror",
+ "thiserror 1.0.68",
  "tinyvec",
  "tracing",
 ]
@@ -4560,7 +4562,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror",
+ "thiserror 1.0.68",
 ]
 
 [[package]]
@@ -4863,7 +4865,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a15e661f0f9dac21f3494fe5d23a6338c0ac116a2d22c2b63010acd89467ffe"
 dependencies = [
  "byteorder",
- "thiserror",
+ "thiserror 1.0.68",
  "twox-hash",
 ]
 
@@ -5504,7 +5506,7 @@ dependencies = [
  "serde_bytes",
  "static_assertions",
  "tarpc-plugins",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tokio-serde",
  "tokio-util",
@@ -5612,7 +5614,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror",
+ "thiserror 1.0.68",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -5625,7 +5627,16 @@ version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.68",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -5633,6 +5644,17 @@ name = "thiserror-impl"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/data-pipeline-ffi/src/trace_exporter.rs
+++ b/data-pipeline-ffi/src/trace_exporter.rs
@@ -624,6 +624,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(all(miri, target_os = "macos"), ignore)]
     fn exporter_constructor_test() {
         unsafe {
             let mut config: MaybeUninit<Box<TraceExporterConfig>> = MaybeUninit::uninit();
@@ -652,6 +653,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(all(miri, target_os = "macos"), ignore)]
     fn exporter_constructor_error_test() {
         unsafe {
             let mut config: MaybeUninit<Box<TraceExporterConfig>> = MaybeUninit::uninit();

--- a/profiling-ffi/Cargo.toml
+++ b/profiling-ffi/Cargo.toml
@@ -50,3 +50,4 @@ symbolic-common = "12.8.0"
 symbolic-demangle = { version = "12.8.0", default-features = false, features = ["rust", "cpp", "msvc"] }
 symbolizer-ffi = { path = "../symbolizer-ffi", optional = true, default-features = false }
 tokio-util = "0.7.1"
+thiserror = "2"

--- a/profiling-replayer/src/replayer.rs
+++ b/profiling-replayer/src/replayer.rs
@@ -95,17 +95,9 @@ impl<'pprof> Replayer<'pprof> {
             .map(|label| {
                 Ok(api::Label {
                     key: profile_index.get_string(label.key)?,
-                    str: if label.str == 0 {
-                        None
-                    } else {
-                        Some(profile_index.get_string(label.str)?)
-                    },
+                    str: profile_index.get_string(label.str)?,
                     num: label.num,
-                    num_unit: if label.num_unit == 0 {
-                        None
-                    } else {
-                        Some(profile_index.get_string(label.num_unit)?)
-                    },
+                    num_unit: profile_index.get_string(label.num_unit)?,
                 })
             })
             .collect();
@@ -126,12 +118,12 @@ impl<'pprof> Replayer<'pprof> {
                 "local root span ids of zero do not make sense"
             );
 
-            let endpoint_value = match endpoint_label.str {
-                Some(v) => v,
-                None => anyhow::bail!("expected trace endpoint label value to have a string"),
-            };
+            anyhow::ensure!(
+                !endpoint_label.str.is_empty(),
+                "expected trace endpoint label value to have a non-empty string",
+            );
 
-            endpoint_info.replace((local_root_span_id, endpoint_value));
+            endpoint_info.replace((local_root_span_id, endpoint_label.str));
         }
 
         let timestamp = labels.iter().find_map(|label| {

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -46,6 +46,7 @@ rustc-hash = { version = "1.1", default-features = false }
 serde = {version = "1.0", features = ["derive"]}
 serde_json = {version = "1.0"}
 target-triple = "0.1.4"
+thiserror = "2"
 tokio = {version = "1.23", features = ["rt", "macros"]}
 tokio-util = "0.7.1"
 

--- a/profiling/src/internal/observation/trimmed_observation.rs
+++ b/profiling/src/internal/observation/trimmed_observation.rs
@@ -122,7 +122,7 @@ impl Drop for TrimmedObservation {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bolero::TypeGenerator;
+    use bolero::generator::*;
 
     #[test]
     fn as_mut_test() {

--- a/profiling/src/internal/profile/interning_api/mod.rs
+++ b/profiling/src/internal/profile/interning_api/mod.rs
@@ -35,7 +35,10 @@ impl Profile {
         unit: Option<GenerationalId<StringId>>,
     ) -> anyhow::Result<GenerationalId<LabelId>> {
         let key = key.get(self.generation)?;
-        let unit = unit.map(|u| u.get(self.generation)).transpose()?;
+        let unit = match unit {
+            Some(gen_id) => gen_id.get(self.generation)?,
+            None => StringId::ZERO,
+        };
         let id = self.labels.dedup(Label::num(key, val, unit));
         Ok(GenerationalId::new(id, self.generation))
     }

--- a/profiling/src/internal/upscaling.rs
+++ b/profiling/src/internal/upscaling.rs
@@ -170,15 +170,7 @@ impl UpscalingRules {
             // get bylabel rules first (if any)
             let mut group_of_rules = labels
                 .iter()
-                .filter_map(|label| {
-                    self.get(&(
-                        label.get_key(),
-                        match label.get_value() {
-                            LabelValue::Str(str) => *str,
-                            LabelValue::Num { .. } => StringId::ZERO,
-                        },
-                    ))
-                })
+                .filter_map(|label| self.get(&(label.get_key(), label.get_str())))
                 .collect::<Vec<&Vec<UpscalingRule>>>();
 
             // get byvalue rules if any

--- a/trace-utils/src/trace_utils.rs
+++ b/trace-utils/src/trace_utils.rs
@@ -938,6 +938,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(all(miri, target_os = "macos"), ignore)]
     async fn test_get_traces_from_request_body_with_span_links() {
         let trace_input = json!([[{
             "service": "test-service",


### PR DESCRIPTION
# What does this PR do?

This fixes GH #958 by:

- Being more cautious around label conversion errors (moved from `From` to `TryFrom`).
- Modeling the exclusive `label.str` or `label.num`+`label.num_value` a bit better.
- Simplifying `Option<*Id>` to just be `*Id`. This removes potential issues around `Some(0)` and `None` not always being considered the same despite the fact they ought to be. Now there's just one way to represent it, (which is 0).

# Motivation

I had a fuzzer error locally, and also hit one in CI. I figured since it cropped up both places recently, it was time to attack it.

# Additional Notes

I hit a 3rd party license job failure. I updated the licenses, but it the CI seems to fetch different values. Not sure what's going on there; we'll see if it keeps happening.

I found another fuzzer error, but it doesn't appear to be around label handling, so I'll leave that to another PR.

# How to test the change?

If you use the FFI, there's nothing to change. If you use the `api::*` layer, you'll have to account for some shifts in representation.
