### PR TITLE
fix: tinybytes serialization feature name

### DIFF
--- a/tinybytes/src/lib.rs
+++ b/tinybytes/src/lib.rs
@@ -13,7 +13,7 @@ use std::{
     sync::Arc,
 };
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serialization")]
 use serde::Serialize;
 
 /// Immutable bytes type with zero copy cloning and slicing.
@@ -281,7 +281,7 @@ impl fmt::Debug for Bytes {
     }
 }
 
-#[cfg(feature = "serde")]
+#[cfg(feature = "serialization")]
 impl Serialize for Bytes {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where


### PR DESCRIPTION
# What does this PR do?

* tinybytes serialization feature is called "serialization" not "serde", as seen here https://github.com/DataDog/libdatadog/blob/paullgdc/tinybites/fix_feature_name/tinybytes/Cargo.toml#L26
 Fix this

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
