### PR TITLE
chore: update bolero and pin cargo-bundle-licenses

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -88,11 +88,11 @@ jobs:
           # cache key contains current version of cargo-bundle-licenses
           # when upstream version is updated we can bump the cache key version,
           # to cache the latest version of the tool
-          key: "v1-2.0.0"
+          key: "v1-4.0.0"
       # cargo-bundle-licenses v2.0 doesn't understand path differences due to
       # sparse vs git index, so force git.
       - run: mkdir -p .cargo && printf "[registries.crates-io]\nprotocol = \"git\"\n" > .cargo/config.toml
-      - run: cargo install cargo-bundle-licenses
+      - run: cargo install --version "4.0.0" cargo-bundle-licenses
       - name: "Generate new LICENSE-3rdparty.yml and check against the previous" 
         env: 
           CARGO_HOME: "/tmp/dd-cargo"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -604,9 +604,9 @@ dependencies = [
 
 [[package]]
 name = "bolero"
-version = "0.10.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212e8dca6d4001cc6cac941d6932ddaa8cd27f57e5e44a9da19c913eb6a43b33"
+checksum = "eeae9bae5224be9a368c3b4f8cc83451473d55bcc1aa522cf56a48828dcf7f6e"
 dependencies = [
  "bolero-afl",
  "bolero-engine",
@@ -615,14 +615,14 @@ dependencies = [
  "bolero-kani",
  "bolero-libfuzzer",
  "cfg-if",
- "rand",
+ "rand 0.9.0",
 ]
 
 [[package]]
 name = "bolero-afl"
-version = "0.10.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b34f05de1527425bb05287da09ff1ff1612538648824db49e16d9693b24065"
+checksum = "d9bf4cbd0bacf9356d3c7e5d9d088480f2076ba3c595c15ee9a6a378cdd7b297"
 dependencies = [
  "bolero-engine",
  "cc",
@@ -630,34 +630,37 @@ dependencies = [
 
 [[package]]
 name = "bolero-engine"
-version = "0.10.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6206263ebdd42e093c1229dab3957f61c9fd68d73c00f238ae25a378778b6bd3"
+checksum = "6b2496696794ca673fd085c7237d2b64b825bfe0dedbd5e947ca633532d8132b"
 dependencies = [
  "anyhow",
  "backtrace",
  "bolero-generator",
  "lazy_static",
  "pretty-hex",
- "rand",
+ "rand 0.9.0",
+ "rand_xoshiro",
 ]
 
 [[package]]
 name = "bolero-generator"
-version = "0.10.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac749fb4f2e14734e835a9352c0d1eb2ab62a025d4c56a823fa3f391e015741a"
+checksum = "06b0c9bd47ec1d25ce698a2b4a0c3d8e527d0046919a04c800035e30bf4ea6d1"
 dependencies = [
  "bolero-generator-derive",
  "either",
- "rand_core",
+ "getrandom 0.3.2",
+ "rand_core 0.9.3",
+ "rand_xoshiro",
 ]
 
 [[package]]
 name = "bolero-generator-derive"
-version = "0.10.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53397bfda19ccb48527faa14025048fc4bb76f090ccdeef1e5a355bfe4a94467"
+checksum = "385f38498675c06532bed10cd40a4313691a8fb7d9b698fcf096739d422e1764"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -667,27 +670,27 @@ dependencies = [
 
 [[package]]
 name = "bolero-honggfuzz"
-version = "0.10.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf78581db1a7263620a8767e645b93ad287c70122ae76f5bd67040c7f06ff8e3"
+checksum = "9a118ef27295eddefadc6a99728ee698d1b18d2e80dc4777d21bee3385096ffd"
 dependencies = [
  "bolero-engine",
 ]
 
 [[package]]
 name = "bolero-kani"
-version = "0.10.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e55cec272a617f5ae4ce670db035108eb97c10cd4f67de851a3c8d3f18f19cb"
+checksum = "852ea5784a9f3e68bfd302ca80b8b863bce140593eb5770fee6ab110899c28fc"
 dependencies = [
  "bolero-engine",
 ]
 
 [[package]]
 name = "bolero-libfuzzer"
-version = "0.10.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb42f66ee3ec89b9c411994de59d4710ced19df96fea2059feea1c2d73904c5b"
+checksum = "858dc57c11725c52662501fa79fdbc6f7050339a05ca1bf1e587add0fed40d62"
 dependencies = [
  "bolero-engine",
  "cc",
@@ -1011,7 +1014,7 @@ dependencies = [
  "http 0.2.12",
  "mime",
  "mime_guess",
- "rand",
+ "rand 0.8.5",
  "thiserror",
 ]
 
@@ -1308,7 +1311,7 @@ dependencies = [
  "httpmock",
  "hyper 0.14.31",
  "log",
- "rand",
+ "rand 0.8.5",
  "regex",
  "rmp-serde",
  "serde",
@@ -1364,7 +1367,7 @@ dependencies = [
  "os_info",
  "page_size",
  "portable-atomic",
- "rand",
+ "rand 0.8.5",
  "schemars",
  "serde",
  "serde_json",
@@ -1518,7 +1521,6 @@ dependencies = [
  "anyhow",
  "bitmaps",
  "bolero",
- "bolero-generator",
  "byteorder",
  "bytes",
  "chrono",
@@ -1673,7 +1675,7 @@ dependencies = [
  "nix 0.27.1",
  "prctl",
  "priority-queue",
- "rand",
+ "rand 0.8.5",
  "sendfd",
  "serde",
  "serde_json",
@@ -1752,7 +1754,7 @@ dependencies = [
  "criterion",
  "datadog-trace-protobuf",
  "duplicate",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1792,7 +1794,6 @@ version = "16.0.3"
 dependencies = [
  "anyhow",
  "bolero",
- "bolero-generator",
  "bytes",
  "cargo-platform",
  "cargo_metadata",
@@ -1808,7 +1809,7 @@ dependencies = [
  "hyper-proxy",
  "log",
  "prost 0.11.9",
- "rand",
+ "rand 0.8.5",
  "rmp",
  "rmp-serde",
  "rmpv",
@@ -1842,7 +1843,7 @@ dependencies = [
  "maplit",
  "memfd",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "regex",
  "rmp",
  "rmp-serde",
@@ -2424,8 +2425,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -3477,7 +3490,7 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -3502,7 +3515,7 @@ dependencies = [
  "hyper 1.5.0",
  "hyper-util",
  "log",
- "rand",
+ "rand 0.8.5",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -3698,7 +3711,7 @@ dependencies = [
  "lazy_static",
  "percent-encoding",
  "pin-project",
- "rand",
+ "rand 0.8.5",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -3989,7 +4002,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -4010,9 +4023,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "pretty-hex"
-version = "0.3.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
+checksum = "bbc83ee4a840062f368f9096d80077a9841ec117e17e7f700df81958f1451254"
 
 [[package]]
 name = "pretty_assertions"
@@ -4057,12 +4070,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.3.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+checksum = "7e8366a6159044a37876a2b9817124296703c586a5c92e2c53751fa06d8d43e8"
 dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
+ "toml_edit 0.20.7",
 ]
 
 [[package]]
@@ -4108,8 +4120,8 @@ dependencies = [
  "bitflags 2.6.0",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax 0.8.5",
  "rusty-fork",
@@ -4387,7 +4399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
 dependencies = [
  "bytes",
- "rand",
+ "rand 0.8.5",
  "ring 0.17.14",
  "rustc-hash 2.0.0",
  "rustls 0.23.18",
@@ -4421,14 +4433,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.23",
 ]
 
 [[package]]
@@ -4438,7 +4467,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -4447,7 +4486,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -4456,7 +4504,16 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -4494,7 +4551,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "libredox",
  "thiserror",
 ]
@@ -4629,7 +4686,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "libc",
  "untrusted 0.9.0",
  "windows-sys 0.52.0",
@@ -5196,7 +5253,7 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1df0290e9bfe79ddd5ff8798ca887cd107b75353d2957efe9777296e17f26b5"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "halfbrown",
  "ref-cast",
  "serde",
@@ -5491,7 +5548,7 @@ dependencies = [
  "opentelemetry-jaeger",
  "pin-project",
  "pin-utils",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_bytes",
  "static_assertions",
@@ -5891,9 +5948,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
+version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
  "indexmap 2.6.0",
  "toml_datetime",
@@ -5994,7 +6051,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -6244,7 +6301,7 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.15",
  "serde",
 ]
 
@@ -6311,6 +6368,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -6872,6 +6938,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6931,7 +7006,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd97444d05a4328b90e75e503a34bad781f14e28a823ad3557f0750df1ebcbc6"
+dependencies = [
+ "zerocopy-derive 0.8.23",
 ]
 
 [[package]]
@@ -6939,6 +7023,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6352c01d0edd5db859a63e2605f4ea3183ddbd15e2c4a9e7d32184df75e4f154"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/alloc/Cargo.toml
+++ b/alloc/Cargo.toml
@@ -24,7 +24,7 @@ features = [
 
 [dev-dependencies]
 allocator-api2 = { version = "0.2", default-features = false, features = ["alloc"] }
-bolero = "0.10.1"
+bolero = "0.13"
 
 [lib]
 bench = false

--- a/alloc/src/chain.rs
+++ b/alloc/src/chain.rs
@@ -313,13 +313,13 @@ mod tests {
     use super::*;
     use crate::utils::*;
     use allocator_api2::alloc::Global;
+    use bolero::TypeGenerator;
 
     #[test]
     fn fuzz() {
         // avoid SUMMARY: libFuzzer: out-of-memory
         const MAX_SIZE: usize = 0x10000000;
 
-        use bolero::TypeGenerator;
         let size_hint = 0..=MAX_SIZE;
         // Giving large values for align bits can lead to failed allocations
         // This would normally be OK, since the fuzz-test is resilient to this.
@@ -330,8 +330,8 @@ mod tests {
         let align_bits = 0..32;
         let size = 0..=MAX_SIZE;
         let idx = 0..=MAX_SIZE;
-        let val = u8::gen();
-        let allocs = Vec::<(usize, u32, usize, u8)>::gen()
+        let val = u8::produce();
+        let allocs = Vec::<(usize, u32, usize, u8)>::produce()
             .with()
             .values((size, align_bits, idx, val));
         bolero::check!()

--- a/alloc/src/linear.rs
+++ b/alloc/src/linear.rs
@@ -140,19 +140,19 @@ mod tests {
     use super::*;
     use crate::utils::*;
     use allocator_api2::alloc::Global;
+    use bolero::generator::TypeGenerator;
 
     #[test]
     fn fuzz() {
         // avoid SUMMARY: libFuzzer: out-of-memory
         const MAX_SIZE: usize = 0x10000000;
 
-        use bolero::TypeGenerator;
         let size_hint = 0..=MAX_SIZE;
         let align_bits = 0..=32;
         let size = 0..=MAX_SIZE;
         let idx = 0..=MAX_SIZE;
-        let val = u8::gen();
-        let allocs = Vec::<(usize, u32, usize, u8)>::gen()
+        let val = u8::produce();
+        let allocs = Vec::<(usize, u32, usize, u8)>::produce()
             .with()
             .values((size, align_bits, idx, val));
         bolero::check!()

--- a/alloc/src/virtual_alloc.rs
+++ b/alloc/src/virtual_alloc.rs
@@ -185,11 +185,10 @@ mod tests {
     use super::*;
     use crate::utils::*;
     use allocator_api2::alloc::Allocator;
+    use bolero::TypeGenerator;
 
     #[test]
     fn fuzz() {
-        use bolero::TypeGenerator;
-
         #[cfg(miri)]
         const MAX_SIZE: usize = 1_000_000;
 
@@ -197,10 +196,10 @@ mod tests {
         const MAX_SIZE: usize = isize::MAX as usize;
 
         let align_bits = 0..=32;
-        let size = usize::gen();
-        let idx = usize::gen();
-        let val = u8::gen();
-        let allocs = Vec::<(usize, u32, usize, u8)>::gen()
+        let size = usize::produce();
+        let idx = usize::produce();
+        let val = u8::produce();
+        let allocs = Vec::<(usize, u32, usize, u8)>::produce()
             .with()
             .values((size, align_bits, idx, val));
         bolero::check!()

--- a/ddcommon-ffi/Cargo.toml
+++ b/ddcommon-ffi/Cargo.toml
@@ -27,4 +27,4 @@ hyper = {version = "0.14", features = ["backports", "deprecated"], default-featu
 serde = "1.0"
 
 [dev-dependencies]
-bolero = "0.10.1"
+bolero = "0.13"

--- a/ddcommon-ffi/src/array_queue.rs
+++ b/ddcommon-ffi/src/array_queue.rs
@@ -298,10 +298,9 @@ pub unsafe extern "C" fn ddog_ArrayQueue_capacity(queue_ptr: &ArrayQueue) -> Arr
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
     use super::*;
     use bolero::TypeGenerator;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     unsafe extern "C" fn drop_item(item: *mut c_void) -> c_void {
         _ = Box::from_raw(item as *mut i32);
@@ -430,7 +429,7 @@ mod tests {
     #[test]
     fn fuzz_with_threads() {
         let capacity_gen = 1..=32usize;
-        let ops_gen = Vec::<Operation>::gen();
+        let ops_gen = Vec::<Operation>::produce();
 
         bolero::check!()
             .with_generator((capacity_gen, ops_gen, ops_gen, ops_gen, ops_gen))

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -48,6 +48,5 @@ tokio-util = "0.7.1"
 byteorder = { version = "1.5", features = ["std"] }
 
 [dev-dependencies]
-bolero = "0.10.1"
-bolero-generator = "0.10.2"
+bolero = "0.13"
 criterion = "0.5.1"

--- a/profiling/src/api.rs
+++ b/profiling/src/api.rs
@@ -184,7 +184,7 @@ pub struct StringIdSample<'a> {
 }
 
 #[derive(Debug)]
-#[cfg_attr(test, derive(bolero_generator::TypeGenerator))]
+#[cfg_attr(test, derive(bolero::generator::TypeGenerator))]
 pub enum UpscalingInfo {
     Poisson {
         // sum_value_offset and count_value_offset are offsets in the profile values type array

--- a/profiling/src/internal/label.rs
+++ b/profiling/src/internal/label.rs
@@ -130,7 +130,7 @@ impl Item for LabelSet {
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[repr(transparent)]
-#[cfg_attr(test, derive(bolero_generator::TypeGenerator))]
+#[cfg_attr(test, derive(bolero::generator::TypeGenerator))]
 pub struct LabelSetId(u32);
 
 impl Id for LabelSetId {

--- a/profiling/src/internal/observation/observations.rs
+++ b/profiling/src/internal/observation/observations.rs
@@ -476,20 +476,20 @@ mod tests {
         bolero::check!()
             .with_generator((obs_len_gen, num_ts_samples_gen, num_samples_gen))
             .and_then(|(observations_len, num_ts_samples, num_samples)| {
-                let ts_samples = Vec::<(Sample, Timestamp, Vec<i64>)>::gen()
+                let ts_samples = Vec::<(Sample, Timestamp, Vec<i64>)>::produce()
                     .with()
                     .values((
-                        Sample::gen(),
-                        Timestamp::gen(),
-                        Vec::<i64>::gen().with().len(observations_len),
+                        Sample::produce(),
+                        Timestamp::produce(),
+                        Vec::<i64>::produce().with().len(observations_len),
                     ))
                     .len(num_ts_samples);
 
-                let no_ts_samples = Vec::<(Sample, Vec<i64>)>::gen()
+                let no_ts_samples = Vec::<(Sample, Vec<i64>)>::produce()
                     .with()
                     .values((
-                        Sample::gen(),
-                        Vec::<i64>::gen().with().len(observations_len),
+                        Sample::produce(),
+                        Vec::<i64>::produce().with().len(observations_len),
                     ))
                     .len(num_samples);
 
@@ -516,14 +516,18 @@ mod tests {
         bolero::check!()
             .with_generator((num_ts_samples_gen, num_samples_gen))
             .and_then(|(num_ts_samples, num_samples)| {
-                let ts_samples = Vec::<(Sample, Timestamp, Vec<i64>)>::gen()
+                let ts_samples = Vec::<(Sample, Timestamp, Vec<i64>)>::produce()
                     .with()
-                    .values((Sample::gen(), Timestamp::gen(), Vec::<i64>::gen()))
+                    .values((
+                        Sample::produce(),
+                        Timestamp::produce(),
+                        Vec::<i64>::produce(),
+                    ))
                     .len(num_ts_samples);
 
-                let no_ts_samples = Vec::<(Sample, Vec<i64>)>::gen()
+                let no_ts_samples = Vec::<(Sample, Vec<i64>)>::produce()
                     .with()
-                    .values((Sample::gen(), Vec::<i64>::gen()))
+                    .values((Sample::produce(), Vec::<i64>::produce()))
                     .len(num_samples);
                 (ts_samples, no_ts_samples)
             })

--- a/profiling/src/internal/owned_types/mod.rs
+++ b/profiling/src/internal/owned_types/mod.rs
@@ -3,7 +3,7 @@
 
 use crate::api;
 
-#[cfg_attr(test, derive(bolero_generator::TypeGenerator))]
+#[cfg_attr(test, derive(bolero::generator::TypeGenerator))]
 #[derive(Clone, Debug)]
 pub struct ValueType {
     pub typ: Box<str>,
@@ -26,7 +26,7 @@ impl<'a> From<&'a ValueType> for api::ValueType<'a> {
     }
 }
 
-#[cfg_attr(test, derive(bolero_generator::TypeGenerator))]
+#[cfg_attr(test, derive(bolero::generator::TypeGenerator))]
 #[derive(Clone, Debug)]
 pub struct Period {
     pub typ: ValueType,

--- a/profiling/src/internal/profile/fuzz_tests.rs
+++ b/profiling/src/internal/profile/fuzz_tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use bolero::TypeGenerator;
+use bolero::generator::TypeGenerator;
 use std::collections::HashSet;
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Hash, TypeGenerator)]
@@ -446,8 +446,8 @@ fn fuzz_failure_001() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn test_fuzz_add_sample() {
-    let sample_types_gen = Vec::<owned_types::ValueType>::gen();
-    let samples_gen = Vec::<(Option<Timestamp>, Sample)>::gen();
+    let sample_types_gen = Vec::<owned_types::ValueType>::produce();
+    let samples_gen = Vec::<(Option<Timestamp>, Sample)>::produce();
 
     bolero::check!()
         .with_generator((sample_types_gen, samples_gen))
@@ -489,16 +489,18 @@ fn fuzz_add_sample_with_fixed_sample_length() {
     bolero::check!()
         .with_generator(sample_length_gen)
         .and_then(|sample_len| {
-            let sample_types = Vec::<owned_types::ValueType>::gen().with().len(sample_len);
+            let sample_types = Vec::<owned_types::ValueType>::produce()
+                .with()
+                .len(sample_len);
 
-            let timestamps = Option::<Timestamp>::gen();
-            let locations = Vec::<Location>::gen();
-            let values = Vec::<i64>::gen().with().len(sample_len);
+            let timestamps = Option::<Timestamp>::produce();
+            let locations = Vec::<Location>::produce();
+            let values = Vec::<i64>::produce().with().len(sample_len);
             // Generate labels with unique keys
-            let labels = HashSet::<Label>::gen();
+            let labels = HashSet::<Label>::produce();
 
             let samples =
-                Vec::<(Option<Timestamp>, Vec<Location>, Vec<i64>, HashSet<Label>)>::gen()
+                Vec::<(Option<Timestamp>, Vec<Location>, Vec<i64>, HashSet<Label>)>::produce()
                     .with()
                     .values((timestamps, locations, values, labels));
             (sample_types, samples)
@@ -597,8 +599,10 @@ fn fuzz_api_function_calls() {
     bolero::check!()
         .with_generator(sample_length_gen)
         .and_then(|sample_len| {
-            let sample_types = Vec::<owned_types::ValueType>::gen().with().len(sample_len);
-            let operations = Vec::<Operation>::gen();
+            let sample_types = Vec::<owned_types::ValueType>::produce()
+                .with()
+                .len(sample_len);
+            let operations = Vec::<Operation>::produce();
 
             (sample_types, operations)
         })

--- a/profiling/src/internal/sample.rs
+++ b/profiling/src/internal/sample.rs
@@ -5,7 +5,7 @@ use super::*;
 use std::hash::Hash;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-#[cfg_attr(test, derive(bolero_generator::TypeGenerator))]
+#[cfg_attr(test, derive(bolero::generator::TypeGenerator))]
 pub struct Sample {
     /// label includes additional context for this sample. It can include
     /// things like a thread id, allocation size, etc

--- a/profiling/src/internal/stack_trace.rs
+++ b/profiling/src/internal/stack_trace.rs
@@ -16,7 +16,7 @@ impl Item for StackTrace {
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[repr(transparent)]
-#[cfg_attr(test, derive(bolero_generator::TypeGenerator))]
+#[cfg_attr(test, derive(bolero::generator::TypeGenerator))]
 pub struct StackTraceId(u32);
 
 impl Id for StackTraceId {

--- a/trace-utils/Cargo.toml
+++ b/trace-utils/Cargo.toml
@@ -59,8 +59,7 @@ httpmock = { version = "0.7.0", optional = true }
 urlencoding = { version = "2.1.3", optional = true }
 
 [dev-dependencies]
-bolero = "0.10.1"
-bolero-generator = "0.10.2"
+bolero = "0.13"
 criterion = "0.5.1"
 httpmock = { version = "0.7.0" }
 serde_json = "1.0"


### PR DESCRIPTION
# What does this PR do?

1. This update bolero from v0.10 to v0.13, and fixes the deprecation warnings about `gen` for 2024 edition compatibility.
2. Removes bolero-generator as a direct dependency, since it's part of the bolero crate and exposed there as `bolero::generator` (and at least currently it is not controlled by a feature, so it's always there).
3. This pins the version of cargo-bundle-licenses to v4.0.0. We pinned this in the past, not sure why it was unpinned.

# Motivation

I was fixing some fuzz tests on another branch realized this was a big enough chunk that I should split it out.

# Additional Notes

If there are any fuzz errors in profiling, we'll ignore them and force-merge if needed. Since I haven't fixed those in this PR, they may fail.

# How to test the change?

Everything should run the same, just updates.
