### PR TITLE
fix: support both ENOTSUP and ENOSYS in shm_open fallback

### DIFF
--- a/ddcommon/src/connector/mod.rs
+++ b/ddcommon/src/connector/mod.rs
@@ -40,7 +40,9 @@ impl Default for Connector {
 }
 
 impl Connector {
-    pub fn new() -> Self {
+    /// Make sure this function is not called frequently. Fetching the root certificates is an
+    /// expensive operation. Access the globally cached connector via Connector::default().
+    fn new() -> Self {
         #[cfg(feature = "https")]
         {
             #[cfg(feature = "use_webpki_roots")]

--- a/ipc/src/platform/unix/mem_handle.rs
+++ b/ipc/src/platform/unix/mem_handle.rs
@@ -25,7 +25,8 @@ fn shm_open<P: ?Sized + NixPath>(
     mode: Mode,
 ) -> nix::Result<std::os::unix::io::OwnedFd> {
     mman::shm_open(name, flag, mode).or_else(|e| {
-        if e == Errno::ENOTSUP {
+        // This can happen on AWS lambda
+        if e == Errno::ENOSYS || e == Errno::ENOTSUP {
             // The path has a leading slash
             let path = name.with_nix_path(|cstr| {
                 let mut path = "/tmp/libdatadog".to_string().into_bytes();
@@ -53,7 +54,7 @@ fn shm_open<P: ?Sized + NixPath>(
 
 pub fn shm_unlink<P: ?Sized + NixPath>(name: &P) -> nix::Result<()> {
     mman::shm_unlink(name).or_else(|e| {
-        if e == Errno::ENOTSUP {
+        if e == Errno::ENOSYS || e == Errno::ENOTSUP {
             unlink(name)
         } else {
             Err(e)


### PR DESCRIPTION
I was informed by the customer that they got a not supported error, but actually it's an ENOSYS ... :-)
Updating it to the right value to make it work for them.