### PR TITLE
build: update cc, ring, and remove spin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,9 +850,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.31"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
+checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
 dependencies = [
  "jobserver",
  "libc",
@@ -3319,7 +3319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4672,15 +4672,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -5279,12 +5278,6 @@ dependencies = [
  "winapi 0.2.8",
  "windows 0.51.1",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"


### PR DESCRIPTION
# What does this PR do?

This updates the versions of the crates `cc` (to 1.2.17) and `ring` (to 0.17.14), and drops `spin`.

# Motivation

The ring crate has dependabot alert on it. It requires an updated `cc` crate, which has been problematic because the 1.2.x series has been incompatible with our *-alpine-linux-musl builds. They recently merged and releases a fix (or at least, it should be fixed) in v 1.2.17, so we can now update cc too.

These changes mean spin is no longer used, so it's dropped.

# Additional Notes

This PR is used in favor of #970 because it also adjusts the windows version _down_, which is wrong. Dependabot also doesn't know to regenerate the 3rd party license file.

Please verify that everything works in gitlab too before merging.

# How to test the change?

Everything should work as normal with regular testing.
