### PR TITLE
Move ddog_setup_crashtracking export to sidecar-ffi

### DIFF
--- a/sidecar-ffi/Cargo.toml
+++ b/sidecar-ffi/Cargo.toml
@@ -24,6 +24,9 @@ paste = "1"
 libc = "0.2"
 dogstatsd-client = { path = "../dogstatsd-client" }
 
+[target.'cfg(windows)'.dependencies]
+datadog-crashtracker-ffi = { path = "../crashtracker-ffi", features = ["collector", "collector_windows"] }
+
 [dev-dependencies]
 http = "1.0"
 tempfile = { version = "3.3" }

--- a/sidecar-ffi/cbindgen.toml
+++ b/sidecar-ffi/cbindgen.toml
@@ -13,6 +13,9 @@ no_includes = true
 sys_includes = ["stdbool.h", "stddef.h", "stdint.h", "stdio.h"]
 includes = ["common.h"]
 
+[defines]
+"target_os = windows" = "_WIN32"
+
 [export]
 prefix = "ddog_"
 renaming_overrides_prefixing = true
@@ -23,6 +26,7 @@ rename_types = "PascalCase"
 [export.rename]
 "ParseTagsResult" = "ddog_Vec_Tag_ParseResult"
 "PushTagResult" = "ddog_Vec_Tag_PushResult"
+"Metadata" = "ddog_crasht_Metadata"
 "FILE" = "FILE"
 
 [enum]

--- a/sidecar-ffi/src/lib.rs
+++ b/sidecar-ffi/src/lib.rs
@@ -7,6 +7,8 @@
 #![cfg_attr(not(test), deny(clippy::todo))]
 #![cfg_attr(not(test), deny(clippy::unimplemented))]
 
+#[cfg(windows)]
+use datadog_crashtracker_ffi::Metadata;
 use datadog_ipc::platform::{
     FileBackedHandle, MappedMem, NamedShmHandle, PlatformHandle, ShmHandle,
 };
@@ -47,6 +49,15 @@ use std::os::windows::io::{FromRawHandle, RawHandle};
 use std::slice;
 use std::sync::Arc;
 use std::time::Duration;
+
+#[no_mangle]
+#[cfg(target_os = "windows")]
+pub extern "C" fn ddog_setup_crashtracking(
+    endpoint: Option<&Endpoint>,
+    metadata: Metadata,
+) -> bool {
+    datadog_sidecar::ddog_setup_crashtracking(endpoint, metadata)
+}
 
 #[repr(C)]
 pub struct NativeFile {

--- a/sidecar/src/windows.rs
+++ b/sidecar/src/windows.rs
@@ -133,8 +133,7 @@ pub fn setup_daemon_process(listener: OwnedHandle, spawn_cfg: &mut SpawnWorker) 
     Ok(())
 }
 
-#[no_mangle]
-pub extern "C" fn ddog_setup_crashtracking(
+pub fn ddog_setup_crashtracking(
     endpoint: Option<&Endpoint>,
     metadata: Metadata,
 ) -> bool {


### PR DESCRIPTION
# What does this PR do?

Move the `ddog_setup_crashtracking` export (used for crashtracking on windows) from sidecar to sidecar-ffi

# Motivation

The export needs to be in sidecar-ffi otherwise it's missing from the generated sidecar.h header file.
