### PR TITLE
feat: Expose ddcommon memfd_create

### DIFF
--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -14,6 +14,7 @@ telemetry = []
 data-pipeline = []
 symbolizer = []
 library-config = []
+ddcommon = []
 
 [lib]
 bench = false

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -14,7 +14,6 @@ telemetry = []
 data-pipeline = []
 symbolizer = []
 library-config = []
-ddcommon = []
 
 [lib]
 bench = false

--- a/ddcommon-ffi/src/lib.rs
+++ b/ddcommon-ffi/src/lib.rs
@@ -19,6 +19,7 @@ pub mod slice_mut;
 pub mod string;
 pub mod tags;
 pub mod timespec;
+pub mod tracer_metadata;
 pub mod utils;
 pub mod vec;
 

--- a/ddcommon-ffi/src/tracer_metadata.rs
+++ b/ddcommon-ffi/src/tracer_metadata.rs
@@ -1,0 +1,85 @@
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::slice::CharSlice;
+#[cfg(target_os = "linux")]
+use ddcommon::tracer_metadata::AnonymousFileHandle;
+use ddcommon::tracer_metadata::{self, TracerMetadata};
+use std::os::raw::c_int;
+
+/// C-compatible representation of an anonymous file handle
+#[repr(C)]
+pub struct TracerMemfdHandle {
+    /// File descriptor (relevant only on Linux)
+    pub fd: c_int,
+    /// Whether the handle is valid
+    pub is_valid: bool,
+}
+
+/// Store tracer metadata to a file handle
+///
+/// # Safety
+///
+/// Accepts raw C-compatible strings
+#[no_mangle]
+pub unsafe extern "C" fn ddog_store_tracer_metadata(
+    schema_version: u8,
+    runtime_id: CharSlice,
+    tracer_language: CharSlice,
+    tracer_version: CharSlice,
+    hostname: CharSlice,
+    service_name: CharSlice,
+    service_env: CharSlice,
+    service_version: CharSlice,
+) -> TracerMemfdHandle {
+    // Convert C strings to Rust types
+    let metadata = TracerMetadata {
+        schema_version,
+        runtime_id: if runtime_id.is_empty() {
+            None
+        } else {
+            Some(runtime_id.to_string())
+        },
+        tracer_language: tracer_language.to_string(),
+        tracer_version: tracer_version.to_string(),
+        hostname: hostname.to_string(),
+        service_name: if service_name.is_empty() {
+            None
+        } else {
+            Some(service_name.to_string())
+        },
+        service_env: if service_env.is_empty() {
+            None
+        } else {
+            Some(service_env.to_string())
+        },
+        service_version: if service_version.is_empty() {
+            None
+        } else {
+            Some(service_version.to_string())
+        },
+    };
+
+    // Call the actual implementation
+    match tracer_metadata::store_tracer_metadata(&metadata) {
+        #[cfg(target_os = "linux")]
+        Ok(handle) => {
+            use std::os::fd::{IntoRawFd, OwnedFd};
+            let AnonymousFileHandle::Linux(memfd) = handle;
+            let owned_fd: OwnedFd = memfd.into_file().into();
+            TracerMemfdHandle {
+                fd: owned_fd.into_raw_fd(),
+                is_valid: true,
+            }
+        }
+        #[cfg(not(target_os = "linux"))]
+        Ok(_) => TracerMemfdHandle {
+            fd: -1,
+            is_valid: false,
+        },
+        Err(_err) => TracerMemfdHandle {
+            fd: -1,
+            is_valid: false,
+        },
+    }
+}

--- a/profiling-ffi/Cargo.toml
+++ b/profiling-ffi/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["staticlib", "cdylib"]
 bench = false
 
 [features]
-default = []
+default = ["ddcommon-ffi"]
 cbindgen = ["build_common/cbindgen", "ddcommon-ffi/cbindgen"]
 ddtelemetry-ffi = ["dep:ddtelemetry-ffi"]
 symbolizer = ["symbolizer-ffi"]
@@ -27,6 +27,7 @@ crashtracker-collector = ["crashtracker-ffi", "datadog-crashtracker-ffi/collecto
 crashtracker-receiver = ["crashtracker-ffi", "datadog-crashtracker-ffi/receiver"]
 demangler = ["crashtracker-ffi", "datadog-crashtracker-ffi/demangler"]
 datadog-library-config-ffi = ["dep:datadog-library-config-ffi"]
+ddcommon-ffi = ["dep:ddcommon-ffi"]
 
 [build-dependencies]
 build_common = { path = "../build-common" }
@@ -38,7 +39,7 @@ datadog-crashtracker-ffi = { path = "../crashtracker-ffi", default-features = fa
 datadog-library-config-ffi = {  path = "../library-config-ffi", default-features = false, optional = true }
 datadog-profiling = { path = "../profiling" }
 ddcommon = { path = "../ddcommon"}
-ddcommon-ffi = { path = "../ddcommon-ffi", default-features = false }
+ddcommon-ffi = { path = "../ddcommon-ffi", default-features = false, optional = true }
 ddtelemetry-ffi = { path = "../ddtelemetry-ffi", default-features = false, optional = true, features = ["expanded_builder_macros"] }
 function_name = "0.3.0"
 futures = { version = "0.3", default-features = false }

--- a/profiling-ffi/src/lib.rs
+++ b/profiling-ffi/src/lib.rs
@@ -29,3 +29,7 @@ pub use data_pipeline_ffi::*;
 // re-export library-config ffi
 #[cfg(feature = "datadog-library-config-ffi")]
 pub use datadog_library_config_ffi::*;
+
+// re-export tracer metadata functions
+#[cfg(feature = "ddcommon-ffi")]
+pub use ddcommon_ffi::*;


### PR DESCRIPTION
# What does this PR do?

In dotnet we're gonna need to expose the FFI 

Related to 
https://datadoghq.atlassian.net/browse/APMAPI-1072
https://github.com/DataDog/libdatadog/pull/867


# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Integrated in the dotnet tracer locally, it's working for me under WSL, I can see and decode the linux file descriptor. 
