### PR TITLE
fix: tokio runtime should be multithread

### DIFF
--- a/data-pipeline-ffi/src/trace_exporter.rs
+++ b/data-pipeline-ffi/src/trace_exporter.rs
@@ -623,6 +623,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[test]
     fn exporter_constructor_test() {
         unsafe {
@@ -651,6 +652,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[test]
     fn exporter_constructor_error_test() {
         unsafe {

--- a/data-pipeline/src/trace_exporter/mod.rs
+++ b/data-pipeline/src/trace_exporter/mod.rs
@@ -1145,7 +1145,7 @@ mod tests {
         assert!(exporter.telemetry.is_some());
     }
 
-    #[cfg_attr(all(miri, target_os = "macos"), ignore)]
+    #[cfg_attr(miri, ignore)]
     #[test]
     fn test_new_defaults() {
         let builder = TraceExporterBuilder::default();

--- a/data-pipeline/src/trace_exporter/mod.rs
+++ b/data-pipeline/src/trace_exporter/mod.rs
@@ -975,7 +975,8 @@ impl TraceExporterBuilder {
             ));
         }
 
-        let runtime = tokio::runtime::Builder::new_current_thread()
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
             .enable_all()
             .build()?;
 

--- a/trace-utils/src/trace_utils.rs
+++ b/trace-utils/src/trace_utils.rs
@@ -938,6 +938,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg_attr(miri, ignore)]
     async fn test_get_traces_from_request_body_with_span_links() {
         let trace_input = json!([[{
             "service": "test-service",


### PR DESCRIPTION

# What does this PR do?

This PR changes the tokio runtime type used in the data-pipeline from `current_thread` to multi-threaded, with a single worker thread.

# Motivation

There is a big in how we run background tasks such as the info fetcher and the stats exporter in the trace exporter. We currently spawn them in the runtime held by the trace exporter. This runtime is a `current_thread`, which according to the tokio documentation only runs background task when the runtime is in a `block_on` https://docs.rs/tokio/latest/tokio/runtime/index.html#current-thread-runtime-behavior-at-the-time-of-writing.

This is called only when sending traces, which means that background tasks are paused in between traces submissions. So if the stats exporter is sending data for instance, and the runtime pauses the requests might be interrupted while it's being sent which will create issues.

The fix is to use the multi threaded runtime, which will keep a worker pool to execute tasks even when we are outside of block_on. I configure the runtime to use only one worker thread instead of the default 4 used because we don't do have that many tasks and to be parsimonious with user resources
