### PR TITLE
[crashtracker] Continue symbolicating after errors

### DIFF
--- a/crashtracker/src/crash_info/mod.rs
+++ b/crashtracker/src/crash_info/mod.rs
@@ -69,11 +69,19 @@ impl CrashInfo {
 #[cfg(unix)]
 impl CrashInfo {
     pub fn normalize_ips(&mut self, pid: u32) -> anyhow::Result<()> {
-        self.error.normalize_ips(pid)
+        if let Err(mut e) = self.error.normalize_ips(pid) {
+            self.log_messages.append(&mut e);
+            anyhow::bail!("Failed to normalize ips, see [log_messages] for detailed errors.")
+        }
+        Ok(())
     }
 
     pub fn resolve_names(&mut self, pid: u32) -> anyhow::Result<()> {
-        self.error.resolve_names(pid)
+        if let Err(mut e) = self.error.resolve_names(pid) {
+            self.log_messages.append(&mut e);
+            anyhow::bail!("Failed to resolve names, see [log_messages] for detailed errors.")
+        }
+        Ok(())
     }
 }
 

--- a/crashtracker/src/crash_info/stacktrace.rs
+++ b/crashtracker/src/crash_info/stacktrace.rs
@@ -73,20 +73,36 @@ impl StackTrace {
 
 #[cfg(unix)]
 impl StackTrace {
-    pub fn normalize_ips(&mut self, normalizer: &Normalizer, pid: Pid) -> anyhow::Result<()> {
+    pub fn normalize_ips(&mut self, normalizer: &Normalizer, pid: Pid) -> Result<(), Vec<String>> {
+        let mut errors = vec![];
         for frame in &mut self.frames {
-            // TODO: Should this keep going on failure, and report at the end?
-            frame.normalize_ip(normalizer, pid)?;
+            if let Err(e) = frame.normalize_ip(normalizer, pid) {
+                errors.push(e.to_string());
+            }
         }
-        Ok(())
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
     }
 
-    pub fn resolve_names(&mut self, src: &Source, symbolizer: &Symbolizer) -> anyhow::Result<()> {
+    pub fn resolve_names(
+        &mut self,
+        src: &Source,
+        symbolizer: &Symbolizer,
+    ) -> Result<(), Vec<String>> {
+        let mut errors = vec![];
         for frame in &mut self.frames {
-            // TODO: Should this keep going on failure, and report at the end?
-            frame.resolve_names(src, symbolizer)?;
+            if let Err(e) = frame.resolve_names(src, symbolizer) {
+                errors.push(e.to_string());
+            }
         }
-        Ok(())
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
     }
 }
 


### PR DESCRIPTION
# What does this PR do?

Fixes a TODO where we stopped symbolicating after the first failure.

# Motivation

Right now, if we have any failures symbolicating, we fly blind and symbolicate nothing.  Instead, lets keep going and log the errors.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
