### PR TITLE
[APMAPI-1284] Package libdatadog v17.0.0 for Ruby

### DIFF
--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -22,22 +22,22 @@ end
 LIB_GITHUB_RELEASES = [
   {
     file: "libdatadog-aarch64-alpine-linux-musl.tar.gz",
-    sha256: "54416e4078fa9d923869ecae1a7b32e0c9ae0a47ab8c999812bb3b69cffb85bd",
+    sha256: "d2a30a155553f5baf334c93e9280f161289697981fef20784f9c6317d061fc1b",
     ruby_platform: "aarch64-linux-musl"
   },
   {
     file: "libdatadog-aarch64-unknown-linux-gnu.tar.gz",
-    sha256: "ad16283494d565a1877c76d4a8765f789ec2acb70b0597b4efe6e7a20e8b4f97",
+    sha256: "4cac537ac7895fe2e640b4d2f70ce96d543e411dabe06492cc31fa2a2d564824",
     ruby_platform: "aarch64-linux"
   },
   {
     file: "libdatadog-x86_64-alpine-linux-musl.tar.gz",
-    sha256: "384a50bb5013f6098b37da650f0fe9aa7c11f44780da971f8a4a35d2e342f00b",
+    sha256: "f4c00a4deab7e2a3ad760e9d9a0d8170322c2a167dede4fdfdec6a350a534257",
     ruby_platform: "x86_64-linux-musl"
   },
   {
     file: "libdatadog-x86_64-unknown-linux-gnu.tar.gz",
-    sha256: "6cea4ef4ecd4f40c1c69118bc1bb842c20782b710b838df3917d02eea7575a4e",
+    sha256: "7601fe816c3d90c3b4756481bd9280c4617866c3f5f6cd391f632459fbca9d1b",
     ruby_platform: "x86_64-linux"
   }
 ]

--- a/ruby/lib/libdatadog/version.rb
+++ b/ruby/lib/libdatadog/version.rb
@@ -2,7 +2,7 @@
 
 module Libdatadog
   # Current libdatadog version
-  LIB_VERSION = "16.0.1"
+  LIB_VERSION = "17.0.0"
 
   GEM_MAJOR_VERSION = "1"
   GEM_MINOR_VERSION = "0"


### PR DESCRIPTION
# What does this PR do?

This PR includes the changes documented in the "Releasing a new version to rubygems.org" part of the README:
[datadog/libdatadog@main/ruby#releasing-a-new-version-to-rubygemsorg](https://github.com/datadog/libdatadog/tree/main/ruby?rgh-link-date=2025-02-07T11%3A02%3A17Z#releasing-a-new-version-to-rubygemsorg)

# Motivation

Enable Ruby to use libdatadog v17.0.0. Of particular interest, this includes a new API for process discovery (#867)

# Additional Notes

N/A

# How to test the change?

When service discovery on dd-trace-rb side will be ready it will be tested against it.
