### PR TITLE
[APMSP-1764] Support borrowed buffer for msgpack decoding

### DIFF
--- a/data-pipeline/src/trace_exporter/mod.rs
+++ b/data-pipeline/src/trace_exporter/mod.rs
@@ -229,7 +229,6 @@ impl TraceExporter {
 
         match self.input_format {
             TraceExporterInputFormat::Proxy => self.send_proxy(data.as_ref(), trace_count),
-            // The goal here is to ultimately replace the usage of `from_bytes` with `from_slice`.
             TraceExporterInputFormat::V04 => match msgpack_decoder::v04::from_bytes(data) {
                 Ok((traces, _)) => self.send_deser_ser(TraceCollection::TraceChunk(traces)),
                 Err(e) => Err(TraceExporterError::Deserialization(e)),

--- a/data-pipeline/src/trace_exporter/mod.rs
+++ b/data-pipeline/src/trace_exporter/mod.rs
@@ -229,11 +229,11 @@ impl TraceExporter {
 
         match self.input_format {
             TraceExporterInputFormat::Proxy => self.send_proxy(data.as_ref(), trace_count),
-            TraceExporterInputFormat::V04 => match msgpack_decoder::v04::from_slice(data) {
+            TraceExporterInputFormat::V04 => match msgpack_decoder::v04::from_bytes(data) {
                 Ok((traces, _)) => self.send_deser_ser(TraceCollection::TraceChunk(traces)),
                 Err(e) => Err(TraceExporterError::Deserialization(e)),
             },
-            TraceExporterInputFormat::V05 => match msgpack_decoder::v05::from_slice(data) {
+            TraceExporterInputFormat::V05 => match msgpack_decoder::v05::from_bytes(data) {
                 Ok((traces, _)) => self.send_deser_ser(TraceCollection::TraceChunk(traces)),
                 Err(e) => Err(TraceExporterError::Deserialization(e)),
             },

--- a/data-pipeline/src/trace_exporter/mod.rs
+++ b/data-pipeline/src/trace_exporter/mod.rs
@@ -229,6 +229,7 @@ impl TraceExporter {
 
         match self.input_format {
             TraceExporterInputFormat::Proxy => self.send_proxy(data.as_ref(), trace_count),
+            // The goal here is to ultimately replace the usage of `from_bytes` with `from_slice`.
             TraceExporterInputFormat::V04 => match msgpack_decoder::v04::from_bytes(data) {
                 Ok((traces, _)) => self.send_deser_ser(TraceCollection::TraceChunk(traces)),
                 Err(e) => Err(TraceExporterError::Deserialization(e)),

--- a/tinybytes/src/bytes_string.rs
+++ b/tinybytes/src/bytes_string.rs
@@ -89,6 +89,10 @@ impl BytesString {
     ///
     /// * `bytes` - A `tinybytes::Bytes` instance that will be converted into a `BytesString`.
     /// * `slice` - The string slice pointing into the given bytes that will form the `BytesString`.
+    ///
+    /// # Return
+    ///
+    /// Returns `None` if `slice` is not pointing into `bytes`.
     pub fn try_from_bytes_slice(bytes: &Bytes, slice: &str) -> Option<Self> {
         // SAFETY: This is safe as a str slice is definitely a valid UTF-8 slice.
         unsafe {

--- a/tinybytes/src/bytes_string.rs
+++ b/tinybytes/src/bytes_string.rs
@@ -83,6 +83,21 @@ impl BytesString {
         }
     }
 
+    /// Creates a `Option<BytesString>` from a string slice within the given buffer.
+    ///
+    /// # Arguments
+    ///
+    /// * `bytes` - A `tinybytes::Bytes` instance that will be converted into a `BytesString`.
+    /// * `slice` - The string slice pointing into the given bytes that will form the `BytesString`.
+    pub fn try_from_bytes_slice(bytes: &Bytes, slice: &str) -> Option<Self> {
+        // SAFETY: This is safe as a str slice is definitely a valid UTF-8 slice.
+        unsafe {
+            Some(Self::from_bytes_unchecked(
+                bytes.slice_ref(slice.as_bytes())?,
+            ))
+        }
+    }
+
     /// Creates a `BytesString` from a `tinybytes::Bytes` instance without validating the bytes.
     ///
     /// This function does not perform any validation on the provided bytes, and assumes that the

--- a/tinybytes/src/lib.rs
+++ b/tinybytes/src/lib.rs
@@ -86,7 +86,7 @@ impl Bytes {
     ///
     /// let slice = bytes.slice(6..11);
     /// assert_eq!(slice.as_ref(), b"world");
-    /// ```    
+    /// ```
     pub fn slice(&self, range: impl RangeBounds<usize>) -> Self {
         use std::ops::Bound;
 
@@ -151,7 +151,7 @@ impl Bytes {
     ///
     /// let invalid_subset = b"invalid";
     /// assert!(bytes.slice_ref(invalid_subset).is_none());
-    /// ```    
+    /// ```
     pub fn slice_ref(&self, subset: &[u8]) -> Option<Bytes> {
         // An empty slice can be a subset of any slice.
         if subset.is_empty() {

--- a/trace-utils/src/msgpack_decoder/decode/error.rs
+++ b/trace-utils/src/msgpack_decoder/decode/error.rs
@@ -1,12 +1,18 @@
 // Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+/// Represent error that can happen while decoding msgpack.
 #[derive(Debug, PartialEq)]
 pub enum DecodeError {
+    /// Failed to convert a number to the expected type.
     InvalidConversion(String),
+    /// Payload does not match the expected type for a trace payload.
     InvalidType(String),
+    /// Payload is not a valid msgpack object.
     InvalidFormat(String),
+    /// Failed to read the buffer.
     IOError,
+    /// The payload contains non-utf8 strings.
     Utf8Error(String),
 }
 
@@ -14,9 +20,9 @@ impl std::fmt::Display for DecodeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             DecodeError::InvalidConversion(msg) => write!(f, "Failed to convert value: {}", msg),
-            DecodeError::IOError => write!(f, "Failed to read from buffer"),
             DecodeError::InvalidType(msg) => write!(f, "Invalid type encountered: {}", msg),
             DecodeError::InvalidFormat(msg) => write!(f, "Invalid format: {}", msg),
+            DecodeError::IOError => write!(f, "Failed to read from buffer"),
             DecodeError::Utf8Error(msg) => write!(f, "Failed to read utf8 value: {}", msg),
         }
     }

--- a/trace-utils/src/msgpack_decoder/decode/map.rs
+++ b/trace-utils/src/msgpack_decoder/decode/map.rs
@@ -4,7 +4,6 @@
 use crate::msgpack_decoder::decode::error::DecodeError;
 use rmp::{decode, decode::RmpRead, Marker};
 use std::collections::HashMap;
-use tinybytes::Bytes;
 
 /// Reads a map from the buffer and returns it as a `HashMap`.
 ///
@@ -14,7 +13,7 @@ use tinybytes::Bytes;
 /// # Arguments
 ///
 /// * `len` - The number of key-value pairs to read from the buffer.
-/// * `buf` - A reference to the Bytes containing the encoded map data.
+/// * `buf` - A reference to the slice containing the encoded map data.
 /// * `read_pair` - A function that reads a key-value pair from the buffer and returns it as a
 ///   `Result<(K, V), DecodeError>`.
 ///
@@ -34,14 +33,14 @@ use tinybytes::Bytes;
 /// * `V` - The type of the values in the map.
 /// * `F` - The type of the function used to read key-value pairs from the buffer.
 #[inline]
-pub fn read_map<K, V, F>(
+pub fn read_map<'a, K, V, F>(
     len: usize,
-    buf: &mut Bytes,
+    buf: &mut &'a [u8],
     read_pair: F,
 ) -> Result<HashMap<K, V>, DecodeError>
 where
     K: std::hash::Hash + Eq,
-    F: Fn(&mut Bytes) -> Result<(K, V), DecodeError>,
+    F: Fn(&mut &'a [u8]) -> Result<(K, V), DecodeError>,
 {
     let mut map = HashMap::with_capacity(len);
     for _ in 0..len {

--- a/trace-utils/src/msgpack_decoder/decode/meta_struct.rs
+++ b/trace-utils/src/msgpack_decoder/decode/meta_struct.rs
@@ -50,7 +50,6 @@ mod tests {
 
         let serialized = rmp_serde::to_vec_named(&meta).unwrap();
         let mut slice = serialized.as_ref();
-            // unsafe { std::mem::transmute::<&'_ [u8], &'static [u8]>(serialized.as_ref()) };
         let res = read_meta_struct(&mut slice).unwrap();
 
         assert_eq!(res.get("key").unwrap().to_vec(), vec![1, 2, 3, 4]);

--- a/trace-utils/src/msgpack_decoder/decode/meta_struct.rs
+++ b/trace-utils/src/msgpack_decoder/decode/meta_struct.rs
@@ -49,8 +49,8 @@ mod tests {
         let meta = HashMap::from([("key".to_string(), Bytes::from(vec![1, 2, 3, 4]))]);
 
         let serialized = rmp_serde::to_vec_named(&meta).unwrap();
-        let mut slice =
-            unsafe { std::mem::transmute::<&'_ [u8], &'static [u8]>(serialized.as_ref()) };
+        let mut slice = serialized.as_ref();
+            // unsafe { std::mem::transmute::<&'_ [u8], &'static [u8]>(serialized.as_ref()) };
         let res = read_meta_struct(&mut slice).unwrap();
 
         assert_eq!(res.get("key").unwrap().to_vec(), vec![1, 2, 3, 4]);
@@ -61,8 +61,7 @@ mod tests {
         let meta = HashMap::from([("key".to_string(), vec![1, 2, 3, 4])]);
 
         let serialized = rmp_serde::to_vec_named(&meta).unwrap();
-        let mut slice =
-            unsafe { std::mem::transmute::<&'_ [u8], &'static [u8]>(serialized.as_ref()) };
+        let mut slice = serialized.as_ref();
         let res = read_meta_struct(&mut slice);
 
         assert!(res.is_err());

--- a/trace-utils/src/msgpack_decoder/decode/meta_struct.rs
+++ b/trace-utils/src/msgpack_decoder/decode/meta_struct.rs
@@ -3,10 +3,10 @@
 
 use crate::msgpack_decoder::decode::error::DecodeError;
 use crate::msgpack_decoder::decode::map::{read_map, read_map_len};
-use crate::msgpack_decoder::decode::string::{handle_null_marker, read_string_bytes};
+use crate::msgpack_decoder::decode::string::{is_null_marker, read_string_ref};
 use rmp::decode;
 use std::collections::HashMap;
-use tinybytes::{Bytes, BytesString};
+use tinybytes::Bytes;
 
 fn read_byte_array_len(buf: &mut &[u8]) -> Result<u32, DecodeError> {
     decode::read_bin_len(buf).map_err(|_| {
@@ -15,27 +15,27 @@ fn read_byte_array_len(buf: &mut &[u8]) -> Result<u32, DecodeError> {
 }
 
 #[inline]
-pub fn read_meta_struct(buf: &mut Bytes) -> Result<HashMap<BytesString, Bytes>, DecodeError> {
-    if let Some(empty_map) = handle_null_marker(buf, HashMap::default) {
-        return Ok(empty_map);
+pub fn read_meta_struct<'a>(buf: &mut &'a [u8]) -> Result<HashMap<&'a str, Bytes>, DecodeError> {
+    if is_null_marker(buf) {
+        return Ok(HashMap::default());
     }
 
-    fn read_meta_struct_pair(buf: &mut Bytes) -> Result<(BytesString, Bytes), DecodeError> {
-        let key = read_string_bytes(buf)?;
-        let byte_array_len = read_byte_array_len(unsafe { buf.as_mut_slice() })? as usize;
+    fn read_meta_struct_pair<'a>(buf: &mut &'a [u8]) -> Result<(&'a str, Bytes), DecodeError> {
+        let key = read_string_ref(buf)?;
+        let byte_array_len = read_byte_array_len(buf)? as usize;
 
-        let data = buf
-            .slice_ref(&buf[0..byte_array_len])
+        let buf_bytes = Bytes::copy_from_slice(buf);
+        let data = buf_bytes
+            .slice_ref(&buf_bytes[0..byte_array_len])
             .ok_or_else(|| DecodeError::InvalidFormat("Invalid data length".to_string()))?;
-        unsafe {
-            // SAFETY: forwarding the buffer requires that buf is borrowed from static.
-            *buf.as_mut_slice() = &buf.as_mut_slice()[byte_array_len..];
-        }
+
+        // SAFETY: forwarding the buffer requires that buf is borrowed from static.
+        *buf = &buf[byte_array_len..];
 
         Ok((key, data))
     }
 
-    let len = read_map_len(unsafe { buf.as_mut_slice() })?;
+    let len = read_map_len(buf)?;
     read_map(len, buf, read_meta_struct_pair)
 }
 
@@ -47,8 +47,10 @@ mod tests {
     fn read_meta_test() {
         let meta = HashMap::from([("key".to_string(), Bytes::from(vec![1, 2, 3, 4]))]);
 
-        let mut bytes = Bytes::from(rmp_serde::to_vec_named(&meta).unwrap());
-        let res = read_meta_struct(&mut bytes).unwrap();
+        let serialized = rmp_serde::to_vec_named(&meta).unwrap();
+        let mut slice =
+            unsafe { std::mem::transmute::<&'_ [u8], &'static [u8]>(serialized.as_ref()) };
+        let res = read_meta_struct(&mut slice).unwrap();
 
         assert_eq!(res.get("key").unwrap().to_vec(), vec![1, 2, 3, 4]);
     }
@@ -57,8 +59,10 @@ mod tests {
     fn read_meta_wrong_family_test() {
         let meta = HashMap::from([("key".to_string(), vec![1, 2, 3, 4])]);
 
-        let mut bytes = Bytes::from(rmp_serde::to_vec_named(&meta).unwrap());
-        let res = read_meta_struct(&mut bytes);
+        let serialized = rmp_serde::to_vec_named(&meta).unwrap();
+        let mut slice =
+            unsafe { std::mem::transmute::<&'_ [u8], &'static [u8]>(serialized.as_ref()) };
+        let res = read_meta_struct(&mut slice);
 
         assert!(res.is_err());
         matches!(res.unwrap_err(), DecodeError::InvalidFormat(_));

--- a/trace-utils/src/msgpack_decoder/decode/meta_struct.rs
+++ b/trace-utils/src/msgpack_decoder/decode/meta_struct.rs
@@ -3,7 +3,7 @@
 
 use crate::msgpack_decoder::decode::error::DecodeError;
 use crate::msgpack_decoder::decode::map::{read_map, read_map_len};
-use crate::msgpack_decoder::decode::string::{is_null_marker, read_string_ref};
+use crate::msgpack_decoder::decode::string::{handle_null_marker, read_string_ref};
 use rmp::decode;
 use std::collections::HashMap;
 use tinybytes::Bytes;
@@ -16,7 +16,7 @@ fn read_byte_array_len(buf: &mut &[u8]) -> Result<u32, DecodeError> {
 
 #[inline]
 pub fn read_meta_struct<'a>(buf: &mut &'a [u8]) -> Result<HashMap<&'a str, Bytes>, DecodeError> {
-    if is_null_marker(buf) {
+    if handle_null_marker(buf) {
         return Ok(HashMap::default());
     }
 

--- a/trace-utils/src/msgpack_decoder/decode/metrics.rs
+++ b/trace-utils/src/msgpack_decoder/decode/metrics.rs
@@ -4,7 +4,7 @@
 use crate::msgpack_decoder::decode::error::DecodeError;
 use crate::msgpack_decoder::decode::map::{read_map, read_map_len};
 use crate::msgpack_decoder::decode::number::read_number_slice;
-use crate::msgpack_decoder::decode::string::{is_null_marker, read_string_ref};
+use crate::msgpack_decoder::decode::string::{handle_null_marker, read_string_ref};
 use std::collections::HashMap;
 
 #[inline]
@@ -16,7 +16,7 @@ pub fn read_metric_pair<'a>(buf: &mut &'a [u8]) -> Result<(&'a str, f64), Decode
 }
 #[inline]
 pub fn read_metrics<'a>(buf: &mut &'a [u8]) -> Result<HashMap<&'a str, f64>, DecodeError> {
-    if is_null_marker(buf) {
+    if handle_null_marker(buf) {
         return Ok(HashMap::default());
     }
 

--- a/trace-utils/src/msgpack_decoder/decode/number.rs
+++ b/trace-utils/src/msgpack_decoder/decode/number.rs
@@ -210,6 +210,20 @@ pub fn read_nullable_number_bytes<T: TryFrom<Number, Error = DecodeError>>(
     read_number(unsafe { buf.as_mut_slice() }, true)?.try_into()
 }
 
+/// Read a msgpack encoded number from `buf`.
+pub fn read_number_slice<T: TryFrom<Number, Error = DecodeError>>(
+    buf: &mut &[u8],
+) -> Result<T, DecodeError> {
+    read_number(buf, false)?.try_into()
+}
+
+/// Read a msgpack encoded number from `buf` and return 0 if null.
+pub fn read_nullable_number_slice<T: TryFrom<Number, Error = DecodeError>>(
+    buf: &mut &[u8],
+) -> Result<T, DecodeError> {
+    read_number(buf, true)?.try_into()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/trace-utils/src/msgpack_decoder/decode/number.rs
+++ b/trace-utils/src/msgpack_decoder/decode/number.rs
@@ -4,7 +4,6 @@
 use crate::msgpack_decoder::decode::error::DecodeError;
 use rmp::{decode::RmpRead, Marker};
 use std::fmt;
-use tinybytes::Bytes;
 
 #[derive(Debug, PartialEq)]
 pub enum Number {
@@ -198,18 +197,6 @@ fn read_number(buf: &mut &[u8], allow_null: bool) -> Result<Number, DecodeError>
     }
 }
 
-pub fn read_number_bytes<T: TryFrom<Number, Error = DecodeError>>(
-    buf: &mut Bytes,
-) -> Result<T, DecodeError> {
-    read_number(unsafe { buf.as_mut_slice() }, false)?.try_into()
-}
-
-pub fn read_nullable_number_bytes<T: TryFrom<Number, Error = DecodeError>>(
-    buf: &mut Bytes,
-) -> Result<T, DecodeError> {
-    read_number(unsafe { buf.as_mut_slice() }, true)?.try_into()
-}
-
 /// Read a msgpack encoded number from `buf`.
 pub fn read_number_slice<T: TryFrom<Number, Error = DecodeError>>(
     buf: &mut &[u8],
@@ -231,45 +218,45 @@ mod tests {
     use std::f64;
 
     #[test]
-    fn test_decoding_not_nullable_bytes_to_unsigned() {
+    fn test_decoding_not_nullable_slice_to_unsigned() {
         let mut buf = Vec::new();
         let expected_value = 42;
         let val = json!(expected_value);
         rmp_serde::encode::write_named(&mut buf, &val).unwrap();
-        let mut bytes = Bytes::from(buf.clone());
-        let result: u8 = read_number_bytes(&mut bytes).unwrap();
+        let mut slice = buf.as_slice();
+        let result: u8 = read_number_slice(&mut slice).unwrap();
         assert_eq!(result, expected_value);
     }
 
     #[test]
-    fn test_decoding_not_nullable_bytes_to_signed() {
+    fn test_decoding_not_nullable_slice_to_signed() {
         let mut buf = Vec::new();
         let expected_value = 42;
         let val = json!(expected_value);
         rmp_serde::encode::write_named(&mut buf, &val).unwrap();
-        let mut bytes = Bytes::from(buf.clone());
-        let result: i8 = read_number_bytes(&mut bytes).unwrap();
+        let mut slice = buf.as_slice();
+        let result: i8 = read_number_slice(&mut slice).unwrap();
         assert_eq!(result, expected_value);
     }
 
     #[test]
-    fn test_decoding_not_nullable_bytes_to_float() {
+    fn test_decoding_not_nullable_slice_to_float() {
         let mut buf = Vec::new();
         let expected_value = 42.98;
         let val = json!(expected_value);
         rmp_serde::encode::write_named(&mut buf, &val).unwrap();
-        let mut bytes = Bytes::from(buf.clone());
-        let result: f64 = read_number_bytes(&mut bytes).unwrap();
+        let mut slice = buf.as_slice();
+        let result: f64 = read_number_slice(&mut slice).unwrap();
         assert_eq!(result, expected_value);
     }
 
     #[test]
-    fn test_decoding_null_through_read_number_bytes_raises_exception() {
+    fn test_decoding_null_through_read_number_slice_raises_exception() {
         let mut buf = Vec::new();
         let val = json!(null);
         rmp_serde::encode::write_named(&mut buf, &val).unwrap();
-        let mut bytes = Bytes::from(buf.clone());
-        let result: Result<u8, DecodeError> = read_number_bytes(&mut bytes);
+        let mut slice = buf.as_slice();
+        let result: Result<u8, DecodeError> = read_number_slice(&mut slice);
         assert!(matches!(result, Err(DecodeError::InvalidType(_))));
 
         assert_eq!(
@@ -279,32 +266,32 @@ mod tests {
     }
 
     #[test]
-    fn test_decoding_null_bytes_to_unsigned() {
+    fn test_decoding_null_slice_to_unsigned() {
         let mut buf = Vec::new();
         let val = json!(null);
         rmp_serde::encode::write_named(&mut buf, &val).unwrap();
-        let mut bytes = Bytes::from(buf.clone());
-        let result: u8 = read_nullable_number_bytes(&mut bytes).unwrap();
+        let mut slice = buf.as_slice();
+        let result: u8 = read_nullable_number_slice(&mut slice).unwrap();
         assert_eq!(result, 0);
     }
 
     #[test]
-    fn test_decoding_null_bytes_to_signed() {
+    fn test_decoding_null_slice_to_signed() {
         let mut buf = Vec::new();
         let val = json!(null);
         rmp_serde::encode::write_named(&mut buf, &val).unwrap();
-        let mut bytes = Bytes::from(buf.clone());
-        let result: i8 = read_nullable_number_bytes(&mut bytes).unwrap();
+        let mut slice = buf.as_slice();
+        let result: i8 = read_nullable_number_slice(&mut slice).unwrap();
         assert_eq!(result, 0);
     }
 
     #[test]
-    fn test_decoding_null_bytes_to_float() {
+    fn test_decoding_null_slice_to_float() {
         let mut buf = Vec::new();
         let val = json!(null);
         rmp_serde::encode::write_named(&mut buf, &val).unwrap();
-        let mut bytes = Bytes::from(buf.clone());
-        let result: f64 = read_nullable_number_bytes(&mut bytes).unwrap();
+        let mut slice = buf.as_slice();
+        let result: f64 = read_nullable_number_slice(&mut slice).unwrap();
         assert_eq!(result, 0.0);
     }
 

--- a/trace-utils/src/msgpack_decoder/decode/span_event.rs
+++ b/trace-utils/src/msgpack_decoder/decode/span_event.rs
@@ -3,7 +3,7 @@
 
 use crate::msgpack_decoder::decode::error::DecodeError;
 use crate::msgpack_decoder::decode::number::read_number_slice;
-use crate::msgpack_decoder::decode::string::{is_null_marker, read_string_ref};
+use crate::msgpack_decoder::decode::string::{handle_null_marker, read_string_ref};
 use crate::span::{AttributeAnyValueSlice, AttributeArrayValueSlice, SpanEventSlice};
 use std::collections::HashMap;
 use std::str::FromStr;
@@ -27,7 +27,7 @@ use std::str::FromStr;
 pub(crate) fn read_span_events<'a>(
     buf: &mut &'a [u8],
 ) -> Result<Vec<SpanEventSlice<'a>>, DecodeError> {
-    if is_null_marker(buf) {
+    if handle_null_marker(buf) {
         return Ok(Vec::default());
     }
 
@@ -171,7 +171,7 @@ fn decode_attribute_any<'a>(buf: &mut &'a [u8]) -> Result<AttributeAnyValueSlice
 fn read_attributes_array<'a>(
     buf: &mut &'a [u8],
 ) -> Result<Vec<AttributeArrayValueSlice<'a>>, DecodeError> {
-    if is_null_marker(buf) {
+    if handle_null_marker(buf) {
         return Ok(Vec::default());
     }
 

--- a/trace-utils/src/msgpack_decoder/decode/span_event.rs
+++ b/trace-utils/src/msgpack_decoder/decode/span_event.rs
@@ -2,15 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::msgpack_decoder::decode::error::DecodeError;
-use crate::msgpack_decoder::decode::number::read_number_bytes;
-use crate::msgpack_decoder::decode::string::{
-    handle_null_marker, read_string_bytes, read_string_ref,
-};
-use crate::span::{AttributeAnyValueBytes, AttributeArrayValueBytes, SpanEventBytes};
-use rmp::decode::ValueReadError;
+use crate::msgpack_decoder::decode::number::read_number_slice;
+use crate::msgpack_decoder::decode::string::{is_null_marker, read_string_ref};
+use crate::span::{AttributeAnyValueSlice, AttributeArrayValueSlice, SpanEventSlice};
 use std::collections::HashMap;
 use std::str::FromStr;
-use tinybytes::{Bytes, BytesString};
 
 /// Reads a slice of bytes and decodes it into a vector of `SpanEvent` objects.
 ///
@@ -28,16 +24,18 @@ use tinybytes::{Bytes, BytesString};
 /// This function will return an error if:
 /// - The marker for the array length cannot be read.
 /// - Any `SpanEvent` cannot be decoded.
-pub(crate) fn read_span_events(buf: &mut Bytes) -> Result<Vec<SpanEventBytes>, DecodeError> {
-    if let Some(empty_vec) = handle_null_marker(buf, Vec::default) {
-        return Ok(empty_vec);
+pub(crate) fn read_span_events<'a>(
+    buf: &mut &'a [u8],
+) -> Result<Vec<SpanEventSlice<'a>>, DecodeError> {
+    if is_null_marker(buf) {
+        return Ok(Vec::default());
     }
 
-    let len = rmp::decode::read_array_len(unsafe { buf.as_mut_slice() }).map_err(|_| {
+    let len = rmp::decode::read_array_len(buf).map_err(|_| {
         DecodeError::InvalidType("Unable to get array len for span events".to_owned())
     })?;
 
-    let mut vec: Vec<SpanEventBytes> = Vec::with_capacity(len as usize);
+    let mut vec: Vec<SpanEventSlice> = Vec::with_capacity(len as usize);
     for _ in 0..len {
         vec.push(decode_span_event(buf)?);
     }
@@ -65,15 +63,15 @@ impl FromStr for SpanEventKey {
     }
 }
 
-fn decode_span_event(buf: &mut Bytes) -> Result<SpanEventBytes, DecodeError> {
-    let mut event = SpanEventBytes::default();
-    let event_size = rmp::decode::read_map_len(unsafe { buf.as_mut_slice() })
+fn decode_span_event<'a>(buf: &mut &'a [u8]) -> Result<SpanEventSlice<'a>, DecodeError> {
+    let mut event = SpanEventSlice::default();
+    let event_size = rmp::decode::read_map_len(buf)
         .map_err(|_| DecodeError::InvalidType("Unable to get map len for event size".to_owned()))?;
 
     for _ in 0..event_size {
-        match read_string_ref(unsafe { buf.as_mut_slice() })?.parse::<SpanEventKey>()? {
-            SpanEventKey::TimeUnixNano => event.time_unix_nano = read_number_bytes(buf)?,
-            SpanEventKey::Name => event.name = read_string_bytes(buf)?,
+        match read_string_ref(buf)?.parse::<SpanEventKey>()? {
+            SpanEventKey::TimeUnixNano => event.time_unix_nano = read_number_slice(buf)?,
+            SpanEventKey::Name => event.name = read_string_ref(buf)?,
             SpanEventKey::Attributes => event.attributes = read_attributes_map(buf)?,
         }
     }
@@ -81,16 +79,16 @@ fn decode_span_event(buf: &mut Bytes) -> Result<SpanEventBytes, DecodeError> {
     Ok(event)
 }
 
-fn read_attributes_map(
-    buf: &mut Bytes,
-) -> Result<HashMap<BytesString, AttributeAnyValueBytes>, DecodeError> {
-    let len = rmp::decode::read_map_len(unsafe { buf.as_mut_slice() })
+fn read_attributes_map<'a>(
+    buf: &mut &'a [u8],
+) -> Result<HashMap<&'a str, AttributeAnyValueSlice<'a>>, DecodeError> {
+    let len = rmp::decode::read_map_len(buf)
         .map_err(|_| DecodeError::InvalidType("Unable to get map len for attributes".to_owned()))?;
 
     #[allow(clippy::expect_used)]
     let mut map = HashMap::with_capacity(len.try_into().expect("Unable to cast map len to usize"));
     for _ in 0..len {
-        let key = read_string_bytes(buf)?;
+        let key = read_string_ref(buf)?;
         let value = decode_attribute_any(buf)?;
         map.insert(key, value);
     }
@@ -123,16 +121,11 @@ impl FromStr for AttributeAnyKey {
     }
 }
 
-pub fn read_boolean_bytes(buf: &mut Bytes) -> Result<bool, ValueReadError> {
-    rmp::decode::read_bool(unsafe { buf.as_mut_slice() })
-}
-
-fn decode_attribute_any(buf: &mut Bytes) -> Result<AttributeAnyValueBytes, DecodeError> {
-    let mut attribute: Option<AttributeAnyValueBytes> = None;
-    let attribute_size =
-        rmp::decode::read_map_len(unsafe { buf.as_mut_slice() }).map_err(|_| {
-            DecodeError::InvalidType("Unable to get map len for attribute size".to_owned())
-        })?;
+fn decode_attribute_any<'a>(buf: &mut &'a [u8]) -> Result<AttributeAnyValueSlice<'a>, DecodeError> {
+    let mut attribute: Option<AttributeAnyValueSlice> = None;
+    let attribute_size = rmp::decode::read_map_len(buf).map_err(|_| {
+        DecodeError::InvalidType("Unable to get map len for attribute size".to_owned())
+    })?;
 
     if attribute_size != 2 {
         return Err(DecodeError::InvalidFormat(
@@ -142,15 +135,15 @@ fn decode_attribute_any(buf: &mut Bytes) -> Result<AttributeAnyValueBytes, Decod
     let mut attribute_type: Option<u8> = None;
 
     for _ in 0..attribute_size {
-        match read_string_ref(unsafe { buf.as_mut_slice() })?.parse::<AttributeAnyKey>()? {
-            AttributeAnyKey::Type => attribute_type = Some(read_number_bytes(buf)?),
+        match read_string_ref(buf)?.parse::<AttributeAnyKey>()? {
+            AttributeAnyKey::Type => attribute_type = Some(read_number_slice(buf)?),
             AttributeAnyKey::SingleValue(key) => {
-                attribute = Some(AttributeAnyValueBytes::SingleValue(get_attribute_from_key(
+                attribute = Some(AttributeAnyValueSlice::SingleValue(get_attribute_from_key(
                     buf, key,
                 )?))
             }
             AttributeAnyKey::ArrayValue => {
-                attribute = Some(AttributeAnyValueBytes::Array(read_attributes_array(buf)?))
+                attribute = Some(AttributeAnyValueSlice::Array(read_attributes_array(buf)?))
             }
         }
     }
@@ -175,16 +168,18 @@ fn decode_attribute_any(buf: &mut Bytes) -> Result<AttributeAnyValueBytes, Decod
     }
 }
 
-fn read_attributes_array(buf: &mut Bytes) -> Result<Vec<AttributeArrayValueBytes>, DecodeError> {
-    if let Some(empty_vec) = handle_null_marker(buf, Vec::default) {
-        return Ok(empty_vec);
+fn read_attributes_array<'a>(
+    buf: &mut &'a [u8],
+) -> Result<Vec<AttributeArrayValueSlice<'a>>, DecodeError> {
+    if is_null_marker(buf) {
+        return Ok(Vec::default());
     }
 
-    let len = rmp::decode::read_array_len(unsafe { buf.as_mut_slice() }).map_err(|_| {
+    let len = rmp::decode::read_array_len(buf).map_err(|_| {
         DecodeError::InvalidType("Unable to get array len for event attributes".to_owned())
     })?;
 
-    let mut vec: Vec<AttributeArrayValueBytes> = Vec::with_capacity(len as usize);
+    let mut vec: Vec<AttributeArrayValueSlice> = Vec::with_capacity(len as usize);
     if len > 0 {
         let first = decode_attribute_array(buf, None)?;
         let array_type = (&first).into();
@@ -222,44 +217,43 @@ impl FromStr for AttributeArrayKey {
     }
 }
 
-fn get_attribute_from_key(
-    buf: &mut Bytes,
+fn get_attribute_from_key<'a>(
+    buf: &mut &'a [u8],
     key: AttributeArrayKey,
-) -> Result<AttributeArrayValueBytes, DecodeError> {
+) -> Result<AttributeArrayValueSlice<'a>, DecodeError> {
     match key {
         AttributeArrayKey::StringValue => {
-            Ok(AttributeArrayValueBytes::String(read_string_bytes(buf)?))
+            Ok(AttributeArrayValueSlice::String(read_string_ref(buf)?))
         }
         AttributeArrayKey::BoolValue => {
-            let boolean = read_boolean_bytes(buf);
+            let boolean = rmp::decode::read_bool(buf);
             if let Ok(value) = boolean {
                 match value {
-                    true => Ok(AttributeArrayValueBytes::Boolean(true)),
-                    false => Ok(AttributeArrayValueBytes::Boolean(false)),
+                    true => Ok(AttributeArrayValueSlice::Boolean(true)),
+                    false => Ok(AttributeArrayValueSlice::Boolean(false)),
                 }
             } else {
                 Err(DecodeError::InvalidType("Invalid boolean field".to_owned()))
             }
         }
         AttributeArrayKey::IntValue => {
-            Ok(AttributeArrayValueBytes::Integer(read_number_bytes(buf)?))
+            Ok(AttributeArrayValueSlice::Integer(read_number_slice(buf)?))
         }
         AttributeArrayKey::DoubleValue => {
-            Ok(AttributeArrayValueBytes::Double(read_number_bytes(buf)?))
+            Ok(AttributeArrayValueSlice::Double(read_number_slice(buf)?))
         }
         _ => Err(DecodeError::InvalidFormat("Invalid attribute".to_owned())),
     }
 }
 
-fn decode_attribute_array(
-    buf: &mut Bytes,
+fn decode_attribute_array<'a>(
+    buf: &mut &'a [u8],
     array_type: Option<u8>,
-) -> Result<AttributeArrayValueBytes, DecodeError> {
-    let mut attribute: Option<AttributeArrayValueBytes> = None;
-    let attribute_size =
-        rmp::decode::read_map_len(unsafe { buf.as_mut_slice() }).map_err(|_| {
-            DecodeError::InvalidType("Unable to get map len for attribute size".to_owned())
-        })?;
+) -> Result<AttributeArrayValueSlice<'a>, DecodeError> {
+    let mut attribute: Option<AttributeArrayValueSlice> = None;
+    let attribute_size = rmp::decode::read_map_len(buf).map_err(|_| {
+        DecodeError::InvalidType("Unable to get map len for attribute size".to_owned())
+    })?;
 
     if attribute_size != 2 {
         return Err(DecodeError::InvalidFormat(
@@ -269,8 +263,8 @@ fn decode_attribute_array(
     let mut attribute_type: Option<u8> = None;
 
     for _ in 0..attribute_size {
-        match read_string_ref(unsafe { buf.as_mut_slice() })?.parse::<AttributeArrayKey>()? {
-            AttributeArrayKey::Type => attribute_type = Some(read_number_bytes(buf)?),
+        match read_string_ref(buf)?.parse::<AttributeArrayKey>()? {
+            AttributeArrayKey::Type => attribute_type = Some(read_number_slice(buf)?),
             key => attribute = Some(get_attribute_from_key(buf, key)?),
         }
     }

--- a/trace-utils/src/msgpack_decoder/decode/span_link.rs
+++ b/trace-utils/src/msgpack_decoder/decode/span_link.rs
@@ -4,7 +4,7 @@
 use crate::msgpack_decoder::decode::error::DecodeError;
 use crate::msgpack_decoder::decode::number::read_number_slice;
 use crate::msgpack_decoder::decode::string::{
-    is_null_marker, read_str_map_to_strings, read_string_ref,
+    handle_null_marker, read_str_map_to_strings, read_string_ref,
 };
 use crate::span::SpanLinkSlice;
 use std::str::FromStr;
@@ -29,7 +29,7 @@ use std::str::FromStr;
 pub(crate) fn read_span_links<'a>(
     buf: &mut &'a [u8],
 ) -> Result<Vec<SpanLinkSlice<'a>>, DecodeError> {
-    if is_null_marker(buf) {
+    if handle_null_marker(buf) {
         return Ok(Vec::default());
     }
 

--- a/trace-utils/src/msgpack_decoder/decode/span_link.rs
+++ b/trace-utils/src/msgpack_decoder/decode/span_link.rs
@@ -2,13 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::msgpack_decoder::decode::error::DecodeError;
-use crate::msgpack_decoder::decode::number::read_number_bytes;
+use crate::msgpack_decoder::decode::number::read_number_slice;
 use crate::msgpack_decoder::decode::string::{
-    handle_null_marker, read_str_map_to_bytes_strings, read_string_bytes, read_string_ref,
+    is_null_marker, read_str_map_to_strings, read_string_ref,
 };
-use crate::span::SpanLinkBytes;
+use crate::span::SpanLinkSlice;
 use std::str::FromStr;
-use tinybytes::Bytes;
 
 /// Reads a slice of bytes and decodes it into a vector of `SpanLink` objects.
 ///
@@ -27,16 +26,18 @@ use tinybytes::Bytes;
 /// - The marker for the array length cannot be read.
 /// - Any `SpanLink` cannot be decoded.
 /// ```
-pub(crate) fn read_span_links(buf: &mut Bytes) -> Result<Vec<SpanLinkBytes>, DecodeError> {
-    if let Some(empty_vec) = handle_null_marker(buf, Vec::default) {
-        return Ok(empty_vec);
+pub(crate) fn read_span_links<'a>(
+    buf: &mut &'a [u8],
+) -> Result<Vec<SpanLinkSlice<'a>>, DecodeError> {
+    if is_null_marker(buf) {
+        return Ok(Vec::default());
     }
 
-    let len = rmp::decode::read_array_len(unsafe { buf.as_mut_slice() }).map_err(|_| {
+    let len = rmp::decode::read_array_len(buf).map_err(|_| {
         DecodeError::InvalidType("Unable to get array len for span links".to_owned())
     })?;
 
-    let mut vec: Vec<SpanLinkBytes> = Vec::with_capacity(len as usize);
+    let mut vec: Vec<SpanLinkSlice> = Vec::with_capacity(len as usize);
     for _ in 0..len {
         vec.push(decode_span_link(buf)?);
     }
@@ -70,19 +71,19 @@ impl FromStr for SpanLinkKey {
     }
 }
 
-fn decode_span_link(buf: &mut Bytes) -> Result<SpanLinkBytes, DecodeError> {
-    let mut span = SpanLinkBytes::default();
-    let span_size = rmp::decode::read_map_len(unsafe { buf.as_mut_slice() })
+fn decode_span_link<'a>(buf: &mut &'a [u8]) -> Result<SpanLinkSlice<'a>, DecodeError> {
+    let mut span = SpanLinkSlice::default();
+    let span_size = rmp::decode::read_map_len(buf)
         .map_err(|_| DecodeError::InvalidType("Unable to get map len for span size".to_owned()))?;
 
     for _ in 0..span_size {
-        match read_string_ref(unsafe { buf.as_mut_slice() })?.parse::<SpanLinkKey>()? {
-            SpanLinkKey::TraceId => span.trace_id = read_number_bytes(buf)?,
-            SpanLinkKey::TraceIdHigh => span.trace_id_high = read_number_bytes(buf)?,
-            SpanLinkKey::SpanId => span.span_id = read_number_bytes(buf)?,
-            SpanLinkKey::Attributes => span.attributes = read_str_map_to_bytes_strings(buf)?,
-            SpanLinkKey::Tracestate => span.tracestate = read_string_bytes(buf)?,
-            SpanLinkKey::Flags => span.flags = read_number_bytes(buf)?,
+        match read_string_ref(buf)?.parse::<SpanLinkKey>()? {
+            SpanLinkKey::TraceId => span.trace_id = read_number_slice(buf)?,
+            SpanLinkKey::TraceIdHigh => span.trace_id_high = read_number_slice(buf)?,
+            SpanLinkKey::SpanId => span.span_id = read_number_slice(buf)?,
+            SpanLinkKey::Attributes => span.attributes = read_str_map_to_strings(buf)?,
+            SpanLinkKey::Tracestate => span.tracestate = read_string_ref(buf)?,
+            SpanLinkKey::Flags => span.flags = read_number_slice(buf)?,
         }
     }
 

--- a/trace-utils/src/msgpack_decoder/v04/mod.rs
+++ b/trace-utils/src/msgpack_decoder/v04/mod.rs
@@ -7,7 +7,8 @@ use self::span::decode_span;
 use crate::msgpack_decoder::decode::error::DecodeError;
 use crate::span::{SpanBytes, SpanSlice};
 
-/// Decodes a Bytes buffer into a `Vec<Vec<SpanBytes>>` object.
+/// Decodes a Bytes buffer into a `Vec<Vec<SpanBytes>>` object, also represented as a vector of
+/// `TracerPayloadV04` objects.
 ///
 /// # Arguments
 ///

--- a/trace-utils/src/msgpack_decoder/v04/mod.rs
+++ b/trace-utils/src/msgpack_decoder/v04/mod.rs
@@ -71,12 +71,12 @@ pub fn from_bytes(data: tinybytes::Bytes) -> Result<(Vec<Vec<SpanBytes>>, usize)
 ///
 /// # Arguments
 ///
-/// * `data` - A tinybytes Bytes buffer containing the encoded data. Bytes are expected to be
-///   encoded msgpack data containing a list of a list of v04 spans.
+/// * `data` - A slice of bytes containing the encoded data. Bytes are expected to be encoded
+///   msgpack data containing a list of a list of v04 spans.
 ///
 /// # Returns
 ///
-/// * `Ok(Vec<TracerPayloadV04>)` - A vector of decoded `TracerPayloadV04` objects if successful.
+/// * `Ok(Vec<TracerPayloadV04>)` - A vector of decoded `Vec<SpanSlice>` objects if successful.
 /// * `Err(DecodeError)` - An error if the decoding process fails.
 ///
 /// # Errors

--- a/trace-utils/src/msgpack_decoder/v04/mod.rs
+++ b/trace-utils/src/msgpack_decoder/v04/mod.rs
@@ -5,11 +5,68 @@ pub(crate) mod span;
 
 use self::span::decode_span;
 use crate::msgpack_decoder::decode::error::DecodeError;
-use crate::span::SpanBytes;
+use crate::span::{SpanBytes, SpanSlice};
 
-/// Decodes a slice of bytes into a vector of `TracerPayloadV04` objects.
+/// Decodes a Bytes buffer into a `Vec<Vec<SpanBytes>>` object.
 ///
+/// # Arguments
 ///
+/// * `data` - A tinybytes Bytes buffer containing the encoded data. Bytes are expected to be
+///   encoded msgpack data containing a list of a list of v04 spans.
+///
+/// # Returns
+///
+/// * `Ok(Vec<TracerPayloadV04>)` - A vector of decoded `TracerPayloadV04` objects if successful.
+/// * `Err(DecodeError)` - An error if the decoding process fails.
+///
+/// # Errors
+///
+/// This function will return an error if:
+/// - The array length for trace count or span count cannot be read.
+/// - Any span cannot be decoded.
+///
+/// # Examples
+///
+/// ```
+/// use datadog_trace_protobuf::pb::Span;
+/// use datadog_trace_utils::msgpack_decoder::v04::from_bytes;
+/// use rmp_serde::to_vec_named;
+/// use tinybytes;
+///
+/// let span = Span {
+///     name: "test-span".to_owned(),
+///     ..Default::default()
+/// };
+/// let encoded_data = to_vec_named(&vec![vec![span]]).unwrap();
+/// let encoded_data_as_tinybytes = tinybytes::Bytes::from(encoded_data);
+/// let (decoded_traces, _payload_size) =
+///     from_bytes(encoded_data_as_tinybytes).expect("Decoding failed");
+///
+/// assert_eq!(1, decoded_traces.len());
+/// assert_eq!(1, decoded_traces[0].len());
+/// let decoded_span = &decoded_traces[0][0];
+/// assert_eq!("test-span", decoded_span.name.as_str());
+/// ```
+pub fn from_bytes(data: tinybytes::Bytes) -> Result<(Vec<Vec<SpanBytes>>, usize), DecodeError> {
+    let mut parsed_data = data.clone();
+    let (traces_ref, size) = from_slice(unsafe { parsed_data.as_mut_slice() })?;
+
+    #[allow(clippy::unwrap_used)]
+    let traces_owned = traces_ref
+        .iter()
+        .map(|trace| {
+            trace
+                .iter()
+                // Safe to unwrap since the spans use subslices of the `data` slice
+                .map(|span| span.try_to_bytes(&data).unwrap())
+                .collect()
+        })
+        .collect();
+    Ok((traces_owned, size))
+}
+
+/// Decodes a slice of bytes into a `Vec<Vec<SpanSlice>>` object.
+/// The resulting spans have the same lifetime as the initial buffer.
 ///
 /// # Arguments
 ///
@@ -42,18 +99,17 @@ use crate::span::SpanBytes;
 /// let encoded_data = to_vec_named(&vec![vec![span]]).unwrap();
 /// let encoded_data_as_tinybytes = tinybytes::Bytes::from(encoded_data);
 /// let (decoded_traces, _payload_size) =
-///     from_slice(encoded_data_as_tinybytes).expect("Decoding failed");
+///     from_slice(&encoded_data_as_tinybytes).expect("Decoding failed");
 ///
 /// assert_eq!(1, decoded_traces.len());
 /// assert_eq!(1, decoded_traces[0].len());
 /// let decoded_span = &decoded_traces[0][0];
-/// assert_eq!("test-span", decoded_span.name.as_str());
+/// assert_eq!("test-span", decoded_span.name);
 /// ```
-pub fn from_slice(mut data: tinybytes::Bytes) -> Result<(Vec<Vec<SpanBytes>>, usize), DecodeError> {
-    let trace_count =
-        rmp::decode::read_array_len(unsafe { data.as_mut_slice() }).map_err(|_| {
-            DecodeError::InvalidFormat("Unable to read array len for trace count".to_owned())
-        })?;
+pub fn from_slice(mut data: &[u8]) -> Result<(Vec<Vec<SpanSlice>>, usize), DecodeError> {
+    let trace_count = rmp::decode::read_array_len(&mut data).map_err(|_| {
+        DecodeError::InvalidFormat("Unable to read array len for trace count".to_owned())
+    })?;
 
     let start_len = data.len();
 
@@ -66,12 +122,9 @@ pub fn from_slice(mut data: tinybytes::Bytes) -> Result<(Vec<Vec<SpanBytes>>, us
                     .expect("Unable to cast trace_count to usize"),
             ),
             |mut traces, _| {
-                let span_count = rmp::decode::read_array_len(unsafe { data.as_mut_slice() })
-                    .map_err(|_| {
-                        DecodeError::InvalidFormat(
-                            "Unable to read array len for span count".to_owned(),
-                        )
-                    })?;
+                let span_count = rmp::decode::read_array_len(&mut data).map_err(|_| {
+                    DecodeError::InvalidFormat("Unable to read array len for span count".to_owned())
+                })?;
 
                 let trace = (0..span_count).try_fold(
                     Vec::with_capacity(
@@ -112,7 +165,7 @@ mod tests {
         let encoded_data =
             unsafe { std::mem::transmute::<&'_ [u8], &'static [u8]>(encoded_data.as_ref()) };
         let bytes = tinybytes::Bytes::from_static(encoded_data);
-        let (_decoded_traces, decoded_size) = from_slice(bytes).expect("Decoding failed");
+        let (_decoded_traces, decoded_size) = from_bytes(bytes).expect("Decoding failed");
 
         assert_eq!(0, decoded_size);
     }
@@ -127,7 +180,7 @@ mod tests {
         let expected_size = encoded_data.len() - 1; // rmp_serde adds additional 0 byte
         encoded_data.extend_from_slice(&[0, 0, 0, 0]); // some garbage, to be ignored
         let (_decoded_traces, decoded_size) =
-            from_slice(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
+            from_bytes(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
 
         assert_eq!(expected_size, decoded_size);
     }
@@ -142,7 +195,7 @@ mod tests {
         let mut encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
         encoded_data.extend_from_slice(&[0, 0, 0, 0]); // some garbage, to be ignored
         let (decoded_traces, _) =
-            from_slice(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
+            from_bytes(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
 
         assert_eq!(1, decoded_traces.len());
         assert_eq!(1, decoded_traces[0].len());
@@ -157,7 +210,7 @@ mod tests {
         let mut encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
         encoded_data.extend_from_slice(&[0, 0, 0, 0]); // some garbage, to be ignored
         let (decoded_traces, _) =
-            from_slice(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
+            from_bytes(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
 
         assert_eq!(1, decoded_traces.len());
         assert_eq!(1, decoded_traces[0].len());
@@ -171,7 +224,7 @@ mod tests {
         let mut encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
         encoded_data.extend_from_slice(&[0, 0, 0, 0]); // some garbage, to be ignored
         let (decoded_traces, _) =
-            from_slice(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
+            from_bytes(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
 
         assert_eq!(1, decoded_traces.len());
         assert_eq!(1, decoded_traces[0].len());
@@ -186,7 +239,7 @@ mod tests {
         let mut encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
         encoded_data.extend_from_slice(&[0, 0, 0, 0]); // some garbage, to be ignored
         let (decoded_traces, _) =
-            from_slice(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
+            from_bytes(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
 
         assert_eq!(1, decoded_traces.len());
         assert_eq!(1, decoded_traces[0].len());
@@ -201,7 +254,7 @@ mod tests {
 
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
         let (decoded_traces, _) =
-            from_slice(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
+            from_bytes(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
 
         assert_eq!(1, decoded_traces.len());
         assert_eq!(1, decoded_traces[0].len());
@@ -219,7 +272,7 @@ mod tests {
 
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
         let (decoded_traces, _) =
-            from_slice(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
+            from_bytes(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
 
         assert_eq!(1, decoded_traces.len());
         assert_eq!(1, decoded_traces[0].len());
@@ -243,7 +296,7 @@ mod tests {
 
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
         let (decoded_traces, _) =
-            from_slice(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
+            from_bytes(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
 
         assert_eq!(1, decoded_traces.len());
         assert_eq!(1, decoded_traces[0].len());
@@ -264,7 +317,7 @@ mod tests {
 
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
         let (decoded_traces, _) =
-            from_slice(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
+            from_bytes(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
 
         assert_eq!(1, decoded_traces.len());
         assert_eq!(1, decoded_traces[0].len());
@@ -289,7 +342,7 @@ mod tests {
 
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
         let (decoded_traces, _) =
-            from_slice(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
+            from_bytes(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
 
         assert_eq!(1, decoded_traces.len());
         assert_eq!(1, decoded_traces[0].len());
@@ -311,7 +364,7 @@ mod tests {
         span["metrics"] = json!(expected_metrics.clone());
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
         let (decoded_traces, _) =
-            from_slice(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
+            from_bytes(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
 
         assert_eq!(1, decoded_traces.len());
         assert_eq!(1, decoded_traces[0].len());
@@ -335,7 +388,7 @@ mod tests {
         span["metrics"] = json!(expected_metrics.clone());
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
         let (decoded_traces, _) =
-            from_slice(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
+            from_bytes(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
 
         assert_eq!(1, decoded_traces.len());
         assert_eq!(1, decoded_traces[0].len());
@@ -355,7 +408,7 @@ mod tests {
         span["metrics"] = json!(null);
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
         let (decoded_traces, _) =
-            from_slice(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
+            from_bytes(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
 
         assert_eq!(1, decoded_traces.len());
         assert_eq!(1, decoded_traces[0].len());
@@ -382,7 +435,7 @@ mod tests {
 
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
         let (decoded_traces, _) =
-            from_slice(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
+            from_bytes(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
 
         assert_eq!(1, decoded_traces.len());
         assert_eq!(1, decoded_traces[0].len());
@@ -429,7 +482,7 @@ mod tests {
 
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
         let (decoded_traces, _) =
-            from_slice(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
+            from_bytes(tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
 
         assert_eq!(1, decoded_traces.len());
         assert_eq!(1, decoded_traces[0].len());
@@ -451,7 +504,7 @@ mod tests {
             unsafe { std::mem::transmute::<&'_ [u8], &'static [u8]>(encoded_data.as_ref()) };
         let bytes = tinybytes::Bytes::from_static(encoded_data);
 
-        let result = from_slice(bytes);
+        let result = from_bytes(bytes);
         assert_eq!(
             Err(DecodeError::InvalidFormat(
                 "Expected at least bytes 1, but only got 0 (pos 0)".to_owned()
@@ -474,7 +527,7 @@ mod tests {
             unsafe { std::mem::transmute::<&'_ [u8], &'static [u8]>(encoded_data.as_ref()) };
         let bytes = tinybytes::Bytes::from_static(encoded_data);
 
-        let result = from_slice(bytes);
+        let result = from_bytes(bytes);
         assert_eq!(
             Err(DecodeError::Utf8Error(
                 "invalid utf-8 sequence of 1 bytes from index 1".to_owned()
@@ -494,7 +547,7 @@ mod tests {
             unsafe { std::mem::transmute::<&'_ [u8], &'static [u8]>(encoded_data.as_ref()) };
         let bytes = tinybytes::Bytes::from_static(encoded_data);
 
-        let result = from_slice(bytes);
+        let result = from_bytes(bytes);
 
         assert_eq!(
             Err(DecodeError::InvalidFormat(
@@ -516,7 +569,7 @@ mod tests {
             unsafe { std::mem::transmute::<&'_ [u8], &'static [u8]>(encoded_data.as_ref()) };
         let bytes = tinybytes::Bytes::from_static(encoded_data);
 
-        let result = from_slice(bytes);
+        let result = from_bytes(bytes);
 
         assert_eq!(
             Err(DecodeError::InvalidFormat(
@@ -537,7 +590,7 @@ mod tests {
             unsafe { std::mem::transmute::<&'_ [u8], &'static [u8]>(encoded_data.as_ref()) };
         let bytes = tinybytes::Bytes::from_static(encoded_data);
 
-        let result = from_slice(bytes);
+        let result = from_bytes(bytes);
 
         assert_eq!(
             Err(DecodeError::InvalidType(
@@ -549,7 +602,7 @@ mod tests {
 
     #[test]
     #[cfg_attr(miri, ignore)]
-    fn fuzz_from_slice() {
+    fn fuzz_from_bytes() {
         check!()
             .with_type::<(
                 String,
@@ -601,7 +654,7 @@ mod tests {
                         ..Default::default()
                     };
                     let encoded_data = to_vec_named(&vec![vec![span]]).unwrap();
-                    let result = from_slice(tinybytes::Bytes::from(encoded_data));
+                    let result = from_bytes(tinybytes::Bytes::from(encoded_data));
 
                     assert!(result.is_ok());
                 },

--- a/trace-utils/src/msgpack_decoder/v04/mod.rs
+++ b/trace-utils/src/msgpack_decoder/v04/mod.rs
@@ -163,10 +163,8 @@ mod tests {
     #[test]
     fn test_empty_array() {
         let encoded_data = vec![0x90];
-        let encoded_data =
-            unsafe { std::mem::transmute::<&'_ [u8], &'static [u8]>(encoded_data.as_ref()) };
-        let bytes = tinybytes::Bytes::from_static(encoded_data);
-        let (_decoded_traces, decoded_size) = from_bytes(bytes).expect("Decoding failed");
+        let slice = encoded_data.as_ref();
+        let (_decoded_traces, decoded_size) = from_slice(slice).expect("Decoding failed");
 
         assert_eq!(0, decoded_size);
     }
@@ -501,11 +499,9 @@ mod tests {
         let mut encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
         // This changes the map size from 11 to 12 to trigger an InvalidMarkerRead error.
         encoded_data[2] = 0x8c;
-        let encoded_data =
-            unsafe { std::mem::transmute::<&'_ [u8], &'static [u8]>(encoded_data.as_ref()) };
-        let bytes = tinybytes::Bytes::from_static(encoded_data);
+        let slice = encoded_data.as_ref();
 
-        let result = from_bytes(bytes);
+        let result = from_slice(slice);
         assert_eq!(
             Err(DecodeError::InvalidFormat(
                 "Expected at least bytes 1, but only got 0 (pos 0)".to_owned()
@@ -524,11 +520,9 @@ mod tests {
             ..Default::default()
         };
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
-        let encoded_data =
-            unsafe { std::mem::transmute::<&'_ [u8], &'static [u8]>(encoded_data.as_ref()) };
-        let bytes = tinybytes::Bytes::from_static(encoded_data);
+        let slice = encoded_data.as_ref();
 
-        let result = from_bytes(bytes);
+        let result = from_slice(slice);
         assert_eq!(
             Err(DecodeError::Utf8Error(
                 "invalid utf-8 sequence of 1 bytes from index 1".to_owned()
@@ -544,12 +538,9 @@ mod tests {
         // This changes the entire payload to a map with 12 keys in order to trigger an error when
         // reading the array len of traces
         encoded_data[0] = 0x8c;
-        let encoded_data =
-            unsafe { std::mem::transmute::<&'_ [u8], &'static [u8]>(encoded_data.as_ref()) };
-        let bytes = tinybytes::Bytes::from_static(encoded_data);
+        let slice = encoded_data.as_ref();
 
-        let result = from_bytes(bytes);
-
+        let result = from_slice(slice);
         assert_eq!(
             Err(DecodeError::InvalidFormat(
                 "Unable to read array len for trace count".to_string()
@@ -565,13 +556,9 @@ mod tests {
         // This changes the entire payload to a map with 12 keys in order to trigger an error when
         // reading the array len of spans
         encoded_data[1] = 0x8c;
+        let slice = encoded_data.as_ref();
 
-        let encoded_data =
-            unsafe { std::mem::transmute::<&'_ [u8], &'static [u8]>(encoded_data.as_ref()) };
-        let bytes = tinybytes::Bytes::from_static(encoded_data);
-
-        let result = from_bytes(bytes);
-
+        let result = from_slice(slice);
         assert_eq!(
             Err(DecodeError::InvalidFormat(
                 "Unable to read array len for span count".to_owned()
@@ -587,12 +574,9 @@ mod tests {
         // Modify the encoded data to cause a type mismatch by changing the marker for the `name`
         // field to an integer marker
         encoded_data[3] = 0x01;
-        let encoded_data =
-            unsafe { std::mem::transmute::<&'_ [u8], &'static [u8]>(encoded_data.as_ref()) };
-        let bytes = tinybytes::Bytes::from_static(encoded_data);
+        let slice = encoded_data.as_ref();
 
-        let result = from_bytes(bytes);
-
+        let result = from_slice(slice);
         assert_eq!(
             Err(DecodeError::InvalidType(
                 "Type mismatch at marker FixPos(1)".to_owned()

--- a/trace-utils/src/msgpack_decoder/v05/mod.rs
+++ b/trace-utils/src/msgpack_decoder/v05/mod.rs
@@ -36,7 +36,7 @@ const SPAN_ELEM_COUNT: u32 = 12;
 /// # Examples
 ///
 /// ```
-/// use datadog_trace_utils::msgpack_decoder::v05::from_slice;
+/// use datadog_trace_utils::msgpack_decoder::v05::from_bytes;
 /// use rmp_serde::to_vec;
 /// use std::collections::HashMap;
 /// use tinybytes;
@@ -61,7 +61,7 @@ const SPAN_ELEM_COUNT: u32 = 12;
 /// let encoded_data = to_vec(&data).unwrap();
 /// let encoded_data_as_tinybytes = tinybytes::Bytes::from(encoded_data);
 /// let (decoded_traces, _payload_size) =
-///     from_slice(encoded_data_as_tinybytes).expect("Decoding failed");
+///     from_bytes(encoded_data_as_tinybytes).expect("Decoding failed");
 ///
 /// assert_eq!(1, decoded_traces.len());
 /// assert_eq!(1, decoded_traces[0].len());

--- a/trace-utils/src/msgpack_decoder/v05/mod.rs
+++ b/trace-utils/src/msgpack_decoder/v05/mod.rs
@@ -68,7 +68,7 @@ const SPAN_ELEM_COUNT: u32 = 12;
 /// let decoded_span = &decoded_traces[0][0];
 /// assert_eq!("", decoded_span.name.as_str());
 /// ```
-pub fn from_slice(mut data: tinybytes::Bytes) -> Result<(Vec<Vec<SpanBytes>>, usize), DecodeError> {
+pub fn from_bytes(mut data: tinybytes::Bytes) -> Result<(Vec<Vec<SpanBytes>>, usize), DecodeError> {
     let data_elem = rmp::decode::read_array_len(unsafe { data.as_mut_slice() })
         .map_err(|_| DecodeError::InvalidFormat("Unable to read payload len".to_string()))?;
 
@@ -241,12 +241,12 @@ mod tests {
     }
 
     #[test]
-    fn from_slice_invalid_size_test() {
+    fn from_bytes_invalid_size_test() {
         // 3 empty array.
         let empty_three: [u8; 3] = [0x93, 0x90, 0x90];
         let payload = unsafe { std::mem::transmute::<&'_ [u8], &'static [u8]>(&empty_three) };
         let bytes = tinybytes::Bytes::from_static(payload);
-        let result = from_slice(bytes);
+        let result = from_bytes(bytes);
 
         assert!(result.is_err());
         matches!(result.err().unwrap(), DecodeError::InvalidFormat(_));
@@ -255,14 +255,14 @@ mod tests {
         let empty_one: [u8; 2] = [0x91, 0x90];
         let payload = unsafe { std::mem::transmute::<&'_ [u8], &'static [u8]>(&empty_one) };
         let bytes = tinybytes::Bytes::from_static(payload);
-        let result = from_slice(bytes);
+        let result = from_bytes(bytes);
 
         assert!(result.is_err());
         matches!(result.err().unwrap(), DecodeError::InvalidFormat(_));
     }
 
     #[test]
-    fn from_slice_test() {
+    fn from_bytes_test() {
         let data: V05Payload = (
             vec![
                 "".to_string(),
@@ -293,7 +293,7 @@ mod tests {
             )]],
         );
         let msgpack = rmp_serde::to_vec(&data).unwrap();
-        let (traces, _) = from_slice(tinybytes::Bytes::from(msgpack)).unwrap();
+        let (traces, _) = from_bytes(tinybytes::Bytes::from(msgpack)).unwrap();
 
         let span = &traces[0][0];
         assert_eq!(span.service.as_str(), "my-service");
@@ -352,7 +352,7 @@ mod tests {
         );
         let payload = rmp_serde::to_vec(&data).unwrap();
         let payload = unsafe { std::mem::transmute::<&'_ [u8], &'static [u8]>(&payload) };
-        let result = from_slice(tinybytes::Bytes::from_static(payload));
+        let result = from_bytes(tinybytes::Bytes::from_static(payload));
 
         assert!(result.is_err());
 
@@ -392,7 +392,7 @@ mod tests {
 
         let payload = rmp_serde::to_vec(&data).unwrap();
         let payload = unsafe { std::mem::transmute::<&'_ [u8], &'static [u8]>(&payload) };
-        let result = from_slice(tinybytes::Bytes::from_static(payload));
+        let result = from_bytes(tinybytes::Bytes::from_static(payload));
 
         assert!(result.is_err());
 

--- a/trace-utils/src/span/mod.rs
+++ b/trace-utils/src/span/mod.rs
@@ -103,7 +103,7 @@ where
     pub meta: HashMap<T, T>,
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub metrics: HashMap<T, f64>,
-    // TODO: Replace `Bytes` with a wrapper that borrows the underlying
+    // TODO: APMSP-1941 - Replace `Bytes` with a wrapper that borrows the underlying
     // slice and serializes to bytes in MessagePack.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub meta_struct: HashMap<T, Bytes>,

--- a/trace-utils/src/span/mod.rs
+++ b/trace-utils/src/span/mod.rs
@@ -104,7 +104,8 @@ where
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub metrics: HashMap<T, f64>,
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub meta_struct: HashMap<T, Bytes>,
+    pub meta_struct: HashMap<T, Bytes>, /* TODO: check if the meta_struct is cloned or/and if i
+                                         * have to do something about it */
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub span_links: Vec<SpanLink<T>>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -251,6 +252,129 @@ pub type SpanEventBytes = SpanEvent<BytesString>;
 pub type AttributeAnyValueBytes = AttributeAnyValue<BytesString>;
 pub type AttributeArrayValueBytes = AttributeArrayValue<BytesString>;
 
+pub type SpanSlice<'a> = Span<&'a str>;
+pub type SpanLinkSlice<'a> = SpanLink<&'a str>;
+pub type SpanEventSlice<'a> = SpanEvent<&'a str>;
+pub type AttributeAnyValueSlice<'a> = AttributeAnyValue<&'a str>;
+pub type AttributeArrayValueSlice<'a> = AttributeArrayValue<&'a str>;
+
+impl SpanSlice<'_> {
+    pub fn try_to_bytes(&self, bytes: &Bytes) -> Option<SpanBytes> {
+        Some(SpanBytes {
+            service: BytesString::try_from_bytes_slice(bytes, self.service)?,
+            name: BytesString::try_from_bytes_slice(bytes, self.name)?,
+            resource: BytesString::try_from_bytes_slice(bytes, self.resource)?,
+            r#type: BytesString::try_from_bytes_slice(bytes, self.r#type)?,
+            trace_id: self.trace_id,
+            span_id: self.span_id,
+            parent_id: self.parent_id,
+            start: self.start,
+            duration: self.duration,
+            error: self.error,
+            meta: self
+                .meta
+                .iter()
+                .map(|(k, v)| {
+                    Some((
+                        BytesString::try_from_bytes_slice(bytes, k)?,
+                        BytesString::try_from_bytes_slice(bytes, v)?,
+                    ))
+                })
+                .collect::<Option<HashMap<BytesString, BytesString>>>()?,
+            metrics: self
+                .metrics
+                .iter()
+                .map(|(k, v)| Some((BytesString::try_from_bytes_slice(bytes, k)?, *v)))
+                .collect::<Option<HashMap<BytesString, f64>>>()?,
+            meta_struct: self
+                .meta_struct
+                .iter()
+                .map(|(k, v)| Some((BytesString::try_from_bytes_slice(bytes, k)?, v.clone())))
+                .collect::<Option<HashMap<BytesString, Bytes>>>()?,
+            span_links: self
+                .span_links
+                .iter()
+                .map(|link| link.try_to_bytes(bytes))
+                .collect::<Option<Vec<SpanLinkBytes>>>()?,
+            span_events: self
+                .span_events
+                .iter()
+                .map(|event| event.try_to_bytes(bytes))
+                .collect::<Option<Vec<SpanEventBytes>>>()?,
+        })
+    }
+}
+
+impl SpanLinkSlice<'_> {
+    pub fn try_to_bytes(&self, bytes: &Bytes) -> Option<SpanLinkBytes> {
+        Some(SpanLinkBytes {
+            trace_id: self.trace_id,
+            trace_id_high: self.trace_id_high,
+            span_id: self.span_id,
+            attributes: self
+                .attributes
+                .iter()
+                .map(|(k, v)| {
+                    Some((
+                        BytesString::try_from_bytes_slice(bytes, k)?,
+                        BytesString::try_from_bytes_slice(bytes, v)?,
+                    ))
+                })
+                .collect::<Option<HashMap<BytesString, BytesString>>>()?,
+            tracestate: BytesString::try_from_bytes_slice(bytes, self.tracestate)?,
+            flags: self.flags,
+        })
+    }
+}
+
+impl SpanEventSlice<'_> {
+    pub fn try_to_bytes(&self, bytes: &Bytes) -> Option<SpanEventBytes> {
+        Some(SpanEventBytes {
+            time_unix_nano: self.time_unix_nano,
+            name: BytesString::try_from_bytes_slice(bytes, self.name)?,
+            attributes: self
+                .attributes
+                .iter()
+                .map(|(k, v)| {
+                    Some((
+                        BytesString::try_from_bytes_slice(bytes, k)?,
+                        v.try_to_bytes(bytes)?,
+                    ))
+                })
+                .collect::<Option<HashMap<BytesString, AttributeAnyValueBytes>>>()?,
+        })
+    }
+}
+
+impl AttributeAnyValueSlice<'_> {
+    pub fn try_to_bytes(&self, bytes: &Bytes) -> Option<AttributeAnyValueBytes> {
+        match self {
+            AttributeAnyValue::SingleValue(value) => {
+                Some(AttributeAnyValue::SingleValue(value.try_to_bytes(bytes)?))
+            }
+            AttributeAnyValue::Array(value) => Some(AttributeAnyValue::Array(
+                value
+                    .iter()
+                    .map(|attribute| attribute.try_to_bytes(bytes))
+                    .collect::<Option<Vec<AttributeArrayValueBytes>>>()?,
+            )),
+        }
+    }
+}
+
+impl AttributeArrayValueSlice<'_> {
+    pub fn try_to_bytes(&self, bytes: &Bytes) -> Option<AttributeArrayValueBytes> {
+        match self {
+            AttributeArrayValue::String(value) => Some(AttributeArrayValue::String(
+                BytesString::try_from_bytes_slice(bytes, value)?,
+            )),
+            AttributeArrayValue::Boolean(value) => Some(AttributeArrayValue::Boolean(*value)),
+            AttributeArrayValue::Integer(value) => Some(AttributeArrayValue::Integer(*value)),
+            AttributeArrayValue::Double(value) => Some(AttributeArrayValue::Double(*value)),
+        }
+    }
+}
+
 #[derive(Debug)]
 pub struct SpanKeyParseError {
     pub message: String,
@@ -335,31 +459,28 @@ mod tests {
         };
 
         let serialized = rmp_serde::encode::to_vec_named(&span).unwrap();
-        let mut serialized_bytes = tinybytes::Bytes::from(serialized);
-        let deserialized = decode_span(&mut serialized_bytes).unwrap();
+        // let mut serialized_bytes = tinybytes::Bytes::from(serialized);
+        let mut serialized_slice =
+            unsafe { std::mem::transmute::<&'_ [u8], &'static [u8]>(serialized.as_ref()) };
+        let deserialized = decode_span(&mut serialized_slice).unwrap();
 
-        assert_eq!(span.name, deserialized.name.as_str());
-        assert_eq!(span.resource, deserialized.resource.as_str());
+        assert_eq!(span.name, deserialized.name);
+        assert_eq!(span.resource, deserialized.resource);
         assert_eq!(
             span.span_links[0].trace_id,
             deserialized.span_links[0].trace_id
         );
         assert_eq!(
             span.span_links[0].tracestate,
-            deserialized.span_links[0].tracestate.as_str()
+            deserialized.span_links[0].tracestate
         );
-        assert_eq!(
-            span.span_events[0].name,
-            deserialized.span_events[0].name.as_str()
-        );
+        assert_eq!(span.span_events[0].name, deserialized.span_events[0].name);
         assert_eq!(
             span.span_events[0].time_unix_nano,
             deserialized.span_events[0].time_unix_nano
         );
         for attribut in &deserialized.span_events[0].attributes {
-            assert!(span.span_events[0]
-                .attributes
-                .contains_key(attribut.0.as_str()))
+            assert!(span.span_events[0].attributes.contains_key(attribut.0))
         }
     }
 

--- a/trace-utils/src/span/mod.rs
+++ b/trace-utils/src/span/mod.rs
@@ -260,6 +260,9 @@ pub type AttributeAnyValueSlice<'a> = AttributeAnyValue<&'a str>;
 pub type AttributeArrayValueSlice<'a> = AttributeArrayValue<&'a str>;
 
 impl SpanSlice<'_> {
+    /// Converts a borrowed `SpanSlice` into an owned `SpanBytes`, by resolving all internal
+    /// references into slices of the provided `Bytes` buffer. Returns `None` if any slice is
+    /// out of bounds or invalid.
     pub fn try_to_bytes(&self, bytes: &Bytes) -> Option<SpanBytes> {
         Some(SpanBytes {
             service: BytesString::try_from_bytes_slice(bytes, self.service)?,
@@ -307,6 +310,9 @@ impl SpanSlice<'_> {
 }
 
 impl SpanLinkSlice<'_> {
+    /// Converts a borrowed `SpanLinkSlice` into an owned `SpanLinkBytes`, using the provided
+    /// `Bytes` buffer to resolve all referenced strings. Returns `None` if conversion fails due
+    /// to invalid slice ranges.
     pub fn try_to_bytes(&self, bytes: &Bytes) -> Option<SpanLinkBytes> {
         Some(SpanLinkBytes {
             trace_id: self.trace_id,
@@ -329,6 +335,9 @@ impl SpanLinkSlice<'_> {
 }
 
 impl SpanEventSlice<'_> {
+    /// Converts a borrowed `SpanEventSlice` into an owned `SpanEventBytes`, resolving references
+    /// into the provided `Bytes` buffer. Fails with `None` if any slice is invalid or cannot be
+    /// converted.
     pub fn try_to_bytes(&self, bytes: &Bytes) -> Option<SpanEventBytes> {
         Some(SpanEventBytes {
             time_unix_nano: self.time_unix_nano,
@@ -348,6 +357,9 @@ impl SpanEventSlice<'_> {
 }
 
 impl AttributeAnyValueSlice<'_> {
+    /// Converts a borrowed `AttributeAnyValueSlice` into its owned `AttributeAnyValueBytes`
+    /// representation, using the provided `Bytes` buffer. Recursively processes inner values if
+    /// it's an array.
     pub fn try_to_bytes(&self, bytes: &Bytes) -> Option<AttributeAnyValueBytes> {
         match self {
             AttributeAnyValue::SingleValue(value) => {
@@ -364,6 +376,9 @@ impl AttributeAnyValueSlice<'_> {
 }
 
 impl AttributeArrayValueSlice<'_> {
+    /// Converts a single `AttributeArrayValueSlice` item into its owned form
+    /// (`AttributeArrayValueBytes`), borrowing data from the provided `Bytes` buffer when
+    /// necessary.
     pub fn try_to_bytes(&self, bytes: &Bytes) -> Option<AttributeArrayValueBytes> {
         match self {
             AttributeArrayValue::String(value) => Some(AttributeArrayValue::String(

--- a/trace-utils/src/span/mod.rs
+++ b/trace-utils/src/span/mod.rs
@@ -103,9 +103,10 @@ where
     pub meta: HashMap<T, T>,
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub metrics: HashMap<T, f64>,
+    // TODO: Replace `Bytes` with a wrapper that borrows the underlying
+    // slice and serializes to bytes in MessagePack.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub meta_struct: HashMap<T, Bytes>, /* TODO: check if the meta_struct is cloned or/and if i
-                                         * have to do something about it */
+    pub meta_struct: HashMap<T, Bytes>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub span_links: Vec<SpanLink<T>>,
     #[serde(skip_serializing_if = "Vec::is_empty")]

--- a/trace-utils/src/span/mod.rs
+++ b/trace-utils/src/span/mod.rs
@@ -459,9 +459,7 @@ mod tests {
         };
 
         let serialized = rmp_serde::encode::to_vec_named(&span).unwrap();
-        // let mut serialized_bytes = tinybytes::Bytes::from(serialized);
-        let mut serialized_slice =
-            unsafe { std::mem::transmute::<&'_ [u8], &'static [u8]>(serialized.as_ref()) };
+        let mut serialized_slice = serialized.as_ref();
         let deserialized = decode_span(&mut serialized_slice).unwrap();
 
         assert_eq!(span.name, deserialized.name);

--- a/trace-utils/src/tracer_payload.rs
+++ b/trace-utils/src/tracer_payload.rs
@@ -379,7 +379,7 @@ impl<'a, T: TraceChunkProcessor + 'a> TryInto<TracerPayloadCollection>
     fn try_into(self) -> Result<TracerPayloadCollection, Self::Error> {
         match self.encoding_type {
             TraceEncoding::V04 => {
-                let (traces, size) = match msgpack_decoder::v04::from_slice(self.data) {
+                let (traces, size) = match msgpack_decoder::v04::from_bytes(self.data) {
                     Ok(res) => res,
                     Err(e) => {
                         anyhow::bail!("Error deserializing trace from request body: {e}")
@@ -399,7 +399,7 @@ impl<'a, T: TraceChunkProcessor + 'a> TryInto<TracerPayloadCollection>
                 )?)
             },
             TraceEncoding::V05 => {
-                let (traces, size) = match msgpack_decoder::v05::from_slice(self.data) {
+                let (traces, size) = match msgpack_decoder::v05::from_bytes(self.data) {
                     Ok(res) => res,
                     Err(e) => {
                         anyhow::bail!("Error deserializing trace from request body: {e}")

--- a/trace-utils/src/tracer_payload.rs
+++ b/trace-utils/src/tracer_payload.rs
@@ -378,7 +378,6 @@ impl<'a, T: TraceChunkProcessor + 'a> TryInto<TracerPayloadCollection>
     /// ```
     fn try_into(self) -> Result<TracerPayloadCollection, Self::Error> {
         match self.encoding_type {
-            // The goal here is to ultimately replace the usage of `from_bytes` with `from_slice`.
             TraceEncoding::V04 => {
                 let (traces, size) = match msgpack_decoder::v04::from_bytes(self.data) {
                     Ok(res) => res,

--- a/trace-utils/src/tracer_payload.rs
+++ b/trace-utils/src/tracer_payload.rs
@@ -378,6 +378,7 @@ impl<'a, T: TraceChunkProcessor + 'a> TryInto<TracerPayloadCollection>
     /// ```
     fn try_into(self) -> Result<TracerPayloadCollection, Self::Error> {
         match self.encoding_type {
+            // The goal here is to ultimately replace the usage of `from_bytes` with `from_slice`.
             TraceEncoding::V04 => {
                 let (traces, size) = match msgpack_decoder::v04::from_bytes(self.data) {
                     Ok(res) => res,


### PR DESCRIPTION
# What does this PR do?

Use &[u8] in the msgpack decoder instead of Bytes and produce a SpanSlice which contains &str instead of BytesString. This allows to parse non-owned buffer containing traces. It also provides a from_bytes wrapper which uses the same parsing logic but convert the &str to BytesString based on the given Bytes buffer.

# Motivation

The trace exporter needs to support reading traces from borrowed buffer.

# Additional Notes

This PR also refactors the string, map and number decoding logic to be moved to separate modules.

# How to test the change?

Describe here in detail how the change can be validated.
