### PR TITLE
Granularize CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,3 +24,8 @@ sidecar                 @Datadog/libdatadog-php @Datadog/libdatadog-apm
 sidecar-ffi             @Datadog/libdatadog-php @Datadog/libdatadog-apm
 data-pipeline*/         @Datadog/libdatadog-apm
 ddsketch                @Datadog/libdatadog-apm @Datadog/libdatadog-telemetry
+
+# Most of the bin_tests are owned by the profiling team, but some are owned by the core team
+bin_tests/              @Datadog/libdatadog-profiling
+bin_tests/tests/test_the_tests.rs   @Datadog/libdatadog-core
+bin_tests/src/bin/test_the_tests.rs @Datadog/libdatadog-core


### PR DESCRIPTION
# What does this PR do?

Currently, bin_tests are universally owned by the core team, even though the overwhelming majority of the actual files are related to crashtracking.

This PR updates the ownership, but still allows core to own the non-crashtracking tests.

This was easy to do, but it might actually be cleaner to refactor the bin tests in order to propagate ownership in a more straightforward way.

# Motivation

Realign the PR review process mostly