### PR TITLE
chore(serverless): update components to drop hashbrown v0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2080,13 +2080,13 @@ dependencies = [
 [[package]]
 name = "dogstatsd"
 version = "0.1.0"
-source = "git+https://github.com/DataDog/serverless-components/?rev=4dfe72ab1850680f41dd79d30a937eb68e7ba6da#4dfe72ab1850680f41dd79d30a937eb68e7ba6da"
+source = "git+https://github.com/DataDog/serverless-components/?rev=1be056e037e345488b148b60c3214deff4fcf511#1be056e037e345488b148b60c3214deff4fcf511"
 dependencies = [
  "datadog-protos",
  "ddsketch-agent",
  "derive_more",
  "fnv",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.1",
  "protobuf",
  "regex",
  "reqwest",

--- a/serverless/Cargo.toml
+++ b/serverless/Cargo.toml
@@ -9,7 +9,7 @@ env_logger = "0.10.0"
 datadog-trace-mini-agent = { path = "../trace-mini-agent" }
 datadog-trace-protobuf = { path = "../trace-protobuf" }
 datadog-trace-utils = { path = "../trace-utils" }
-dogstatsd = { git = "https://github.com/DataDog/serverless-components/", rev = "4dfe72ab1850680f41dd79d30a937eb68e7ba6da", default-features = false }
+dogstatsd = { git = "https://github.com/DataDog/serverless-components/", rev = "1be056e037e345488b148b60c3214deff4fcf511", default-features = false }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"]}
 tokio-util = { version = "0.7", default-features = false }
 tracing = { version = "0.1", default-features = false }


### PR DESCRIPTION
# What does this PR do?

This updates serverless-components to the latest commit hash.

# Motivation

This gets us one step closer to dropping hashbrown v0.14.


# How to test the change?

Regular tests apply.
