### PR TITLE
build: upgrade nix from 0.27 to 0.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,7 +477,7 @@ dependencies = [
  "datadog-profiling",
  "ddcommon",
  "libc",
- "nix 0.27.1",
+ "nix",
  "once_cell",
  "serde_json",
  "strum",
@@ -1374,7 +1374,7 @@ dependencies = [
  "goblin",
  "http 1.1.0",
  "libc",
- "nix 0.27.1",
+ "nix",
  "num-derive",
  "num-traits",
  "os_info",
@@ -1441,7 +1441,7 @@ dependencies = [
  "io-lifetimes",
  "libc",
  "memfd",
- "nix 0.27.1",
+ "nix",
  "page_size",
  "pin-project",
  "pretty_assertions",
@@ -1691,7 +1691,7 @@ dependencies = [
  "manual_future",
  "memory-stats",
  "microseh",
- "nix 0.27.1",
+ "nix",
  "prctl",
  "priority-queue",
  "rand 0.8.5",
@@ -3637,18 +3637,6 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
-version = "0.27.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
-dependencies = [
- "bitflags 2.6.0",
- "cfg-if",
- "libc",
- "memoffset",
-]
-
-[[package]]
-name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
@@ -3657,6 +3645,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -4097,7 +4086,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "059a34f111a9dee2ce1ac2826a68b24601c4298cfeb1a587c3cb493d5ab46f52"
 dependencies = [
  "libc",
- "nix 0.29.0",
+ "nix",
 ]
 
 [[package]]
@@ -5326,7 +5315,7 @@ dependencies = [
  "io-lifetimes",
  "kernel32-sys",
  "memfd",
- "nix 0.27.1",
+ "nix",
  "rlimit",
  "tempfile",
  "winapi 0.2.8",

--- a/bin_tests/Cargo.toml
+++ b/bin_tests/Cargo.toml
@@ -19,7 +19,7 @@ tempfile = "3.3"
 serde_json = { version = "1.0" }
 strum = { version = "0.26.2", features = ["derive"] }
 libc = "0.2"
-nix = { version = "0.27.1", features = ["socket"] }
+nix = { version = "0.29", features = ["signal", "socket"] }
 
 [lib]
 bench = false

--- a/crashtracker/Cargo.toml
+++ b/crashtracker/Cargo.toml
@@ -37,7 +37,7 @@ ddcommon = {path = "../ddcommon"}
 ddtelemetry = {path = "../ddtelemetry"}
 http = "1.0"
 libc = "0.2"
-nix = { version = "0.27.1", features = ["poll", "signal", "socket"] }
+nix = { version = "0.29", features = ["poll", "signal", "socket"] }
 num-derive = "0.4.2"
 num-traits = "0.2.19"
 os_info = "3.7.0"

--- a/ipc/Cargo.toml
+++ b/ipc/Cargo.toml
@@ -42,7 +42,7 @@ tracing-subscriber = { version = "0.3.11" }
 spawn_worker = { path = "../spawn_worker" }
 
 [target.'cfg(not(windows))'.dependencies]
-nix = { version = "0.27.1", features = ["mman", "socket", "poll"] }
+nix = { version = "0.29", features = ["fs", "mman", "process", "poll", "socket"] }
 sendfd = { version = "0.4", features = ["tokio"] }
 tokio = { version = "1.23", features = ["sync", "io-util", "signal"] }
 

--- a/ipc/src/platform/mem_handle.rs
+++ b/ipc/src/platform/mem_handle.rs
@@ -25,7 +25,7 @@ where
     T: MemoryHandle,
 {
     #[cfg(unix)]
-    pub(crate) ptr: *mut libc::c_void,
+    pub(crate) ptr: std::ptr::NonNull<libc::c_void>,
     #[cfg(windows)]
     pub(crate) ptr: *mut winapi::ctypes::c_void,
     pub(crate) mem: T,
@@ -133,11 +133,11 @@ impl FileBackedHandle for NamedShmHandle {
 
 impl<T: MemoryHandle> MappedMem<T> {
     pub fn as_slice(&self) -> &[u8] {
-        unsafe { std::slice::from_raw_parts(self.ptr as *const u8, self.mem.get_size()) }
+        unsafe { std::slice::from_raw_parts(self.ptr.as_ptr().cast(), self.mem.get_size()) }
     }
 
     pub fn as_slice_mut(&mut self) -> &mut [u8] {
-        unsafe { std::slice::from_raw_parts_mut(self.ptr as *mut u8, self.mem.get_size()) }
+        unsafe { std::slice::from_raw_parts_mut(self.ptr.as_ptr().cast(), self.mem.get_size()) }
     }
 
     pub fn get_size(&self) -> usize {

--- a/ipc/src/platform/mem_handle.rs
+++ b/ipc/src/platform/mem_handle.rs
@@ -4,7 +4,7 @@
 use crate::handles::{HandlesTransport, TransferHandles};
 use crate::platform::{mmap_handle, munmap_handle, OwnedFileHandle, PlatformHandle};
 use serde::{Deserialize, Serialize};
-use std::{ffi::CString, io};
+use std::{ffi::CString, io, ptr::NonNull};
 #[cfg(feature = "tiny-bytes")]
 use tinybytes::UnderlyingBytes;
 
@@ -25,9 +25,9 @@ where
     T: MemoryHandle,
 {
     #[cfg(unix)]
-    pub(crate) ptr: std::ptr::NonNull<libc::c_void>,
+    pub(crate) ptr: NonNull<libc::c_void>,
     #[cfg(windows)]
-    pub(crate) ptr: *mut winapi::ctypes::c_void,
+    pub(crate) ptr: NonNull<winapi::ctypes::c_void>,
     pub(crate) mem: T,
 }
 

--- a/ipc/src/platform/unix/channel.rs
+++ b/ipc/src/platform/unix/channel.rs
@@ -7,9 +7,12 @@ use nix::sys::select::FdSet;
 use nix::sys::time::{TimeVal, TimeValLike};
 use std::{
     io::{self, ErrorKind, Read, Write},
-    os::unix::{
-        net::UnixStream,
-        prelude::{AsRawFd, RawFd},
+    os::{
+        fd::AsFd,
+        unix::{
+            net::UnixStream,
+            prelude::{AsRawFd, RawFd},
+        },
     },
     time::Duration,
 };
@@ -57,7 +60,7 @@ impl Channel {
 
     pub fn probe_readable(&self) -> bool {
         #[allow(clippy::unwrap_used)]
-        let raw_fd = self.inner.as_owned_fd().unwrap();
+        let raw_fd = self.inner.as_owned_fd().unwrap().as_fd();
         let mut fds = FdSet::new();
         fds.insert(raw_fd);
         nix::sys::select::select(None, Some(&mut fds), None, None, Some(&mut TimeVal::zero()))

--- a/ipc/src/platform/unix/mem_handle.rs
+++ b/ipc/src/platform/unix/mem_handle.rs
@@ -85,9 +85,7 @@ pub(crate) fn mmap_handle<T: FileBackedHandle>(handle: T) -> io::Result<MappedMe
 }
 
 pub(crate) fn munmap_handle<T: MemoryHandle>(mapped: &mut MappedMem<T>) {
-    unsafe {
-        _ = munmap(mapped.ptr.as_ptr(), mapped.mem.get_size());
-    }
+    _ = unsafe { munmap(mapped.ptr, mapped.mem.get_size()) };
 }
 
 static ANON_SHM_ID: AtomicI32 = AtomicI32::new(0);

--- a/ipc/src/platform/unix/mem_handle.rs
+++ b/ipc/src/platform/unix/mem_handle.rs
@@ -16,6 +16,7 @@ use std::ffi::{CStr, CString};
 use std::fs::File;
 use std::io;
 use std::num::NonZeroUsize;
+use std::os::fd::AsFd;
 use std::os::unix::fs::MetadataExt;
 use std::sync::atomic::{AtomicI32, Ordering};
 
@@ -63,7 +64,7 @@ pub fn shm_unlink<P: ?Sized + NixPath>(name: &P) -> nix::Result<()> {
 }
 
 pub(crate) fn mmap_handle<T: FileBackedHandle>(handle: T) -> io::Result<MappedMem<T>> {
-    let fd = handle.get_shm().handle.as_owned_fd()?;
+    let fd = handle.get_shm().handle.as_owned_fd()?.as_fd();
     if let Some(size) = NonZeroUsize::new(handle.get_shm().size) {
         Ok(MappedMem {
             ptr: unsafe {
@@ -72,7 +73,7 @@ pub(crate) fn mmap_handle<T: FileBackedHandle>(handle: T) -> io::Result<MappedMe
                     size,
                     ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
                     MapFlags::MAP_SHARED,
-                    Some(fd),
+                    fd,
                     0,
                 )?
             },
@@ -85,7 +86,7 @@ pub(crate) fn mmap_handle<T: FileBackedHandle>(handle: T) -> io::Result<MappedMe
 
 pub(crate) fn munmap_handle<T: MemoryHandle>(mapped: &mut MappedMem<T>) {
     unsafe {
-        _ = munmap(mapped.ptr, mapped.mem.get_size());
+        _ = munmap(mapped.ptr.as_ptr(), mapped.mem.get_size());
     }
 }
 

--- a/ipc/src/platform/unix/sockets.rs
+++ b/ipc/src/platform/unix/sockets.rs
@@ -44,7 +44,11 @@ mod linux {
         let sock = socket_stream()?;
         let addr = UnixAddr::new_abstract(path.as_ref().as_os_str().as_bytes())?;
         bind(sock.as_raw_fd(), &addr)?;
-        listen(&sock, Backlog::new(128)?)?;
+        // This was previously 128, but due to this bug in 0.29.0 which has
+        // been fixed but not released, we're using 127:
+        // https://github.com/nix-rust/nix/pull/2500
+        const SOMAXCONN: i32 = 127;
+        listen(&sock, Backlog::new(SOMAXCONN)?)?;
         Ok(sock.into())
     }
 }

--- a/ipc/src/platform/unix/sockets.rs
+++ b/ipc/src/platform/unix/sockets.rs
@@ -21,7 +21,7 @@ mod linux {
 
     use io_lifetimes::OwnedFd;
     use nix::sys::socket::{
-        bind, connect, listen, socket, AddressFamily, SockFlag, SockType, UnixAddr,
+        bind, connect, listen, socket, AddressFamily, Backlog, SockFlag, SockType, UnixAddr,
     };
 
     fn socket_stream() -> nix::Result<OwnedFd> {
@@ -44,7 +44,7 @@ mod linux {
         let sock = socket_stream()?;
         let addr = UnixAddr::new_abstract(path.as_ref().as_os_str().as_bytes())?;
         bind(sock.as_raw_fd(), &addr)?;
-        listen(&sock, 128)?;
+        listen(&sock, Backlog::new(128)?)?;
         Ok(sock.into())
     }
 }

--- a/ipc/src/platform/windows/mem_handle.rs
+++ b/ipc/src/platform/windows/mem_handle.rs
@@ -45,7 +45,7 @@ pub(crate) fn mmap_handle<T: FileBackedHandle>(mut handle: T) -> io::Result<Mapp
             shm.size = unsafe {
                 let mut info = MaybeUninit::<MEMORY_BASIC_INFORMATION>::uninit();
                 if VirtualQuery(
-                    ptr,
+                    ptr.as_ptr().cast_const(),
                     info.as_mut_ptr(),
                     mem::size_of::<MEMORY_BASIC_INFORMATION>(),
                 ) == 0

--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -79,11 +79,12 @@ features = [
 ]
 version = "0.51.0"
 
+# simd-json v0.15 uses Rust 2024 Edition, so it needs Rust 1.85+.
 [target.'cfg(not(target_arch = "x86"))'.dependencies]
-simd-json = "0.14.1"
+simd-json = "=0.14"
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.27.1", features = ["socket", "mman"] }
+nix = { version = "0.29", features = ["socket", "mman"] }
 sendfd = { version = "0.4", features = ["tokio"] }
 
 [target.'cfg(windows)'.dependencies]

--- a/spawn_worker/Cargo.toml
+++ b/spawn_worker/Cargo.toml
@@ -31,7 +31,7 @@ kernel32-sys = "0.2.2"
 
 [target.'cfg(not(windows))'.dependencies]
 memfd = { version = "0.6" }
-nix = { version = "0.27.1", features = ["dir", "process"] }
+nix = { version = "0.29", features = ["dir", "process"] }
 tempfile = { version = "3.3" }
 
 [target.'cfg(windows)'.dev-dependencies]


### PR DESCRIPTION
# What does this PR do?

This upgrades nix from v0.27 to v0.29. There's an off-by-one error in the new `Backlog` type, so this lowers the backlog used for `listen` from 128 to 127.

Also pins simd-json to 0.14. I noticed v0.15 requires Rust 1.85 and I was editing this file anyway.

# Motivation

Version 0.29 was already in our tree, so this removes a duplicate dependency (everything is now on 0.29).

# Additional Notes

I tried to use Cursor to do this upgrade, and it failed, even when I provided the changelog for versions 0.29 and 0.28. Did it all manually.

# How to test the change?

Everything should test the same.
