### PR TITLE
Add default-features=false to crashtracker-ffi

### DIFF
--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -88,7 +88,7 @@ sendfd = { version = "0.4", features = ["tokio"] }
 
 [target.'cfg(windows)'.dependencies]
 ddcommon-ffi = { path = "../ddcommon-ffi", default-features = false }
-datadog-crashtracker-ffi = { path = "../crashtracker-ffi", features = ["collector", "collector_windows"] }
+datadog-crashtracker-ffi = { path = "../crashtracker-ffi", default-features = false, features = ["collector", "collector_windows"] }
 winapi = { version = "0.3.9", features = ["securitybaseapi", "sddl"] }
 windows-sys = { version = "0.52.0", features = ["Win32_System_SystemInformation"] }
 


### PR DESCRIPTION
The sidecar must not use the cbindgen builder, otherwise upstream will fail to build it.