### PR TITLE
build: bump allocator-api2 to v0.2.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.18"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"


### PR DESCRIPTION
# What does this PR do?

Bumps allocator-api2 from v0.2.18 to v0.2.21.

# Motivation

I hit a weird build error locally when doing `cargo bench -- --list` and it seemed like updating would fix it, and it did.

# How to test the change?

Everything should work as normal.
