### PR TITLE
refactor(prof): Labels have T directly, not Option<T>

### DIFF
--- a/profiling-ffi/src/profiles/datatypes.rs
+++ b/profiling-ffi/src/profiles/datatypes.rs
@@ -319,13 +319,7 @@ impl<'a> TryFrom<&'a Label<'a>> for api::Label<'a> {
     fn try_from(label: &'a Label<'a>) -> Result<Self, Self::Error> {
         let key = label.key.try_to_utf8()?;
         let str = label.str.try_to_utf8()?;
-        let str = if str.is_empty() { None } else { Some(str) };
         let num_unit = label.num_unit.try_to_utf8()?;
-        let num_unit = if num_unit.is_empty() {
-            None
-        } else {
-            Some(num_unit)
-        };
 
         Ok(Self {
             key,
@@ -340,13 +334,7 @@ impl<'a> From<&'a Label<'a>> for api::StringIdLabel {
     fn from(label: &'a Label<'a>) -> Self {
         let key = label.key_id;
         let str = label.str_id;
-        let str = if str.value == 0 { None } else { Some(str) };
         let num_unit = label.num_unit_id;
-        let num_unit = if num_unit.value == 0 {
-            None
-        } else {
-            Some(num_unit)
-        };
 
         Self {
             key,

--- a/profiling-ffi/src/profiles/interning_api.rs
+++ b/profiling-ffi/src/profiles/interning_api.rs
@@ -70,7 +70,13 @@ pub unsafe extern "C" fn ddog_prof_Profile_intern_label_num(
     key: GenerationalId<StringId>,
     val: i64,
 ) -> Result<GenerationalId<LabelId>> {
-    wrap_with_ffi_result!({ profile_ptr_to_inner(profile)?.intern_label_num(key, val, None) })
+    wrap_with_ffi_result!({
+        profile_ptr_to_inner(profile)?.intern_label_num(
+            key,
+            val,
+            GenerationalId::new_immortal(StringId::ZERO),
+        )
+    })
 }
 
 /// This function interns its argument into the profiler.
@@ -93,7 +99,7 @@ pub unsafe extern "C" fn ddog_prof_Profile_intern_label_num_with_unit(
     val: i64,
     unit: GenerationalId<StringId>,
 ) -> Result<GenerationalId<LabelId>> {
-    wrap_with_ffi_result!({ profile_ptr_to_inner(profile)?.intern_label_num(key, val, Some(unit)) })
+    wrap_with_ffi_result!({ profile_ptr_to_inner(profile)?.intern_label_num(key, val, unit) })
 }
 
 /// This function interns its argument into the profiler.

--- a/profiling-replayer/src/replayer.rs
+++ b/profiling-replayer/src/replayer.rs
@@ -95,17 +95,9 @@ impl<'pprof> Replayer<'pprof> {
             .map(|label| {
                 Ok(api::Label {
                     key: profile_index.get_string(label.key)?,
-                    str: if label.str == 0 {
-                        None
-                    } else {
-                        Some(profile_index.get_string(label.str)?)
-                    },
+                    str: profile_index.get_string(label.str)?,
                     num: label.num,
-                    num_unit: if label.num_unit == 0 {
-                        None
-                    } else {
-                        Some(profile_index.get_string(label.num_unit)?)
-                    },
+                    num_unit: profile_index.get_string(label.num_unit)?,
                 })
             })
             .collect();
@@ -126,9 +118,9 @@ impl<'pprof> Replayer<'pprof> {
                 "local root span ids of zero do not make sense"
             );
 
-            let endpoint_value = match endpoint_label.str {
-                Some(v) => v,
-                None => anyhow::bail!("expected trace endpoint label value to have a string"),
+            let endpoint_value = endpoint_label.str;
+            if endpoint_value.is_empty() {
+                anyhow::bail!("expected trace endpoint label value to have a string")
             };
 
             endpoint_info.replace((local_root_span_id, endpoint_value));

--- a/profiling/src/internal/label.rs
+++ b/profiling/src/internal/label.rs
@@ -6,10 +6,7 @@ use super::*;
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub enum LabelValue {
     Str(StringId),
-    Num {
-        num: i64,
-        num_unit: Option<StringId>,
-    },
+    Num { num: i64, num_unit: StringId },
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
@@ -35,7 +32,7 @@ impl Label {
         &self.value
     }
 
-    pub fn num(key: StringId, num: i64, num_unit: Option<StringId>) -> Self {
+    pub fn num(key: StringId, num: i64, num_unit: StringId) -> Self {
         Self {
             key,
             value: LabelValue::Num { num, num_unit },
@@ -70,7 +67,7 @@ impl From<&Label> for pprof::Label {
                 key,
                 str: 0,
                 num,
-                num_unit: num_unit.map(StringId::into_raw_id).unwrap_or_default(),
+                num_unit: num_unit.into_raw_id(),
             },
         }
     }

--- a/profiling/src/internal/profile/interning_api/mod.rs
+++ b/profiling/src/internal/profile/interning_api/mod.rs
@@ -32,10 +32,10 @@ impl Profile {
         &mut self,
         key: GenerationalId<StringId>,
         val: i64,
-        unit: Option<GenerationalId<StringId>>,
+        unit: GenerationalId<StringId>,
     ) -> anyhow::Result<GenerationalId<LabelId>> {
         let key = key.get(self.generation)?;
-        let unit = unit.map(|u| u.get(self.generation)).transpose()?;
+        let unit = unit.get(self.generation)?;
         let id = self.labels.dedup(Label::num(key, val, unit));
         Ok(GenerationalId::new(id, self.generation))
     }


### PR DESCRIPTION
# What does this PR do?

Labels now have strings rather than `Option<T>` where T is some string type.

This supersedes #959, which got all tangled and also out-of-date from main.

# Motivation

The fuzzer can get into weird differences between `None` and `Some(0)`/`Some("")`/etc.

# Additional Notes

There is another issue with labels in the fuzzer, but I wanted to fix this issue independently so it's easier to review. This may need to be force-merged if the only failure is the profiling fuzzer.

# How to test the change?

Update your APIs to use strings directly instead of Option of strings, then run as normal.