### PR TITLE
ci: stop caching buildx bake

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -248,6 +248,8 @@ jobs:
         uses: docker/bake-action@4ba453fbc2db7735392b93edf935aaf9b1e8f747 # 6.5.0
         with:
           targets: ${{ matrix.target }}
-          set: |
-            *.cache-from=type=gha,scope=${{ matrix.target }}
-            *.cache-to=type=gha,mode=max,scope=${{ matrix.target }}
+          # Caching is useful, when it works. We are routinely hanging, maybe this:
+          # https://github.com/docker/buildx/issues/537
+          #set: |
+          #  *.cache-from=type=gha,scope=${{ matrix.target }}
+          #  *.cache-to=type=gha,mode=max,scope=${{ matrix.target }}


### PR DESCRIPTION
# What does this PR do?

This stops using the buildx bake cache.

# Motivation

This routinely seems to hang, possibly the same as this:
https://github.com/docker/buildx/issues/537

# Additional Notes

Caches are hard, some would say one of the hardest problems in computer science.

# How to test the change?

CI should run as normal, the buildx bake job should just be a bit slower, but shouldn't try to cache and hopefully 🤞🏻 the slowdown is acceptable.
