### PR TITLE
fix(ddcommon): Update rustls-native-certs to 0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1094,6 +1094,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1876,7 +1886,7 @@ dependencies = [
  "rmp",
  "rmp-serde",
  "rustls",
- "rustls-native-certs 0.8.0",
+ "rustls-native-certs 0.8.1",
  "serde",
  "static_assertions",
  "tokio",
@@ -2969,7 +2979,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "rustls",
- "rustls-native-certs 0.8.0",
+ "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -4713,7 +4723,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs 0.8.0",
+ "rustls-native-certs 0.8.1",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
@@ -4851,20 +4861,19 @@ dependencies = [
  "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -4992,7 +5001,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.6.0",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -5000,9 +5022,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
 dependencies = [
  "core-foundation-sys",
  "libc",

--- a/ddcommon/Cargo.toml
+++ b/ddcommon/Cargo.toml
@@ -36,7 +36,7 @@ regex = "1.5"
 rmp = "0.8.14"
 rmp-serde = "1.3.0"
 rustls = { version = "0.23", default-features = false, optional = true }
-rustls-native-certs = { version = "0.8", optional = true }
+rustls-native-certs = { version = "0.8.1", optional = true }
 tokio = { version = "1.23", features = ["rt", "macros"] }
 tokio-rustls = { version = "0.26", default-features = false, optional = true }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
# What does this PR do?

Updates rustls-native-certs to 0.8.1.

# Motivation

`connector::tests::test_missing_root_certificates_only_allow_http_connections` test fails when run from `ddcommon` directory.

```
--- STDERR:              ddcommon connector::tests::test_missing_root_certificates_only_allow_http_connections ---
thread 'connector::tests::test_missing_root_certificates_only_allow_http_connections' panicked at ddcommon/src/connector/mod.rs:231:9:
assertion failed: matches!(connector, Connector::Http(_))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

        PASS [   1.250s] ddcommon connector::tests::test_hyper_client_from_connector
------------
     Summary [   1.286s] 58 tests run: 57 passed, 1 failed, 0 skipped
        FAIL [   1.218s] ddcommon connector::tests::test_missing_root_certificates_only_allow_http_connections
error: test run failed
```

# Additional Notes

- Discovered while testing https://github.com/DataDog/libdatadog/pull/1030.
- rustls-native-certs release notes: https://github.com/rustls/rustls-native-certs/releases/tag/v%2F0.8.1

# How to test the change?

```
cd ddcommon
cargo nextest run --no-fail-fast
```

