### PR TITLE
fix(ddcommon): Add ubuntu ssl cert directory for unit test

### DIFF
--- a/ddcommon/src/connector/mod.rs
+++ b/ddcommon/src/connector/mod.rs
@@ -224,10 +224,14 @@ mod tests {
     /// are not found
     async fn test_missing_root_certificates_only_allow_http_connections() {
         const ENV_SSL_CERT_FILE: &str = "SSL_CERT_FILE";
+        const ENV_SSL_CERT_DIR: &str = "SSL_CERT_DIR";
         let old_value = env::var(ENV_SSL_CERT_FILE).unwrap_or_default();
+        let old_dir_value = env::var(ENV_SSL_CERT_DIR).unwrap_or_default();
 
         env::set_var(ENV_SSL_CERT_FILE, "this/folder/does/not/exist");
+        env::set_var(ENV_SSL_CERT_DIR, "this/folder/does/not/exist");
         let mut connector = Connector::new();
+
         assert!(matches!(connector, Connector::Http(_)));
 
         let stream = connector
@@ -241,6 +245,7 @@ mod tests {
         );
 
         env::set_var(ENV_SSL_CERT_FILE, old_value);
+        env::set_var(ENV_SSL_CERT_DIR, old_dir_value);
     }
 
     #[tokio::test]


### PR DESCRIPTION
# What does this PR do?

Add ubuntu ssl cert directory for `test_missing_root_certificates_only_allow_http_connections`.

# Motivation

 Test `test_missing_root_certificates_only_allow_http_connections` failing on ubuntu when ddcommon feature `use_webpki_roots` is disabled.

# Additional Notes

Follows https://github.com/DataDog/libdatadog/pull/1033

Since `trace-mini-agent` imports trace-utils with the [mini_agent feature](https://github.com/DataDog/libdatadog/blob/ac445fa8810d4a07f536e415fd00c92648ab8f85/trace-mini-agent/Cargo.toml#L26) enabled, the [use_webpki_roots feature](https://github.com/DataDog/libdatadog/blob/ac445fa8810d4a07f536e415fd00c92648ab8f85/trace-utils/Cargo.toml#L68) is enabled for test runs. This means that `test_missing_root_certificates_use_webpki_certificates` runs in CI while `test_missing_root_certificates_only_allow_http_connections` does not run in CI, resulting in this test failure being hidden from past PRs.

Following https://github.com/DataDog/libdatadog/pull/1030 the default behavior will be to run `test_missing_root_certificates_only_allow_http_connections` in CI.

# How to test the change?

Validated by applying this change and running CI in https://github.com/DataDog/libdatadog/pull/1030.
https://github.com/DataDog/libdatadog/actions/runs/14579303934/job/40892263238?pr=1030

<img width="867" alt="Screenshot 2025-04-21 at 3 06 06 PM" src="https://github.com/user-attachments/assets/ffbc085f-f0a5-4496-9d47-2c25ac13f256" />


