### PR TITLE
style: fix some lints from nightly clippy

### DIFF
--- a/ipc/src/platform/channel/metadata.rs
+++ b/ipc/src/platform/channel/metadata.rs
@@ -25,10 +25,9 @@ impl HandlesTransport for &mut ChannelMetadata {
             let handle = hint.as_raw_fd();
             #[cfg(windows)]
             let handle = hint.as_raw_handle();
-            io::Error::new(
-                io::ErrorKind::Other,
-                format!("can't provide expected handle for hint: {:?}", handle),
-            )
+            io::Error::other(format!(
+                "can't provide expected handle for hint: {handle:?}"
+            ))
         })
     }
 }

--- a/ipc/src/platform/platform_handle.rs
+++ b/ipc/src/platform/platform_handle.rs
@@ -63,9 +63,8 @@ impl<T> PlatformHandle<T> {
     pub(crate) fn as_owned_fd(&self) -> io::Result<&Arc<OwnedFileHandle>> {
         match &self.inner {
             Some(fd) => Ok(fd),
-            None => Err(io::Error::new(
-                io::ErrorKind::Other,
-                "attempting to unwrap FD from invalid handle".to_string(),
+            None => Err(io::Error::other(
+                "attempting to unwrap FD from invalid handle",
             )),
         }
     }
@@ -83,19 +82,14 @@ impl<T> PlatformHandle<T> {
         let shared_handle = match self.inner {
             Some(shared_handle) => shared_handle,
             None => {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "attempting to unwrap FD from invalid handle".to_string(),
+                return Err(io::Error::other(
+                    "attempting to unwrap FD from invalid handle",
                 ))
             }
         };
 
-        Arc::try_unwrap(shared_handle).map_err(|_| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                "attempting to unwrap FD from shared platform handle".to_string(),
-            )
-        })
+        Arc::try_unwrap(shared_handle)
+            .map_err(|_| io::Error::other("attempting to unwrap FD from shared platform handle"))
     }
 
     /// casts the associated type

--- a/ipc/src/transport/blocking.rs
+++ b/ipc/src/transport/blocking.rs
@@ -104,10 +104,7 @@ where
                 }
             }
         }
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            "couldn't read entire item",
-        ))
+        Err(io::Error::other("couldn't read entire item"))
     }
 
     fn do_send(&mut self, req: OutgoingItem) -> Result<(), io::Error> {
@@ -192,10 +189,7 @@ where
                 return resp.message.map_err(|e| io::Error::new(e.kind, e.detail));
             }
         }
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            "Request is without a response",
-        ))
+        Err(io::Error::other("Request is without a response"))
     }
 }
 

--- a/ipc/src/transport/mod.rs
+++ b/ipc/src/transport/mod.rs
@@ -76,7 +76,7 @@ where
                 Some(Err(e)) => Some(Err(e.into())),
                 None => None,
             })
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+            .map_err(io::Error::other)
     }
 }
 
@@ -92,7 +92,7 @@ where
         self.project()
             .inner
             .poll_ready(cx)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+            .map_err(io::Error::other)
     }
 
     fn start_send(self: Pin<&mut Self>, item: SinkItem) -> io::Result<()> {
@@ -101,23 +101,21 @@ where
         let mut message = this.channel_metadata.lock().unwrap();
         let message = message.create_message(item)?;
 
-        this.inner
-            .start_send(message)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+        this.inner.start_send(message).map_err(io::Error::other)
     }
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         self.project()
             .inner
             .poll_flush(cx)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+            .map_err(io::Error::other)
     }
 
     fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         self.project()
             .inner
             .poll_close(cx)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))
+            .map_err(io::Error::other)
     }
 }
 

--- a/profiling-ffi/src/profiles/datatypes.rs
+++ b/profiling-ffi/src/profiles/datatypes.rs
@@ -835,7 +835,6 @@ mod tests {
     #[test]
     // TODO FIX
     #[cfg_attr(miri, ignore)]
-
     fn aggregate_samples() -> anyhow::Result<()> {
         unsafe {
             let sample_type: *const ValueType = &ValueType::new("samples", "count");

--- a/sidecar/src/entry.rs
+++ b/sidecar/src/entry.rs
@@ -203,7 +203,7 @@ pub fn daemonize(listener: IpcServer, mut cfg: Config) -> anyhow::Result<()> {
     spawn_cfg
         .shared_lib_dependencies(lib_deps)
         .wait_spawn()
-        .map_err(|err| io::Error::new(io::ErrorKind::Other, err))
+        .map_err(io::Error::other)
         .context("Could not spawn the sidecar daemon")?;
 
     Ok(())

--- a/sidecar/src/service/blocking.rs
+++ b/sidecar/src/service/blocking.rs
@@ -58,14 +58,14 @@ impl SidecarTransport {
     pub fn set_read_timeout(&mut self, timeout: Option<Duration>) -> io::Result<()> {
         match self.inner.lock() {
             Ok(mut t) => t.set_read_timeout(timeout),
-            Err(e) => Err(io::Error::new(io::ErrorKind::Other, e.to_string())),
+            Err(e) => Err(io::Error::other(e.to_string())),
         }
     }
 
     pub fn set_write_timeout(&mut self, timeout: Option<Duration>) -> io::Result<()> {
         match self.inner.lock() {
             Ok(mut t) => t.set_write_timeout(timeout),
-            Err(e) => Err(io::Error::new(io::ErrorKind::Other, e.to_string())),
+            Err(e) => Err(io::Error::other(e.to_string())),
         }
     }
 
@@ -81,14 +81,14 @@ impl SidecarTransport {
     pub fn send(&mut self, item: SidecarInterfaceRequest) -> io::Result<()> {
         match self.inner.lock() {
             Ok(mut t) => t.send(item),
-            Err(e) => Err(io::Error::new(io::ErrorKind::Other, e.to_string())),
+            Err(e) => Err(io::Error::other(e.to_string())),
         }
     }
 
     pub fn call(&mut self, item: SidecarInterfaceRequest) -> io::Result<SidecarInterfaceResponse> {
         match self.inner.lock() {
             Ok(mut t) => t.call(item),
-            Err(e) => Err(io::Error::new(io::ErrorKind::Other, e.to_string())),
+            Err(e) => Err(io::Error::other(e.to_string())),
         }
     }
 }

--- a/tinybytes/src/bytes_string.rs
+++ b/tinybytes/src/bytes_string.rs
@@ -7,7 +7,7 @@ use serde::ser::{Serialize, Serializer};
 use std::fmt::{Debug, Formatter};
 use std::{borrow::Borrow, hash, str::Utf8Error};
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Default, Eq, PartialEq)]
 pub struct BytesString {
     bytes: Bytes,
 }
@@ -138,14 +138,6 @@ impl BytesString {
     /// Returns `true` if the underlying bytes are empty.
     pub fn is_empty(&self) -> bool {
         self.bytes.is_empty()
-    }
-}
-
-impl Default for BytesString {
-    fn default() -> Self {
-        Self {
-            bytes: Bytes::empty(),
-        }
     }
 }
 


### PR DESCRIPTION
# What does this PR do?

Fixes these lints on nightly clippy:

  - `clippy::derivable_impls`
  - `clippy::empty_line_after_outer_attr`
  - `clippy::io_other_error`

# Motivation

I was working with nightly for another reason, and figured I'd run clippy to see what it surfaced. All of these changes look like improvements to me, so I figured I'd ship them.

# Additional Notes

One of the nightly lints, `clippy::ptr_eq`, seems wrong. That lint seems to _intend_ to warn when you have two references, and you turn them into pointers to compare the pointers, but in practice it just whines about every pointer comparison. I'll leave it for now.

Another one is `clippy::large_enum_variant`. I think it's legitimate, but I think best left for a different PR. There are two cases, the first being:

```
warning: large size difference between variants
   --> sidecar/src/shm_remote_config.rs:404:1
    |
404 | /  pub enum RemoteConfigUpdate {
405 | |      None,
406 | |/     Add {
407 | ||         value: RemoteConfigValue,
408 | ||         limiter_index: u32,
409 | ||     },
    | ||_____- the largest variant contains at least 420 bytes
410 | |      Remove(RemoteConfigPath),
    | |      ------------------------ the second-largest variant contains at least 72 bytes
411 | |  }
    | |__^ the entire enum is at least 424 bytes
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
    = note: `#[warn(clippy::large_enum_variant)]` on by default
help: consider boxing the large fields to reduce the total size of the enum
    |
407 -         value: RemoteConfigValue,
407 +         value: Box<RemoteConfigValue>,
    |
```

And the second:

```
warning: large size difference between variants
   --> live-debugger/src/probe_defs.rs:155:1
    |
155 | / pub enum LiveDebuggingData {
156 | |     Probe(Probe),
    | |     ------------ the largest variant contains at least 352 bytes
157 | |     ServiceConfiguration(ServiceConfiguration),
    | |     ------------------------------------------ the second-largest variant contains at least 128 bytes
158 | | }
    | |_^ the entire enum is at least 352 bytes
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
    = note: `#[warn(clippy::large_enum_variant)]` on by default
help: consider boxing the large fields to reduce the total size of the enum
    |
156 -     Probe(Probe),
156 +     Probe(Box<Probe>),
    |
```

# How to test the change?

Regular testing is sufficient--these should only be style changes.
