### PR TITLE
fix(data-pipeline): add a wait loop in the test checking if data has been swapped

### DIFF
--- a/data-pipeline/src/agent_info/fetcher.rs
+++ b/data-pipeline/src/agent_info/fetcher.rs
@@ -359,7 +359,17 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
 
-        let version_2 = info.load().as_ref().unwrap().info.version.clone().unwrap();
-        assert_eq!(version_2, "2");
+        // This check is not 100% deterministic, but between the time the mock returns the response
+        // and we swap the atomic pointer holding the agent_info we only need to perform
+        // very few operations. We wait for a maximum of 1s before failing the test and that should
+        // give way more time than necesssary.
+        for _ in 0..10 {
+            let version_2 = info.load().as_ref().unwrap().info.version.clone().unwrap();
+            if version_2 != version_1 {
+                assert_eq!(version_2, "2");
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
     }
 }


### PR DESCRIPTION
# What does this PR do?

Add a wait loop in the test checking if data has been swapped

This test is still not 100% deterministic, but between the time the mock returns the response and we swap the atomic pointer holding the agent_info we only need to perform very few operations. We wait for a maximum of 1s before failing the test and that should give way more time than necessary.

# Motivation

@morrisonlevi  messaged me about a failing test in data-pipeline.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
