### PR TITLE
chore: [SVLS-6242] adding some currently unnecessary clippy checkers

### DIFF
--- a/ddcommon/clippy.toml
+++ b/ddcommon/clippy.toml
@@ -1,0 +1,4 @@
+disallowed-methods = [
+    # reqwest clients should be built with our adapter for datadog-lambda-extension bottlecap correctness
+    { path = "reqwest::Client::builder", reason = "prefer the FIPS-compatible adapter", replacement = "datadog_fips::reqwest_adapter::create_reqwest_client_builder" },
+]

--- a/trace-normalization/clippy.toml
+++ b/trace-normalization/clippy.toml
@@ -1,0 +1,4 @@
+disallowed-methods = [
+    # reqwest clients should be built with our adapter for datadog-lambda-extension bottlecap correctness
+    { path = "reqwest::Client::builder", reason = "prefer the FIPS-compatible adapter", replacement = "datadog_fips::reqwest_adapter::create_reqwest_client_builder" },
+]

--- a/trace-obfuscation/clippy.toml
+++ b/trace-obfuscation/clippy.toml
@@ -1,0 +1,4 @@
+disallowed-methods = [
+    # reqwest clients should be built with our adapter for datadog-lambda-extension bottlecap correctness
+    { path = "reqwest::Client::builder", reason = "prefer the FIPS-compatible adapter", replacement = "datadog_fips::reqwest_adapter::create_reqwest_client_builder" },
+]

--- a/trace-protobuf/clippy.toml
+++ b/trace-protobuf/clippy.toml
@@ -1,0 +1,4 @@
+disallowed-methods = [
+    # reqwest clients should be built with our adapter for datadog-lambda-extension bottlecap correctness
+    { path = "reqwest::Client::builder", reason = "prefer the FIPS-compatible adapter", replacement = "datadog_fips::reqwest_adapter::create_reqwest_client_builder" },
+]

--- a/trace-utils/clippy.toml
+++ b/trace-utils/clippy.toml
@@ -1,0 +1,4 @@
+disallowed-methods = [
+    # reqwest clients should be built with our adapter for datadog-lambda-extension bottlecap correctness
+    { path = "reqwest::Client::builder", reason = "prefer the FIPS-compatible adapter", replacement = "datadog_fips::reqwest_adapter::create_reqwest_client_builder" },
+]


### PR DESCRIPTION
for future safety. These rules apply to the crates that are used in the datadog-lambda-extension bottlecap crate. We don't actually use `reqwest` in these crates now, so these rules are just there for future safety.