### PR TITLE
APMSP-1969 fix dropped trace payloads for the sidecar

### DIFF
--- a/datadog-trace-utils/src/trace_utils.rs
+++ b/datadog-trace-utils/src/trace_utils.rs
@@ -23,14 +23,16 @@ use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::env;
 
+/// The maximum payload size for a single request that can be sent to the trace agent. Payloads
+/// larger than this size will be dropped and the agent will return a 413 error if
+/// `datadog-send-real-http-status` is set.
+pub const MAX_PAYLOAD_SIZE: usize = 25 * 1024 * 1024;
 /// Span metric the mini agent must set for the backend to recognize top level span
 const TOP_LEVEL_KEY: &str = "_top_level";
 /// Span metric the tracer sets to denote a top level span
 const TRACER_TOP_LEVEL_KEY: &str = "_dd.top_level";
 const MEASURED_KEY: &str = "_dd.measured";
 const PARTIAL_VERSION_KEY: &str = "_dd.partial_version";
-
-const MAX_PAYLOAD_SIZE: usize = 50 * 1024 * 1024;
 const MAX_STRING_DICT_SIZE: u32 = 25_000_000;
 const SPAN_ELEMENT_COUNT: usize = 12;
 


### PR DESCRIPTION

# What does this PR do?

- The `MAX_PAYLOAD_SIZE` used in trace_utils::coalesce_send_data() was 50mb. The agent drops payloads greater than > 25mb and returns a 413. So it was potentially combining payloads that would result in an error and drop. 

- In the sidecar's trace_flusher, payloads were being dropped if the queue's size exceeded the min drop size. The correct behavior is to check if the payload being enqueued exceeds min drop size, not the entire queue. Additionally, the default minimum drop size was 10mb. This has been changed to `trace_utils::MAX_PAYLOAD_SIZE`. 

- When the sidecar's trace_flusher was dropping a payload that was too large it was still adding that payload's size to the queue size. This could have lead to subsequent payloads being dropped, regardless of their size, due to an incorrectly large queue size until a time based flush was done.

- A bug was discovered in the test helper function `poll_for_mock_hits()` where we were incorrectly returning true always when expected hits was 0.

# Motivation

@bwoebi observed large spans being silently dropped in a php app.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
