### PR TITLE
fix(crashtracker) Cache virtual memory address to speed up normalization

### DIFF
--- a/datadog-crashtracker/src/crash_info/error_data.rs
+++ b/datadog-crashtracker/src/crash_info/error_data.rs
@@ -20,7 +20,11 @@ pub struct ErrorData {
 impl ErrorData {
     pub fn normalize_ips(&mut self, pid: u32) -> anyhow::Result<()> {
         let mut errors = 0;
-        let normalizer = blazesym::normalize::Normalizer::new();
+        let normalizer = blazesym::normalize::Normalizer::builder()
+            .enable_vma_caching(true)
+            .enable_build_ids(true)
+            .enable_build_id_caching(true)
+            .build();
         let pid = pid.into();
         self.stack
             .normalize_ips(&normalizer, pid)


### PR DESCRIPTION
# What does this PR do?

This PR creates a normalizer which caches VMA (Virtual Memory Addresses) to speed up normalization.

# Motivation

For each frame we call into blazesym. If we do not instruct blazesym to cache the VMA, it will parse them at each call.

# Additional Notes

Added also build_id caching. `build ids` are important thingy for remote symbolication (in datadog backend)
There is no caching in the blazesym rc2 for names resolution. We would need to upgrade blazesym to benefit from it.

