### PR TITLE
Make datadog-profiling-ffi exportable in external projects.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,7 +786,9 @@ dependencies = [
  "build_common",
  "cmake",
  "pico-args",
+ "serde",
  "tar",
+ "toml",
  "tools",
 ]
 
@@ -4739,9 +4741,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
@@ -4757,9 +4759,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5572,21 +5574,21 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
 dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.22",
+ "toml_edit 0.22.26",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 dependencies = [
  "serde",
 ]
@@ -5604,16 +5606,23 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap 2.6.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.6.20",
+ "toml_write",
+ "winnow 0.7.9",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "tonic"
@@ -6514,9 +6523,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "d9fb597c990f03753e08d3c29efbfcf2019a003b4bf4ba19225c158e1549f0f3"
 dependencies = [
  "memchr",
 ]

--- a/build-profiling-ffi.sh
+++ b/build-profiling-ffi.sh
@@ -165,7 +165,7 @@ FEATURES=$(IFS=, ; echo "${FEATURES[*]}")
 echo "Building for features: $FEATURES"
 
 # build inside the crate to use the config.toml file
-( cd datadog-profiling-ffi && DESTDIR="$destdir" cargo build --features $FEATURES --release --target "${target}" )
+( cd datadog-profiling-ffi && DESTDIR="$destdir" cargo rustc --features $FEATURES --release --target "${target}" --crate-type cdylib && DESTDIR="$destdir" cargo rustc --features $FEATURES --release --target "${target}" --crate-type staticlib)
 
 # Remove _ffi suffix when copying
 shared_library_name="${library_prefix}datadog_profiling_ffi${shared_library_suffix}"

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -27,8 +27,8 @@ cmake = "0.1.50"
 pico-args = "0.5.0"
 tar = "0.4.41"
 tools = { path = "../tools" }
-toml = "0.8.22"
-serde = "1.0.219"
+toml = "0.8.19"
+serde = "1.0.209"
 
 [[bin]]
 name = "release"

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -20,7 +20,6 @@ bench = false
 test = false
 doctest = false
 
-
 [dependencies]
 anyhow = { version = "1.0" }
 build_common = { path = "../build-common", features = ["cbindgen"] }
@@ -28,6 +27,8 @@ cmake = "0.1.50"
 pico-args = "0.5.0"
 tar = "0.4.41"
 tools = { path = "../tools" }
+toml = "0.8.22"
+serde = "1.0.219"
 
 [[bin]]
 name = "release"

--- a/builder/src/builder.rs
+++ b/builder/src/builder.rs
@@ -89,8 +89,7 @@ impl Builder {
             features: features.into(),
             main_header: (target_dir.to_string() + "/" + HEADER_PATH + "/" + "common.h").into(),
             profile: profile.into(),
-            source_lib: (source_dir.to_string() + "/" + target_arch + "/" + profile + "/deps")
-                .into(),
+            source_lib: (source_dir.to_string() + "/" + target_arch + "/" + profile).into(),
             source_inc: (source_dir.to_string() + "/" + HEADER_PATH).into(),
             target_dir: target_dir.into(),
             target_lib: (target_dir.to_string() + "/" + "/lib").into(),

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -9,5 +9,5 @@ pub mod crashtracker;
 pub mod module;
 pub mod utils;
 
-// #[cfg(feature = "profiling")]
+#[cfg(feature = "profiling")]
 pub mod profiling;

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -9,5 +9,5 @@ pub mod crashtracker;
 pub mod module;
 pub mod utils;
 
-#[cfg(feature = "profiling")]
+// #[cfg(feature = "profiling")]
 pub mod profiling;

--- a/builder/src/profiling.rs
+++ b/builder/src/profiling.rs
@@ -174,11 +174,15 @@ impl Module for Profiling {
             cargo_args.push("--release");
         }
 
+        // Parse profiling-ffi manifest in order to get the crate-type array.
         let prof_path: PathBuf = [project_root().to_str().unwrap(), CRATE_FOLDER, "Cargo.toml"]
             .iter()
             .collect();
+        // Buffer the manifest file.
         let cargo_toml = fs::read_to_string(prof_path).unwrap();
+        // Use serde to get access to the lib section.
         let parsed: CargoFile = toml::from_str(&cargo_toml).unwrap();
+        // Iterate over all the crate types in order to build the artifacts for each one.
         for crate_type in parsed.lib.crate_type.iter() {
             // Ignore lib crate-type
             if crate_type == "lib" {

--- a/datadog-crashtracker/Cargo.toml
+++ b/datadog-crashtracker/Cargo.toml
@@ -27,7 +27,7 @@ collector_windows = []
 
 [target.'cfg(unix)'.dependencies]
 # Should be kept in sync with the libdatadog symbolizer crate (also using blasesym)
-blazesym = "0.2.0-rc.2"
+blazesym = "=0.2.0-rc.2"
 
 [dependencies]
 anyhow = "1.0"

--- a/datadog-profiling-ffi/Cargo.toml
+++ b/datadog-profiling-ffi/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 [lib]
 # LTO is ignored if "lib" is added as crate type
 # cf. https://github.com/rust-lang/rust/issues/51009
-crate-type = ["staticlib", "cdylib"]
+crate-type = ["lib", "staticlib", "cdylib"]
 bench = false
 
 [features]

--- a/windows/build-artifacts.ps1
+++ b/windows/build-artifacts.ps1
@@ -33,10 +33,18 @@ $features = @(
 Write-Host "Building for features: $features" -ForegroundColor Magenta
 
 pushd datadog-profiling-ffi
-Invoke-Call -ScriptBlock { cargo build --features $features --target i686-pc-windows-msvc --release --target-dir $output_dir }
-Invoke-Call -ScriptBlock { cargo build --features $features --target i686-pc-windows-msvc --target-dir $output_dir }
-Invoke-Call -ScriptBlock { cargo build --features $features --target x86_64-pc-windows-msvc --release --target-dir $output_dir }
-Invoke-Call -ScriptBlock { cargo build --features $features --target x86_64-pc-windows-msvc --target-dir $output_dir }
+#i686 Release
+Invoke-Call -ScriptBlock { cargo rustc --features $features --target i686-pc-windows-msvc --release --target-dir $output_dir --crate-type cdylib }
+Invoke-Call -ScriptBlock { cargo rustc --features $features --target i686-pc-windows-msvc --release --target-dir $output_dir --crate-type staticlib }
+#i686 Debug
+Invoke-Call -ScriptBlock { cargo rustc --features $features --target i686-pc-windows-msvc --target-dir $output_dir --crate-type cdylib }
+Invoke-Call -ScriptBlock { cargo rustc --features $features --target i686-pc-windows-msvc --target-dir $output_dir --crate-type staticlib }
+#x86_64 Release
+Invoke-Call -ScriptBlock { cargo rustc --features $features --target x86_64-pc-windows-msvc --release --target-dir $output_dir --crate-type cdylib}
+Invoke-Call -ScriptBlock { cargo rustc --features $features --target x86_64-pc-windows-msvc --release --target-dir $output_dir --crate-type staticlib}
+#x86_64 Debug
+Invoke-Call -ScriptBlock { cargo rustc --features $features --target x86_64-pc-windows-msvc --target-dir $output_dir --crate-type cdylib}
+Invoke-Call -ScriptBlock { cargo rustc --features $features --target x86_64-pc-windows-msvc --target-dir $output_dir --crate-type staticlib}
 popd
 
 Write-Host "Building tools" -ForegroundColor Magenta


### PR DESCRIPTION
# What does this PR do?

This PR adds 'lib' to datadog-profiling-ffi crate type list so it symbols can be reexported in an external project.

# Motivation
Some SDKs were already integrating some parts of libdatadog using a language framework and profiling using the released artifacts. As a result there were two libraries, one generated by framework and another one for wrapping libdatadog-ffi functions. This led to symbol duplication across libraries. In order to overcome that issue, hence reducing the overall size, we decided to merge both libraries, for that we needed to compile profiling as a 'lib'.
# Additional Notes
As a side effect the builder and build scripts has been modified in order to overcome problems with LTO linkage where cargo build has some issues when adding 'lib' to the crate-type list.

Another side effect is that when crashtracker is imported as a dependency in another project the cargo dependency resolver resolved blazesym to version "0.2.0-rc.3" instead of "rc.2" leading to some compilation errors because the are breaking changes between the two versions.