### PR TITLE
feat: add client_computed_stats to TraceExporterConfig and expose API to set it

### DIFF
--- a/data-pipeline-ffi/src/trace_exporter.rs
+++ b/data-pipeline-ffi/src/trace_exporter.rs
@@ -65,6 +65,7 @@ pub struct TraceExporterConfig {
     input_format: TraceExporterInputFormat,
     output_format: TraceExporterOutputFormat,
     compute_stats: bool,
+    client_computed_stats: bool,
     telemetry_cfg: Option<TelemetryConfig>,
     test_session_token: Option<String>,
 }
@@ -275,6 +276,31 @@ pub unsafe extern "C" fn ddog_trace_exporter_config_set_compute_stats(
     }
 }
 
+/// Sets `Datadog-Client-Computed-Stats` header to `true`.
+/// This indicates that the upstream system has already computed the stats,
+/// and no further stats computation should be performed.
+///
+/// <div class="warning">
+/// This method must not be used when `compute_stats` is enabled, as it could
+/// result in duplicate stats computation.
+/// </div>
+///
+/// A common use case is in Application Security Monitoring (ASM) scenarios:
+/// when APM is disabled but ASM is enabled, setting this header to `true`
+/// ensures that no stats are computed at any level (exporter or agent).
+#[no_mangle]
+pub unsafe extern "C" fn ddog_trace_exporter_config_set_client_computed_stats(
+    config: Option<&mut TraceExporterConfig>,
+    client_computed_stats: bool,
+) -> Option<Box<ExporterError>> {
+    if let Option::Some(config) = config {
+        config.client_computed_stats = client_computed_stats;
+        None
+    } else {
+        gen_error!(ErrorCode::InvalidArgument)
+    }
+}
+
 /// Sets the `X-Datadog-Test-Session-Token` header. Only used for testing with the test agent.
 #[no_mangle]
 pub unsafe extern "C" fn ddog_trace_exporter_config_set_test_session_token(
@@ -325,6 +351,8 @@ pub unsafe extern "C" fn ddog_trace_exporter_new(
             .set_output_format(config.output_format);
         if config.compute_stats {
             builder.enable_stats(Duration::from_secs(10));
+        } else if config.client_computed_stats {
+            builder.set_client_computed_stats();
         }
 
         if let Some(cfg) = &config.telemetry_cfg {
@@ -611,6 +639,24 @@ mod tests {
     }
 
     #[test]
+    fn config_client_computed_stats_test() {
+        unsafe {
+            let error = ddog_trace_exporter_config_set_client_computed_stats(None, true);
+            assert_eq!(error.as_ref().unwrap().code, ErrorCode::InvalidArgument);
+
+            ddog_trace_exporter_error_free(error);
+
+            let mut config = Some(TraceExporterConfig::default());
+            let error = ddog_trace_exporter_config_set_client_computed_stats(config.as_mut(), true);
+
+            assert_eq!(error, None);
+
+            let cfg = config.unwrap();
+            assert!(cfg.client_computed_stats);
+        }
+    }
+
+    #[test]
     fn config_telemetry_test() {
         unsafe {
             let error = ddog_trace_exporter_config_enable_telemetry(
@@ -781,6 +827,7 @@ mod tests {
                 compute_stats: false,
                 telemetry_cfg: None,
                 test_session_token: None,
+                client_computed_stats: false,
             };
 
             let mut ptr: MaybeUninit<Box<TraceExporter>> = MaybeUninit::uninit();
@@ -851,6 +898,7 @@ mod tests {
                 compute_stats: false,
                 telemetry_cfg: None,
                 test_session_token: None,
+                client_computed_stats: false,
             };
 
             let mut ptr: MaybeUninit<Box<TraceExporter>> = MaybeUninit::uninit();
@@ -927,6 +975,7 @@ mod tests {
                     debug_enabled: true,
                 }),
                 test_session_token: None,
+                client_computed_stats: false,
             };
 
             let mut ptr: MaybeUninit<Box<TraceExporter>> = MaybeUninit::uninit();


### PR DESCRIPTION
# What does this PR do?

This pull request introduces support for a new `client_computed_stats` configuration in the `TraceExporterConfig` structure, enabling more flexible handling of stats computation in Datadog's trace exporter. The changes include updates to the configuration structure, a new method for setting the `client_computed_stats` flag, and corresponding logic and test cases to ensure proper functionality.

# Motivation

System tests are failing in .NET

https://dev.azure.com/datadoghq/dd-trace-dotnet/_build/results?buildId=177394&view=logs&j=b8b8344c-200f-58ee-939b-983868d59647&t=25e5ff76-b821-5391-6a6d-ead53dc1b1b4&l=631

# Additional Notes

A current use of this new API is ASM. When ASM is enabled and APM is disabled, tracers use this to make sure stats computation is skipped.

# How to test the change?

Test cases.
