### PR TITLE
Prepare for libdatadog v18.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "build_common"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "cbindgen",
  "serde",
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "builder"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1336,7 +1336,7 @@ checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 
 [[package]]
 name = "data-pipeline"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "data-pipeline-ffi"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "build_common",
  "data-pipeline",
@@ -1382,7 +1382,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-alloc"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "allocator-api2",
  "bolero",
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-crashtracker"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -1422,7 +1422,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-crashtracker-ffi"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1442,7 +1442,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-ddsketch"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "bitmaps",
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-ffi"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-replayer"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1737,7 +1737,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-normalization"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-obfuscation"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1766,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-protobuf"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-utils"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "bolero",
@@ -1815,7 +1815,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "cc",
@@ -1853,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon-ffi"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "bolero",
@@ -1867,7 +1867,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1891,7 +1891,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry-ffi"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "build_common",
  "ddcommon",
@@ -2014,7 +2014,7 @@ dependencies = [
 
 [[package]]
 name = "dogstatsd-client"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "cadence",
@@ -5118,7 +5118,7 @@ dependencies = [
 
 [[package]]
 name = "symbolizer-ffi"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "blazesym-c",
  "build_common",
@@ -5441,7 +5441,7 @@ dependencies = [
 
 [[package]]
 name = "tinybytes"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "once_cell",
  "pretty_assertions",
@@ -5656,7 +5656,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "17.0.0"
+version = "18.0.0"
 dependencies = [
  "regex",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.78.0"
 edition = "2021"
-version = "17.0.0"
+version = "18.0.0"
 license = "Apache-2.0"
 
 [profile.dev]


### PR DESCRIPTION
# What does this PR do?

This  prepares for the v18.0.0 release of libdatadog.

# Motivation

Bob asked me to release a new version for the PHP tracer to use in their own new release.

# Additional Notes

There is a known issue with crashtracking with forks on v17 that is still not fixed, to the best of my knowledge.

