### PR TITLE
Allow for generic refcounting of tinybytes values

### DIFF
--- a/tinybytes/src/test.rs
+++ b/tinybytes/src/test.rs
@@ -3,6 +3,7 @@
 
 use core::str;
 use std::sync::atomic::{self, AtomicUsize};
+use std::sync::Arc;
 
 use super::*;
 use once_cell::sync::OnceCell;


### PR DESCRIPTION
This means though, that addref and delref go through vtable lookups rather than being inlined in Clone and Drop respectively.

On the flip-side it allows directly exposing refcounters on underlying values (e.g. from a zend_string in PHP), without a nested allocation and indirection.