### PR TITLE
feat(tinybytes): use a custom vtable to be able to use custom refcounted type

### DIFF
--- a/tinybytes/src/lib.rs
+++ b/tinybytes/src/lib.rs
@@ -10,6 +10,7 @@
 use std::{
     borrow, cmp, fmt, hash,
     ops::{self, RangeBounds},
+    ptr::NonNull,
     sync::Arc,
 };
 
@@ -22,7 +23,7 @@ pub struct Bytes {
     slice: &'static [u8],
     // The `bytes`` field is used to ensure that the underlying bytes are freed when there are no
     // more references to the `Bytes` object. For static buffers the field is `None`.
-    bytes: Option<Arc<dyn UnderlyingBytes>>,
+    bytes: Option<RefCountedBytes>,
 }
 
 /// The underlying bytes that the `Bytes` object references.
@@ -188,7 +189,7 @@ impl Bytes {
     fn from_underlying(value: impl UnderlyingBytes) -> Self {
         Self {
             slice: unsafe { std::mem::transmute::<&'_ [u8], &'static [u8]>(value.as_ref()) },
-            bytes: Some(Arc::new(value)),
+            bytes: Some(arc_refcounted_bytes(Arc::new(value))),
         }
     }
 
@@ -291,6 +292,59 @@ impl Serialize for Bytes {
     }
 }
 
+fn arc_refcounted_bytes<T>(data: Arc<T>) -> RefCountedBytes {
+    unsafe fn arc_clone<T>(data: *const ()) -> RawRefCountedBytes {
+        Arc::increment_strong_count(data as *const T);
+        RawRefCountedBytes {
+            data: unsafe { NonNull::new_unchecked(data as *mut ()) },
+            vtable: RefCountedBytesVTable {
+                clone: arc_clone::<T>,
+                drop: arc_drop::<T>,
+            },
+        }
+    }
+    unsafe fn arc_drop<T>(data: *const ()) {
+        Arc::from_raw(data as *const T);
+    }
+    RefCountedBytes {
+        raw: RawRefCountedBytes {
+            data: unsafe { NonNull::new_unchecked(Arc::into_raw(data) as *const () as *mut ()) },
+            vtable: RefCountedBytesVTable {
+                clone: arc_clone::<T>,
+                drop: arc_drop::<T>,
+            },
+        },
+    }
+}
+
+struct RefCountedBytes {
+    raw: RawRefCountedBytes,
+}
+
+impl Clone for RefCountedBytes {
+    fn clone(&self) -> Self {
+        RefCountedBytes {
+            raw: unsafe { (self.raw.vtable.clone)(self.raw.data.as_ptr().cast_const()) },
+        }
+    }
+}
+
+impl Drop for RefCountedBytes {
+    fn drop(&mut self) {
+        unsafe { (self.raw.vtable.drop)(self.raw.data.as_ptr().cast_const()) }
+    }
+}
+
+struct RawRefCountedBytes {
+    data: NonNull<()>,
+    vtable: RefCountedBytesVTable,
+}
+
+struct RefCountedBytesVTable {
+    clone: unsafe fn(*const ()) -> RawRefCountedBytes,
+    drop: unsafe fn(*const ()),
+}
+
 #[cfg(feature = "bytes_string")]
 mod bytes_string;
 #[cfg(feature = "bytes_string")]
@@ -298,3 +352,81 @@ pub use bytes_string::BytesString;
 
 #[cfg(test)]
 mod test;
+
+#[cfg(test)]
+mod tests {
+    use std::{ptr::NonNull, sync::atomic::AtomicUsize};
+
+    use crate::{RawRefCountedBytes, RefCountedBytes, RefCountedBytesVTable};
+
+    struct CustomArc<T> {
+        rc: AtomicUsize,
+        #[allow(unused)]
+        data: T,
+    }
+
+    fn custom_arc_refcounted<T>(data: T) -> RefCountedBytes {
+        unsafe fn custom_arc_clone<T>(data: *const ()) -> RawRefCountedBytes {
+            let custom_arc = data as *const CustomArc<T>;
+            let rc = unsafe {
+                std::ptr::addr_of!((*custom_arc).rc)
+                    .as_ref()
+                    .unwrap_unchecked()
+            };
+            rc.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            RawRefCountedBytes {
+                data: NonNull::new_unchecked(data as *mut ()),
+                vtable: RefCountedBytesVTable {
+                    clone: custom_arc_clone::<T>,
+                    drop: custom_arc_drop::<T>,
+                },
+            }
+        }
+
+        unsafe fn custom_arc_drop<T>(data: *const ()) {
+            let custom_arc = data as *const CustomArc<T>;
+            let rc: &AtomicUsize = unsafe {
+                std::ptr::addr_of!((*custom_arc).rc)
+                    .as_ref()
+                    .unwrap_unchecked()
+            };
+            if rc.fetch_sub(1, std::sync::atomic::Ordering::Release) == 1 {
+                {
+                    let custom_arc = (custom_arc as *mut CustomArc<T>)
+                        .as_mut()
+                        .unwrap_unchecked();
+                    std::ptr::drop_in_place(custom_arc);
+                }
+                std::alloc::dealloc(
+                    data as *mut () as *mut u8,
+                    std::alloc::Layout::new::<CustomArc<T>>(),
+                );
+            }
+        }
+
+        let rc = Box::leak(Box::new(CustomArc {
+            rc: AtomicUsize::new(1),
+            data,
+        })) as *mut _ as *const ();
+        RefCountedBytes {
+            raw: RawRefCountedBytes {
+                data: unsafe { NonNull::new_unchecked(rc as *mut ()) },
+                vtable: RefCountedBytesVTable {
+                    clone: custom_arc_clone::<T>,
+                    drop: custom_arc_drop::<T>,
+                },
+            },
+        }
+    }
+
+    #[test]
+    /// Run with miri to check that this works
+    fn test_custom_arc_refcounted() {
+        let data = vec![1, 2, 3];
+        let refcounted = custom_arc_refcounted(data);
+        let refcounted_clone = refcounted.clone();
+
+        drop(refcounted);
+        drop(refcounted_clone);
+    }
+}


### PR DESCRIPTION
# What does this PR do?

Allow to replace the refcounted type used in tinybytes, by using a custom dispatch table for clone a drop

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
