### PR TITLE
style: fix lints from Rust 1.87

### DIFF
--- a/builder/src/arch/apple.rs
+++ b/builder/src/arch/apple.rs
@@ -18,7 +18,7 @@ pub const RUSTFLAGS: [&str; 2] = ["-C", "relocation-model=pic"];
 
 pub fn fix_rpath(lib_path: &str) {
     if REMOVE_RPATH {
-        let lib_name = lib_path.split('/').last().unwrap();
+        let lib_name = lib_path.split('/').next_back().unwrap();
 
         let exit_status = Command::new("install_name_tool")
             .arg("-id")

--- a/datadog-live-debugger/src/probe_defs.rs
+++ b/datadog-live-debugger/src/probe_defs.rs
@@ -151,6 +151,7 @@ pub struct ServiceConfiguration {
     pub sampling_snapshots_per_second: u32,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum LiveDebuggingData {
     Probe(Probe),

--- a/datadog-sidecar/src/shm_remote_config.rs
+++ b/datadog-sidecar/src/shm_remote_config.rs
@@ -400,6 +400,7 @@ pub struct RemoteConfigManager {
     pub current_runtime_id: String,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum RemoteConfigUpdate {
     None,

--- a/spawn_worker/src/unix/spawn.rs
+++ b/spawn_worker/src/unix/spawn.rs
@@ -134,21 +134,15 @@ impl Target {
         let default_method = SpawnMethod::Exec;
 
         let target_path = match self {
-            Target::Entrypoint(e) => e.get_fs_path().ok_or_else(|| {
-                std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "can't find the entrypoint's target path",
-                )
-            }),
+            Target::Entrypoint(e) => e
+                .get_fs_path()
+                .ok_or_else(|| std::io::Error::other("can't find the entrypoint's target path")),
             Target::ManualTrampoline(p, _) => Ok(std::path::PathBuf::from(p)),
             Target::Noop => return Ok(default_method),
         }?;
-        let target_filename = target_path.file_name().ok_or_else(|| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                "can't extract actual target filename",
-            )
-        })?;
+        let target_filename = target_path
+            .file_name()
+            .ok_or_else(|| std::io::Error::other("can't extract actual target filename"))?;
 
         // simple heuristic that should cover most cases
         // if both executable path and target's entrypoint path end up having the same filenames


### PR DESCRIPTION
# What does this PR do?

Fixes new lints from the Rust 1.87 release.

# Motivation

A new release was made, so my CI now fails.

# Additional Notes

I fixed a bunch of these before the release dropped (#1038), so thankfully it's not too much work now.

The `allow(large_enum_variant)` was based on @bwoebi's recommendation. He doesn't feel these are problematic because it's not embedded in other data structures, and is used on the stack. Plus it's more invasive to fix, so even if we do fix it, the first step to unblock CI is to allow it. 

# How to test the change?

Should be the same, it's just style changes.
