### PR TITLE
feat(profiling): upload compression config

### DIFF
--- a/datadog-profiling-ffi/src/lib.rs
+++ b/datadog-profiling-ffi/src/lib.rs
@@ -14,6 +14,8 @@ mod exporter;
 mod profiles;
 mod string_storage;
 
+pub use profiles::*;
+
 // re-export crashtracker ffi
 #[cfg(feature = "crashtracker-ffi")]
 pub use datadog_crashtracker_ffi::*;

--- a/datadog-profiling-ffi/src/profiles/interning_api.rs
+++ b/datadog-profiling-ffi/src/profiles/interning_api.rs
@@ -407,14 +407,9 @@ pub unsafe extern "C" fn ddog_prof_Profile_get_generation(
 }
 
 /// This functions returns whether the given generations are equal.
-///
-/// # Safety: No safety requirements
 #[must_use]
 #[no_mangle]
-pub unsafe extern "C" fn ddog_prof_Profile_generations_are_equal(
-    a: Generation,
-    b: Generation,
-) -> bool {
+pub extern "C" fn ddog_prof_Profile_generations_are_equal(a: Generation, b: Generation) -> bool {
     a == b
 }
 

--- a/datadog-profiling-ffi/src/profiles/mod.rs
+++ b/datadog-profiling-ffi/src/profiles/mod.rs
@@ -3,3 +3,6 @@
 
 mod datatypes;
 mod interning_api;
+
+pub use datatypes::*;
+pub use interning_api::*;

--- a/datadog-profiling/src/lib.rs
+++ b/datadog-profiling/src/lib.rs
@@ -12,3 +12,13 @@ pub mod exporter;
 pub mod internal;
 pub mod iter;
 pub mod pprof;
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default)]
+pub enum UploadCompression {
+    Off,
+    /// On is the default. The compression algorithm used can change over time.
+    #[default]
+    On,
+    Lz4,
+}

--- a/ddcommon-ffi/src/result.rs
+++ b/ddcommon-ffi/src/result.rs
@@ -46,6 +46,15 @@ pub enum Result<T> {
     Err(Error),
 }
 
+impl From<VoidResult> for std::result::Result<(), Error> {
+    fn from(result: VoidResult) -> Self {
+        match result {
+            VoidResult::Ok(_) => Ok(()),
+            VoidResult::Err(err) => Err(err),
+        }
+    }
+}
+
 impl<T> Result<T> {
     pub fn unwrap(self) -> T {
         match self {


### PR DESCRIPTION
# What does this PR do?

Adds upload compression configuration. For now, the options are Off,
On, and Lz4:
 - Off: no compression.
 - On: default, and which algorithm it chooses can change.
 - Lz4: lz4 frame encoded. Currently what On uses.

Also adds some conversions between FFI Result types and
`std::result::Result` and exposes some more public members, so that
they can be used in examples.

# Motivation

This is being done in preparation for having Zstd as an option, and
possibly the new default.

# Additional Notes

We may want `roundtrip_to_pprof` to be configurable on what
compression algorithm it uses. `None` would speed up tests,
but once we have zstd, we may wish to test each one.

# How to test the change?

There's nothing to change unless you want to test out the different
compression algorithms. In that case, call
`ddog_prof_Profile_set_upload_compression` before uploading.
