### PR TITLE
[PROF-11524] Bump libdatadog version to 18.1.0 in preparation for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "build_common"
-version = "18.0.0"
+version = "18.1.0"
 dependencies = [
  "cbindgen",
  "serde",
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "builder"
-version = "18.0.0"
+version = "18.1.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1336,7 +1336,7 @@ checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 
 [[package]]
 name = "data-pipeline"
-version = "18.0.0"
+version = "18.1.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "data-pipeline-ffi"
-version = "18.0.0"
+version = "18.1.0"
 dependencies = [
  "build_common",
  "data-pipeline",
@@ -1382,7 +1382,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-alloc"
-version = "18.0.0"
+version = "18.1.0"
 dependencies = [
  "allocator-api2",
  "bolero",
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-crashtracker"
-version = "18.0.0"
+version = "18.1.0"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -1422,7 +1422,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-crashtracker-ffi"
-version = "18.0.0"
+version = "18.1.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1442,7 +1442,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-ddsketch"
-version = "18.0.0"
+version = "18.1.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling"
-version = "18.0.0"
+version = "18.1.0"
 dependencies = [
  "anyhow",
  "bitmaps",
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-ffi"
-version = "18.0.0"
+version = "18.1.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-replayer"
-version = "18.0.0"
+version = "18.1.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1737,7 +1737,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-normalization"
-version = "18.0.0"
+version = "18.1.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-obfuscation"
-version = "18.0.0"
+version = "18.1.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1766,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-protobuf"
-version = "18.0.0"
+version = "18.1.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-utils"
-version = "18.0.0"
+version = "18.1.0"
 dependencies = [
  "anyhow",
  "bolero",
@@ -1815,7 +1815,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-tracer-flare"
-version = "18.0.0"
+version = "18.1.0"
 dependencies = [
  "anyhow",
  "datadog-remote-config",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon"
-version = "18.0.0"
+version = "18.1.0"
 dependencies = [
  "anyhow",
  "cc",
@@ -1864,7 +1864,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon-ffi"
-version = "18.0.0"
+version = "18.1.0"
 dependencies = [
  "anyhow",
  "bolero",
@@ -1878,7 +1878,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry"
-version = "18.0.0"
+version = "18.1.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1902,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry-ffi"
-version = "18.0.0"
+version = "18.1.0"
 dependencies = [
  "build_common",
  "ddcommon",
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "dogstatsd-client"
-version = "18.0.0"
+version = "18.1.0"
 dependencies = [
  "anyhow",
  "cadence",
@@ -5129,7 +5129,7 @@ dependencies = [
 
 [[package]]
 name = "symbolizer-ffi"
-version = "18.0.0"
+version = "18.1.0"
 dependencies = [
  "blazesym-c",
  "build_common",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "tinybytes"
-version = "18.0.0"
+version = "18.1.0"
 dependencies = [
  "once_cell",
  "pretty_assertions",
@@ -5667,7 +5667,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "18.0.0"
+version = "18.1.0"
 dependencies = [
  "regex",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.78.0"
 edition = "2021"
-version = "18.0.0"
+version = "18.1.0"
 license = "Apache-2.0"
 
 [profile.dev]


### PR DESCRIPTION
# What does this PR do?

This PR bumps the libdatadog version from 18.0.0 to 18.1.0 in preparation for release.

We're going from v18.0 to v18.1 as I'm not aware of any backwards-incompatible changes being merged to master.

# Motivation

Ruby has been stuck on an old libdatadog release due to a few API changes, and I want to finally move it to latest libdatadog.

# Additional Notes

I did a diff of the v18.0 to v18.1 headers to validate there's no backwards-incompatible changes using the `difft` tool:

```
library-config.h --- C++
No changes.

blazesym.h --- C++
No changes.

profiling.h --- C++
No changes.

crashtracker.h --- 1/2 --- C++
57 57 extern "C" {
58 58 #endif // __cplusplus
.. 59
.. 60 /**
.. 61  * Disables the crashtracker.
.. 62  * Note that this does not restore the old signal handlers, but rather turns crash-tracking into a
.. 63  * no-op, and then chains the old handlers.  This means that handlers registered after the
.. 64  * crashtracker will continue to work as expected.
.. 65  *
.. 66  * # Preconditions
.. 67  *   None
.. 68  * # Safety
.. 69  *   None
.. 70  * # Atomicity
.. 71  *   This function is atomic and idempotent.  Calling it multiple times is allowed.
.. 72  */
.. 73 DDOG_CHECK_RETURN struct ddog_VoidResult ddog_crasht_disable(void);
.. 74
.. 75 /**
.. 76  * Enables the crashtracker, if it had been previously disabled.
.. 77  * If crashtracking has not been initialized, this function will have no effect.
.. 78  *
.. 79  * # Preconditions
.. 80  *   None
.. 81  * # Safety
.. 82  *   None
.. 83  * # Atomicity
.. 84  *   This function is atomic and idempotent.  Calling it multiple times is allowed.
.. 85  */
.. 86 DDOG_CHECK_RETURN struct ddog_VoidResult ddog_crasht_enable(void);
59 87
60 88 /**
61 89  * Reinitialize the crash-tracking infrastructure after a fork.

crashtracker.h --- 2/2 --- C++
 98 126                                         struct ddog_crasht_ReceiverConfig receiver_config,
 99 127                                         struct ddog_crasht_Metadata metadata);
 .. 128
 .. 129 /**
 .. 130  * Reconfigure the crashtracker and re-enables it.
 .. 131  * If the crashtracker has not been initialized, this function will have no effect.
 .. 132  *
 .. 133  * # Preconditions
 .. 134  *   None.
 .. 135  * # Safety
 .. 136  *   Crash-tracking functions are not reentrant.
 .. 137  *   No other crash-handler functions should be called concurrently.
 .. 138  * # Atomicity
 .. 139  *   This function is not atomic. A crash during its execution may lead to
 .. 140  *   unexpected crash-handling behaviour.
 .. 141  */
 .. 142 DDOG_CHECK_RETURN
 .. 143 struct ddog_VoidResult ddog_crasht_reconfigure(struct ddog_crasht_Config config,
 .. 144                                                struct ddog_crasht_ReceiverConfig receiver_config,
 .. 145                                                struct ddog_crasht_Metadata metadata);
100 146
101 147 /**
102 148  * Initialize the crash-tracking infrastructure without launching the receiver.

data-pipeline.h --- C++
No changes.

telemetry.h --- C++
No changes.

common.h --- C++
No changes.
```

# How to test the change?

I've tested the libdatadog 18.1 release locally using the Ruby test suite and https://github.com/DataDog/dd-trace-rb/pull/4577 .