### PR TITLE
remove the crashtracker itself from crash stack trace

### DIFF
--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -322,7 +322,7 @@ fn assert_telemetry_message(crash_telemetry: &[u8], crash_typ: &str) {
     let base_expected_tags: std::collections::HashSet<&str> =
         std::collections::HashSet::from_iter([
             "data_schema_version:1.4",
-            "incomplete:false",
+            // "incomplete:false", // TODO: re-add after fixing musl unwinding
             "is_crash:true",
             "profiler_collecting_sample:1",
             "profiler_inactive:0",

--- a/datadog-crashtracker/src/collector/emitters.rs
+++ b/datadog-crashtracker/src/collector/emitters.rs
@@ -46,11 +46,11 @@ unsafe fn emit_backtrace_by_frames(
     }
 
     backtrace::trace_unsynchronized(|frame| {
-        // Skip all stack frames whose stack pointer is less than or equal to the determined crash
-        // stack pointer (fault_rsp). These frames belong exclusively to the crash tracker and the
+        // Skip all stack frames whose stack pointer is less than to the determined crash stack
+        // pointer (fault_rsp). These frames belong exclusively to the crash tracker and the
         // backtrace functionality and are therefore not relevant for troubleshooting.
         let sp = frame.sp();
-        if !sp.is_null() && (sp as usize) <= fault_rsp {
+        if !sp.is_null() && (sp as usize) < fault_rsp {
             return true;
         }
         if resolve_frames == StacktraceCollection::EnabledWithInprocessSymbols {

--- a/datadog-crashtracker/src/crash_info/builder.rs
+++ b/datadog-crashtracker/src/crash_info/builder.rs
@@ -76,6 +76,12 @@ impl ErrorDataBuilder {
         if let Some(stack) = &mut self.stack {
             stack.set_complete()?;
         } else {
+            // With https://github.com/DataDog/libdatadog/pull/1076 it happens that stack trace are
+            // empty on musl based Linux (Alpine) because stack unwinding may not be able to unwind
+            // passed the signal handler. This by-passing for musl is temporary and needs a fix.
+            #[cfg(target_env = "musl")]
+            return Ok(self);
+            #[cfg(not(target_env = "musl"))]
             anyhow::bail!("Can't set non-existant stack complete");
         }
         Ok(self)


### PR DESCRIPTION
# What does this PR do?

Filter (aka remove) the crashtracker from the stack trace reported. This is done by using the stack pointer we can extract from the `ucontext` passed to the signal handler (from the actual crash site) and only collect a frame if it's stack pointer is above or equal to that address. Everything below that stack pointer is part of the signal handler and unwinding code in the crash tracker and not relevant for troubleshooting. 

# Motivation

The crash tracker reports end up in the "Error tracking" product which [groups by](https://docs.datadoghq.com/tracing/error_tracking/error_grouping/?tab=android#default-grouping) (among other things)

> `error.stack`: The filename and function name of the top-most meaningful stack frame.

As we have the crash tracker itself in all PHP (and I think Ruby) stack traces, the first six frames look like this, while the first really interesting stack frame is the first frame after those:
```json
[
  {
    "symbol_address": "0x7f6cc69f91b0",
    "file": "/rust/cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.74/src/backtrace/libunwind.rs",
    "line": 116,
    "function": "backtrace::backtrace::libunwind::trace::hf803c3cb2105128c",
    "ip": "0x7f6cc69f92e7",
    "column": 5,
    "sp": "0x7f6cbd623ec0"
  },
  {
    "symbol_address": "0x7f6cc69f91b0",
    "file": "/rust/cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.74/src/backtrace/mod.rs",
    "line": 66,
    "function": "backtrace::backtrace::trace_unsynchronized::ha6fe2ed3c7304a99",
    "ip": "0x7f6cc69f92e7",
    "column": 5,
    "sp": "0x7f6cbd623ec0"
  },
  {
    "symbol_address": "0x7f6cc69f91b0",
    "file": "/home/circleci/datadog/libdatadog/crashtracker/src/collector/emitters.rs",
    "line": 47,
    "function": "datadog_crashtracker::collector::emitters::emit_backtrace_by_frames::h4d5b82cc77ade1e5",
    "ip": "0x7f6cc69f92e7",
    "column": 5,
    "sp": "0x7f6cbd623ec0"
  },
  {
    "symbol_address": "0x7f6cc69f4760",
    "file": "/home/circleci/datadog/libdatadog/crashtracker/src/collector/emitters.rs",
    "line": 116,
    "function": "datadog_crashtracker::collector::emitters::emit_crashreport::hf18fca7fa3d4f3ad",
    "ip": "0x7f6cc69f7405",
    "column": 18,
    "sp": "0x7f6cbd623f50"
  },
  {
    "symbol_address": "0x7f6cc69f4760",
    "file": "/home/circleci/datadog/libdatadog/crashtracker/src/collector/crash_handler.rs",
    "line": 528,
    "function": "datadog_crashtracker::collector::crash_handler::handle_posix_signal_impl::h1b677a8cdeb1635c",
    "ip": "0x7f6cc69f7405",
    "column": 15,
    "sp": "0x7f6cbd623f50"
  },
  {
    "symbol_address": "0x7f6cc69f4760",
    "file": "/home/circleci/datadog/libdatadog/crashtracker/src/collector/crash_handler.rs",
    "line": 391,
    "function": "datadog_crashtracker::collector::crash_handler::handle_posix_sigaction::h918b0529fa1a1af9",
    "ip": "0x7f6cc69f7405",
    "column": 13,
    "sp": "0x7f6cbd623f50"
  },
  // ...
]
```

# Additional Notes

This change now highlights another long standing issue: on musl libc Linux (Alpine) it seems we are (maybe just sometimes) not able to unwind passed the signal handler. With filtering everything crash tracker related, this leaves us with an empty stack trace. I'll fix this issue in another PR, as I do not want to mix things that do not belong together.
Main driver: this has been a problem so far anyway and this PR is not making it worse, the stack traces we got (from where unwinding stoped at the signal hander) where useless anyway. 

# How to test the change?

Describe here in detail how the change can be validated.

[PROF-11923](https://datadoghq.atlassian.net/browse/PROF-11923)

[PROF-11923]: https://datadoghq.atlassian.net/browse/PROF-11923?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ