### PR TITLE
Pin backtrace to 0.3.74 as 0.3.75 needs rust 1.82

### DIFF
--- a/datadog-crashtracker/Cargo.toml
+++ b/datadog-crashtracker/Cargo.toml
@@ -31,7 +31,7 @@ blazesym = "=0.2.0-rc.2"
 
 [dependencies]
 anyhow = "1.0"
-backtrace = "0.3.74"
+backtrace = "=0.3.74"
 chrono = {version = "0.4", default-features = false, features = ["std", "clock", "serde"]}
 ddcommon = {path = "../ddcommon" }
 ddtelemetry = {path = "../ddtelemetry" }


### PR DESCRIPTION
# What does this PR do?

Pins version of the `backtrace` dependency to 0.3.74

# Motivation

Without it, projects depending on libdatadog (e.g. https://github.com/DataDog/libdatadog-nodejs) will try to use 0.3.75 which requires Rust 1.82.0, and we currently compile with 1.78.0. 

Apparently this passed CI because of `Cargo.lock` keeping it at 0.3.74, but if it's forced to be recomputed then compilation breaks.
