### PR TITLE
[PROF-11524] Package libdatadog v18.1.0 for Ruby

### DIFF
--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -22,22 +22,22 @@ end
 LIB_GITHUB_RELEASES = [
   {
     file: "libdatadog-aarch64-alpine-linux-musl.tar.gz",
-    sha256: "54416e4078fa9d923869ecae1a7b32e0c9ae0a47ab8c999812bb3b69cffb85bd",
+    sha256: "36ff4cacef2e574e8c97dae02fc02fb9a581dd23448e3a6eba9161e76fca671e",
     ruby_platform: "aarch64-linux-musl"
   },
   {
     file: "libdatadog-aarch64-unknown-linux-gnu.tar.gz",
-    sha256: "ad16283494d565a1877c76d4a8765f789ec2acb70b0597b4efe6e7a20e8b4f97",
+    sha256: "47258657397a23d625559da180da3d1666083900c2679b1664d0f396c8d0b514",
     ruby_platform: "aarch64-linux"
   },
   {
     file: "libdatadog-x86_64-alpine-linux-musl.tar.gz",
-    sha256: "384a50bb5013f6098b37da650f0fe9aa7c11f44780da971f8a4a35d2e342f00b",
+    sha256: "ced9376adb75227fe5d8a78a13e3f7ef11e6e156761e4cb57105403bfb024b42",
     ruby_platform: "x86_64-linux-musl"
   },
   {
     file: "libdatadog-x86_64-unknown-linux-gnu.tar.gz",
-    sha256: "6cea4ef4ecd4f40c1c69118bc1bb842c20782b710b838df3917d02eea7575a4e",
+    sha256: "bd6bbb62b3b29b71dea607b63aac540790aba8456d22328c8a66c20d563546c9",
     ruby_platform: "x86_64-linux"
   }
 ]

--- a/ruby/lib/libdatadog/version.rb
+++ b/ruby/lib/libdatadog/version.rb
@@ -2,7 +2,7 @@
 
 module Libdatadog
   # Current libdatadog version
-  LIB_VERSION = "16.0.1"
+  LIB_VERSION = "18.1.0"
 
   GEM_MAJOR_VERSION = "1"
   GEM_MINOR_VERSION = "0"
@@ -10,7 +10,7 @@ module Libdatadog
   private_constant :GEM_MAJOR_VERSION, :GEM_MINOR_VERSION, :GEM_PRERELEASE_VERSION
 
   # The gem version scheme is lib_version.gem_major.gem_minor[.prerelease].
-  # This allows a version constraint such as ~> 0.2.0.1.0 in the consumer (ddtrace), in essence pinning libdatadog to
+  # This allows a version constraint such as ~> 0.2.0.1.0 in the consumer (dd-trace-rb), in essence pinning libdatadog to
   # a specific version like = 0.2.0, but still allow a) introduction of a gem-level breaking change by bumping gem_major
   # and b) allow to push automatically picked up bugfixes by bumping gem_minor.
   VERSION = "#{LIB_VERSION}.#{GEM_MAJOR_VERSION}.#{GEM_MINOR_VERSION}#{GEM_PRERELEASE_VERSION}"

--- a/ruby/spec/gem_packaging.rb
+++ b/ruby/spec/gem_packaging.rb
@@ -45,7 +45,9 @@ RSpec.describe "gem release process (after packaging)" do
       symbols = raw_symbols.split("\n").map { |it| it.split(" ").last }.sort
       expect(symbols.size).to be > 20 # Quick sanity check
 
-      expect(symbols).to all(start_with("ddog_").or(start_with("blaze_")))
+      expect(symbols).to all(
+        start_with("ddog_").or(start_with("blaze_")).or(eq("INTERNED_EMPTY_STRING"))
+      )
     end
   end
 end


### PR DESCRIPTION
# What does this PR do?

This PR includes the changes documented in the "Releasing a new version to rubygems.org" part of the README: https://github.com/datadog/libdatadog/tree/main/ruby#releasing-a-new-version-to-rubygemsorg

It also includes an updated to the `gem_packaging.rb` test to add the new `INTERNED_EMPTY_STRING` public symbol added in #917 .

# Motivation:

Enable Ruby to use libdatadog v18.1.0. This includes A LOT of changes to profiling, crashtracking, configuration, process discovery etc that have been pending for Ruby for too long.

# Additional Notes

The `INTERNED_EMPTY_STRING` new symbol seems ok to have (e.g. I don't expect it to clash with other libraries), but just in case I will discuss with @danielsn prefixing it with `ddog_`.

Also it's cool to see our tests working! A new symbol that's not prefixed with the expected strings showed up, and we caught it :)

# How to test the change?

I've tested this release locally using the changes in https://github.com/datadog/dd-trace-rb/pull/4577 .

As a reminder, new libdatadog releases don't get automatically picked up by dd-trace-rb, so the PR that bumps the dependency will also test this release against all supported Ruby versions.