### PR TITLE
[NO-TICKET] Rename ffi `INTERNED_EMPTY_STRING` symbol to `ddog_INTERNED_EMPTY_STRING`

### DIFF
--- a/datadog-profiling-ffi/src/profiles/interning_api.rs
+++ b/datadog-profiling-ffi/src/profiles/interning_api.rs
@@ -24,7 +24,8 @@ type CbindgenIsDumbStringId = GenerationalId<StringId>;
 
 #[no_mangle]
 #[used]
-pub static INTERNED_EMPTY_STRING: CbindgenIsDumbStringId = internal::Profile::INTERNED_EMPTY_STRING;
+pub static ddog_INTERNED_EMPTY_STRING: CbindgenIsDumbStringId =
+    internal::Profile::INTERNED_EMPTY_STRING;
 
 /// This function interns its argument into the profiler.
 /// If successful, it returns an opaque interning ID.

--- a/examples/ffi/profile_intern.cpp
+++ b/examples/ffi/profile_intern.cpp
@@ -90,9 +90,9 @@ int main(void) {
   auto root_file_name = extract_result(
       ddog_prof_Profile_intern_string(profile, to_slice_c_char("/srv/example/index.php")));
   auto root_mapping = extract_result(
-      ddog_prof_Profile_intern_mapping(profile, 0, 0, 0, root_file_name, INTERNED_EMPTY_STRING));
+      ddog_prof_Profile_intern_mapping(profile, 0, 0, 0, root_file_name, ddog_INTERNED_EMPTY_STRING));
   auto root_function = extract_result(ddog_prof_Profile_intern_function(
-      profile, root_function_name, INTERNED_EMPTY_STRING, root_file_name));
+      profile, root_function_name, ddog_INTERNED_EMPTY_STRING, root_file_name));
   auto root_location = extract_result(ddog_prof_Profile_intern_location_with_mapping_id(
       profile, root_mapping, root_function, 0, 0));
   ddog_prof_Slice_LocationId locations = {.ptr = &root_location, .len = 1};

--- a/ruby/spec/gem_packaging.rb
+++ b/ruby/spec/gem_packaging.rb
@@ -46,7 +46,7 @@ RSpec.describe "gem release process (after packaging)" do
       expect(symbols.size).to be > 20 # Quick sanity check
 
       expect(symbols).to all(
-        start_with("ddog_").or(start_with("blaze_")).or(eq("INTERNED_EMPTY_STRING"))
+        start_with("ddog_").or(start_with("blaze_"))
       )
     end
   end


### PR DESCRIPTION
# What does this PR do?

This PR renames the public ffi symbol `INTERNED_EMPTY_STRING` (introduced in #917) to `ddog_INTERNED_EMPTY_STRING`.

This is technically a breaking API change but nobody is yet using this API
([from GitHub searches](https://github.com/search?q=org%3ADataDog%20INTERNED_EMPTY_STRING&type=code)) so doing it now is much better than doing it anytime later.

# Motivation

We've been trying to make sure our public ffi symbols (e.g. things that end up in `.so` and `.dll` files and whatnot) are all prefixed with `ddog_` to avoid clashing with any other libraries in the system.

While it's not extremely likely that `INTERNED_EMPTY_STRING` will collide, I discussed with @danielsn that it also doesn't quite seem worth it to create an exception for this symbol.

So this keeps the consistency with our other symbols so far.

# Additional Notes

N/A

# How to test the change?

The existing example can be used to validate this change is working.