### PR TITLE
fix: correct metric names for chunks sent and dropped in telemetry

### DIFF
--- a/data-pipeline/src/telemetry/metrics.rs
+++ b/data-pipeline/src/telemetry/metrics.rs
@@ -23,18 +23,20 @@ pub enum MetricKind {
     ApiBytes,
     /// trace_api.responses metric
     ApiResponses,
-    /// trace_chunk_sent metric
+    /// trace_chunks_sent metric
     ChunksSent,
-    /// trace_chunk_dropped metric
+    /// trace_chunks_dropped metric
     ChunksDropped,
 }
 
+/// Constants for metric names
+/// These must match https://github.com/DataDog/dd-go/blob/prod/trace/apps/tracer-telemetry-intake/telemetry-metrics/static/common_metrics.json
 const API_REQUEST_STR: &str = "trace_api.requests";
 const API_ERRORS_STR: &str = "trace_api.errors";
 const API_BYTES_STR: &str = "trace_api.bytes";
 const API_RESPONSES_STR: &str = "trace_api.responses";
-const CHUNKS_SENT_STR: &str = "trace_chunk_sent";
-const CHUNKS_DROPPED_STR: &str = "trace_chunk_dropped";
+const CHUNKS_SENT_STR: &str = "trace_chunks_sent";
+const CHUNKS_DROPPED_STR: &str = "trace_chunks_dropped";
 
 #[derive(Debug)]
 struct Metric {

--- a/data-pipeline/src/telemetry/mod.rs
+++ b/data-pipeline/src/telemetry/mod.rs
@@ -492,7 +492,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn chunks_sent_test() {
-        let payload = Regex::new(r#""metric":"trace_chunk_sent","points":\[\[\d+,1\.0\]\],"tags":\["src_library:libdatadog"\],"common":true,"type":"count"#).unwrap();
+        let payload = Regex::new(r#""metric":"trace_chunks_sent","points":\[\[\d+,1\.0\]\],"tags":\["src_library:libdatadog"\],"common":true,"type":"count"#).unwrap();
         let server = MockServer::start_async().await;
 
         let telemetry_srv = server
@@ -518,7 +518,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn chunks_dropped_test() {
-        let payload = Regex::new(r#""metric":"trace_chunk_dropped","points":\[\[\d+,1\.0\]\],"tags":\["src_library:libdatadog"\],"common":true,"type":"count"#).unwrap();
+        let payload = Regex::new(r#""metric":"trace_chunks_dropped","points":\[\[\d+,1\.0\]\],"tags":\["src_library:libdatadog"\],"common":true,"type":"count"#).unwrap();
         let server = MockServer::start_async().await;
 
         let telemetry_srv = server

--- a/datadog-trace-utils/src/send_data/send_data_result.rs
+++ b/datadog-trace-utils/src/send_data/send_data_result.rs
@@ -22,7 +22,7 @@ pub struct SendDataResult {
     pub errors_status_code: u64,
     /// Count metric for 'trace_api.bytes'
     pub bytes_sent: u64,
-    /// Count metric for 'trace_chunk_sent'
+    /// Count metric for 'trace_chunks_sent'
     pub chunks_sent: u64,
     /// Count metric for 'trace_chunks_dropped'
     pub chunks_dropped: u64,


### PR DESCRIPTION
# What does this PR do?

Matches the metric names as we should.

# Motivation

Some alarms went off due to invalid names of metric events.

# Additional Notes

Our metric names must always match https://github.com/DataDog/dd-go/blob/prod/trace/apps/tracer-telemetry-intake/telemetry-metrics/static/common_metrics.json

# How to test the change?

Tests updated
