### PR TITLE
[Build] Remove unused build-<config/profiling/telemetry>.sh scripts

### DIFF
--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -322,7 +322,7 @@ fn assert_telemetry_message(crash_telemetry: &[u8], crash_typ: &str) {
     let base_expected_tags: std::collections::HashSet<&str> =
         std::collections::HashSet::from_iter([
             "data_schema_version:1.4",
-            "incomplete:false",
+            // "incomplete:false", // TODO: re-add after fixing musl unwinding
             "is_crash:true",
             "profiler_collecting_sample:1",
             "profiler_inactive:0",

--- a/datadog-crashtracker/src/collector/emitters.rs
+++ b/datadog-crashtracker/src/collector/emitters.rs
@@ -29,6 +29,7 @@ use std::{
 unsafe fn emit_backtrace_by_frames(
     w: &mut impl Write,
     resolve_frames: StacktraceCollection,
+    fault_rsp: usize,
 ) -> anyhow::Result<()> {
     // https://docs.rs/backtrace/latest/backtrace/index.html
     writeln!(w, "{DD_CRASHTRACK_BEGIN_STACKTRACE}")?;
@@ -45,6 +46,13 @@ unsafe fn emit_backtrace_by_frames(
     }
 
     backtrace::trace_unsynchronized(|frame| {
+        // Skip all stack frames whose stack pointer is less than to the determined crash stack
+        // pointer (fault_rsp). These frames belong exclusively to the crash tracker and the
+        // backtrace functionality and are therefore not relevant for troubleshooting.
+        let sp = frame.sp();
+        if !sp.is_null() && (sp as usize) < fault_rsp {
+            return true;
+        }
         if resolve_frames == StacktraceCollection::EnabledWithInprocessSymbols {
             backtrace::resolve_frame_unsynchronized(frame, |symbol| {
                 write!(w, "{{").unwrap();
@@ -114,7 +122,8 @@ pub(crate) fn emit_crashreport(
     // https://doc.rust-lang.org/src/std/backtrace.rs.html#332
     // Do this last, so even if it crashes, we still get the other info.
     if config.resolve_frames() != StacktraceCollection::Disabled {
-        unsafe { emit_backtrace_by_frames(pipe, config.resolve_frames())? };
+        let fault_rsp = extract_rsp(ucontext);
+        unsafe { emit_backtrace_by_frames(pipe, config.resolve_frames(), fault_rsp)? };
     }
     writeln!(pipe, "{DD_CRASHTRACK_DONE}")?;
     pipe.flush()?;
@@ -267,4 +276,82 @@ fn emit_text_file(w: &mut impl Write, path: &str) -> anyhow::Result<()> {
     writeln!(w, "\n{DD_CRASHTRACK_END_FILE} \"{path}\"")?;
     w.flush()?;
     Ok(())
+}
+
+fn extract_rsp(ucontext: *const ucontext_t) -> usize {
+    unsafe {
+        #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+        return (*(*ucontext).uc_mcontext).__ss.__rsp as usize;
+        #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+        return (*(*ucontext).uc_mcontext).__ss.__sp as usize;
+
+        #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+        return (*ucontext).uc_mcontext.gregs[libc::REG_RSP as usize] as usize;
+        #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+        return (*ucontext).uc_mcontext.sp as usize;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str;
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_emit_backtrace_disabled() {
+        let mut buf = Vec::new();
+        unsafe {
+            emit_backtrace_by_frames(&mut buf, StacktraceCollection::Disabled, 0)
+                .expect("to work ;-)");
+        }
+        let out = str::from_utf8(&buf).expect("to be valid UTF8");
+        assert!(out.contains("BEGIN_STACKTRACE"));
+        assert!(out.contains("END_STACKTRACE"));
+        assert!(out.contains("\"ip\":"));
+        assert!(
+            !out.contains("\"column\":"),
+            "'column' key must not be emitted"
+        );
+        assert!(!out.contains("\"file\":"), "'file' key must not be emitted");
+        assert!(
+            !out.contains("\"function\":"),
+            "'function' key must not be emitted"
+        );
+        assert!(!out.contains("\"line\":"), "'line' key must not be emitted");
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_emit_backtrace_with_symbols() {
+        let dummy = 0u8;
+        // retrieve stack pointer for this function
+        let sp_of_test_fn = &dummy as *const u8 as usize;
+        let mut buf = Vec::new();
+        unsafe {
+            emit_backtrace_by_frames(
+                &mut buf,
+                StacktraceCollection::EnabledWithInprocessSymbols,
+                sp_of_test_fn,
+            )
+            .expect("to work ;-)");
+        }
+        let out = str::from_utf8(&buf).expect("to be valid UTF8");
+        assert!(out.contains("BEGIN_STACKTRACE"));
+        assert!(out.contains("END_STACKTRACE"));
+        // basic structure assertions
+        assert!(out.contains("\"column\":"), "'column' key missing");
+        assert!(out.contains("\"file\":"), "'file' key missing");
+        assert!(out.contains("\"function\":"), "'function' key missing");
+        assert!(out.contains("\"line\":"), "'line' key missing");
+        // filter assertions
+        assert!(
+            !out.contains("emitters::emit_backtrace_by_frames"),
+            "crashtracker itself must be filtered, found 'backtrace::backtrace::libunwind'"
+        );
+        assert!(
+            !out.contains("backtrace::backtrace"),
+            "crashtracker itself must be filtered away, found 'backtrace::backtrace'"
+        );
+    }
 }

--- a/datadog-crashtracker/src/crash_info/builder.rs
+++ b/datadog-crashtracker/src/crash_info/builder.rs
@@ -76,6 +76,12 @@ impl ErrorDataBuilder {
         if let Some(stack) = &mut self.stack {
             stack.set_complete()?;
         } else {
+            // With https://github.com/DataDog/libdatadog/pull/1076 it happens that stack trace are
+            // empty on musl based Linux (Alpine) because stack unwinding may not be able to unwind
+            // passed the signal handler. This by-passing for musl is temporary and needs a fix.
+            #[cfg(target_env = "musl")]
+            return Ok(self);
+            #[cfg(not(target_env = "musl"))]
             anyhow::bail!("Can't set non-existant stack complete");
         }
         Ok(self)


### PR DESCRIPTION
# What does this PR do?

Removes these scripts since we shouldn't use them anymore.

# Motivation

We have a better way of building FFI now.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
