### PR TITLE
[Crashtracker][bug]Add `is_crash`  field to Log message

### DIFF
--- a/datadog-crashtracker/src/crash_info/telemetry.rs
+++ b/datadog-crashtracker/src/crash_info/telemetry.rs
@@ -135,6 +135,7 @@ impl TelemetryCrashUploader {
                 tags,
                 is_sensitive: true,
                 count: 1,
+                is_crash: true,
             }]),
             origin: Some("Crashtracker"),
         };
@@ -268,6 +269,7 @@ mod tests {
         assert_eq!(payload["application"]["service_version"], "bar");
         assert_eq!(payload["request_type"], "logs");
         assert_eq!(payload["tracer_time"], 1568898000);
+        assert_eq!(payload["origin"], "Crashtracker");
 
         assert_eq!(payload["payload"].as_array().unwrap().len(), 1);
         let tags = payload["payload"][0]["tags"]
@@ -296,6 +298,7 @@ mod tests {
         let body: CrashInfo =
             serde_json::from_str(payload["payload"][0]["message"].as_str().unwrap())?;
         assert_eq!(body, test_instance);
+        assert_eq!(payload["payload"][0]["is_crash"], true);
         Ok(())
     }
 }

--- a/ddtelemetry/src/data/payloads.rs
+++ b/ddtelemetry/src/data/payloads.rs
@@ -83,6 +83,8 @@ pub struct Log {
     pub tags: String,
     #[serde(default)]
     pub is_sensitive: bool,
+    #[serde(default)]
+    pub is_crash: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]

--- a/ddtelemetry/src/worker/mod.rs
+++ b/ddtelemetry/src/worker/mod.rs
@@ -883,6 +883,7 @@ impl TelemetryWorkerHandle {
                 count: 1,
                 tags: String::new(),
                 is_sensitive: false,
+                is_crash: false,
             },
         )))?;
         Ok(())


### PR DESCRIPTION
# What does this PR do?

Add `is_crash` to Log message

# Motivation

In this [PR](https://github.com/DataDog/libdatadog/pull/1005)  we do not fill the `Stacktrace` field of the log message to reduce the size of the message.
Except that in the backend, we use that field to recognize crash log and symbolize them.

In the backend code, I saw that the `Log` struct has a `IsCrash/is_crash` field.https://github.com/DataDog/dd-go/blob/prod/trace/apps/tracer-telemetry-intake/telemetry-payload/logs.go#L65

