### PR TITLE
increase polling window for trace exporter shutdown unit test

### DIFF
--- a/data-pipeline/src/trace_exporter/mod.rs
+++ b/data-pipeline/src/trace_exporter/mod.rs
@@ -1279,11 +1279,11 @@ mod tests {
         exporter.shutdown(None).unwrap();
 
         // Wait for the mock server to process the stats
-        for _ in 0..10 {
+        for _ in 0..500 {
             if mock_traces.hits() > 0 && mock_stats.hits() > 0 {
                 break;
             } else {
-                std::thread::sleep(Duration::from_millis(100));
+                std::thread::sleep(Duration::from_millis(10));
             }
         }
 


### PR DESCRIPTION
# What does this PR do?

CI runners can be slow sometimes and the shutdown test has been flaky. Sleep less, but poll more to minimize time impact. Observation window has been changed from 1s to 5s max.

# Motivation

[Flakiness observed in CI runs](https://github.com/DataDog/libdatadog/actions/runs/15482749290/job/43591458483?pr=1092)

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
