### PR TITLE
refactor(ddcommon-ffi)!: upgrade cbindgen, fix VoidResult::Ok

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@ variables:
   # These are gitlab variables so that it's easier to do a manual deploy
   # If these are set witih value and description, then it gives you UI elements
   DOWNSTREAM_BRANCH:
-    value: "main"
+    value: "levi/cbindgen"
     description: "downstream jobs are triggered on this branch"
 
 include:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -865,12 +865,12 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cbindgen"
-version = "0.27.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fce8dd7fcfcbf3a0a87d8f515194b49d6135acab73e18bd380d1d93bb1a15eb"
+checksum = "975982cdb7ad6a142be15bdf84aea7ec6a9e5d4d797c004d43185b24cfe4e684"
 dependencies = [
  "clap",
- "heck 0.4.1",
+ "heck 0.5.0",
  "indexmap 2.6.0",
  "log",
  "proc-macro2",

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ bash build-profiling-ffi.sh /opt/libdatadog
 #### Build dependencies
 
 - Rust 1.84.1 or newer with cargo. See the Cargo.toml for information about bumping this version.
-- `cbindgen` 0.26
+- `cbindgen` 0.29
 - `cmake` and `protoc`
 
 ### Running tests

--- a/build-common/Cargo.toml
+++ b/build-common/Cargo.toml
@@ -13,7 +13,7 @@ default = []
 cbindgen = []
 
 [dependencies]
-cbindgen = {version = "0.27"}
+cbindgen = { version = "0.29" }
 serde = "1.0"
 serde_json = "1.0"
 

--- a/datadog-crashtracker-ffi/src/collector/mod.rs
+++ b/datadog-crashtracker-ffi/src/collector/mod.rs
@@ -29,7 +29,7 @@ pub use spans::*;
 ///   This function is atomic and idempotent.  Calling it multiple times is allowed.
 pub unsafe extern "C" fn ddog_crasht_disable() -> VoidResult {
     datadog_crashtracker::disable();
-    VoidResult::Ok(true)
+    VoidResult::Ok
 }
 
 #[no_mangle]
@@ -45,7 +45,7 @@ pub unsafe extern "C" fn ddog_crasht_disable() -> VoidResult {
 ///   This function is atomic and idempotent.  Calling it multiple times is allowed.
 pub unsafe extern "C" fn ddog_crasht_enable() -> VoidResult {
     datadog_crashtracker::enable();
-    VoidResult::Ok(true)
+    VoidResult::Ok
 }
 
 #[no_mangle]

--- a/ddcommon-ffi/src/result.rs
+++ b/ddcommon-ffi/src/result.rs
@@ -7,23 +7,19 @@ use crate::Error;
 /// but there's nothing to return in the case of success.
 #[repr(C)]
 pub enum VoidResult {
-    Ok(
-        /// Do not use the value of Ok. This value only exists to overcome
-        /// Rust -> C code generation.
-        bool,
-    ),
+    Ok,
     Err(Error),
 }
 
 impl VoidResult {
     pub fn unwrap(self) {
-        assert!(matches!(self, Self::Ok(_)));
+        assert!(matches!(self, Self::Ok));
     }
 
     pub fn unwrap_err(self) -> Error {
         match self {
             #[allow(clippy::panic)]
-            Self::Ok(_) => panic!("Expected error, got value"),
+            Self::Ok => panic!("Expected error, got value"),
             Self::Err(err) => err,
         }
     }
@@ -32,7 +28,7 @@ impl VoidResult {
 impl From<anyhow::Result<()>> for VoidResult {
     fn from(value: anyhow::Result<()>) -> Self {
         match value {
-            Ok(_) => Self::Ok(true),
+            Ok(_) => Self::Ok,
             Err(err) => Self::Err(err.into()),
         }
     }


### PR DESCRIPTION
# What does this PR do?

This "fixes" a wart that's been around for a while because cbindgen didn't handle `Ok(())` or similar very well. On newer cbindgen versions at least, this isn't the case if we use a plain `Ok` instead of `Ok(())`.

So previously `VoidResult` turned into:

```c
typedef struct ddog_VoidResult {
  ddog_VoidResult_Tag tag;
  union {
    struct {
      /**
       * Do not use the value of Ok. This value only exists to overcome
       * Rust -> C code generation.
       */
      bool ok;
    };
    struct {
      struct ddog_Error err;
    };
  };
} ddog_VoidResult;
```

With this change, the bool you aren't supposed to use is gone:

```c
typedef struct ddog_VoidResult {
  ddog_VoidResult_Tag tag;
  union {
    struct {
      struct ddog_Error err;
    };
  };
} ddog_VoidResult;
```

# Motivation

I've been working on FFI stuff and noticed that this wasn't an issue. I didn't want to mingle these changes with my own for better reviewing.

# Additional Notes

Technically, this is a backwards compatibility break, but you weren't supposed to use that bool, so if something breaks, you probably had bad code before.

Also, this is currently waiting for a libddprof-build PR to merge to update cbindgen on Windows, so that's why it's a draft.

# How to test the change?

Everything should be the same, as long as you didn't use the lame `bool ok` like the comment instructed.