### PR TITLE
Bump libdatadog version to 19.0.0 in preparation for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,7 +774,7 @@ dependencies = [
 
 [[package]]
 name = "build_common"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "cbindgen",
  "serde",
@@ -783,7 +783,7 @@ dependencies = [
 
 [[package]]
 name = "builder"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1339,7 +1339,7 @@ checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 
 [[package]]
 name = "data-pipeline"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1372,7 +1372,7 @@ dependencies = [
 
 [[package]]
 name = "data-pipeline-ffi"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "build_common",
  "data-pipeline",
@@ -1385,7 +1385,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-alloc"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "allocator-api2",
  "bolero",
@@ -1395,7 +1395,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-crashtracker"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-crashtracker-ffi"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1446,7 +1446,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-ddsketch"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -1559,7 +1559,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-log"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "chrono",
  "ddcommon-ffi",
@@ -1571,7 +1571,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-log-ffi"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "build_common",
  "datadog-log",
@@ -1580,7 +1580,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "anyhow",
  "bitmaps",
@@ -1611,7 +1611,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-ffi"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1635,7 +1635,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-protobuf"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "bolero",
  "datadog-profiling-protobuf",
@@ -1644,7 +1644,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-replayer"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-normalization"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1778,7 +1778,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-obfuscation"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1796,7 +1796,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-protobuf"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -1809,7 +1809,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-utils"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "anyhow",
  "bolero",
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-tracer-flare"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "anyhow",
  "datadog-remote-config",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "anyhow",
  "cc",
@@ -1890,7 +1890,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon-ffi"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "anyhow",
  "bolero",
@@ -1904,7 +1904,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1928,7 +1928,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry-ffi"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "build_common",
  "ddcommon",
@@ -2040,7 +2040,7 @@ dependencies = [
 
 [[package]]
 name = "dogstatsd-client"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "anyhow",
  "cadence",
@@ -5145,7 +5145,7 @@ dependencies = [
 
 [[package]]
 name = "symbolizer-ffi"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "blazesym-c",
  "build_common",
@@ -5468,7 +5468,7 @@ dependencies = [
 
 [[package]]
 name = "tinybytes"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "once_cell",
  "pretty_assertions",
@@ -5683,7 +5683,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "18.1.0"
+version = "19.0.0"
 dependencies = [
  "regex",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.84.1"
 edition = "2021"
-version = "18.1.0"
+version = "19.0.0"
 license = "Apache-2.0"
 
 [profile.dev]


### PR DESCRIPTION
# What does this PR do?

This PR bumps the libdatadog version from 18.1.0 to 19.0.0 in preparation for release. 

# Motivation

Use the new log subsystem in the current integrations.

# Additional Notes

The reason for bumping the major is that there is an API change in profiling.h:
```
diff --color /home/julio/Releases/libdatadog/v18.1.0/include/datadog/profiling.h release/include/datadog/profiling.h
21c21
< extern const ddog_prof_StringId INTERNED_EMPTY_STRING;
---
> extern const ddog_prof_StringId ddog_INTERNED_EMPTY_STRING;
```


