### PR TITLE
do not include devflow/merge check in all checks as it creates a circular block

### DIFF
--- a/.github/workflows/all-checks.yml
+++ b/.github/workflows/all-checks.yml
@@ -16,3 +16,4 @@ jobs:
                 delay: '3'
                 retries: '30'
                 polling_interval: '1'
+                checks_exclude: 'devflow/merge'


### PR DESCRIPTION

# What does this PR do?

When trying to use the merge queue there is an action called `devflow/merge` that checks to see if required actions are complete. `all_checks` never completes because it's waiting on `devflow/merge`, and in turn `devflow/merge` never completes because `all_checks` never pass.

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
