### PR TITLE
Make max memory of sidecar configurable

### DIFF
--- a/datadog-sidecar/src/watchdog.rs
+++ b/datadog-sidecar/src/watchdog.rs
@@ -18,7 +18,7 @@ use tracing::error;
 
 pub struct Watchdog {
     interval: tokio::time::Interval,
-    max_memory_usage_bytes: usize,
+    pub max_memory_usage_bytes: usize,
     shutdown_receiver: Receiver<()>,
 }
 


### PR DESCRIPTION
With very heavy bursting of PHP processes (with distinct service names) the sidecar can currently run OOM.
Providing an escape hatch for those cases.