### PR TITLE
Workaround in order to fix flaky tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@ variables:
   # These are gitlab variables so that it's easier to do a manual deploy
   # If these are set witih value and description, then it gives you UI elements
   DOWNSTREAM_BRANCH:
-    value: "main"
+    value: "julio/trigger-release-pr"
     description: "downstream jobs are triggered on this branch"
 
 include:

--- a/bin_tests/src/bin/crashtracker_bin_test.rs
+++ b/bin_tests/src/bin/crashtracker_bin_test.rs
@@ -20,12 +20,11 @@ mod unix {
     use std::env;
     use std::path::Path;
 
+    use bin_tests::TEST_COLLECTOR_TIMEOUT_MS;
     use datadog_crashtracker::{
         self as crashtracker, CrashtrackerConfiguration, CrashtrackerReceiverConfig, Metadata,
     };
     use ddcommon::{tag, Endpoint};
-
-    const TEST_COLLECTOR_TIMEOUT_MS: u32 = 10_000;
 
     #[inline(never)]
     pub unsafe fn cause_segfault() -> anyhow::Result<()> {

--- a/bin_tests/src/constants.rs
+++ b/bin_tests/src/constants.rs
@@ -1,0 +1,4 @@
+// Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+//
+pub const TEST_COLLECTOR_TIMEOUT_MS: u32 = 10_000;

--- a/bin_tests/src/lib.rs
+++ b/bin_tests/src/lib.rs
@@ -1,7 +1,10 @@
 // Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+mod constants;
 pub mod modes;
+
+pub use constants::*;
 
 use std::{collections::HashMap, env, ops::DerefMut, path::PathBuf, process, sync::Mutex};
 

--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -7,7 +7,11 @@ use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::path::Path;
 use std::process;
-use std::{fs, path::PathBuf, time::{Duration, Instant}};
+use std::{
+    fs,
+    path::PathBuf,
+    time::{Duration, Instant},
+};
 
 use anyhow::Context;
 use bin_tests::{build_artifacts, ArtifactType, ArtifactsBuild, BuildProfile};
@@ -23,7 +27,7 @@ fn check_file_existence(path: &Path, timeout: Duration) -> bool {
             true => return true,
             false => {
                 if start.elapsed() > timeout {
-                    return false
+                    return false;
                 } else {
                     std::thread::sleep(Duration::from_millis(100));
                 }
@@ -203,7 +207,10 @@ fn test_crash_tracking_bin(
     );
     assert_eq!(Ok(""), String::from_utf8(stdout).as_deref());
 
-    assert!(check_file_existence(fixtures.crash_profile_path.as_path(), Duration::from_secs(CHECK_TIMEOUT_MS)));
+    assert!(check_file_existence(
+        fixtures.crash_profile_path.as_path(),
+        Duration::from_secs(CHECK_TIMEOUT_MS)
+    ));
 
     // Check the crash data
     let crash_profile = fs::read(fixtures.crash_profile_path)

--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -17,7 +17,7 @@ use anyhow::Context;
 use bin_tests::{build_artifacts, ArtifactType, ArtifactsBuild, BuildProfile};
 use serde_json::Value;
 
-const CHECK_TIMEOUT_MS: u64 = 20_000;
+use bin_tests::TEST_COLLECTOR_TIMEOUT_MS;
 
 fn check_file_existence(path: &Path, timeout: Duration) -> bool {
     let start = Instant::now();
@@ -209,7 +209,7 @@ fn test_crash_tracking_bin(
 
     assert!(check_file_existence(
         fixtures.crash_profile_path.as_path(),
-        Duration::from_secs(CHECK_TIMEOUT_MS)
+        Duration::from_secs(TEST_COLLECTOR_TIMEOUT_MS as u64)
     ));
 
     // Check the crash data

--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -184,6 +184,10 @@ fn test_crash_tracking_bin(
     );
     assert_eq!(Ok(""), String::from_utf8(stdout).as_deref());
 
+    while !fixtures.crash_profile_path.as_path().exists() {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+
     // Check the crash data
     let crash_profile = fs::read(fixtures.crash_profile_path)
         .context("reading crashtracker profiling payload")


### PR DESCRIPTION
# What does this PR do?

Check the file system entry before the file is parsed.

# Motivation

Flaky tests on macos runners.

# Additional Notes

Since macos tests are disabled on regular merges this PR sets a test branch for the gitlab workflow so the macos runners are triggered. Once the fix is validated the changes in workflow should be reverted.
