### PR TITLE
set squash as the default merge method for mergequeue

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -1,0 +1,6 @@
+---
+# This file defines overrides for the merge queue configuration.
+# See https://datadoghq.atlassian.net/wiki/spaces/DEVX/pages/3121612126/MergeQueue#Configuration-Specification for defaults.
+schema-version: v1
+kind: mergequeue
+merge_method: squash


### PR DESCRIPTION
# What does this PR do?

Add `repository.datadog.yml` to repo for custom config of the mergequeue

# Motivation

For the repo, `merge`, `squash`, and `rebase` merge methods are enabled, but for the `main` branch `merge` is disabled by the `require linear history` setting. By default, when no merge method is specified by the user, the mergequeue will use the first enabled method in order of `merge`, `squash`, `rebase`. Mergequeue gets confused because it sees `merge` is enabled when, in reality, it's not and the mergequeue fails to merge the PR.

# Additional Notes

If you comment `/merge` your PR will be added to the mergequeue and `squash` will be used by default.

If you wish to use `rebase` use the command `/merge -m rebase` 
# How to test the change?

Describe here in detail how the change can be validated.
