### PR TITLE
[crashtracker] Try actually waiting on child processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1882,6 +1882,7 @@ dependencies = [
  "rustls-native-certs 0.8.1",
  "serde",
  "static_assertions",
+ "thiserror",
  "tokio",
  "tokio-rustls",
  "tower-service",

--- a/bin_tests/src/bin/crashtracker_bin_test.rs
+++ b/bin_tests/src/bin/crashtracker_bin_test.rs
@@ -19,13 +19,14 @@ mod unix {
     };
     use std::env;
     use std::path::Path;
+    use std::time::Duration;
 
     use datadog_crashtracker::{
         self as crashtracker, CrashtrackerConfiguration, CrashtrackerReceiverConfig, Metadata,
     };
     use ddcommon::{tag, Endpoint};
 
-    const TEST_COLLECTOR_TIMEOUT_MS: u32 = 10_000;
+    const TEST_COLLECTOR_TIMEOUT: Duration = Duration::from_secs(10);
 
     #[inline(never)]
     pub unsafe fn cause_segfault() -> anyhow::Result<()> {
@@ -70,7 +71,7 @@ mod unix {
             endpoint,
             crashtracker::StacktraceCollection::WithoutSymbols,
             crashtracker::default_signals(),
-            TEST_COLLECTOR_TIMEOUT_MS,
+            Some(TEST_COLLECTOR_TIMEOUT),
             Some("".to_string()),
             true,
         )?;

--- a/datadog-crashtracker-ffi/src/collector/datatypes.rs
+++ b/datadog-crashtracker-ffi/src/collector/datatypes.rs
@@ -69,7 +69,9 @@ pub struct Config<'a> {
     /// If empty, use the default set.
     pub signals: Slice<'a, i32>,
     /// Timeout in milliseconds before the signal handler starts tearing things down to return.
-    /// If 0, uses the default timeout. Otherwise, uses the specified timeout value.
+    /// If 0, uses the default timeout as specified in
+    /// `datadog_crashtracker::shared::constants::DD_CRASHTRACK_DEFAULT_TIMEOUT`. Otherwise, uses
+    /// the specified timeout value.
     /// This is given as a uint32_t, but the actual timeout needs to fit inside of an i32 (max
     /// 2^31-1). This is a limitation of the various interfaces used to guarantee the timeout.
     pub timeout_ms: u32,

--- a/datadog-crashtracker/src/collector/api.rs
+++ b/datadog-crashtracker/src/collector/api.rs
@@ -94,683 +94,675 @@ pub fn reconfigure(
     Ok(())
 }
 
-// We can't run this in the main test runner because it (deliberately) crashes,
-// and would make all following tests unrunable.
-// To run this test,
-// ./build-profiling-ffi /tmp/libdatadog
-// mkdir /tmp/crashreports
-// look in /tmp/crashreports for the crash reports and output files
-#[ignore]
-#[test]
-fn test_crash() -> anyhow::Result<()> {
-    use crate::{begin_op, StacktraceCollection};
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{begin_op, insert_span, insert_trace, StacktraceCollection};
     use chrono::Utc;
     use ddcommon::tag;
     use ddcommon::Endpoint;
     use std::time::Duration;
+    // We can't run this in the main test runner because it (deliberately) crashes,
+    // and would make all following tests unrunable.
+    // To run this test,
+    // ./build-profiling-ffi /tmp/libdatadog
+    // mkdir /tmp/crashreports
+    // look in /tmp/crashreports for the crash reports and output files
+    #[ignore]
+    #[test]
+    fn test_crash() -> anyhow::Result<()> {
+        let time = Utc::now().to_rfc3339();
+        let dir = "/tmp/crashreports/";
+        let output_url = format!("file://{dir}{time}.txt");
 
-    let time = Utc::now().to_rfc3339();
-    let dir = "/tmp/crashreports/";
-    let output_url = format!("file://{dir}{time}.txt");
+        let endpoint = Some(Endpoint::from_slice(&output_url));
 
-    let endpoint = Some(Endpoint::from_slice(&output_url));
+        let path_to_receiver_binary =
+            "/tmp/libdatadog/bin/libdatadog-crashtracking-receiver".to_string();
+        let create_alt_stack = true;
+        let use_alt_stack = true;
+        let resolve_frames = StacktraceCollection::EnabledWithInprocessSymbols;
+        let stderr_filename = Some(format!("{dir}/stderr_{time}.txt"));
+        let stdout_filename = Some(format!("{dir}/stdout_{time}.txt"));
+        let timeout = Duration::from_secs(10);
+        let receiver_config = CrashtrackerReceiverConfig::new(
+            vec![],
+            vec![],
+            path_to_receiver_binary,
+            stderr_filename,
+            stdout_filename,
+        )?;
+        let config = CrashtrackerConfiguration::new(
+            vec![],
+            create_alt_stack,
+            use_alt_stack,
+            endpoint,
+            resolve_frames,
+            default_signals(),
+            Some(timeout),
+            None,
+            true,
+        )?;
+        let metadata = Metadata::new(
+            "libname".to_string(),
+            "version".to_string(),
+            "family".to_string(),
+            vec![],
+        );
+        init(config, receiver_config, metadata)?;
+        begin_op(crate::OpTypes::ProfilerCollectingSample)?;
+        insert_span(42)?;
+        insert_trace(u128::MAX)?;
+        insert_span(12)?;
+        insert_trace(99399939399939393993)?;
 
-    let path_to_receiver_binary =
-        "/tmp/libdatadog/bin/libdatadog-crashtracking-receiver".to_string();
-    let create_alt_stack = true;
-    let use_alt_stack = true;
-    let resolve_frames = StacktraceCollection::EnabledWithInprocessSymbols;
-    let stderr_filename = Some(format!("{dir}/stderr_{time}.txt"));
-    let stdout_filename = Some(format!("{dir}/stdout_{time}.txt"));
-    let timeout_ms = 10_000;
-    let receiver_config = CrashtrackerReceiverConfig::new(
-        vec![],
-        vec![],
-        path_to_receiver_binary,
-        stderr_filename,
-        stdout_filename,
-    )?;
-    let config = CrashtrackerConfiguration::new(
-        vec![],
-        create_alt_stack,
-        use_alt_stack,
-        endpoint,
-        resolve_frames,
-        default_signals(),
-        timeout_ms,
-        None,
-        true,
-    )?;
-    let metadata = Metadata::new(
-        "libname".to_string(),
-        "version".to_string(),
-        "family".to_string(),
-        vec![],
-    );
-    init(config, receiver_config, metadata)?;
-    begin_op(crate::OpTypes::ProfilerCollectingSample)?;
-    super::insert_span(42)?;
-    super::insert_trace(u128::MAX)?;
-    super::insert_span(12)?;
-    super::insert_trace(99399939399939393993)?;
+        let tag = tag!("apple", "banana");
+        let metadata2 = Metadata::new(
+            "libname".to_string(),
+            "version".to_string(),
+            "family".to_string(),
+            vec![tag.to_string()],
+        );
+        update_metadata(metadata2).expect("metadata");
 
-    let tag = tag!("apple", "banana");
-    let metadata2 = Metadata::new(
-        "libname".to_string(),
-        "version".to_string(),
-        "family".to_string(),
-        vec![tag.to_string()],
-    );
-    update_metadata(metadata2).expect("metadata");
+        std::thread::sleep(Duration::from_secs(2));
 
-    std::thread::sleep(Duration::from_secs(2));
-
-    let p: *const u32 = std::ptr::null();
-    let q = unsafe { *p };
-    assert_eq!(q, 3);
-    Ok(())
-}
-
-#[test]
-fn test_altstack_paradox() -> anyhow::Result<()> {
-    use crate::StacktraceCollection;
-    use chrono::Utc;
-    use ddcommon::Endpoint;
-
-    let time = Utc::now().to_rfc3339();
-    let dir = "/tmp/crashreports/";
-    let output_url = format!("file://{dir}{time}.txt");
-
-    let endpoint = Some(Endpoint::from_slice(&output_url));
-
-    let create_alt_stack = true;
-    let use_alt_stack = false;
-    let resolve_frames = StacktraceCollection::EnabledWithInprocessSymbols;
-    let timeout_ms = 10_000;
-
-    // This should return an error, because we're creating an altstack without using it
-    let config = CrashtrackerConfiguration::new(
-        vec![],
-        create_alt_stack,
-        use_alt_stack,
-        endpoint,
-        resolve_frames,
-        default_signals(),
-        timeout_ms,
-        None,
-        true,
-    );
-
-    // This is slightly over-tuned to the language of the error message, but it'd require some
-    // novel engineering just for this test in order to tighten this up.
-    let err = config.unwrap_err();
-    assert_eq!(
-        err.to_string(),
-        "Cannot create an altstack without using it"
-    );
-    Ok(())
-}
-
-#[cfg(test)]
-#[cfg(target_os = "linux")]
-fn get_sigaltstack() -> Option<libc::stack_t> {
-    let mut sigaltstack = libc::stack_t {
-        ss_sp: std::ptr::null_mut(),
-        ss_flags: 0,
-        ss_size: 0,
-    };
-    let res = unsafe { libc::sigaltstack(std::ptr::null(), &mut sigaltstack) };
-    if res == 0 {
-        Some(sigaltstack)
-    } else {
-        None
+        let p: *const u32 = std::ptr::null();
+        let q = unsafe { *p };
+        assert_eq!(q, 3);
+        Ok(())
     }
-}
 
-#[cfg_attr(miri, ignore)]
-#[cfg(target_os = "linux")]
-#[test]
-fn test_altstack_use_create() -> anyhow::Result<()> {
-    // This test initializes crashtracking in a fork, then waits on the exit status of the child.
-    // We check for an atypical exit status in order to ensure that only our desired exit path is
-    // taken.
-    use crate::StacktraceCollection;
-    use chrono::Utc;
-    use ddcommon::Endpoint;
+    #[test]
+    fn test_altstack_paradox() -> anyhow::Result<()> {
+        let time = Utc::now().to_rfc3339();
+        let dir = "/tmp/crashreports/";
+        let output_url = format!("file://{dir}{time}.txt");
 
-    let time = Utc::now().to_rfc3339();
-    let dir = "/tmp/crashreports/";
-    let output_url = format!("file://{dir}{time}.txt");
+        let endpoint = Some(Endpoint::from_slice(&output_url));
 
-    let endpoint = Some(Endpoint::from_slice(&output_url));
+        let create_alt_stack = true;
+        let use_alt_stack = false;
+        let resolve_frames = StacktraceCollection::EnabledWithInprocessSymbols;
+        let timeout = Duration::from_secs(10);
 
-    let path_to_receiver_binary =
-        "/tmp/libdatadog/bin/libdatadog-crashtracking-receiver".to_string();
-    let create_alt_stack = true;
-    let use_alt_stack = true;
-    let resolve_frames = StacktraceCollection::EnabledWithInprocessSymbols;
-    let stderr_filename = Some(format!("{dir}/stderr_{time}.txt"));
-    let stdout_filename = Some(format!("{dir}/stdout_{time}.txt"));
-    let signals = default_signals();
-    let timeout_ms = 10_000;
-    let receiver_config = CrashtrackerReceiverConfig::new(
-        vec![],
-        vec![],
-        path_to_receiver_binary,
-        stderr_filename,
-        stdout_filename,
-    )?;
-    let config = CrashtrackerConfiguration::new(
-        vec![],
-        create_alt_stack,
-        use_alt_stack,
-        endpoint,
-        resolve_frames,
-        signals,
-        timeout_ms,
-        None,
-        true,
-    )?;
-    let metadata = Metadata::new(
-        "libname".to_string(),
-        "version".to_string(),
-        "family".to_string(),
-        vec![],
-    );
+        // This should return an error, because we're creating an altstack without using it
+        let config = CrashtrackerConfiguration::new(
+            vec![],
+            create_alt_stack,
+            use_alt_stack,
+            endpoint,
+            resolve_frames,
+            default_signals(),
+            Some(timeout),
+            None,
+            true,
+        );
 
-    // At this point we fork, because we're going to be looking at process-level state
-    match unsafe { libc::fork() } {
-        -1 => {
-            panic!("Failed to fork");
+        // This is slightly over-tuned to the language of the error message, but it'd require some
+        // novel engineering just for this test in order to tighten this up.
+        let err = config.unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "Cannot create an altstack without using it"
+        );
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    fn get_sigaltstack() -> Option<libc::stack_t> {
+        let mut sigaltstack = libc::stack_t {
+            ss_sp: std::ptr::null_mut(),
+            ss_flags: 0,
+            ss_size: 0,
+        };
+        let res = unsafe { libc::sigaltstack(std::ptr::null(), &mut sigaltstack) };
+        if res == 0 {
+            Some(sigaltstack)
+        } else {
+            None
         }
-        0 => {
-            // Child process
-            // Get the current state of the altstack
-            let initial_sigaltstack = get_sigaltstack();
-            assert!(
-                initial_sigaltstack.is_some(),
-                "Failed to get initial sigaltstack"
-            );
+    }
 
-            // Initialize crashtracking.  This will
-            // - create a new altstack
-            // - set the SIGUBS/SIGSEGV handlers with SA_ONSTACK
-            init(config, receiver_config, metadata)?;
+    #[cfg_attr(miri, ignore)]
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_altstack_use_create() -> anyhow::Result<()> {
+        // This test initializes crashtracking in a fork, then waits on the exit status of the
+        // child. We check for an atypical exit status in order to ensure that only our
+        // desired exit path is taken.
 
-            // Get the state of the altstack after initialization
-            let after_init_sigaltstack = get_sigaltstack();
+        let time = Utc::now().to_rfc3339();
+        let dir = "/tmp/crashreports/";
+        let output_url = format!("file://{dir}{time}.txt");
 
-            // Compare the initial and after-init sigaltstacks
-            if initial_sigaltstack == after_init_sigaltstack {
-                eprintln!("Initial sigaltstack: {:?}", initial_sigaltstack);
-                std::process::exit(-5);
+        let endpoint = Some(Endpoint::from_slice(&output_url));
+
+        let path_to_receiver_binary =
+            "/tmp/libdatadog/bin/libdatadog-crashtracking-receiver".to_string();
+        let create_alt_stack = true;
+        let use_alt_stack = true;
+        let resolve_frames = StacktraceCollection::EnabledWithInprocessSymbols;
+        let stderr_filename = Some(format!("{dir}/stderr_{time}.txt"));
+        let stdout_filename = Some(format!("{dir}/stdout_{time}.txt"));
+        let signals = default_signals();
+        let timeout = Duration::from_secs(10);
+        let receiver_config = CrashtrackerReceiverConfig::new(
+            vec![],
+            vec![],
+            path_to_receiver_binary,
+            stderr_filename,
+            stdout_filename,
+        )?;
+        let config = CrashtrackerConfiguration::new(
+            vec![],
+            create_alt_stack,
+            use_alt_stack,
+            endpoint,
+            resolve_frames,
+            signals,
+            Some(timeout),
+            None,
+            true,
+        )?;
+        let metadata = Metadata::new(
+            "libname".to_string(),
+            "version".to_string(),
+            "family".to_string(),
+            vec![],
+        );
+
+        // At this point we fork, because we're going to be looking at process-level state
+        match unsafe { libc::fork() } {
+            -1 => {
+                panic!("Failed to fork");
             }
+            0 => {
+                // Child process
+                // Get the current state of the altstack
+                let initial_sigaltstack = get_sigaltstack();
+                assert!(
+                    initial_sigaltstack.is_some(),
+                    "Failed to get initial sigaltstack"
+                );
 
-            // Check the SIGBUS and SIGSEGV handlers are set with SA_ONSTACK
-            let mut sigaction = libc::sigaction {
-                sa_sigaction: 0,
-                sa_mask: unsafe { std::mem::zeroed::<libc::sigset_t>() },
-                sa_flags: 0,
-                sa_restorer: None,
-            };
+                // Initialize crashtracking.  This will
+                // - create a new altstack
+                // - set the SIGUBS/SIGSEGV handlers with SA_ONSTACK
+                init(config, receiver_config, metadata)?;
 
-            let mut exit_code = -5;
+                // Get the state of the altstack after initialization
+                let after_init_sigaltstack = get_sigaltstack();
 
-            for signal in default_signals() {
-                let signame = crate::signal_from_signum(signal)?;
-                exit_code -= 1;
-                let res = unsafe { libc::sigaction(signal, std::ptr::null(), &mut sigaction) };
+                // Compare the initial and after-init sigaltstacks
+                if initial_sigaltstack == after_init_sigaltstack {
+                    eprintln!("Initial sigaltstack: {:?}", initial_sigaltstack);
+                    std::process::exit(-5);
+                }
+
+                // Check the SIGBUS and SIGSEGV handlers are set with SA_ONSTACK
+                let mut sigaction = libc::sigaction {
+                    sa_sigaction: 0,
+                    sa_mask: unsafe { std::mem::zeroed::<libc::sigset_t>() },
+                    sa_flags: 0,
+                    sa_restorer: None,
+                };
+
+                let mut exit_code = -5;
+
+                for signal in default_signals() {
+                    let signame = crate::signal_from_signum(signal)?;
+                    exit_code -= 1;
+                    let res = unsafe { libc::sigaction(signal, std::ptr::null(), &mut sigaction) };
+                    if res != 0 {
+                        eprintln!("Failed to get {signame:?} handler");
+                        std::process::exit(exit_code);
+                    }
+
+                    exit_code -= 1;
+                    if sigaction.sa_flags & libc::SA_ONSTACK != libc::SA_ONSTACK {
+                        eprintln!("Expected {signame:?} handler to have SA_ONSTACK");
+                        std::process::exit(exit_code);
+                    }
+                }
+
+                // OK, we're done
+                std::process::exit(42);
+            }
+            pid => {
+                // Parent process
+                let mut status = 0;
+                let _ = unsafe { libc::waitpid(pid, &mut status, 0) };
+
+                // `status` is not the exit code, gotta unwrap some layers
+                if libc::WIFEXITED(status) {
+                    let exit_code = libc::WEXITSTATUS(status);
+                    assert_eq!(exit_code, 42, "Child process exited with unexpected status");
+                } else {
+                    panic!("Child process did not exit normally");
+                }
+            }
+        }
+
+        // OK, we're done
+        Ok(())
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_altstack_use_nocreate() -> anyhow::Result<()> {
+        // Similar to the other test, this one operates inside of a fork in order to prevent
+        // poisoning the main process state.
+
+        let time = Utc::now().to_rfc3339();
+        let dir = "/tmp/crashreports/";
+        let output_url = format!("file://{dir}{time}.txt");
+
+        let endpoint = Some(Endpoint::from_slice(&output_url));
+
+        let path_to_receiver_binary =
+            "/tmp/libdatadog/bin/libdatadog-crashtracking-receiver".to_string();
+        let create_alt_stack = false; // Use, but do _not_ create
+        let use_alt_stack = true;
+        let resolve_frames = StacktraceCollection::EnabledWithInprocessSymbols;
+        let stderr_filename = Some(format!("{dir}/stderr_{time}.txt"));
+        let stdout_filename = Some(format!("{dir}/stdout_{time}.txt"));
+        let signals = default_signals();
+        let timeout = Duration::from_secs(10);
+        let receiver_config = CrashtrackerReceiverConfig::new(
+            vec![],
+            vec![],
+            path_to_receiver_binary,
+            stderr_filename,
+            stdout_filename,
+        )?;
+        let config = CrashtrackerConfiguration::new(
+            vec![],
+            create_alt_stack,
+            use_alt_stack,
+            endpoint,
+            resolve_frames,
+            signals,
+            Some(timeout),
+            None,
+            true,
+        )?;
+        let metadata = Metadata::new(
+            "libname".to_string(),
+            "version".to_string(),
+            "family".to_string(),
+            vec![],
+        );
+
+        // At this point we fork, because we're going to be looking at process-level state
+        match unsafe { libc::fork() } {
+            -1 => {
+                panic!("Failed to fork");
+            }
+            0 => {
+                // Child process
+                // Get the current state of the altstack
+                let initial_sigaltstack = get_sigaltstack();
+                assert!(
+                    initial_sigaltstack.is_some(),
+                    "Failed to get initial sigaltstack"
+                );
+
+                // Initialize crashtracking.  This will
+                // - create a new altstack
+                // - set the SIGUBS/SIGSEGV handlers with SA_ONSTACK
+                init(config, receiver_config, metadata)?;
+
+                // Get the state of the altstack after initialization
+                let after_init_sigaltstack = get_sigaltstack();
+
+                // Compare the initial and after-init sigaltstacks:  they should be the same!
+                if initial_sigaltstack != after_init_sigaltstack {
+                    eprintln!("Initial sigaltstack: {:?}", initial_sigaltstack);
+                    std::process::exit(-5);
+                }
+
+                // Even though the other test checks for the SA_ONSTACK flag on the signal handlers,
+                // we double-check here because the options need to be decoupled
+                let mut sigaction = libc::sigaction {
+                    sa_sigaction: 0,
+                    sa_mask: unsafe { std::mem::zeroed::<libc::sigset_t>() },
+                    sa_flags: 0,
+                    sa_restorer: None,
+                };
+
+                // First, SIGBUS
+                let res =
+                    unsafe { libc::sigaction(libc::SIGBUS, std::ptr::null(), &mut sigaction) };
                 if res != 0 {
-                    eprintln!("Failed to get {signame:?} handler");
-                    std::process::exit(exit_code);
-                }
-
-                exit_code -= 1;
-                if sigaction.sa_flags & libc::SA_ONSTACK != libc::SA_ONSTACK {
-                    eprintln!("Expected {signame:?} handler to have SA_ONSTACK");
-                    std::process::exit(exit_code);
-                }
-            }
-
-            // OK, we're done
-            std::process::exit(42);
-        }
-        pid => {
-            // Parent process
-            let mut status = 0;
-            let _ = unsafe { libc::waitpid(pid, &mut status, 0) };
-
-            // `status` is not the exit code, gotta unwrap some layers
-            if libc::WIFEXITED(status) {
-                let exit_code = libc::WEXITSTATUS(status);
-                assert_eq!(exit_code, 42, "Child process exited with unexpected status");
-            } else {
-                panic!("Child process did not exit normally");
-            }
-        }
-    }
-
-    // OK, we're done
-    Ok(())
-}
-
-#[cfg_attr(miri, ignore)]
-#[cfg(target_os = "linux")]
-#[test]
-fn test_altstack_use_nocreate() -> anyhow::Result<()> {
-    // Similar to the other test, this one operates inside of a fork in order to prevent poisoning
-    // the main process state.
-    use crate::StacktraceCollection;
-    use chrono::Utc;
-    use ddcommon::Endpoint;
-
-    let time = Utc::now().to_rfc3339();
-    let dir = "/tmp/crashreports/";
-    let output_url = format!("file://{dir}{time}.txt");
-
-    let endpoint = Some(Endpoint::from_slice(&output_url));
-
-    let path_to_receiver_binary =
-        "/tmp/libdatadog/bin/libdatadog-crashtracking-receiver".to_string();
-    let create_alt_stack = false; // Use, but do _not_ create
-    let use_alt_stack = true;
-    let resolve_frames = StacktraceCollection::EnabledWithInprocessSymbols;
-    let stderr_filename = Some(format!("{dir}/stderr_{time}.txt"));
-    let stdout_filename = Some(format!("{dir}/stdout_{time}.txt"));
-    let signals = default_signals();
-    let timeout_ms = 10_000;
-    let receiver_config = CrashtrackerReceiverConfig::new(
-        vec![],
-        vec![],
-        path_to_receiver_binary,
-        stderr_filename,
-        stdout_filename,
-    )?;
-    let config = CrashtrackerConfiguration::new(
-        vec![],
-        create_alt_stack,
-        use_alt_stack,
-        endpoint,
-        resolve_frames,
-        signals,
-        timeout_ms,
-        None,
-        true,
-    )?;
-    let metadata = Metadata::new(
-        "libname".to_string(),
-        "version".to_string(),
-        "family".to_string(),
-        vec![],
-    );
-
-    // At this point we fork, because we're going to be looking at process-level state
-    match unsafe { libc::fork() } {
-        -1 => {
-            panic!("Failed to fork");
-        }
-        0 => {
-            // Child process
-            // Get the current state of the altstack
-            let initial_sigaltstack = get_sigaltstack();
-            assert!(
-                initial_sigaltstack.is_some(),
-                "Failed to get initial sigaltstack"
-            );
-
-            // Initialize crashtracking.  This will
-            // - create a new altstack
-            // - set the SIGUBS/SIGSEGV handlers with SA_ONSTACK
-            init(config, receiver_config, metadata)?;
-
-            // Get the state of the altstack after initialization
-            let after_init_sigaltstack = get_sigaltstack();
-
-            // Compare the initial and after-init sigaltstacks:  they should be the same!
-            if initial_sigaltstack != after_init_sigaltstack {
-                eprintln!("Initial sigaltstack: {:?}", initial_sigaltstack);
-                std::process::exit(-5);
-            }
-
-            // Even though the other test checks for the SA_ONSTACK flag on the signal handlers, we
-            // double-check here because the options need to be decoupled
-            let mut sigaction = libc::sigaction {
-                sa_sigaction: 0,
-                sa_mask: unsafe { std::mem::zeroed::<libc::sigset_t>() },
-                sa_flags: 0,
-                sa_restorer: None,
-            };
-
-            // First, SIGBUS
-            let res = unsafe { libc::sigaction(libc::SIGBUS, std::ptr::null(), &mut sigaction) };
-            if res != 0 {
-                eprintln!("Failed to get SIGBUS handler");
-                std::process::exit(-6);
-            }
-            if sigaction.sa_flags & libc::SA_ONSTACK != libc::SA_ONSTACK {
-                eprintln!("Expected SIGBUS handler to have SA_ONSTACK");
-                std::process::exit(-7);
-            }
-
-            // Second, SIGSEGV
-            let res = unsafe { libc::sigaction(libc::SIGSEGV, std::ptr::null(), &mut sigaction) };
-            if res != 0 {
-                eprintln!("Failed to get SIGSEGV handler");
-                std::process::exit(-8);
-            }
-            if sigaction.sa_flags & libc::SA_ONSTACK != libc::SA_ONSTACK {
-                eprintln!("Expected SIGSEGV handler to have SA_ONSTACK");
-                std::process::exit(-9);
-            }
-
-            // OK, we're done
-            std::process::exit(42);
-        }
-        pid => {
-            // Parent process
-            let mut status = 0;
-            let _ = unsafe { libc::waitpid(pid, &mut status, 0) };
-
-            // `status` is not the exit code, gotta unwrap some layers
-            if libc::WIFEXITED(status) {
-                let exit_code = libc::WEXITSTATUS(status);
-                assert_eq!(exit_code, 42, "Child process exited with unexpected status");
-            } else {
-                panic!("Child process did not exit normally");
-            }
-        }
-    }
-
-    // OK, we're done
-    Ok(())
-}
-
-#[cfg_attr(miri, ignore)]
-#[cfg(target_os = "linux")]
-#[test]
-fn test_altstack_nouse() -> anyhow::Result<()> {
-    // This checks that when we do not request the altstack, we do not get the altstack
-    use crate::StacktraceCollection;
-    use chrono::Utc;
-    use ddcommon::Endpoint;
-
-    let time = Utc::now().to_rfc3339();
-    let dir = "/tmp/crashreports/";
-    let output_url = format!("file://{dir}{time}.txt");
-
-    let endpoint = Some(Endpoint::from_slice(&output_url));
-
-    let path_to_receiver_binary =
-        "/tmp/libdatadog/bin/libdatadog-crashtracking-receiver".to_string();
-    let create_alt_stack = false;
-    let use_alt_stack = false;
-    let resolve_frames = StacktraceCollection::EnabledWithInprocessSymbols;
-    let stderr_filename = Some(format!("{dir}/stderr_{time}.txt"));
-    let stdout_filename = Some(format!("{dir}/stdout_{time}.txt"));
-    let signals = default_signals();
-    let timeout_ms = 10_000;
-    let receiver_config = CrashtrackerReceiverConfig::new(
-        vec![],
-        vec![],
-        path_to_receiver_binary,
-        stderr_filename,
-        stdout_filename,
-    )?;
-    let config = CrashtrackerConfiguration::new(
-        vec![],
-        create_alt_stack,
-        use_alt_stack,
-        endpoint,
-        resolve_frames,
-        signals,
-        timeout_ms,
-        None,
-        true,
-    )?;
-    let metadata = Metadata::new(
-        "libname".to_string(),
-        "version".to_string(),
-        "family".to_string(),
-        vec![],
-    );
-
-    // At this point we fork, because we're going to be looking at process-level state
-    match unsafe { libc::fork() } {
-        -1 => {
-            panic!("Failed to fork");
-        }
-        0 => {
-            // Child process
-            // Get the current state of the altstack
-            let initial_sigaltstack = get_sigaltstack();
-            assert!(
-                initial_sigaltstack.is_some(),
-                "Failed to get initial sigaltstack"
-            );
-
-            // Initialize crashtracking.  This will
-            // - create a new altstack
-            // - set the SIGUBS/SIGSEGV handlers with SA_ONSTACK
-            init(config, receiver_config, metadata)?;
-
-            // Get the state of the altstack after initialization
-            let after_init_sigaltstack = get_sigaltstack();
-
-            // Compare the initial and after-init sigaltstacks:  they should be the same because we
-            // did not enable anything!  This checks that we don't erroneously build the altstack.
-            if initial_sigaltstack != after_init_sigaltstack {
-                eprintln!("Initial sigaltstack: {:?}", initial_sigaltstack);
-                std::process::exit(-5);
-            }
-
-            // Similarly, we need to be extra sure that SA_ONSTACK is not present.
-            let mut sigaction = libc::sigaction {
-                sa_sigaction: 0,
-                sa_mask: unsafe { std::mem::zeroed::<libc::sigset_t>() },
-                sa_flags: 0,
-                sa_restorer: None,
-            };
-
-            // First, SIGBUS
-            let res = unsafe { libc::sigaction(libc::SIGBUS, std::ptr::null(), &mut sigaction) };
-            if res != 0 {
-                eprintln!("Failed to get SIGBUS handler");
-                std::process::exit(-6);
-            }
-            if sigaction.sa_flags & libc::SA_ONSTACK == libc::SA_ONSTACK {
-                eprintln!("Expected SIGBUS handler not to have SA_ONSTACK");
-                std::process::exit(-7);
-            }
-
-            // Second, SIGSEGV
-            let res = unsafe { libc::sigaction(libc::SIGSEGV, std::ptr::null(), &mut sigaction) };
-            if res != 0 {
-                eprintln!("Failed to get SIGSEGV handler");
-                std::process::exit(-8);
-            }
-            if sigaction.sa_flags & libc::SA_ONSTACK == libc::SA_ONSTACK {
-                eprintln!("Expected SIGSEGV handler not to have SA_ONSTACK");
-                std::process::exit(-9);
-            }
-
-            // OK, we're done
-            std::process::exit(42);
-        }
-        pid => {
-            // Parent process
-            let mut status = 0;
-            let _ = unsafe { libc::waitpid(pid, &mut status, 0) };
-
-            // `status` is not the exit code, gotta unwrap some layers
-            if libc::WIFEXITED(status) {
-                let exit_code = libc::WEXITSTATUS(status);
-                assert_eq!(exit_code, 42, "Child process exited with unexpected status");
-            } else {
-                panic!("Child process did not exit normally");
-            }
-        }
-    }
-
-    // OK, we're done
-    Ok(())
-}
-
-#[cfg_attr(miri, ignore)]
-#[cfg(target_os = "linux")]
-#[test]
-#[ignore]
-fn test_waitall_nohang() -> anyhow::Result<()> {
-    // This test checks whether the crashtracking implementation can cause malformed `waitall()`
-    // idioms to hang.
-    // Consider the following code from the Ruby runtime:
-    //
-    //   static VALUE
-    //   proc_waitall(VALUE _)
-    //   {
-    //       VALUE result;
-    //       rb_pid_t pid;
-    //       int status;
-    //
-    //       result = rb_ary_new();
-    //       rb_last_status_clear();
-    //
-    //       for (pid = -1;;) {
-    //           pid = rb_waitpid(-1, &status, 0);
-    //           if (pid == -1) {
-    //               int e = errno;
-    //               if (e == ECHILD)
-    //                   break;
-    //               rb_syserr_fail(e, 0);
-    //           }
-    //           rb_ary_push(result, rb_assoc_new(PIDT2NUM(pid), rb_last_status_get()));
-    //       }
-    //       return result;
-    //   }
-    //
-    // The intent here is to wait for all of one's child processes to exit.  This is a pretty
-    // standard operation in multi-process situations, with one important caveat:  usually you know
-    // your children ahead of time and can wait on them in a controlled, intentional matter.
-    // Previous versions of crashtracking, which spawned long-lived receiver processes, would
-    // interfere with this
-    //
-    // This implements the inner behavior of a test which allows the caller to control which
-    // options are used.
-    use crate::StacktraceCollection;
-    use chrono::Utc;
-    use ddcommon::Endpoint;
-
-    let time = Utc::now().to_rfc3339();
-    let dir = "/tmp/crashreports/";
-    let output_url = format!("file://{dir}{time}.txt");
-
-    let endpoint = Some(Endpoint::from_slice(&output_url));
-
-    let path_to_receiver_binary =
-        "/tmp/libdatadog/bin/libdatadog-crashtracking-receiver".to_string();
-    let create_alt_stack = true; // doesn't matter, but most runtimes use it, so take it
-    let use_alt_stack = true;
-    let resolve_frames = StacktraceCollection::EnabledWithInprocessSymbols;
-    let stderr_filename = Some(format!("{dir}/stderr_{time}.txt"));
-    let stdout_filename = Some(format!("{dir}/stdout_{time}.txt"));
-    let signals = default_signals();
-    let timeout_ms = 10_000;
-    let receiver_config = CrashtrackerReceiverConfig::new(
-        vec![],
-        vec![],
-        path_to_receiver_binary,
-        stderr_filename,
-        stdout_filename,
-    )?;
-    let config = CrashtrackerConfiguration::new(
-        vec![],
-        create_alt_stack,
-        use_alt_stack,
-        endpoint,
-        resolve_frames,
-        signals,
-        timeout_ms,
-        None,
-        true,
-    )?;
-
-    let metadata = Metadata::new(
-        "libname".to_string(),
-        "version".to_string(),
-        "family".to_string(),
-        vec![],
-    );
-
-    // Since this test ultimately mutates process state, it's done inside of a fork just like the
-    // other tests of the same ilk.
-    match unsafe { libc::fork() } {
-        -1 => {
-            panic!("Failed to fork");
-        }
-        0 => {
-            // Child process
-            // This is where the test actually happens!
-            init(config, receiver_config, metadata)?;
-
-            // Now spawn some short-lived child processes.
-            // Note:  it's easy to confirm this test actually works by cranking the sleep duration
-            // up past the timeout duration. At such a point, the test should fail.
-            let mut children = vec![];
-            let sleep_duration_ms = 100;
-            let timeout_duration_ms = 150;
-            for _ in 0..10 {
-                match unsafe { libc::fork() } {
-                    -1 => {
-                        panic!("Failed to fork");
-                    }
-                    0 => {
-                        // Grandchild process
-                        std::thread::sleep(std::time::Duration::from_millis(sleep_duration_ms));
-                        std::process::exit(0); // normal exit, since we're testing waitall
-                    }
-                    pid => {
-                        // Parent process
-                        children.push(pid); // unused in this test
-                    }
-                }
-            }
-
-            // Now, do the equivalent of the waitall loop.
-            // One caveat is that we do not want to hang the test, so rather than an unbounded
-            // `waitpid()`, use WNOHANG within a timer loop.
-            let timeout = std::time::Duration::from_millis(timeout_duration_ms);
-            let start_time = std::time::Instant::now();
-            loop {
-                if start_time.elapsed() > timeout {
-                    eprintln!("Timed out waiting for children to exit");
+                    eprintln!("Failed to get SIGBUS handler");
                     std::process::exit(-6);
                 }
+                if sigaction.sa_flags & libc::SA_ONSTACK != libc::SA_ONSTACK {
+                    eprintln!("Expected SIGBUS handler to have SA_ONSTACK");
+                    std::process::exit(-7);
+                }
 
-                // Call waitpid with WNOHANG
+                // Second, SIGSEGV
+                let res =
+                    unsafe { libc::sigaction(libc::SIGSEGV, std::ptr::null(), &mut sigaction) };
+                if res != 0 {
+                    eprintln!("Failed to get SIGSEGV handler");
+                    std::process::exit(-8);
+                }
+                if sigaction.sa_flags & libc::SA_ONSTACK != libc::SA_ONSTACK {
+                    eprintln!("Expected SIGSEGV handler to have SA_ONSTACK");
+                    std::process::exit(-9);
+                }
+
+                // OK, we're done
+                std::process::exit(42);
+            }
+            pid => {
+                // Parent process
                 let mut status = 0;
-                let pid = unsafe { libc::waitpid(-1, &mut status, libc::WNOHANG) };
-                let errno = std::io::Error::last_os_error().raw_os_error().unwrap();
+                let _ = unsafe { libc::waitpid(pid, &mut status, 0) };
 
-                if pid == -1 && errno == libc::ECHILD {
-                    // No more children!  Done!
-                    std::process::exit(42);
+                // `status` is not the exit code, gotta unwrap some layers
+                if libc::WIFEXITED(status) {
+                    let exit_code = libc::WEXITSTATUS(status);
+                    assert_eq!(exit_code, 42, "Child process exited with unexpected status");
+                } else {
+                    panic!("Child process did not exit normally");
                 }
             }
         }
-        pid => {
-            // Parent process
-            let mut status = 0;
-            let _ = unsafe { libc::waitpid(pid, &mut status, 0) };
 
-            // `status` is not the exit code, gotta unwrap some layers
-            if libc::WIFEXITED(status) {
-                let exit_code = libc::WEXITSTATUS(status);
-                assert_eq!(exit_code, 42, "Child process exited with unexpected status");
-            } else {
-                panic!("Child process did not exit normally");
-            }
-        }
+        // OK, we're done
+        Ok(())
     }
 
-    // Confirmed that we have no children, so we're done.
-    Ok(())
+    #[cfg_attr(miri, ignore)]
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_altstack_nouse() -> anyhow::Result<()> {
+        // This checks that when we do not request the altstack, we do not get the altstack
+
+        let time = Utc::now().to_rfc3339();
+        let dir = "/tmp/crashreports/";
+        let output_url = format!("file://{dir}{time}.txt");
+
+        let endpoint = Some(Endpoint::from_slice(&output_url));
+
+        let path_to_receiver_binary =
+            "/tmp/libdatadog/bin/libdatadog-crashtracking-receiver".to_string();
+        let create_alt_stack = false;
+        let use_alt_stack = false;
+        let resolve_frames = StacktraceCollection::EnabledWithInprocessSymbols;
+        let stderr_filename = Some(format!("{dir}/stderr_{time}.txt"));
+        let stdout_filename = Some(format!("{dir}/stdout_{time}.txt"));
+        let signals = default_signals();
+        let timeout = Duration::from_secs(10);
+        let receiver_config = CrashtrackerReceiverConfig::new(
+            vec![],
+            vec![],
+            path_to_receiver_binary,
+            stderr_filename,
+            stdout_filename,
+        )?;
+        let config = CrashtrackerConfiguration::new(
+            vec![],
+            create_alt_stack,
+            use_alt_stack,
+            endpoint,
+            resolve_frames,
+            signals,
+            Some(timeout),
+            None,
+            true,
+        )?;
+        let metadata = Metadata::new(
+            "libname".to_string(),
+            "version".to_string(),
+            "family".to_string(),
+            vec![],
+        );
+
+        // At this point we fork, because we're going to be looking at process-level state
+        match unsafe { libc::fork() } {
+            -1 => {
+                panic!("Failed to fork");
+            }
+            0 => {
+                // Child process
+                // Get the current state of the altstack
+                let initial_sigaltstack = get_sigaltstack();
+                assert!(
+                    initial_sigaltstack.is_some(),
+                    "Failed to get initial sigaltstack"
+                );
+
+                // Initialize crashtracking.  This will
+                // - create a new altstack
+                // - set the SIGUBS/SIGSEGV handlers with SA_ONSTACK
+                init(config, receiver_config, metadata)?;
+
+                // Get the state of the altstack after initialization
+                let after_init_sigaltstack = get_sigaltstack();
+
+                // Compare the initial and after-init sigaltstacks:  they should be the same because
+                // we did not enable anything!  This checks that we don't
+                // erroneously build the altstack.
+                if initial_sigaltstack != after_init_sigaltstack {
+                    eprintln!("Initial sigaltstack: {:?}", initial_sigaltstack);
+                    std::process::exit(-5);
+                }
+
+                // Similarly, we need to be extra sure that SA_ONSTACK is not present.
+                let mut sigaction = libc::sigaction {
+                    sa_sigaction: 0,
+                    sa_mask: unsafe { std::mem::zeroed::<libc::sigset_t>() },
+                    sa_flags: 0,
+                    sa_restorer: None,
+                };
+
+                // First, SIGBUS
+                let res =
+                    unsafe { libc::sigaction(libc::SIGBUS, std::ptr::null(), &mut sigaction) };
+                if res != 0 {
+                    eprintln!("Failed to get SIGBUS handler");
+                    std::process::exit(-6);
+                }
+                if sigaction.sa_flags & libc::SA_ONSTACK == libc::SA_ONSTACK {
+                    eprintln!("Expected SIGBUS handler not to have SA_ONSTACK");
+                    std::process::exit(-7);
+                }
+
+                // Second, SIGSEGV
+                let res =
+                    unsafe { libc::sigaction(libc::SIGSEGV, std::ptr::null(), &mut sigaction) };
+                if res != 0 {
+                    eprintln!("Failed to get SIGSEGV handler");
+                    std::process::exit(-8);
+                }
+                if sigaction.sa_flags & libc::SA_ONSTACK == libc::SA_ONSTACK {
+                    eprintln!("Expected SIGSEGV handler not to have SA_ONSTACK");
+                    std::process::exit(-9);
+                }
+
+                // OK, we're done
+                std::process::exit(42);
+            }
+            pid => {
+                // Parent process
+                let mut status = 0;
+                let _ = unsafe { libc::waitpid(pid, &mut status, 0) };
+
+                // `status` is not the exit code, gotta unwrap some layers
+                if libc::WIFEXITED(status) {
+                    let exit_code = libc::WEXITSTATUS(status);
+                    assert_eq!(exit_code, 42, "Child process exited with unexpected status");
+                } else {
+                    panic!("Child process did not exit normally");
+                }
+            }
+        }
+
+        // OK, we're done
+        Ok(())
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[cfg(target_os = "linux")]
+    #[test]
+    #[ignore]
+    fn test_waitall_nohang() -> anyhow::Result<()> {
+        // This test checks whether the crashtracking implementation can cause malformed `waitall()`
+        // idioms to hang.
+        // Consider the following code from the Ruby runtime:
+        //
+        //   static VALUE
+        //   proc_waitall(VALUE _)
+        //   {
+        //       VALUE result;
+        //       rb_pid_t pid;
+        //       int status;
+        //
+        //       result = rb_ary_new();
+        //       rb_last_status_clear();
+        //
+        //       for (pid = -1;;) {
+        //           pid = rb_waitpid(-1, &status, 0);
+        //           if (pid == -1) {
+        //               int e = errno;
+        //               if (e == ECHILD)
+        //                   break;
+        //               rb_syserr_fail(e, 0);
+        //           }
+        //           rb_ary_push(result, rb_assoc_new(PIDT2NUM(pid), rb_last_status_get()));
+        //       }
+        //       return result;
+        //   }
+        //
+        // The intent here is to wait for all of one's child processes to exit.  This is a pretty
+        // standard operation in multi-process situations, with one important caveat:  usually you
+        // know your children ahead of time and can wait on them in a controlled,
+        // intentional matter. Previous versions of crashtracking, which spawned long-lived
+        // receiver processes, would interfere with this
+        //
+        // This implements the inner behavior of a test which allows the caller to control which
+        // options are used.
+
+        let time = Utc::now().to_rfc3339();
+        let dir = "/tmp/crashreports/";
+        let output_url = format!("file://{dir}{time}.txt");
+
+        let endpoint = Some(Endpoint::from_slice(&output_url));
+
+        let path_to_receiver_binary =
+            "/tmp/libdatadog/bin/libdatadog-crashtracking-receiver".to_string();
+        let create_alt_stack = true; // doesn't matter, but most runtimes use it, so take it
+        let use_alt_stack = true;
+        let resolve_frames = StacktraceCollection::EnabledWithInprocessSymbols;
+        let stderr_filename = Some(format!("{dir}/stderr_{time}.txt"));
+        let stdout_filename = Some(format!("{dir}/stdout_{time}.txt"));
+        let signals = default_signals();
+        let timeout = Duration::from_secs(10);
+        let receiver_config = CrashtrackerReceiverConfig::new(
+            vec![],
+            vec![],
+            path_to_receiver_binary,
+            stderr_filename,
+            stdout_filename,
+        )?;
+        let config = CrashtrackerConfiguration::new(
+            vec![],
+            create_alt_stack,
+            use_alt_stack,
+            endpoint,
+            resolve_frames,
+            signals,
+            Some(timeout),
+            None,
+            true,
+        )?;
+
+        let metadata = Metadata::new(
+            "libname".to_string(),
+            "version".to_string(),
+            "family".to_string(),
+            vec![],
+        );
+
+        // Since this test ultimately mutates process state, it's done inside of a fork just like
+        // the other tests of the same ilk.
+        match unsafe { libc::fork() } {
+            -1 => {
+                panic!("Failed to fork");
+            }
+            0 => {
+                // Child process
+                // This is where the test actually happens!
+                init(config, receiver_config, metadata)?;
+
+                // Now spawn some short-lived child processes.
+                // Note:  it's easy to confirm this test actually works by cranking the sleep
+                // duration up past the timeout duration. At such a point, the test
+                // should fail.
+                let mut children = vec![];
+                let sleep_duration_ms = 100;
+                let timeout_duration_ms = 150;
+                for _ in 0..10 {
+                    match unsafe { libc::fork() } {
+                        -1 => {
+                            panic!("Failed to fork");
+                        }
+                        0 => {
+                            // Grandchild process
+                            std::thread::sleep(std::time::Duration::from_millis(sleep_duration_ms));
+                            std::process::exit(0); // normal exit, since we're testing waitall
+                        }
+                        pid => {
+                            // Parent process
+                            children.push(pid); // unused in this test
+                        }
+                    }
+                }
+
+                // Now, do the equivalent of the waitall loop.
+                // One caveat is that we do not want to hang the test, so rather than an unbounded
+                // `waitpid()`, use WNOHANG within a timer loop.
+                let timeout = Duration::from_secs(10);
+                let start_time = std::time::Instant::now();
+                loop {
+                    if start_time.elapsed() > timeout {
+                        eprintln!("Timed out waiting for children to exit");
+                        std::process::exit(-6);
+                    }
+
+                    // Call waitpid with WNOHANG
+                    let mut status = 0;
+                    let pid = unsafe { libc::waitpid(-1, &mut status, libc::WNOHANG) };
+                    let errno = std::io::Error::last_os_error().raw_os_error().unwrap();
+
+                    if pid == -1 && errno == libc::ECHILD {
+                        // No more children!  Done!
+                        std::process::exit(42);
+                    }
+                }
+            }
+            pid => {
+                // Parent process
+                let mut status = 0;
+                let _ = unsafe { libc::waitpid(pid, &mut status, 0) };
+
+                // `status` is not the exit code, gotta unwrap some layers
+                if libc::WIFEXITED(status) {
+                    let exit_code = libc::WEXITSTATUS(status);
+                    assert_eq!(exit_code, 42, "Child process exited with unexpected status");
+                } else {
+                    panic!("Child process did not exit normally");
+                }
+            }
+        }
+
+        // Confirmed that we have no children, so we're done.
+        Ok(())
+    }
 }

--- a/datadog-crashtracker/src/collector/api.rs
+++ b/datadog-crashtracker/src/collector/api.rs
@@ -706,8 +706,8 @@ mod tests {
                 // duration up past the timeout duration. At such a point, the test
                 // should fail.
                 let mut children = vec![];
-                let sleep_duration_ms = 100;
-                let timeout_duration_ms = 150;
+                let sleep_duration = Duration::from_millis(100);
+                let timeout_duration = Duration::from_millis(150);
                 for _ in 0..10 {
                     match unsafe { libc::fork() } {
                         -1 => {
@@ -715,7 +715,7 @@ mod tests {
                         }
                         0 => {
                             // Grandchild process
-                            std::thread::sleep(std::time::Duration::from_millis(sleep_duration_ms));
+                            std::thread::sleep(sleep_duration);
                             std::process::exit(0); // normal exit, since we're testing waitall
                         }
                         pid => {
@@ -728,10 +728,9 @@ mod tests {
                 // Now, do the equivalent of the waitall loop.
                 // One caveat is that we do not want to hang the test, so rather than an unbounded
                 // `waitpid()`, use WNOHANG within a timer loop.
-                let timeout = Duration::from_secs(10);
                 let start_time = std::time::Instant::now();
                 loop {
-                    if start_time.elapsed() > timeout {
+                    if start_time.elapsed() > timeout_duration {
                         eprintln!("Timed out waiting for children to exit");
                         std::process::exit(-6);
                     }

--- a/datadog-crashtracker/src/collector/process_handle.rs
+++ b/datadog-crashtracker/src/collector/process_handle.rs
@@ -1,46 +1,39 @@
 // Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::shared::constants::DD_CRASHTRACK_MINIMUM_REAP_TIME_MS;
-use ddcommon::unix_utils::{reap_child_non_blocking, wait_for_pollhup};
+use ddcommon::unix_utils::{reap_child_non_blocking, wait_for_pollhup, TimeoutManager};
 use nix::unistd::Pid;
 use std::os::unix::io::RawFd;
-use std::time::Instant;
 
 pub(crate) struct ProcessHandle {
     pub uds_fd: RawFd,
-    pub pid: i32,
-    pub oneshot: bool,
+    pub pid: Option<i32>,
 }
 
 impl ProcessHandle {
-    pub fn new(uds_fd: RawFd, pid: i32, oneshot: bool) -> Self {
-        Self {
-            uds_fd,
-            pid,
-            oneshot,
-        }
+    pub fn new(uds_fd: RawFd, pid: Option<i32>) -> Self {
+        Self { uds_fd, pid }
     }
 
-    pub fn finish(&self, start_time: Instant, timeout_ms: u32) {
-        let pollhup_allowed_ms = timeout_ms
-            .saturating_sub(start_time.elapsed().as_millis() as u32)
-            .min(i32::MAX as u32) as i32;
-        let _ = wait_for_pollhup(self.uds_fd, pollhup_allowed_ms);
+    pub fn finish(&self, timeout_manager: &TimeoutManager) {
+        let result = wait_for_pollhup(self.uds_fd, timeout_manager);
+        debug_assert_eq!(result, Ok(true), "wait_for_pollhup failed: {result:?}");
 
-        if self.oneshot {
+        if let Some(pid) = self.pid {
             // If we have less than the minimum amount of time, give ourselves a few scheduler
             // slices worth of headroom to help guarantee that we don't leak a zombie process.
-            let _ = unsafe { libc::kill(self.pid, libc::SIGKILL) };
+            let kill_result = unsafe { libc::kill(pid, libc::SIGKILL) };
+            debug_assert_eq!(kill_result, 0, "kill failed with result: {}", kill_result);
 
             // `self` is actually a handle to a child process and `self.pid` is the child process's
             // pid.
-            let child_pid = Pid::from_raw(self.pid);
-            let reaping_allowed_ms = std::cmp::min(
-                timeout_ms.saturating_sub(start_time.elapsed().as_millis() as u32),
-                DD_CRASHTRACK_MINIMUM_REAP_TIME_MS,
+            let child_pid = Pid::from_raw(pid);
+            let result = reap_child_non_blocking(child_pid, timeout_manager);
+            debug_assert_eq!(
+                result,
+                Ok(true),
+                "reap_child_non_blocking failed: {result:?}"
             );
-            let _ = reap_child_non_blocking(child_pid, reaping_allowed_ms);
         }
     }
 }

--- a/datadog-crashtracker/src/receiver/mod.rs
+++ b/datadog-crashtracker/src/receiver/mod.rs
@@ -56,7 +56,7 @@ mod tests {
                 None,
                 StacktraceCollection::Disabled,
                 default_signals(),
-                3000,
+                Some(Duration::from_secs(3)),
                 None,
                 true,
             )?)?,

--- a/datadog-crashtracker/src/shared/constants.rs
+++ b/datadog-crashtracker/src/shared/constants.rs
@@ -1,6 +1,8 @@
 // Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+use std::time::Duration;
+
 pub const DD_CRASHTRACK_BEGIN_ADDITIONAL_TAGS: &str = "DD_CRASHTRACK_BEGIN_ADDITIONAL_TAGS";
 pub const DD_CRASHTRACK_BEGIN_CONFIG: &str = "DD_CRASHTRACK_BEGIN_CONFIG";
 pub const DD_CRASHTRACK_BEGIN_COUNTERS: &str = "DD_CRASHTRACK_BEGIN_COUNTERS";
@@ -25,6 +27,4 @@ pub const DD_CRASHTRACK_END_STACKTRACE: &str = "DD_CRASHTRACK_END_STACKTRACE";
 pub const DD_CRASHTRACK_END_TRACE_IDS: &str = "DD_CRASHTRACK_END_TRACE_IDS";
 pub const DD_CRASHTRACK_END_UCONTEXT: &str = "DD_CRASHTRACK_END_UCONTEXT";
 
-pub const DD_CRASHTRACK_DEFAULT_TIMEOUT_MS: u32 = 5_000;
-pub const DD_CRASHTRACK_MINIMUM_REAP_TIME_MS: u32 = 160; // 4ms per sched slice, give ~4x10 slices
-                                                         // for safety
+pub const DD_CRASHTRACK_DEFAULT_TIMEOUT: Duration = Duration::from_millis(5_000);

--- a/ddcommon/Cargo.toml
+++ b/ddcommon/Cargo.toml
@@ -33,6 +33,7 @@ pin-project = "1"
 regex = "1.5"
 rustls = { version = "0.23", default-features = false, optional = true }
 rustls-native-certs = { version = "0.8.1", optional = true }
+thiserror = "1.0"
 tokio = { version = "1.23", features = ["rt", "macros"] }
 tokio-rustls = { version = "0.26", default-features = false, optional = true }
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
# What does this PR do?

1. Fixes a bug where we never actually waited on child processes
2. Introduces a `TimeoutManager` which enables easier reasoning about timeouts.
3. Fixes a bug where we failed to loop on the `poll` when we had a resumable error code
4. Uses static errors instead of `anyhow` in several places. Anyhow can allocate, and is not safe in a signal handler.
5. Various other cleanups

# Motivation

Make the crashtracker code easier to reason about as I try to debug some Ruby hangs.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
