### PR TITLE
Enable logging feature for windows builds.

### DIFF
--- a/windows/build-artifacts.ps1
+++ b/windows/build-artifacts.ps1
@@ -27,7 +27,8 @@ $features = @(
     "datadog-profiling-ffi/crashtracker-receiver",
     "datadog-profiling-ffi/ddtelemetry-ffi",
     "datadog-profiling-ffi/demangler",
-    "datadog-library-config-ffi"
+    "datadog-library-config-ffi",
+    "datadog-log-ffi"
 ) -join ","
 
 Write-Host "Building for features: $features" -ForegroundColor Magenta


### PR DESCRIPTION
# What does this PR do?

Enables the datadog-log-ffi feature for windows builds.

# Motivation

Missed to enable it when the feature was introduced.
