### PR TITLE
Add config for dd-octo-sts so gitlab jobs can access repo

### DIFF
--- a/.github/chainguard/gitlab.libddprof-comment-pr.sts.yaml
+++ b/.github/chainguard/gitlab.libddprof-comment-pr.sts.yaml
@@ -1,0 +1,7 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/libdatadog
+
+permissions:
+  metadata: read
+  pull_requests: write

--- a/.github/chainguard/gitlab.libddprof-draft-release.sts.yaml
+++ b/.github/chainguard/gitlab.libddprof-draft-release.sts.yaml
@@ -1,0 +1,7 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/libdatadog
+
+permissions:
+  contents: write
+  metadata: read


### PR DESCRIPTION
# What does this PR do?

We want to use dd-octo-sts to give github access to gitlab pipelines. These files define the access the draft release and PR comment scripts will have in gitlab. 

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Can't be validated until merged unfortunately. 
