### PR TITLE
style: fix new lints in Rust 1.88

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,7 +20,8 @@
     // Features to add to the dev container. More info: https://containers.dev/features.
     "features": {
         "ghcr.io/devcontainers/features/rust:1": {},
-        "ghcr.io/devcontainers-extra/features/cmake:1": {}
+        "ghcr.io/devcontainers-extra/features/cmake:1": {},
+        "ghcr.io/devcontainers/features/go:1": {}
     },
 
     // Use 'postCreateCommand' to run commands after the container is created.

--- a/bin_tests/src/modes/behavior.rs
+++ b/bin_tests/src/modes/behavior.rs
@@ -101,6 +101,6 @@ pub fn get_behavior(mode_str: &str) -> Box<dyn Behavior> {
         "chained" => Box::new(test_007_chaining::Test),
         "fork" => Box::new(test_008_fork::Test),
         "prechain_abort" => Box::new(test_009_prechain_with_abort::Test),
-        _ => panic!("Unknown mode: {}", mode_str),
+        _ => panic!("Unknown mode: {mode_str}"),
     }
 }

--- a/builder/src/arch/apple.rs
+++ b/builder/src/arch/apple.rs
@@ -28,18 +28,13 @@ pub fn fix_rpath(lib_path: &str) {
             .expect("Failed to fix rpath using install_name_tool");
         match exit_status.code() {
             Some(0) => {}
-            Some(rc) => panic!(
-                "Failed to fix rpath using install_name_tool: return code {}",
-                rc
-            ),
+            Some(rc) => panic!("Failed to fix rpath using install_name_tool: return code {rc}"),
             None => match exit_status.signal() {
-                Some(sig) => panic!(
-                    "Failed to fix rpath using install_name_tool: killed by signal {}",
-                    sig
-                ),
+                Some(sig) => {
+                    panic!("Failed to fix rpath using install_name_tool: killed by signal {sig}")
+                }
                 None => panic!(
-                    "Failed to fix rpath using install_name_tool: exit status {:?}",
-                    exit_status
+                    "Failed to fix rpath using install_name_tool: exit status {exit_status:?}"
                 ),
             },
         }

--- a/builder/src/bin/release.rs
+++ b/builder/src/bin/release.rs
@@ -123,6 +123,6 @@ pub fn main() {
             builder.sanitize_libraries();
             builder.pack().unwrap()
         }
-        Err(err) => panic!("{}", format!("Building failed: {}", err)),
+        Err(err) => panic!("{}", format!("Building failed: {err}")),
     }
 }

--- a/data-pipeline/src/telemetry/error.rs
+++ b/data-pipeline/src/telemetry/error.rs
@@ -17,8 +17,8 @@ pub enum TelemetryError {
 impl Display for TelemetryError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TelemetryError::Builder(e) => write!(f, "Telemetry client builder failed: {}", e),
-            TelemetryError::Send(e) => write!(f, "Send metric failed: {}", e),
+            TelemetryError::Builder(e) => write!(f, "Telemetry client builder failed: {e}"),
+            TelemetryError::Send(e) => write!(f, "Send metric failed: {e}"),
         }
     }
 }

--- a/data-pipeline/src/trace_exporter/error.rs
+++ b/data-pipeline/src/trace_exporter/error.rs
@@ -40,12 +40,12 @@ pub enum BuilderErrorKind {
 impl Display for BuilderErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            BuilderErrorKind::InvalidUri(msg) => write!(f, "Invalid URI: {}", msg),
+            BuilderErrorKind::InvalidUri(msg) => write!(f, "Invalid URI: {msg}"),
             BuilderErrorKind::InvalidTelemetryConfig => {
                 write!(f, "Invalid telemetry configuration")
             }
             BuilderErrorKind::InvalidConfiguration(msg) => {
-                write!(f, "Invalid configuration: {}", msg)
+                write!(f, "Invalid configuration: {msg}")
             }
         }
     }
@@ -63,7 +63,7 @@ impl Display for InternalErrorKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             InternalErrorKind::InvalidWorkerState(msg) => {
-                write!(f, "Invalid worker state: {}", msg)
+                write!(f, "Invalid worker state: {msg}")
             }
         }
     }

--- a/data-pipeline/tests/test_trace_exporter.rs
+++ b/data-pipeline/tests/test_trace_exporter.rs
@@ -126,7 +126,7 @@ mod tracing_integration_tests {
             let data = get_v04_trace_snapshot_test_payload("test_exporter_v04_snapshot");
 
             let response = trace_exporter.send(data.as_ref(), 1);
-            let expected_response = format!("{{\"rate_by_service\": {}}}", rate_param);
+            let expected_response = format!("{{\"rate_by_service\": {rate_param}}}");
 
             assert!(response.is_ok());
             assert_eq!(response.unwrap().body, expected_response)
@@ -176,7 +176,7 @@ mod tracing_integration_tests {
             let data = get_v04_trace_snapshot_test_payload("test_exporter_v04_v05_snapshot");
 
             let response = trace_exporter.send(data.as_ref(), 1);
-            let expected_response = format!("{{\"rate_by_service\": {}}}", rate_param);
+            let expected_response = format!("{{\"rate_by_service\": {rate_param}}}");
 
             assert!(response.is_ok());
             assert_eq!(response.unwrap().body, expected_response)
@@ -219,7 +219,7 @@ mod tracing_integration_tests {
             let data = get_v05_trace_snapshot_test_payload();
 
             let response = trace_exporter.send(data.as_ref(), 1);
-            let expected_response = format!("{{\"rate_by_service\": {}}}", rate_param);
+            let expected_response = format!("{{\"rate_by_service\": {rate_param}}}");
 
             assert!(response.is_ok());
             assert_eq!(response.unwrap().body, expected_response)

--- a/data-pipeline/tests/test_trace_exporter.rs
+++ b/data-pipeline/tests/test_trace_exporter.rs
@@ -292,7 +292,7 @@ mod tracing_integration_tests {
             let data = get_v04_trace_snapshot_test_payload("test_exporter_v04_snapshot_uds");
 
             let response = trace_exporter.send(data.as_ref(), 1);
-            let expected_response = format!("{{\"rate_by_service\": {}}}", rate_param);
+            let expected_response = format!("{{\"rate_by_service\": {rate_param}}}");
 
             assert!(response.is_ok());
             assert_eq!(response.unwrap().body, expected_response)

--- a/datadog-crashtracker-ffi/src/collector_windows/api.rs
+++ b/datadog-crashtracker-ffi/src/collector_windows/api.rs
@@ -39,7 +39,7 @@ pub extern "C" fn ddog_crasht_init_windows(
     })();
 
     if let Err(e) = result {
-        output_debug_string(format!("ddog_crasht_init_windows failed: {}", e).as_str());
+        output_debug_string(format!("ddog_crasht_init_windows failed: {e}").as_str());
         return false;
     }
 
@@ -110,7 +110,7 @@ pub extern "C" fn OutOfProcessExceptionEventCallback(
     })();
 
     if let Err(e) = result {
-        output_debug_string(format!("OutOfProcessExceptionEventCallback failed: {}", e).as_str());
+        output_debug_string(format!("OutOfProcessExceptionEventCallback failed: {e}").as_str());
         return E_FAIL;
     }
 

--- a/datadog-crashtracker-ffi/tests/collector_windows_test.rs
+++ b/datadog-crashtracker-ffi/tests/collector_windows_test.rs
@@ -15,7 +15,7 @@ fn test_crash() {
         "release"
     };
 
-    println!("Profile: {:?}", profile);
+    println!("Profile: {profile:?}");
 
     let tmpdir = tempfile::TempDir::new().unwrap();
     let dirpath = tmpdir.path();
@@ -23,7 +23,7 @@ fn test_crash() {
 
     let test_app_path = get_artifact_dir().join(profile).join("test_app.exe");
 
-    println!("Test app path: {:?}", test_app_path);
+    println!("Test app path: {test_app_path:?}");
 
     let output = process::Command::new(test_app_path)
         .arg(crash_path.to_str().unwrap())
@@ -41,7 +41,7 @@ fn test_crash() {
         .context("deserializing crash report to json")
         .unwrap();
 
-    println!("Crash payload: {:?}", crash_payload);
+    println!("Crash payload: {crash_payload:?}");
 
     assert_eq!(&crash_payload["error"]["is_crash"], true);
     assert_eq!(&crash_payload["error"]["kind"], "Panic");

--- a/datadog-crashtracker-ffi/tests/test_app/src/main.rs
+++ b/datadog-crashtracker-ffi/tests/test_app/src/main.rs
@@ -47,15 +47,12 @@ fn init_crashtracking(crash_path: &str, module_name: &str) -> bool {
     // SAFETY: No preconditions
     unsafe { SetErrorMode(THREAD_ERROR_MODE(0x0001)) };
 
-    println!(
-        "Registering crash handler with module name: {}",
-        module_name
-    );
+    println!("Registering crash handler with module name: {module_name}");
 
     // Check if file exists
     let path = Path::new(&module_name);
     if !path.exists() {
-        println!("File does not exist: {:?}", path);
+        println!("File does not exist: {path:?}");
         return false;
     }
 

--- a/datadog-crashtracker-ffi/tests/test_app/src/main.rs
+++ b/datadog-crashtracker-ffi/tests/test_app/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
     }
 
     let crash_path = &args[1];
-    println!("Crash path: {}", crash_path);
+    println!("Crash path: {crash_path}");
 
     // Get the directory of the current exe
     let exe_path = std::env::current_exe().unwrap();

--- a/datadog-crashtracker-ffi/tests/test_app/src/main.rs
+++ b/datadog-crashtracker-ffi/tests/test_app/src/main.rs
@@ -59,7 +59,7 @@ fn init_crashtracking(crash_path: &str, module_name: &str) -> bool {
         return false;
     }
 
-    let endpoint = Endpoint::from_slice(format!("file://{}", crash_path).as_str());
+    let endpoint = Endpoint::from_slice(format!("file://{crash_path}").as_str());
 
     let metadata = Metadata {
         family: CharSlice::from("test_family"),

--- a/datadog-crashtracker/src/collector/api.rs
+++ b/datadog-crashtracker/src/collector/api.rs
@@ -296,7 +296,7 @@ mod tests {
 
                 // Compare the initial and after-init sigaltstacks
                 if initial_sigaltstack == after_init_sigaltstack {
-                    eprintln!("Initial sigaltstack: {:?}", initial_sigaltstack);
+                    eprintln!("Initial sigaltstack: {initial_sigaltstack:?}");
                     std::process::exit(-5);
                 }
 
@@ -419,7 +419,7 @@ mod tests {
 
                 // Compare the initial and after-init sigaltstacks:  they should be the same!
                 if initial_sigaltstack != after_init_sigaltstack {
-                    eprintln!("Initial sigaltstack: {:?}", initial_sigaltstack);
+                    eprintln!("Initial sigaltstack: {initial_sigaltstack:?}");
                     std::process::exit(-5);
                 }
 
@@ -550,7 +550,7 @@ mod tests {
                 // we did not enable anything!  This checks that we don't
                 // erroneously build the altstack.
                 if initial_sigaltstack != after_init_sigaltstack {
-                    eprintln!("Initial sigaltstack: {:?}", initial_sigaltstack);
+                    eprintln!("Initial sigaltstack: {initial_sigaltstack:?}");
                     std::process::exit(-5);
                 }
 

--- a/datadog-crashtracker/src/collector/emitters.rs
+++ b/datadog-crashtracker/src/collector/emitters.rs
@@ -133,7 +133,7 @@ pub(crate) fn emit_crashreport(
 
 fn emit_config(w: &mut impl Write, config_str: &str) -> anyhow::Result<()> {
     writeln!(w, "{DD_CRASHTRACK_BEGIN_CONFIG}")?;
-    writeln!(w, "{}", config_str)?;
+    writeln!(w, "{config_str}")?;
     writeln!(w, "{DD_CRASHTRACK_END_CONFIG}")?;
     w.flush()?;
     Ok(())
@@ -141,7 +141,7 @@ fn emit_config(w: &mut impl Write, config_str: &str) -> anyhow::Result<()> {
 
 fn emit_metadata(w: &mut impl Write, metadata_str: &str) -> anyhow::Result<()> {
     writeln!(w, "{DD_CRASHTRACK_BEGIN_METADATA}")?;
-    writeln!(w, "{}", metadata_str)?;
+    writeln!(w, "{metadata_str}")?;
     writeln!(w, "{DD_CRASHTRACK_END_METADATA}")?;
     w.flush()?;
     Ok(())

--- a/datadog-crashtracker/src/collector/process_handle.rs
+++ b/datadog-crashtracker/src/collector/process_handle.rs
@@ -24,7 +24,7 @@ impl ProcessHandle {
             // If we have less than the minimum amount of time, give ourselves a few scheduler
             // slices worth of headroom to help guarantee that we don't leak a zombie process.
             let kill_result = unsafe { libc::kill(pid, libc::SIGKILL) };
-            debug_assert_eq!(kill_result, 0, "kill failed with result: {}", kill_result);
+            debug_assert_eq!(kill_result, 0, "kill failed with result: {kill_result}");
 
             // `self` is actually a handle to a child process and `self.pid` is the child process's
             // pid.

--- a/datadog-crashtracker/src/receiver/entry_points.rs
+++ b/datadog-crashtracker/src/receiver/entry_points.rs
@@ -58,9 +58,8 @@ pub fn get_receiver_unix_socket(socket_path: impl AsRef<str>) -> anyhow::Result<
     fn path_bind(socket_path: impl AsRef<str>) -> anyhow::Result<UnixListener> {
         let socket_path = socket_path.as_ref();
         if std::fs::metadata(socket_path).is_ok() {
-            std::fs::remove_file(socket_path).with_context(|| {
-                format!("could not delete previous socket at {:?}", socket_path)
-            })?;
+            std::fs::remove_file(socket_path)
+                .with_context(|| format!("could not delete previous socket at {socket_path:?}"))?;
         }
         Ok(UnixListener::bind(socket_path)?)
     }

--- a/datadog-crashtracker/src/receiver/receive_report.rs
+++ b/datadog-crashtracker/src/receiver/receive_report.rs
@@ -57,7 +57,7 @@ fn process_line(
                 // The config might contain sensitive data, don't log it.
                 eprintln!("Unexpected double config");
             }
-            std::mem::swap(config, &mut Some(serde_json::from_str(line)?));
+            *config = Some(serde_json::from_str(line)?);
             StdinState::Config
         }
 

--- a/datadog-ipc/src/platform/windows/mem_handle.rs
+++ b/datadog-ipc/src/platform/windows/mem_handle.rs
@@ -166,8 +166,7 @@ impl<T: FileBackedHandle + From<MappedMem<T>>> MappedMem<T> {
         #[allow(clippy::panic)]
         if expected_size > MAPPING_MAX_SIZE {
             panic!(
-                "Tried to allocate {} bytes for shared mapping (limit: {} bytes)",
-                expected_size, MAPPING_MAX_SIZE
+                "Tried to allocate {expected_size} bytes for shared mapping (limit: {MAPPING_MAX_SIZE} bytes)",
             );
         }
 

--- a/datadog-ipc/tarpc/src/server.rs
+++ b/datadog-ipc/tarpc/src/server.rs
@@ -1085,7 +1085,7 @@ mod tests {
 
         let request = match requests.as_mut().poll_next(&mut noop_context()) {
             Poll::Ready(Some(Ok(request))) => request,
-            result => panic!("Unexpected result: {:?}", result),
+            result => panic!("Unexpected result: {result:?}"),
         };
         drop(request);
 
@@ -1106,7 +1106,7 @@ mod tests {
 
         let request = match requests.as_mut().poll_next(&mut noop_context()) {
             Poll::Ready(Some(Ok(request))) => request,
-            result => panic!("Unexpected result: {:?}", result),
+            result => panic!("Unexpected result: {result:?}"),
         };
         request.execute(|_, _| async {}).await;
         assert!(requests

--- a/datadog-library-config/src/lib.rs
+++ b/datadog-library-config/src/lib.rs
@@ -471,7 +471,7 @@ impl Configurator {
         if self.debug_logs {
             eprintln!("Called library_config_common_component:");
             eprintln!("\tsource: {source:?}");
-            eprintln!("\tconfigurator: {:?}", self);
+            eprintln!("\tconfigurator: {self:?}");
             eprintln!("\tprocess args:");
             process_info
                 .args
@@ -513,8 +513,8 @@ impl Configurator {
     ) -> anyhow::Result<Vec<LibraryConfig>> {
         if self.debug_logs {
             eprintln!("Reading stable configuration from files:");
-            eprintln!("\tlocal: {:?}", path_local);
-            eprintln!("\tfleet: {:?}", path_managed);
+            eprintln!("\tlocal: {path_local:?}");
+            eprintln!("\tfleet: {path_managed:?}");
         }
         let local_config = match fs::File::open(path_local) {
             Ok(file) => self.parse_stable_config_file(file)?,

--- a/datadog-library-config/src/tracer_metadata.rs
+++ b/datadog-library-config/src/tracer_metadata.rs
@@ -52,7 +52,7 @@ mod linux {
             .map(char::from)
             .collect();
 
-        let mfd_name: String = format!("datadog-tracer-info-{}", uid);
+        let mfd_name: String = format!("datadog-tracer-info-{uid}");
 
         let mfd = memfd::MemfdOptions::default()
             .close_on_exec(true)

--- a/datadog-log/src/logger.rs
+++ b/datadog-log/src/logger.rs
@@ -150,7 +150,7 @@ impl Logger {
                     }
                 }
             })
-            .map_err(|e| Error::from(format!("Failed to update logger configuration: {}", e)))?;
+            .map_err(|e| Error::from(format!("Failed to update logger configuration: {e}")))?;
 
         Ok(())
     }
@@ -185,7 +185,7 @@ impl Logger {
             .modify(|filter| {
                 *filter = new_filter;
             })
-            .map_err(|e| Error::from(format!("Failed to update log level: {}", e)))?;
+            .map_err(|e| Error::from(format!("Failed to update log level: {e}")))?;
 
         Ok(())
     }
@@ -226,7 +226,7 @@ fn file_layer(
     Error,
 > {
     let writer = FileWriter::new(config)
-        .map_err(|e| Error::from(format!("Failed to create file writer: {}", e)))?;
+        .map_err(|e| Error::from(format!("Failed to create file writer: {e}")))?;
 
     Ok(fmt::layer()
         .with_writer(writer)
@@ -262,7 +262,7 @@ pub fn logger_configure_file(file_config: FileConfig) -> Result<(), Error> {
     let logger_mutex = &LOGGER;
     let mut logger_guard = logger_mutex
         .lock()
-        .map_err(|e| Error::from(format!("Failed to acquire logger lock: {}", e)))?;
+        .map_err(|e| Error::from(format!("Failed to acquire logger lock: {e}")))?;
 
     if let Some(logger) = logger_guard.as_mut() {
         logger.configure_file(file_config)
@@ -281,7 +281,7 @@ pub fn logger_disable_file() -> Result<(), Error> {
     let logger_mutex = &LOGGER;
     let mut logger_guard = logger_mutex
         .lock()
-        .map_err(|e| Error::from(format!("Failed to acquire logger lock: {}", e)))?;
+        .map_err(|e| Error::from(format!("Failed to acquire logger lock: {e}")))?;
 
     if let Some(logger) = logger_guard.as_mut() {
         logger.disable_file()
@@ -298,7 +298,7 @@ pub fn logger_configure_std(std_config: StdConfig) -> Result<(), Error> {
     let logger_mutex = &LOGGER;
     let mut logger_guard = logger_mutex
         .lock()
-        .map_err(|e| Error::from(format!("Failed to acquire logger lock: {}", e)))?;
+        .map_err(|e| Error::from(format!("Failed to acquire logger lock: {e}")))?;
 
     if let Some(logger) = logger_guard.as_mut() {
         logger.configure_std(std_config)
@@ -317,7 +317,7 @@ pub fn logger_disable_std() -> Result<(), Error> {
     let logger_mutex = &LOGGER;
     let mut logger_guard = logger_mutex
         .lock()
-        .map_err(|e| Error::from(format!("Failed to acquire logger lock: {}", e)))?;
+        .map_err(|e| Error::from(format!("Failed to acquire logger lock: {e}")))?;
 
     if let Some(logger) = logger_guard.as_mut() {
         logger.disable_std()
@@ -334,7 +334,7 @@ pub fn logger_set_log_level(log_level: LogEventLevel) -> Result<(), Error> {
     let logger_mutex = &LOGGER;
     let logger_guard = logger_mutex
         .lock()
-        .map_err(|e| Error::from(format!("Failed to acquire logger lock: {}", e)))?;
+        .map_err(|e| Error::from(format!("Failed to acquire logger lock: {e}")))?;
 
     if let Some(logger) = logger_guard.as_ref() {
         logger.set_log_level(log_level)
@@ -406,7 +406,7 @@ mod tests {
 
         fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
             let field_name = field.name();
-            let field_value = format!("{:?}", value);
+            let field_value = format!("{value:?}");
             self.all_fields
                 .insert(field_name.to_string(), field_value.clone());
 
@@ -553,8 +553,7 @@ mod tests {
 
         assert!(
             log_path.exists(),
-            "Log file should be created at {:?}",
-            log_path
+            "Log file should be created at {log_path:?}"
         );
 
         // add delay to ensure file is written
@@ -621,8 +620,7 @@ mod tests {
         // Verify that the log file was created
         assert!(
             log_path.exists(),
-            "Log file should be created at {:?}",
-            log_path
+            "Log file should be created at {log_path:?}"
         );
 
         drop(logger);

--- a/datadog-log/src/writers.rs
+++ b/datadog-log/src/writers.rs
@@ -125,11 +125,11 @@ impl CustomFileAppender {
             .filter_map(|entry| {
                 let file_name = entry.file_name().to_string_lossy().to_string();
 
-                let expected_prefix = format!("{}_", base_name);
+                let expected_prefix = format!("{base_name}_");
                 if file_name.starts_with(&expected_prefix) {
                     match &extension {
                         Some(ext) => {
-                            if file_name.ends_with(&format!(".{}", ext)) {
+                            if file_name.ends_with(&format!(".{ext}")) {
                                 let timestamp_part = &file_name
                                     [expected_prefix.len()..file_name.len() - ext.len() - 1];
                                 Some((entry.path(), timestamp_part.to_string()))

--- a/datadog-profiling-replayer/src/main.rs
+++ b/datadog-profiling-replayer/src/main.rs
@@ -103,9 +103,9 @@ impl Sysinfo {
         for (label, m) in &self.observations {
             if let Some(p) = prev {
                 let delta = *m as i64 - p;
-                println!("{}:\t{}\tDelta: {}", label, *m / 1000, delta / 1000);
+                println!("{label}:\t{}\tDelta: {}", *m / 1000, delta / 1000);
             } else {
-                println!("{}:\t{}", label, *m / 1000);
+                println!("{label}:\t{}", *m / 1000);
             }
             prev = Some(*m as i64);
         }

--- a/datadog-profiling-replayer/src/replayer.rs
+++ b/datadog-profiling-replayer/src/replayer.rs
@@ -112,6 +112,11 @@ impl<'pprof> Replayer<'pprof> {
         let mut endpoint_info = None;
         if let (Some(lsri_label), Some(endpoint_label)) = (lrsi, endpoint) {
             let num: i64 = lsri_label.num;
+            #[allow(
+                unknown_lints,
+                unnecessary_transmutes,
+                reason = "i64::cast_unsigned requires MSRV 1.87.0"
+            )]
             let local_root_span_id: u64 = unsafe { std::mem::transmute(num) };
             anyhow::ensure!(
                 local_root_span_id != 0,

--- a/datadog-profiling/src/collections/identifiable/mod.rs
+++ b/datadog-profiling/src/collections/identifiable/mod.rs
@@ -78,7 +78,7 @@ impl<T: Item> Dedup<T> for FxIndexSet<T> {
             id,
             self.len()
         );
-        small_non_zero_pprof_id(id).with_context(|| format!("invalid id generated {:?}", id))?;
+        small_non_zero_pprof_id(id).with_context(|| format!("invalid id generated {id:?}"))?;
 
         Ok(<T as Item>::Id::from_offset(id))
     }

--- a/datadog-profiling/src/internal/observation/trimmed_observation.rs
+++ b/datadog-profiling/src/internal/observation/trimmed_observation.rs
@@ -246,7 +246,7 @@ mod tests {
                             }
                             (None, None) => {}
                             _ => {
-                                panic!("a: {}, b: {}", a, b);
+                                panic!("a: {a}, b: {b}");
                             }
                         }
                     });

--- a/datadog-profiling/src/internal/profile/mod.rs
+++ b/datadog-profiling/src/internal/profile/mod.rs
@@ -2348,6 +2348,11 @@ mod api_tests {
 
         let large_span_id = u64::MAX;
         // Safety: an u64 can fit into an i64, and we're testing that it's not mis-handled.
+        #[allow(
+            unknown_lints,
+            unnecessary_transmutes,
+            reason = "u64::cast_signed requires MSRV 1.87.0"
+        )]
         let large_num: i64 = unsafe { std::mem::transmute(large_span_id) };
 
         let id2_label = api::Label {

--- a/datadog-profiling/src/internal/profile/mod.rs
+++ b/datadog-profiling/src/internal/profile/mod.rs
@@ -651,7 +651,14 @@ impl Profile {
         let local_root_span_id = if let LabelValue::Num { num, .. } = label.get_value() {
             // Safety: the value is an u64, but pprof only has signed values, so we
             // transmute it; the backend does the same.
-            unsafe { std::mem::transmute::<i64, u64>(*num) }
+            #[allow(
+                unknown_lints,
+                unnecessary_transmutes,
+                reason = "i64::cast_unsigned requires MSRV 1.87.0"
+            )]
+            unsafe {
+                std::mem::transmute::<i64, u64>(*num)
+            }
         } else {
             return Err(anyhow::format_err!("the local root span id label value must be sent as a number, not a string, given {:?}",
             label));
@@ -695,7 +702,7 @@ impl Profile {
     fn get_stacktrace(&self, st: StackTraceId) -> anyhow::Result<&StackTrace> {
         self.stack_traces
             .get_index(st.to_raw_id())
-            .with_context(|| format!("StackTraceId {:?} to exist in profile", st))
+            .with_context(|| format!("StackTraceId {st:?} to exist in profile"))
     }
 
     /// Interns the `str` as a string, returning the id in the string table.

--- a/datadog-remote-config/examples/remote_config_fetch.rs
+++ b/datadog-remote-config/examples/remote_config_fetch.rs
@@ -86,10 +86,10 @@ fn print_file_contents(contents: &anyhow::Result<RemoteConfigData>) {
     // Note: these contents may be large. Do not actually print it fully in a non-dev env.
     match contents {
         Ok(data) => {
-            println!("File contents: {:?}", data);
+            println!("File contents: {data:?}");
         }
         Err(e) => {
-            println!("Failed parsing file: {:?}", e);
+            println!("Failed parsing file: {e:?}");
         }
     }
 }

--- a/datadog-remote-config/src/path.rs
+++ b/datadog-remote-config/src/path.rs
@@ -38,7 +38,7 @@ impl Display for RemoteConfigProduct {
             RemoteConfigProduct::AsmFeatures => "ASM_FEATURES",
             RemoteConfigProduct::LiveDebugger => "LIVE_DEBUGGING",
         };
-        write!(f, "{}", str)
+        write!(f, "{str}")
     }
 }
 

--- a/datadog-sidecar-ffi/src/lib.rs
+++ b/datadog-sidecar-ffi/src/lib.rs
@@ -778,7 +778,7 @@ pub unsafe extern "C" fn ddog_sidecar_dump(
 ) -> ffi::CharSlice {
     let str = match blocking::dump(transport) {
         Ok(dump) => dump,
-        Err(e) => format!("{:?}", e),
+        Err(e) => format!("{e:?}"),
     };
     let size = str.len();
     let malloced = libc::malloc(size) as *mut u8;
@@ -795,7 +795,7 @@ pub unsafe extern "C" fn ddog_sidecar_stats(
 ) -> ffi::CharSlice {
     let str = match blocking::stats(transport) {
         Ok(stats) => stats,
-        Err(e) => format!("{:?}", e),
+        Err(e) => format!("{e:?}"),
     };
     let size = str.len();
     let malloced = libc::malloc(size) as *mut u8;

--- a/datadog-sidecar/src/service/debugger_diagnostics_bookkeeper.rs
+++ b/datadog-sidecar/src/service/debugger_diagnostics_bookkeeper.rs
@@ -118,8 +118,8 @@ impl DebuggerDiagnosticsBookkeeper {
         DebuggerDiagnosticsBookkeeperStats {
             runtime_ids: buffers.len() as u32,
             total_probes: buffers
-                .iter()
-                .map(|(_, active)| active.active_probes.len() as u32)
+                .values()
+                .map(|active| active.active_probes.len() as u32)
                 .sum(),
         }
     }

--- a/datadog-sidecar/src/shm_remote_config.rs
+++ b/datadog-sidecar/src/shm_remote_config.rs
@@ -180,7 +180,7 @@ fn store_shm(
     let sliced_path = &hashed_path[..30 - name.len()];
     #[cfg(not(target_os = "macos"))]
     let sliced_path = &hashed_path;
-    let name = format!("/{}-{}", name, sliced_path);
+    let name = format!("/{name}-{sliced_path}");
     let len = file.len();
     #[cfg(windows)]
     let len = len + 4;
@@ -210,7 +210,7 @@ impl MultiTargetHandlers<StoredShmFile> for ConfigFileStorage {
             Entry::Vacant(e) => e.insert(match RemoteConfigWriter::new(&self.invariants, target) {
                 Ok(w) => w,
                 Err(e) => {
-                    let msg = format!("Failed acquiring a remote config shm writer: {:?}", e);
+                    let msg = format!("Failed acquiring a remote config shm writer: {e:?}");
                     error!(msg);
                     return false;
                 }

--- a/datadog-trace-obfuscation/src/credit_cards.rs
+++ b/datadog-trace-obfuscation/src/credit_cards.rs
@@ -258,8 +258,7 @@ mod tests {
             let actual = valid_card_prefix(num);
             assert_eq!(
                 actual, expected,
-                "card prefix '{}' was expected to be {:?} but got {:?}",
-                num, expected, actual
+                "card prefix '{num}' was expected to be {expected:?} but got {actual:?}"
             )
         }
     }
@@ -280,8 +279,7 @@ mod tests {
         for invalid_card in invalid_cards {
             assert!(
                 !is_card_number(invalid_card, false),
-                "invalid card '{}' was detected as valid",
-                invalid_card
+                "invalid card '{invalid_card}' was detected as valid"
             );
         }
     }
@@ -418,8 +416,7 @@ mod tests {
         for valid_card in valid_cards {
             assert!(
                 is_card_number(valid_card, false),
-                "valid card '{}' was detected as invalid",
-                valid_card
+                "valid card '{valid_card}' was detected as invalid"
             );
         }
     }

--- a/datadog-trace-obfuscation/src/redis_tokenizer.rs
+++ b/datadog-trace-obfuscation/src/redis_tokenizer.rs
@@ -396,7 +396,7 @@ mod tests {
         for i in 0..expected.len() {
             let res = tokenizer.scan();
             assert_eq!(
-                format!("{:?}", res),
+                format!("{res:?}"),
                 format!("RedisTokenizerScanResult {}", expected[i])
             );
         }

--- a/datadog-trace-utils/src/msgpack_decoder/decode/error.rs
+++ b/datadog-trace-utils/src/msgpack_decoder/decode/error.rs
@@ -19,11 +19,11 @@ pub enum DecodeError {
 impl std::fmt::Display for DecodeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            DecodeError::InvalidConversion(msg) => write!(f, "Failed to convert value: {}", msg),
-            DecodeError::InvalidType(msg) => write!(f, "Invalid type encountered: {}", msg),
-            DecodeError::InvalidFormat(msg) => write!(f, "Invalid format: {}", msg),
+            DecodeError::InvalidConversion(msg) => write!(f, "Failed to convert value: {msg}"),
+            DecodeError::InvalidType(msg) => write!(f, "Invalid type encountered: {msg}"),
+            DecodeError::InvalidFormat(msg) => write!(f, "Invalid format: {msg}"),
             DecodeError::IOError => write!(f, "Failed to read from buffer"),
-            DecodeError::Utf8Error(msg) => write!(f, "Failed to read utf8 value: {}", msg),
+            DecodeError::Utf8Error(msg) => write!(f, "Failed to read utf8 value: {msg}"),
         }
     }
 }

--- a/datadog-trace-utils/src/msgpack_decoder/decode/number.rs
+++ b/datadog-trace-utils/src/msgpack_decoder/decode/number.rs
@@ -15,9 +15,9 @@ pub enum Number {
 impl fmt::Display for Number {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Number::Signed(val) => write!(f, "{}", val),
-            Number::Unsigned(val) => write!(f, "{}", val),
-            Number::Float(val) => write!(f, "{}", val),
+            Number::Signed(val) => write!(f, "{val}"),
+            Number::Unsigned(val) => write!(f, "{val}"),
+            Number::Float(val) => write!(f, "{val}"),
         }
     }
 }
@@ -47,11 +47,10 @@ impl Number {
                 };
                 if val >= lower_bound.try_into().unwrap() && upper_bound_check {
                     val.try_into()
-                        .map_err(|e| DecodeError::InvalidConversion(format!("{:?}", e)))
+                        .map_err(|e| DecodeError::InvalidConversion(format!("{e:?}")))
                 } else {
                     Err(DecodeError::InvalidConversion(format!(
-                        "{} is out of bounds for conversion",
-                        val
+                        "{val} is out of bounds for conversion"
                     )))
                 }
             }
@@ -64,11 +63,10 @@ impl Number {
 
                 if upper_bound_check {
                     val.try_into()
-                        .map_err(|e| DecodeError::InvalidConversion(format!("{:?}", e)))
+                        .map_err(|e| DecodeError::InvalidConversion(format!("{e:?}")))
                 } else {
                     Err(DecodeError::InvalidConversion(format!(
-                        "{} is out of bounds for conversion",
-                        val
+                        "{val} is out of bounds for conversion"
                     )))
                 }
             }
@@ -130,8 +128,7 @@ impl TryFrom<Number> for f64 {
                     Ok(val as f64)
                 } else {
                     Err(DecodeError::InvalidConversion(format!(
-                        "{} is out of bounds for conversion",
-                        val
+                        "{val} is out of bounds for conversion"
                     )))
                 }
             }
@@ -140,8 +137,7 @@ impl TryFrom<Number> for f64 {
                     Ok(val as f64)
                 } else {
                     Err(DecodeError::InvalidConversion(format!(
-                        "{} is out of bounds for conversion",
-                        val
+                        "{val} is out of bounds for conversion"
                     )))
                 }
             }
@@ -324,8 +320,7 @@ mod tests {
         );
         assert_eq!(
             Err(DecodeError::InvalidConversion(format!(
-                "{} is out of bounds for conversion",
-                invalid_unsigned
+                "{invalid_unsigned} is out of bounds for conversion"
             ))),
             TryInto::<i64>::try_into(invalid_unsigned_number)
         );
@@ -369,22 +364,19 @@ mod tests {
         );
         assert_eq!(
             Err(DecodeError::InvalidConversion(format!(
-                "{} is out of bounds for conversion",
-                invalid_unsigned
+                "{invalid_unsigned} is out of bounds for conversion"
             ))),
             TryInto::<i32>::try_into(invalid_unsigned_number)
         );
         assert_eq!(
             Err(DecodeError::InvalidConversion(format!(
-                "{} is out of bounds for conversion",
-                invalid_signed_upper
+                "{invalid_signed_upper} is out of bounds for conversion"
             ))),
             TryInto::<i32>::try_into(invalid_signed_number_upper)
         );
         assert_eq!(
             Err(DecodeError::InvalidConversion(format!(
-                "{} is out of bounds for conversion",
-                invalid_signed_lower
+                "{invalid_signed_lower} is out of bounds for conversion"
             ))),
             TryInto::<i32>::try_into(invalid_signed_number_lower)
         );
@@ -429,22 +421,19 @@ mod tests {
         );
         assert_eq!(
             Err(DecodeError::InvalidConversion(format!(
-                "{} is out of bounds for conversion",
-                invalid_unsigned
+                "{invalid_unsigned} is out of bounds for conversion"
             ))),
             TryInto::<i8>::try_into(invalid_unsigned_number)
         );
         assert_eq!(
             Err(DecodeError::InvalidConversion(format!(
-                "{} is out of bounds for conversion",
-                invalid_signed_upper
+                "{invalid_signed_upper} is out of bounds for conversion"
             ))),
             TryInto::<i8>::try_into(invalid_signed_number_upper)
         );
         assert_eq!(
             Err(DecodeError::InvalidConversion(format!(
-                "{} is out of bounds for conversion",
-                invalid_signed_lower
+                "{invalid_signed_lower} is out of bounds for conversion"
             ))),
             TryInto::<i8>::try_into(invalid_signed_number_lower)
         );
@@ -489,22 +478,19 @@ mod tests {
         );
         assert_eq!(
             Err(DecodeError::InvalidConversion(format!(
-                "{} is out of bounds for conversion",
-                invalid_unsigned
+                "{invalid_unsigned} is out of bounds for conversion"
             ))),
             TryInto::<i8>::try_into(invalid_unsigned_number)
         );
         assert_eq!(
             Err(DecodeError::InvalidConversion(format!(
-                "{} is out of bounds for conversion",
-                invalid_signed_upper
+                "{invalid_signed_upper} is out of bounds for conversion"
             ))),
             TryInto::<i8>::try_into(invalid_signed_number_upper)
         );
         assert_eq!(
             Err(DecodeError::InvalidConversion(format!(
-                "{} is out of bounds for conversion",
-                invalid_signed_lower
+                "{invalid_signed_lower} is out of bounds for conversion"
             ))),
             TryInto::<i8>::try_into(invalid_signed_number_lower)
         );
@@ -549,22 +535,19 @@ mod tests {
         );
         assert_eq!(
             Err(DecodeError::InvalidConversion(format!(
-                "{} is out of bounds for conversion",
-                invalid_unsigned
+                "{invalid_unsigned} is out of bounds for conversion"
             ))),
             TryInto::<u8>::try_into(invalid_unsigned_number)
         );
         assert_eq!(
             Err(DecodeError::InvalidConversion(format!(
-                "{} is out of bounds for conversion",
-                invalid_signed_upper
+                "{invalid_signed_upper} is out of bounds for conversion"
             ))),
             TryInto::<u8>::try_into(invalid_signed_number_upper)
         );
         assert_eq!(
             Err(DecodeError::InvalidConversion(format!(
-                "{} is out of bounds for conversion",
-                invalid_signed_lower
+                "{invalid_signed_lower} is out of bounds for conversion"
             ))),
             TryInto::<u8>::try_into(invalid_signed_number_lower)
         );
@@ -609,22 +592,19 @@ mod tests {
         );
         assert_eq!(
             Err(DecodeError::InvalidConversion(format!(
-                "{} is out of bounds for conversion",
-                invalid_unsigned
+                "{invalid_unsigned} is out of bounds for conversion"
             ))),
             TryInto::<u32>::try_into(invalid_unsigned_number)
         );
         assert_eq!(
             Err(DecodeError::InvalidConversion(format!(
-                "{} is out of bounds for conversion",
-                invalid_signed_upper
+                "{invalid_signed_upper} is out of bounds for conversion"
             ))),
             TryInto::<u32>::try_into(invalid_signed_number_upper)
         );
         assert_eq!(
             Err(DecodeError::InvalidConversion(format!(
-                "{} is out of bounds for conversion",
-                invalid_signed_lower
+                "{invalid_signed_lower} is out of bounds for conversion"
             ))),
             TryInto::<u32>::try_into(invalid_signed_number_lower)
         );
@@ -666,8 +646,7 @@ mod tests {
         );
         assert_eq!(
             Err(DecodeError::InvalidConversion(format!(
-                "{} is out of bounds for conversion",
-                invalid_signed_lower
+                "{invalid_signed_lower} is out of bounds for conversion"
             ))),
             TryInto::<u64>::try_into(invalid_signed_number_lower)
         );
@@ -702,8 +681,7 @@ mod tests {
         assert_eq!(0f64, TryInto::<f64>::try_into(zero_unsigned).unwrap());
         assert_eq!(
             Err(DecodeError::InvalidConversion(format!(
-                "{} is out of bounds for conversion",
-                invalid_unsigned
+                "{invalid_unsigned} is out of bounds for conversion"
             ))),
             TryInto::<i64>::try_into(invalid_unsigned_number)
         );

--- a/datadog-trace-utils/src/msgpack_decoder/decode/span_event.rs
+++ b/datadog-trace-utils/src/msgpack_decoder/decode/span_event.rs
@@ -57,7 +57,7 @@ impl FromStr for SpanEventKey {
             "name" => Ok(SpanEventKey::Name),
             "attributes" => Ok(SpanEventKey::Attributes),
             _ => Err(DecodeError::InvalidFormat(
-                format!("Invalid span event key: {}", s).to_owned(),
+                format!("Invalid span event key: {s}").to_owned(),
             )),
         }
     }
@@ -211,7 +211,7 @@ impl FromStr for AttributeArrayKey {
             "int_value" => Ok(AttributeArrayKey::IntValue),
             "double_value" => Ok(AttributeArrayKey::DoubleValue),
             _ => Err(DecodeError::InvalidFormat(
-                format!("Invalid attribute key: {}", s).to_owned(),
+                format!("Invalid attribute key: {s}").to_owned(),
             )),
         }
     }

--- a/datadog-trace-utils/src/msgpack_decoder/decode/span_link.rs
+++ b/datadog-trace-utils/src/msgpack_decoder/decode/span_link.rs
@@ -65,7 +65,7 @@ impl FromStr for SpanLinkKey {
             "tracestate" => Ok(SpanLinkKey::Tracestate),
             "flags" => Ok(SpanLinkKey::Flags),
             _ => Err(DecodeError::InvalidFormat(
-                format!("Invalid span link key: {}", s).to_owned(),
+                format!("Invalid span link key: {s}").to_owned(),
             )),
         }
     }

--- a/datadog-trace-utils/src/msgpack_decoder/decode/string.rs
+++ b/datadog-trace-utils/src/msgpack_decoder/decode/string.rs
@@ -19,7 +19,7 @@ pub fn read_string_ref_nomut(buf: &[u8]) -> Result<(&str, &[u8]), DecodeError> {
         DecodeStringError::InvalidMarkerRead(e) => DecodeError::InvalidFormat(e.to_string()),
         DecodeStringError::InvalidDataRead(e) => DecodeError::InvalidConversion(e.to_string()),
         DecodeStringError::TypeMismatch(marker) => {
-            DecodeError::InvalidType(format!("Type mismatch at marker {:?}", marker))
+            DecodeError::InvalidType(format!("Type mismatch at marker {marker:?}"))
         }
         DecodeStringError::InvalidUtf8(_, e) => DecodeError::Utf8Error(e.to_string()),
         _ => DecodeError::IOError,

--- a/datadog-trace-utils/src/msgpack_decoder/v04/mod.rs
+++ b/datadog-trace-utils/src/msgpack_decoder/v04/mod.rs
@@ -332,8 +332,8 @@ mod tests {
         let expected_meta: HashMap<String, String> = (0..20)
             .map(|i| {
                 (
-                    format!("key {}", i).to_owned(),
-                    format!("value {}", i).to_owned(),
+                    format!("key {i}").to_owned(),
+                    format!("value {i}").to_owned(),
                 )
             })
             .collect();
@@ -381,9 +381,8 @@ mod tests {
 
     #[test]
     fn test_decoder_metrics_map16_success() {
-        let expected_metrics: HashMap<String, f64> = (0..20)
-            .map(|i| (format!("metric{}", i), i as f64))
-            .collect();
+        let expected_metrics: HashMap<String, f64> =
+            (0..20).map(|i| (format!("metric{i}"), i as f64)).collect();
 
         let mut span = create_test_json_span(1, 2, 0, 0, false);
         span["metrics"] = json!(expected_metrics.clone());

--- a/datadog-trace-utils/src/span/mod.rs
+++ b/datadog-trace-utils/src/span/mod.rs
@@ -55,7 +55,7 @@ impl FromStr for SpanKey {
             "meta_struct" => Ok(SpanKey::MetaStruct),
             "span_links" => Ok(SpanKey::SpanLinks),
             "span_events" => Ok(SpanKey::SpanEvents),
-            _ => Err(SpanKeyParseError::new(format!("Invalid span key: {}", s))),
+            _ => Err(SpanKeyParseError::new(format!("Invalid span key: {s}"))),
         }
     }
 }

--- a/datadog-trace-utils/src/stats_utils.rs
+++ b/datadog-trace-utils/src/stats_utils.rs
@@ -139,7 +139,7 @@ mod mini_agent_tests {
         let v: Value = match serde_json::from_str(stats_json) {
             Ok(value) => value,
             Err(err) => {
-                panic!("Failed to parse stats JSON: {}", err);
+                panic!("Failed to parse stats JSON: {err}");
             }
         };
 

--- a/datadog-trace-utils/src/stats_utils.rs
+++ b/datadog-trace-utils/src/stats_utils.rs
@@ -213,7 +213,7 @@ mod mini_agent_tests {
         let v: Value = match serde_json::from_str(stats_json) {
             Ok(value) => value,
             Err(err) => {
-                panic!("Failed to parse stats JSON: {}", err);
+                panic!("Failed to parse stats JSON: {err}");
             }
         };
 

--- a/datadog-trace-utils/src/test_utils/datadog_test_agent.rs
+++ b/datadog-trace-utils/src/test_utils/datadog_test_agent.rs
@@ -491,10 +491,8 @@ impl DatadogTestAgent {
                         return Ok(response);
                     } else {
                         println!(
-                            "Request failed with status code: {}. Request attempt {} of {}",
-                            response.status(),
-                            attempts,
-                            max_attempts
+                            "Request failed with status code: {}. Request attempt {attempts} of {max_attempts}",
+                            response.status()
                         );
                         last_response = Ok(response);
                     }

--- a/datadog-trace-utils/src/test_utils/datadog_test_agent.rs
+++ b/datadog-trace-utils/src/test_utils/datadog_test_agent.rs
@@ -222,7 +222,7 @@ impl DatadogTestAgent {
             .await
             .unwrap();
 
-        format!("http://{}:{}", container_host, container_port)
+        format!("http://{container_host}:{container_port}")
     }
 
     /// Constructs the URI for a provided endpoint of the Datadog Test Agent by concatenating the
@@ -241,11 +241,8 @@ impl DatadogTestAgent {
     pub async fn get_uri_for_endpoint(&self, endpoint: &str, snapshot_token: Option<&str>) -> Uri {
         let base_uri_string = self.get_base_uri_string().await;
         let uri_string = match snapshot_token {
-            Some(token) => format!(
-                "{}/{}?test_session_token={}",
-                base_uri_string, endpoint, token
-            ),
-            None => format!("{}/{}", base_uri_string, endpoint),
+            Some(token) => format!("{base_uri_string}/{endpoint}?test_session_token={token}"),
+            None => format!("{base_uri_string}/{endpoint}"),
         };
 
         Uri::from_str(&uri_string).expect("Invalid URI")
@@ -265,7 +262,7 @@ impl DatadogTestAgent {
                 .map(|(k, v)| format!("{}={}", urlencoding::encode(k), urlencoding::encode(v)))
                 .collect::<Vec<_>>()
                 .join("&");
-            format!("?{}", query)
+            format!("?{query}")
         } else {
             String::new()
         };
@@ -323,8 +320,7 @@ impl DatadogTestAgent {
 
         assert_eq!(
             status_code, 200,
-            "Expected status 200, but got {}. Response body: {}",
-            status_code, body_string
+            "Expected status 200, but got {status_code}. Response body: {body_string}"
         );
     }
 
@@ -505,8 +501,7 @@ impl DatadogTestAgent {
                 }
                 Err(e) => {
                     println!(
-                        "Request failed with error: {}. Request attempt {} of {}",
-                        e, attempts, max_attempts
+                        "Request failed with error: {e}. Request attempt {attempts} of {max_attempts}"
                     );
                     last_response = Err(e)
                 }

--- a/datadog-trace-utils/src/trace_utils.rs
+++ b/datadog-trace-utils/src/trace_utils.rs
@@ -990,7 +990,7 @@ mod tests {
             .unwrap();
 
         let res = get_traces_from_request_body(request.into_body()).await;
-        assert!(res.is_ok(), "Failed to deserialize: {:?}", res);
+        assert!(res.is_ok(), "Failed to deserialize: {res:?}");
         assert_eq!(res.unwrap().1, expected_output);
     }
 

--- a/datadog-tracer-flare/src/error.rs
+++ b/datadog-tracer-flare/src/error.rs
@@ -19,10 +19,10 @@ pub enum FlareError {
 impl std::fmt::Display for FlareError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            FlareError::NoFlare(msg) => write!(f, "No flare prepared to send: {}", msg),
-            FlareError::ListeningError(msg) => write!(f, "Listening failed with: {}", msg),
-            FlareError::ParsingError(msg) => write!(f, "Parsing failed with: {}", msg),
-            FlareError::ZipError(msg) => write!(f, "Creating the zip failed with: {}", msg),
+            FlareError::NoFlare(msg) => write!(f, "No flare prepared to send: {msg}"),
+            FlareError::ListeningError(msg) => write!(f, "Listening failed with: {msg}"),
+            FlareError::ParsingError(msg) => write!(f, "Parsing failed with: {msg}"),
+            FlareError::ZipError(msg) => write!(f, "Creating the zip failed with: {msg}"),
         }
     }
 }

--- a/datadog-tracer-flare/src/lib.rs
+++ b/datadog-tracer-flare/src/lib.rs
@@ -127,8 +127,7 @@ pub fn init_remote_config_listener(
         Ok(uri) => uri,
         Err(_) => {
             return Err(FlareError::ListeningError(format!(
-                "Invalid agent url: {}",
-                agent_url
+                "Invalid agent url: {agent_url}"
             )));
         }
     };

--- a/datadog-tracer-flare/src/zip.rs
+++ b/datadog-tracer-flare/src/zip.rs
@@ -20,20 +20,20 @@ fn add_file_to_zip(
     options: &FileOptions<()>,
 ) -> Result<(), FlareError> {
     let mut file = File::open(file_path)
-        .map_err(|e| FlareError::ZipError(format!("Failed to open file {:?}: {}", file_path, e)))?;
+        .map_err(|e| FlareError::ZipError(format!("Failed to open file {file_path:?}: {e}")))?;
 
     let path = match relative_path {
         Some(relative_path) => relative_path.as_os_str(),
         None => file_path.file_name().ok_or_else(|| {
-            FlareError::ZipError(format!("Invalid file name for path: {:?}", file_path))
+            FlareError::ZipError(format!("Invalid file name for path: {file_path:?}"))
         })?,
     };
 
     zip.start_file(path.to_string_lossy().as_ref(), *options)
-        .map_err(|e| FlareError::ZipError(format!("Failed to add file to zip: {}", e)))?;
+        .map_err(|e| FlareError::ZipError(format!("Failed to add file to zip: {e}")))?;
 
     io::copy(&mut file, zip)
-        .map_err(|e| FlareError::ZipError(format!("Failed to write file to zip: {}", e)))?;
+        .map_err(|e| FlareError::ZipError(format!("Failed to write file to zip: {e}")))?;
 
     Ok(())
 }
@@ -70,7 +70,7 @@ fn zip_files(files: Vec<String>) -> Result<File, FlareError> {
 
     let file = temp_file
         .try_clone()
-        .map_err(|e| FlareError::ZipError(format!("Failed to clone temp file: {}", e)))?;
+        .map_err(|e| FlareError::ZipError(format!("Failed to clone temp file: {e}")))?;
 
     let mut zip = ZipWriter::new(file);
     let options = FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
@@ -83,19 +83,19 @@ fn zip_files(files: Vec<String>) -> Result<File, FlareError> {
             // If it's a directory, iterate through all files
             for entry in WalkDir::new(&path) {
                 let entry = entry.map_err(|e| {
-                    FlareError::ZipError(format!("Failed to read directory entry: {}", e))
+                    FlareError::ZipError(format!("Failed to read directory entry: {e}"))
                 })?;
 
                 let file_path = entry.path();
                 if file_path.is_file() {
                     // Get the directory name to create a folder in the zip
                     let dir_name = path.file_name().ok_or_else(|| {
-                        FlareError::ZipError(format!("Invalid directory name for path: {:?}", path))
+                        FlareError::ZipError(format!("Invalid directory name for path: {path:?}"))
                     })?;
 
                     // Calculate the relative path from the base directory
                     let relative_path = file_path.strip_prefix(&path).map_err(|e| {
-                        FlareError::ZipError(format!("Failed to calculate relative path: {}", e))
+                        FlareError::ZipError(format!("Failed to calculate relative path: {e}"))
                     })?;
 
                     // Create the zip path with the directory name as prefix
@@ -117,7 +117,7 @@ fn zip_files(files: Vec<String>) -> Result<File, FlareError> {
 
     // Finalize the zip
     zip.finish()
-        .map_err(|e| FlareError::ZipError(format!("Failed to finalize zip file: {}", e)))?;
+        .map_err(|e| FlareError::ZipError(format!("Failed to finalize zip file: {e}")))?;
 
     Ok(temp_file)
 }

--- a/ddcommon/src/timeout.rs
+++ b/ddcommon/src/timeout.rs
@@ -110,7 +110,7 @@ mod tests {
         let timeout = Duration::from_secs(1);
         let manager = TimeoutManager::new(timeout);
 
-        let debug_str = format!("{:?}", manager);
+        let debug_str = format!("{manager:?}");
 
         // Debug output should contain the expected fields
         assert!(debug_str.contains("TimeoutManager"));

--- a/ddcommon/src/unix_utils/execve.rs
+++ b/ddcommon/src/unix_utils/execve.rs
@@ -234,7 +234,7 @@ mod tests {
     #[test]
     fn test_prepared_execve_new_large_args() {
         let binary_path = "/bin/echo";
-        let args: Vec<String> = (0..1000).map(|i| format!("arg{}", i)).collect();
+        let args: Vec<String> = (0..1000).map(|i| format!("arg{i}")).collect();
         let env = vec![("TEST".to_string(), "value".to_string())];
 
         let prepared = PreparedExecve::new(binary_path, &args, &env).unwrap();
@@ -248,7 +248,7 @@ mod tests {
         let binary_path = "/bin/echo";
         let args = vec!["test".to_string()];
         let env: Vec<(String, String)> = (0..1000)
-            .map(|i| (format!("VAR{}", i), format!("value{}", i)))
+            .map(|i| (format!("VAR{i}"), format!("value{i}")))
             .collect();
 
         let prepared = PreparedExecve::new(binary_path, &args, &env).unwrap();

--- a/ddcommon/src/unix_utils/process.rs
+++ b/ddcommon/src/unix_utils/process.rs
@@ -168,7 +168,7 @@ mod tests {
             Err(PollError::UnexpectedResult(revents)) => {
                 println!("wait_for_pollhup({invalid_fd}, ..) returned UnexpectedResult({revents}) as allowed on this platform");
             }
-            _ => panic!("Expected error for invalid FD, got: {:?}", result),
+            _ => panic!("Expected error for invalid FD, got: {result:?}"),
         }
     }
 }

--- a/ddcommon/tests/execve_integration.rs
+++ b/ddcommon/tests/execve_integration.rs
@@ -53,15 +53,14 @@ fn test_prepared_execve_exec_echo_with_output() {
             WaitStatus::Exited(_, status) => {
                 assert_eq!(
                     status, 0,
-                    "Child did not exit successfully: status={}",
-                    status
+                    "Child did not exit successfully: status={status}"
                 );
             }
             WaitStatus::Signaled(_, sig, _) => {
-                panic!("Child terminated by signal: {:?}", sig);
+                panic!("Child terminated by signal: {sig:?}");
             }
             other => {
-                panic!("Unexpected wait status: {:?}", other);
+                panic!("Unexpected wait status: {other:?}");
             }
         }
         // Check the output
@@ -124,15 +123,14 @@ fn test_prepared_execve_exec_env_with_environment_variables() {
             WaitStatus::Exited(_, status) => {
                 assert_eq!(
                     status, 0,
-                    "Child did not exit successfully: status={}",
-                    status
+                    "Child did not exit successfully: status={status}"
                 );
             }
             WaitStatus::Signaled(_, sig, _) => {
-                panic!("Child terminated by signal: {:?}", sig);
+                panic!("Child terminated by signal: {sig:?}");
             }
             other => {
-                panic!("Unexpected wait status: {:?}", other);
+                panic!("Unexpected wait status: {other:?}");
             }
         }
         // Check the output contains our environment variables
@@ -196,15 +194,14 @@ fn test_prepared_execve_exec_with_complex_arguments() {
             WaitStatus::Exited(_, status) => {
                 assert_eq!(
                     status, 0,
-                    "Child did not exit successfully: status={}",
-                    status
+                    "Child did not exit successfully: status={status}"
                 );
             }
             WaitStatus::Signaled(_, sig, _) => {
-                panic!("Child terminated by signal: {:?}", sig);
+                panic!("Child terminated by signal: {sig:?}");
             }
             other => {
-                panic!("Unexpected wait status: {:?}", other);
+                panic!("Unexpected wait status: {other:?}");
             }
         }
         // Check the output contains all arguments
@@ -244,15 +241,14 @@ fn test_prepared_execve_exec_nonexistent_binary() {
                 // Should exit with 127 (command not found)
                 assert_eq!(
                     status, 127,
-                    "Child should have exited with 127, got {}",
-                    status
+                    "Child should have exited with 127, got {status}"
                 );
             }
             WaitStatus::Signaled(_, sig, _) => {
-                panic!("Child terminated by signal: {:?}", sig);
+                panic!("Child terminated by signal: {sig:?}");
             }
             other => {
-                panic!("Unexpected wait status: {:?}", other);
+                panic!("Unexpected wait status: {other:?}");
             }
         }
     }

--- a/ddtelemetry-ffi/src/builder/expanded.rs
+++ b/ddtelemetry-ffi/src/builder/expanded.rs
@@ -24,7 +24,7 @@ mod macros {
                 Err(e) => {
                     return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                         ({
-                            let res = std::fmt::format(format_args!("{0:?}", e));
+                            let res = std::fmt::format(format_args!("{e:?}"));
                             res
                         }),
                     ));
@@ -45,7 +45,7 @@ mod macros {
             Err(e) => {
                 return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                     ({
-                        let res = std::fmt::format(format_args!("{0:?}", e));
+                        let res = std::fmt::format(format_args!("{e:?}"));
                         res
                     }),
                 ));
@@ -67,7 +67,7 @@ mod macros {
                 Err(e) => {
                     return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                         ({
-                            let res = std::fmt::format(format_args!("{0:?}", e));
+                            let res = std::fmt::format(format_args!("{e:?}"));
                             res
                         }),
                     ));
@@ -89,7 +89,7 @@ mod macros {
                 Err(e) => {
                     return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                         ({
-                            let res = std::fmt::format(format_args!("{0:?}", e));
+                            let res = std::fmt::format(format_args!("{e:?}"));
                             res
                         }),
                     ));
@@ -111,7 +111,7 @@ mod macros {
                 Err(e) => {
                     return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                         ({
-                            let res = std::fmt::format(format_args!("{0:?}", e));
+                            let res = std::fmt::format(format_args!("{e:?}"));
                             res
                         }),
                     ));
@@ -132,7 +132,7 @@ mod macros {
             Err(e) => {
                 return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                     ({
-                        let res = std::fmt::format(format_args!("{0:?}", e));
+                        let res = std::fmt::format(format_args!("{e:?}"));
                         res
                     }),
                 ));
@@ -153,7 +153,7 @@ mod macros {
             Err(e) => {
                 return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                     ({
-                        let res = std::fmt::format(format_args!("{0:?}", e));
+                        let res = std::fmt::format(format_args!("{e:?}"));
                         res
                     }),
                 ));
@@ -174,7 +174,7 @@ mod macros {
             Err(e) => {
                 return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                     ({
-                        let res = std::fmt::format(format_args!("{0:?}", e));
+                        let res = std::fmt::format(format_args!("{e:?}"));
                         res
                     }),
                 ));
@@ -195,7 +195,7 @@ mod macros {
             Err(e) => {
                 return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                     ({
-                        let res = std::fmt::format(format_args!("{0:?}", e));
+                        let res = std::fmt::format(format_args!("{e:?}"));
                         res
                     }),
                 ));
@@ -216,7 +216,7 @@ mod macros {
             Err(e) => {
                 return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                     ({
-                        let res = std::fmt::format(format_args!("{0:?}", e));
+                        let res = std::fmt::format(format_args!("{e:?}"));
                         res
                     }),
                 ));
@@ -237,7 +237,7 @@ mod macros {
             Err(e) => {
                 return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                     ({
-                        let res = std::fmt::format(format_args!("{0:?}", e));
+                        let res = std::fmt::format(format_args!("{e:?}"));
                         res
                     }),
                 ));
@@ -306,7 +306,7 @@ mod macros {
                         Err(e) => {
                             return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                                 ({
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    let res = std::fmt::format(format_args!("{e:?}"));
                                     res
                                 }),
                             ));
@@ -323,7 +323,7 @@ mod macros {
                         Err(e) => {
                             return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                                 ({
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    let res = std::fmt::format(format_args!("{e:?}"));
                                     res
                                 }),
                             ));
@@ -340,7 +340,7 @@ mod macros {
                         Err(e) => {
                             return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                                 ({
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    let res = std::fmt::format(format_args!("{e:?}"));
                                     res
                                 }),
                             ));
@@ -357,7 +357,7 @@ mod macros {
                         Err(e) => {
                             return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                                 ({
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    let res = std::fmt::format(format_args!("{e:?}"));
                                     res
                                 }),
                             ));
@@ -374,7 +374,7 @@ mod macros {
                         Err(e) => {
                             return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                                 ({
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    let res = std::fmt::format(format_args!("{e:?}"));
                                     res
                                 }),
                             ));
@@ -391,7 +391,7 @@ mod macros {
                         Err(e) => {
                             return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                                 ({
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    let res = std::fmt::format(format_args!("{e:?}"));
                                     res
                                 }),
                             ));
@@ -407,7 +407,7 @@ mod macros {
                     Err(e) => {
                         return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                             ({
-                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                let res = std::fmt::format(format_args!("{e:?}"));
                                 res
                             }),
                         ));
@@ -424,7 +424,7 @@ mod macros {
                         Err(e) => {
                             return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                                 ({
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    let res = std::fmt::format(format_args!("{e:?}"));
                                     res
                                 }),
                             ));
@@ -441,7 +441,7 @@ mod macros {
                         Err(e) => {
                             return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                                 ({
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    let res = std::fmt::format(format_args!("{e:?}"));
                                     res
                                 }),
                             ));
@@ -458,7 +458,7 @@ mod macros {
                         Err(e) => {
                             return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                                 ({
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    let res = std::fmt::format(format_args!("{e:?}"));
                                     res
                                 }),
                             ));
@@ -474,7 +474,7 @@ mod macros {
                     Err(e) => {
                         return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                             ({
-                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                let res = std::fmt::format(format_args!("{e:?}"));
                                 res
                             }),
                         ));
@@ -523,7 +523,7 @@ mod macros {
             Err(e) => {
                 return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                     ({
-                        let res = std::fmt::format(format_args!("{0:?}", e));
+                        let res = std::fmt::format(format_args!("{e:?}"));
                         res
                     }),
                 ));
@@ -540,7 +540,7 @@ mod macros {
                         Err(e) => {
                             return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                                 ({
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    let res = std::fmt::format(format_args!("{e:?}"));
                                     res
                                 }),
                             ));
@@ -557,7 +557,7 @@ mod macros {
                         Err(e) => {
                             return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                                 ({
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    let res = std::fmt::format(format_args!("{e:?}"));
                                     res
                                 }),
                             ));
@@ -574,7 +574,7 @@ mod macros {
                         Err(e) => {
                             return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                                 ({
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    let res = std::fmt::format(format_args!("{e:?}"));
                                     res
                                 }),
                             ));
@@ -591,7 +591,7 @@ mod macros {
                         Err(e) => {
                             return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                                 ({
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    let res = std::fmt::format(format_args!("{e:?}"));
                                     res
                                 }),
                             ));
@@ -608,7 +608,7 @@ mod macros {
                         Err(e) => {
                             return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                                 ({
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    let res = std::fmt::format(format_args!("{e:?}"));
                                     res
                                 }),
                             ));
@@ -625,7 +625,7 @@ mod macros {
                         Err(e) => {
                             return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                                 ({
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    let res = std::fmt::format(format_args!("{e:?}"));
                                     res
                                 }),
                             ));
@@ -641,7 +641,7 @@ mod macros {
                     Err(e) => {
                         return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                             ({
-                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                let res = std::fmt::format(format_args!("{e:?}"));
                                 res
                             }),
                         ));
@@ -658,7 +658,7 @@ mod macros {
                         Err(e) => {
                             return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                                 ({
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    let res = std::fmt::format(format_args!("{e:?}"));
                                     res
                                 }),
                             ));
@@ -675,7 +675,7 @@ mod macros {
                         Err(e) => {
                             return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                                 ({
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    let res = std::fmt::format(format_args!("{e:?}"));
                                     res
                                 }),
                             ));
@@ -692,7 +692,7 @@ mod macros {
                         Err(e) => {
                             return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                                 ({
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    let res = std::fmt::format(format_args!("{e:?}"));
                                     res
                                 }),
                             ));
@@ -708,7 +708,7 @@ mod macros {
                     Err(e) => {
                         return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                             ({
-                                let res = std::fmt::format(format_args!("{0:?}", e));
+                                let res = std::fmt::format(format_args!("{e:?}"));
                                 res
                             }),
                         ));
@@ -730,7 +730,7 @@ mod macros {
                 Err(e) => {
                     return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                         ({
-                            let res = std::fmt::format(format_args!("{0:?}", e));
+                            let res = std::fmt::format(format_args!("{e:?}"));
                             res
                         }),
                     ));
@@ -766,7 +766,7 @@ mod macros {
                         Err(e) => {
                             return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                                 ({
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    let res = std::fmt::format(format_args!("{e:?}"));
                                     res
                                 }),
                             ));
@@ -795,7 +795,7 @@ mod macros {
             Err(e) => {
                 return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                     ({
-                        let res = std::fmt::format(format_args!("{0:?}", e));
+                        let res = std::fmt::format(format_args!("{e:?}"));
                         res
                     }),
                 ));
@@ -809,7 +809,7 @@ mod macros {
                         Err(e) => {
                             return ffi::MaybeError::Some(ddcommon_ffi::Error::from(
                                 ({
-                                    let res = std::fmt::format(format_args!("{0:?}", e));
+                                    let res = std::fmt::format(format_args!("{e:?}"));
                                     res
                                 }),
                             ));

--- a/spawn_worker/tests/trampoline_windows.rs
+++ b/spawn_worker/tests/trampoline_windows.rs
@@ -41,7 +41,7 @@ fn test_spawning_trampoline_worker() {
 
     if !status.success() {
         eprintln!("{}", fs::read_to_string(stderr.as_os_str()).unwrap());
-        panic!("unexpected exit status = {:?}", status)
+        panic!("unexpected exit status = {status:?}")
     }
 
     assert_eq!("__dummy_mirror_test symbol_name", output);

--- a/tests/spawn_from_lib/tests/spawn.rs
+++ b/tests/spawn_from_lib/tests/spawn.rs
@@ -46,7 +46,7 @@ fn test_spawning_trampoline_worker() {
 
     if !success {
         eprintln!("{stderr}");
-        panic!("unexpected exit status = {:?}", status)
+        panic!("unexpected exit status = {status:?}")
     }
 
     assert_eq!("stderr_works_as_expected", stderr.trim());

--- a/tests/spawn_from_lib/tests/spawn.rs
+++ b/tests/spawn_from_lib/tests/spawn.rs
@@ -45,7 +45,7 @@ fn test_spawning_trampoline_worker() {
     let success = status.success();
 
     if !success {
-        eprintln!("{}", stderr);
+        eprintln!("{stderr}");
         panic!("unexpected exit status = {:?}", status)
     }
 

--- a/tests/spawn_from_lib/tests/spawn_unix.rs
+++ b/tests/spawn_from_lib/tests/spawn_unix.rs
@@ -46,8 +46,8 @@ fn test_spawning_trampoline_worker() {
     let shared_file = rewind_and_read(&mut shared_file).unwrap();
 
     if code != 0 {
-        eprintln!("{}", stderr);
-        println!("{}", stdout);
+        eprintln!("{stderr}");
+        println!("{stdout}");
 
         assert_eq!(0, code, "non zero exit code");
     }

--- a/tools/sidecar_mockgen/src/bin/sidecar_mockgen.rs
+++ b/tools/sidecar_mockgen/src/bin/sidecar_mockgen.rs
@@ -17,9 +17,9 @@ fn main() {
     let binary_path = Path::new(&args[1]);
     let object_paths: Vec<_> = args.iter().skip(2).map(Path::new).collect();
     match generate_mock_symbols(binary_path, object_paths.as_slice()) {
-        Ok(symbols) => print!("{}", symbols),
+        Ok(symbols) => print!("{symbols}"),
         Err(err) => {
-            eprintln!("{}", err);
+            eprintln!("{err}");
             process::exit(1);
         }
     }

--- a/tools/sidecar_mockgen/src/lib.rs
+++ b/tools/sidecar_mockgen/src/lib.rs
@@ -64,7 +64,7 @@ pub fn generate_mock_symbols(binary: &Path, objects: &[&Path]) -> Result<String,
                     _ = match sym.kind() {
                         SymbolKind::Text => {
                             if !sym.is_weak() {
-                                writeln!(generated, "void {}() {{}}", name)
+                                writeln!(generated, "void {name}() {{}}")
                             } else {
                                 Ok(())
                             }
@@ -77,7 +77,7 @@ pub fn generate_mock_symbols(binary: &Path, objects: &[&Path]) -> Result<String,
                                 #[cfg(not(target_os = "macos"))]
                                 let ret = Ok(());
                                 #[cfg(target_os = "macos")]
-                                let ret = writeln!(generated, "char {}[1];", name);
+                                let ret = writeln!(generated, "char {name}[1];");
                                 ret
                             }
                         }
@@ -88,7 +88,7 @@ pub fn generate_mock_symbols(binary: &Path, objects: &[&Path]) -> Result<String,
                                 #[cfg(not(target_os = "macos"))]
                                 let ret = Ok(());
                                 #[cfg(target_os = "macos")]
-                                let ret = writeln!(generated, "__thread char {}[1];", name);
+                                let ret = writeln!(generated, "__thread char {name}[1];");
                                 ret
                             }
                         }


### PR DESCRIPTION
[PROF-12063](https://datadoghq.atlassian.net/browse/PROF-12063)

# What does this PR do?

This fixes lints since Rust 1.88 was just released!

# Motivation

DSN had unrelated clippy failures on another PR.

# Additional Notes

There are a few `allow`s in there because our MSRV isn't high enough for the fix.

I also added `go` to the `devcontainer.json` file, because it's required for fips. Running:

```sh
cargo clippy --workspace --all-targets --all-features 
```

On macOS doesn't work, because the FIPS mode doesn't compile. So I had to use the dev container for it.

# How to test the change?

No change in behavior! Regular tests apply.


[PROF-12063]: https://datadoghq.atlassian.net/browse/PROF-12063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ