### PR TITLE
refactor(ddcommon-ffi): `AsBytes`/`CharSlice` improvements

### DIFF
--- a/data-pipeline-ffi/src/trace_exporter.rs
+++ b/data-pipeline-ffi/src/trace_exporter.rs
@@ -855,14 +855,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
-    // TODO(APMSP-1632): investigate why test fails on ARM platforms due to a CharSlice constructor.
     fn config_invalid_input_test() {
         unsafe {
             let mut config = Some(TraceExporterConfig::default());
-            let invalid: [i8; 2] = [0x80u8 as i8, 0xFFu8 as i8];
-            let error =
-                ddog_trace_exporter_config_set_service(config.as_mut(), CharSlice::new(&invalid));
+            let invalid: [u8; 2] = [0x80u8, 0xFFu8];
+            let error = ddog_trace_exporter_config_set_service(
+                config.as_mut(),
+                CharSlice::from_bytes(&invalid),
+            );
 
             assert_eq!(error.unwrap().code, ErrorCode::InvalidInput);
         }

--- a/datadog-live-debugger-ffi/src/parse.rs
+++ b/datadog-live-debugger-ffi/src/parse.rs
@@ -11,11 +11,13 @@ pub struct LiveDebuggingParseResult {
     opaque_data: Option<Box<datadog_live_debugger::LiveDebuggingData>>,
 }
 
+/// # Safety
+/// The `json` must be a valid UTF-8 string.
 #[no_mangle]
-pub extern "C" fn ddog_parse_live_debugger_json(json: CharSlice) -> LiveDebuggingParseResult {
-    if let Ok(parsed) =
-        datadog_live_debugger::parse_json(unsafe { std::str::from_utf8_unchecked(json.as_bytes()) })
-    {
+pub unsafe extern "C" fn ddog_parse_live_debugger_json(
+    json: CharSlice,
+) -> LiveDebuggingParseResult {
+    if let Ok(parsed) = datadog_live_debugger::parse_json(unsafe { json.assume_utf8() }) {
         let parsed = Box::new(parsed);
         LiveDebuggingParseResult {
             // we have the box. Rust doesn't allow us to specify a self-referential struct, so

--- a/datadog-sidecar-ffi/src/lib.rs
+++ b/datadog-sidecar-ffi/src/lib.rs
@@ -197,9 +197,7 @@ where
     OneWayShmReader<T, Option<AgentRemoteConfigEndpoint>>: ReaderOpener<T>,
 {
     let (new, contents) = reader.read();
-    // c_char may be u8 or i8 depending on target... convert it.
-    let contents: &[c_char] = unsafe { std::mem::transmute::<&[u8], &[c_char]>(contents) };
-    *data = contents.into();
+    *data = CharSlice::from_bytes(contents);
     new
 }
 
@@ -291,9 +289,7 @@ pub extern "C" fn ddog_remote_config_read<'a>(
     data: &mut ffi::CharSlice<'a>,
 ) -> bool {
     let (new, contents) = reader.read();
-    // c_char may be u8 or i8 depending on target... convert it.
-    let contents: &[c_char] = unsafe { std::mem::transmute::<&[u8], &[c_char]>(contents) };
-    *data = contents.into();
+    *data = CharSlice::from_bytes(contents);
     new
 }
 

--- a/ddcommon-ffi/src/error.rs
+++ b/ddcommon-ffi/src/error.rs
@@ -1,7 +1,7 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::slice::CharSlice;
+use crate::slice::{AsBytes, CharSlice};
 use crate::vec::Vec;
 use std::fmt::{Debug, Display, Formatter};
 
@@ -19,7 +19,7 @@ pub struct Error {
 impl AsRef<str> for Error {
     fn as_ref(&self) -> &str {
         // Safety: .message is a String (just FFI safe).
-        unsafe { std::str::from_utf8_unchecked(self.message.as_slice().as_slice()) }
+        unsafe { self.message.as_slice().assume_utf8() }
     }
 }
 

--- a/ddcommon-ffi/src/slice_mut.rs
+++ b/ddcommon-ffi/src/slice_mut.rs
@@ -1,16 +1,15 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::slice::AsBytes;
 use core::slice;
 use serde::ser::Error;
 use serde::Serializer;
-use std::borrow::Cow;
 use std::fmt::{Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use std::os::raw::c_char;
 use std::ptr::NonNull;
-use std::str::Utf8Error;
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -49,36 +48,6 @@ pub type ByteMutSlice<'a> = MutSlice<'a, u8>;
 #[inline]
 fn is_aligned<T>(ptr: NonNull<T>) -> bool {
     ptr.as_ptr() as usize % std::mem::align_of::<T>() == 0
-}
-
-pub trait AsBytes<'a> {
-    fn as_bytes(&self) -> &'a [u8];
-
-    #[inline]
-    fn try_to_utf8(&self) -> Result<&'a str, Utf8Error> {
-        std::str::from_utf8(self.as_bytes())
-    }
-
-    fn try_to_string(&self) -> Result<String, Utf8Error> {
-        Ok(self.try_to_utf8()?.to_string())
-    }
-
-    #[inline]
-    fn try_to_string_option(&self) -> Result<Option<String>, Utf8Error> {
-        Ok(Some(self.try_to_string()?).filter(|x| !x.is_empty()))
-    }
-
-    #[inline]
-    fn to_utf8_lossy(&self) -> Cow<'a, str> {
-        String::from_utf8_lossy(self.as_bytes())
-    }
-
-    #[inline]
-    /// # Safety
-    /// Must only be used when the underlying data was already confirmed to be utf8.
-    unsafe fn assume_utf8(&self) -> &'a str {
-        std::str::from_utf8_unchecked(self.as_bytes())
-    }
 }
 
 impl<'a> AsBytes<'a> for MutSlice<'a, u8> {

--- a/ddcommon-ffi/src/string.rs
+++ b/ddcommon-ffi/src/string.rs
@@ -1,7 +1,7 @@
 // Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::slice::CharSlice;
+use crate::slice::{AsBytes, CharSlice};
 use crate::vec::Vec;
 use crate::Error;
 
@@ -16,7 +16,7 @@ pub struct StringWrapper {
 impl AsRef<str> for StringWrapper {
     fn as_ref(&self) -> &str {
         // Safety: .message is a String (just FFI safe).
-        unsafe { std::str::from_utf8_unchecked(self.message.as_slice().as_slice()) }
+        unsafe { self.message.as_slice().assume_utf8() }
     }
 }
 


### PR DESCRIPTION
# What does this PR do?

This makes some improvements to `AsBytes`:

- New `CharSlice::from_bytes` method to avoid ambiguous constructors.
- Uses `assume_utf8` in more places.
- Removes deduplicate `AsBytes` trait in `slice_mut.rs`.

# Motivation

I was working on some different FFI improvements and wanted to untangle this from my work.

# Additional Notes

`ddog_parse_live_debugger_json` is now properly marked unsafe. As far as I can tell it's only called from C, so it won't matter, but it's correctly documented now.

# How to test the change?

Everything should test the same, except possibly `ddog_parse_live_debugger_json` as mentioned before.
