### PR TITLE
[crashtracker] Generate and Set `error.message` field

### DIFF
--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -203,6 +203,9 @@ fn test_crash_tracking_bin(
     let sig_info = &crash_payload["sig_info"];
     assert_siginfo_message(sig_info, crash_typ);
 
+    let error = &crash_payload["error"];
+    assert_error_message(&error["message"], sig_info);
+
     let crash_telemetry = fs::read(fixtures.crash_telemetry_path)
         .context("reading crashtracker telemetry payload")
         .unwrap();
@@ -220,6 +223,16 @@ fn test_crash_tracking_bin(
     if let Ok(invalid) = fs::read(invalid_path) {
         assert_eq!(invalid, b"O");
     }
+}
+
+fn assert_error_message(message: &Value, sig_info: &Value) {
+    let expected_message = format!(
+        "Process terminated with {} ({})",
+        sig_info["si_code_human_readable"].as_str().unwrap(),
+        sig_info["si_signo_human_readable"].as_str().unwrap()
+    );
+    let message_str = message.as_str().unwrap_or("");
+    assert_eq!(message_str, expected_message);
 }
 
 fn assert_siginfo_message(sig_info: &Value, crash_typ: &str) {

--- a/datadog-crashtracker-ffi/src/crash_info/builder.rs
+++ b/datadog-crashtracker-ffi/src/crash_info/builder.rs
@@ -429,3 +429,22 @@ pub unsafe extern "C" fn ddog_crasht_CrashInfoBuilder_with_uuid_random(
         builder.to_inner_mut()?.with_uuid_random()?;
     })
 }
+
+/// # Safety
+/// The `crash_info` can be null, but if non-null it must point to a Builder made by this module,
+/// which has not previously been dropped.
+/// The CharSlice must be valid.
+#[no_mangle]
+#[must_use]
+#[named]
+pub unsafe extern "C" fn ddog_crasht_CrashInfoBuilder_with_message(
+    mut builder: *mut Handle<CrashInfoBuilder>,
+    message: CharSlice,
+) -> VoidResult {
+    wrap_with_void_ffi_result!({
+        let message = message
+            .try_to_string_option()?
+            .context("message cannot be empty string")?;
+        builder.to_inner_mut()?.with_message(message)?;
+    })
+}

--- a/datadog-crashtracker/src/receiver/receive_report.rs
+++ b/datadog-crashtracker/src/receiver/receive_report.rs
@@ -108,12 +108,18 @@ fn process_line(
 
         StdinState::SigInfo if line.starts_with(DD_CRASHTRACK_END_SIGINFO) => StdinState::Waiting,
         StdinState::SigInfo => {
-            let sig_info = serde_json::from_str(line)?;
+            let sig_info: crate::SigInfo = serde_json::from_str(line)?;
             // By convention, siginfo is the first thing sent.
+            let message = format!(
+                "Process terminated with {:?} ({:?})",
+                sig_info.si_code_human_readable, sig_info.si_signo_human_readable
+            );
+
             builder
                 .with_timestamp_now()?
                 .with_sig_info(sig_info)?
-                .with_incomplete(true)?;
+                .with_incomplete(true)?
+                .with_message(message)?;
             StdinState::SigInfo
         }
 


### PR DESCRIPTION
# What does this PR do?

This PR set the `error.message`  field in the crash report.

# Motivation

Today, the `error.message` is empty and in the backend (telemetry), we take the whole crash report to fill the `error.message` field.
In order to make it clean in the UI (crash tracking), we should set the `error.message` to something informational.
The backend will then use it.

For older version of the report, we'll try to generate the same kind of message.


# How to test the change?

Added assert in `bin_tests`.
