### PR TITLE
attempt to reduce flakiness of trace exporter shutdown tests

### DIFF
--- a/data-pipeline/src/trace_exporter/mod.rs
+++ b/data-pipeline/src/trace_exporter/mod.rs
@@ -906,6 +906,25 @@ impl TraceExporter {
     fn get_agent_url(&self) -> Uri {
         self.output_format.add_path(&self.endpoint.url)
     }
+
+    #[cfg(test)]
+    /// Test only function to check if the stats computation is active and the worker is running
+    pub fn is_stats_worker_active(&self) -> bool {
+        if !matches!(
+            **self.client_side_stats.load(),
+            StatsComputationStatus::Enabled { .. }
+        ) {
+            return false;
+        }
+
+        if let Ok(workers) = self.workers.try_lock() {
+            if let Some(stats_worker) = &workers.stats {
+                return matches!(stats_worker, PausableWorker::Running { .. });
+            }
+        }
+
+        false
+    }
 }
 
 const DEFAULT_AGENT_URL: &str = "http://127.0.0.1:8126";
@@ -1385,7 +1404,7 @@ mod tests {
             then.status(200).body("");
         });
 
-        let mock_info = server.mock(|when, then| {
+        let _mock_info = server.mock(|when, then| {
             when.method(GET).path("/info");
             then.status(200)
                 .header("content-type", "application/json")
@@ -1415,7 +1434,7 @@ mod tests {
         let data = rmp_serde::to_vec_named(&vec![trace_chunk]).unwrap();
 
         // Wait for the info fetcher to get the config
-        while mock_info.hits() == 0 {
+        while agent_info::get_agent_info().is_none() {
             exporter
                 .runtime
                 .lock()
@@ -1431,10 +1450,20 @@ mod tests {
         // Error received because server is returning an empty body.
         assert!(result.is_err());
 
+        // Wait for the stats worker to be active before shutting down to avoid potential flaky
+        // tests on CI where we shutdown before the stats worker had time to start
+        let start_time = std::time::Instant::now();
+        while !exporter.is_stats_worker_active() {
+            if start_time.elapsed() > Duration::from_secs(10) {
+                panic!("Timeout waiting for stats worker to become active");
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
         exporter.shutdown(None).unwrap();
 
         // Wait for the mock server to process the stats
-        for _ in 0..500 {
+        for _ in 0..1000 {
             if mock_traces.hits() > 0 && mock_stats.hits() > 0 {
                 break;
             } else {
@@ -1472,7 +1501,7 @@ mod tests {
             then.delay(Duration::from_secs(10)).status(200).body("");
         });
 
-        let mock_info = server.mock(|when, then| {
+        let _mock_info = server.mock(|when, then| {
             when.method(GET).path("/info");
             then.status(200)
                 .header("content-type", "application/json")
@@ -1505,8 +1534,9 @@ mod tests {
 
         let data = rmp_serde::to_vec_named(&vec![trace_chunk]).unwrap();
 
-        // Wait for the info fetcher to get the config
-        while mock_info.hits() == 0 {
+        // Wait for agent_info to be present so that sending a trace will trigger the stats worker
+        // to start
+        while agent_info::get_agent_info().is_none() {
             exporter
                 .runtime
                 .lock()
@@ -1519,6 +1549,16 @@ mod tests {
         }
 
         exporter.send(data.as_ref(), 1).unwrap();
+
+        // Wait for the stats worker to be active before shutting down to avoid potential flaky
+        // tests on CI where we shutdown before the stats worker had time to start
+        let start_time = std::time::Instant::now();
+        while !exporter.is_stats_worker_active() {
+            if start_time.elapsed() > Duration::from_secs(10) {
+                panic!("Timeout waiting for stats worker to become active");
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
 
         exporter
             .shutdown(Some(Duration::from_millis(5)))


### PR DESCRIPTION
# What does this PR do?

Attempts to reduce the likelihood of the trace exporter shutdown unit tests flaking on CI by:
- Directly checking `AGENT_INFO_CACHE` to be `Some` instead of checking the mock `/info` endpoint is hit. This is a potential race condition in tests as there is a non-zero amount of time between the endpoint being hit, the cache being populated, and the exporter checking the cache to know if it should enable the stats worker. 
- Added a test-only function to check if stats computation is enabled and the worker is running. In tests it may be possible that we start the shutdown before stats worker is active. 

# Motivation

Flaky tests aren't cool

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
