### PR TITLE
fix span even deserialization to match test agent changes

### DIFF
--- a/data-pipeline/tests/snapshots/compare_exporter_v04_trace_snapshot_test.json
+++ b/data-pipeline/tests/snapshots/compare_exporter_v04_trace_snapshot_test.json
@@ -31,10 +31,12 @@
             "exception.version": {"type": 3, "double_value": 4.2},
             "exception.escaped": {"type": 1, "bool_value": true},
             "exception.count": {"type": 2, "int_value": 1},
-            "exception.lines": {"type": 4, "array_value": [
-              {"type": 0, "string_value": "  File \"<string>\", line 1, in <module>"},
-              {"type": 0, "string_value": "  File \"<string>\", line 1, in divide"}
-            ]}
+            "exception.lines": {"type": 4, "array_value": {
+              "values": [
+                {"type": 0, "string_value": "  File \"<string>\", line 1, in <module>"},
+                {"type": 0, "string_value": "  File \"<string>\", line 1, in divide"}
+              ]
+            }}
           }
         }
       ]

--- a/data-pipeline/tests/snapshots/compare_exporter_v04_trace_snapshot_uds_test.json
+++ b/data-pipeline/tests/snapshots/compare_exporter_v04_trace_snapshot_uds_test.json
@@ -31,10 +31,12 @@
             "exception.version": {"type": 3, "double_value": 4.2},
             "exception.escaped": {"type": 1, "bool_value": true},
             "exception.count": {"type": 2, "int_value": 1},
-            "exception.lines": {"type": 4, "array_value": [
-              {"type": 0, "string_value": "  File \"<string>\", line 1, in <module>"},
-              {"type": 0, "string_value": "  File \"<string>\", line 1, in divide"}
-            ]}
+            "exception.lines": {"type": 4, "array_value": {
+              "values": [
+                {"type": 0, "string_value": "  File \"<string>\", line 1, in <module>"},
+                {"type": 0, "string_value": "  File \"<string>\", line 1, in divide"}
+              ]
+            }}
           }
         }
       ]

--- a/data-pipeline/tests/test_trace_exporter.rs
+++ b/data-pipeline/tests/test_trace_exporter.rs
@@ -32,10 +32,12 @@ mod tracing_integration_tests {
                     "exception.version": {"type": 3, "double_value": 4.2},
                     "exception.escaped": {"type": 1, "bool_value": true},
                     "exception.count": {"type": 2, "int_value": 1},
-                    "exception.lines": {"type": 4, "array_value": [
-                        {"type": 0, "string_value": "  File \"<string>\", line 1, in <module>"},
-                        {"type": 0, "string_value": "  File \"<string>\", line 1, in divide"},
-                    ]}
+                    "exception.lines": {"type": 4, "array_value": {
+                        "values": [
+                            {"type": 0, "string_value": "  File \"<string>\", line 1, in <module>"},
+                            {"type": 0, "string_value": "  File \"<string>\", line 1, in divide"},
+                        ]
+                    }}
                 }
             }
         ]);

--- a/datadog-trace-utils/src/msgpack_decoder/decode/span_event.rs
+++ b/datadog-trace-utils/src/msgpack_decoder/decode/span_event.rs
@@ -175,8 +175,29 @@ fn read_attributes_array<'a>(
         return Ok(Vec::default());
     }
 
+    let map_len = rmp::decode::read_map_len(buf).map_err(|_| {
+        DecodeError::InvalidType(
+            "Unable to get map len for event attributes array_value object".to_owned(),
+        )
+    })?;
+
+    if map_len != 1 {
+        return Err(DecodeError::InvalidFormat(
+            "event attributes array_value object should only have 'values' field".to_owned(),
+        ));
+    }
+
+    let key = read_string_ref(buf)?;
+    if key != "values" {
+        return Err(DecodeError::InvalidFormat(
+            "Expected 'values' field in event attributes array_value object".to_owned(),
+        ));
+    }
+
     let len = rmp::decode::read_array_len(buf).map_err(|_| {
-        DecodeError::InvalidType("Unable to get array len for event attributes".to_owned())
+        DecodeError::InvalidType(
+            "Unable to get array len for event attributes values field".to_owned(),
+        )
     })?;
 
     let mut vec: Vec<AttributeArrayValueSlice> = Vec::with_capacity(len as usize);

--- a/datadog-trace-utils/src/span/mod.rs
+++ b/datadog-trace-utils/src/span/mod.rs
@@ -168,6 +168,11 @@ where
     Array(Vec<AttributeArrayValue<T>>),
 }
 
+#[derive(Serialize)]
+struct ArrayValueWrapper<'a, T: SpanText> {
+    values: &'a Vec<AttributeArrayValue<T>>,
+}
+
 impl<T> Serialize for AttributeAnyValue<T>
 where
     T: SpanText,
@@ -185,7 +190,8 @@ where
             AttributeAnyValue::Array(value) => {
                 let value_type: u8 = self.into();
                 state.serialize_field("type", &value_type)?;
-                state.serialize_field("array_value", value)?;
+                let wrapped_value = ArrayValueWrapper { values: value };
+                state.serialize_field("array_value", &wrapped_value)?;
             }
         }
 

--- a/datadog-trace-utils/tests/snapshots/compare_send_data_v04_trace_snapshot_test.json
+++ b/datadog-trace-utils/tests/snapshots/compare_send_data_v04_trace_snapshot_test.json
@@ -31,10 +31,12 @@
             "exception.version": {"type": 3, "double_value": 4.2},
             "exception.escaped": {"type": 1, "bool_value": true},
             "exception.count": {"type": 2, "int_value": 1},
-            "exception.lines": {"type": 4, "array_value": [
-              {"type": 0, "string_value": "  File \"<string>\", line 1, in <module>"},
-              {"type": 0, "string_value": "  File \"<string>\", line 1, in divide"}
-            ]}
+            "exception.lines": {"type": 4, "array_value": {
+              "values": [
+                {"type": 0, "string_value": "  File \"<string>\", line 1, in <module>"},
+                {"type": 0, "string_value": "  File \"<string>\", line 1, in divide"}
+              ]
+            }}
           }
         }
       ]

--- a/datadog-trace-utils/tests/snapshots/compare_send_data_v04_trace_snapshot_uds_test.json
+++ b/datadog-trace-utils/tests/snapshots/compare_send_data_v04_trace_snapshot_uds_test.json
@@ -31,10 +31,12 @@
             "exception.version": {"type": 3, "double_value": 4.2},
             "exception.escaped": {"type": 1, "bool_value": true},
             "exception.count": {"type": 2, "int_value": 1},
-            "exception.lines": {"type": 4, "array_value": [
-              {"type": 0, "string_value": "  File \"<string>\", line 1, in <module>"},
-              {"type": 0, "string_value": "  File \"<string>\", line 1, in divide"}
-            ]}
+            "exception.lines": {"type": 4, "array_value": {
+              "values": [
+                {"type": 0, "string_value": "  File \"<string>\", line 1, in <module>"},
+                {"type": 0, "string_value": "  File \"<string>\", line 1, in divide"}
+              ]
+            }}
           }
         }
       ]

--- a/datadog-trace-utils/tests/test_send_data.rs
+++ b/datadog-trace-utils/tests/test_send_data.rs
@@ -42,10 +42,12 @@ mod tracing_integration_tests {
                     "exception.version": {"type": 3, "double_value": 4.2},
                     "exception.escaped": {"type": 1, "bool_value": true},
                     "exception.count": {"type": 2, "int_value": 1},
-                    "exception.lines": {"type": 4, "array_value": [
-                        {"type": 0, "string_value": "  File \"<string>\", line 1, in <module>"},
-                        {"type": 0, "string_value": "  File \"<string>\", line 1, in divide"},
-                    ]}
+                    "exception.lines": {"type": 4, "array_value": {
+                        "values": [
+                            {"type": 0, "string_value": "  File \"<string>\", line 1, in <module>"},
+                            {"type": 0, "string_value": "  File \"<string>\", line 1, in divide"},
+                        ]
+                    }}
                 }
             }
         ]);


### PR DESCRIPTION
# What does this PR do?

The latest version of the test-agent contains [changes to expectations of how span event should be formatted](https://github.com/DataDog/dd-apm-test-agent/pull/218). This broke the existing deserialization code in trace-utils and the snapshot tests. 

# Motivation

CI for main is broken

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

If you are testing the change locally you will need to delete your existing test agent docker image to ensure you pull the latest one.
