### PR TITLE
Implement set_target for SendData

### DIFF
--- a/datadog-trace-utils/src/send_data/mod.rs
+++ b/datadog-trace-utils/src/send_data/mod.rs
@@ -205,6 +205,15 @@ impl SendData {
         self.retry_strategy = retry_strategy;
     }
 
+    /// Overrides the set target Endpoint.
+    ///
+    /// # Arguments
+    ///
+    /// * `endpoint`: The new endpoint to be used.
+    pub fn set_target(&mut self, endpoint: Endpoint) {
+        self.target = endpoint;
+    }
+
     /// Sends the data to the target endpoint.
     ///
     /// # Returns


### PR DESCRIPTION
# What does this PR do?

Implements `set_target` to override the endpoint for a `SendData`.

# Motivation

Supporting dual shipping for traces in the Lambda Extension.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
