### PR TITLE
feat(data-pipeline): Add getter for RequestError message

### DIFF
--- a/data-pipeline/src/trace_exporter/error.rs
+++ b/data-pipeline/src/trace_exporter/error.rs
@@ -157,6 +157,10 @@ impl RequestError {
     pub fn status(&self) -> StatusCode {
         self.code
     }
+
+    pub fn msg(&self) -> &str {
+        &self.msg
+    }
 }
 
 /// TraceExporterError holds different types of errors that occur when handling traces.

--- a/data-pipeline/src/trace_exporter/error.rs
+++ b/data-pipeline/src/trace_exporter/error.rs
@@ -308,3 +308,15 @@ impl Display for TraceExporterError {
 }
 
 impl Error for TraceExporterError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_request_error() {
+        let error = RequestError::new(StatusCode::NOT_FOUND, "Not found");
+        assert_eq!(error.status(), StatusCode::NOT_FOUND);
+        assert_eq!(error.msg(), "Not found")
+    }
+}


### PR DESCRIPTION
# What does this PR do?

Add a getter for the error message to access it in the dd-trace-py bindings

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
