### PR TITLE
Add functions to SendDataBuilder

### DIFF
--- a/datadog-trace-utils/src/send_data/mod.rs
+++ b/datadog-trace-utils/src/send_data/mod.rs
@@ -125,24 +125,6 @@ impl SendDataBuilder {
         self
     }
 
-    /// Returns the user defined approximate size of the data to be sent in bytes.
-    ///
-    /// # Returns
-    ///
-    /// The size of the data.
-    pub fn len(&self) -> usize {
-        self.size
-    }
-
-    /// Checks if the user defined approximate size of the data to be sent is zero.
-    ///
-    /// # Returns
-    ///
-    /// `true` if size is 0, `false` otherwise.
-    pub fn is_empty(&self) -> bool {
-        self.size == 0
-    }
-
     pub fn build(self) -> SendData {
         SendData {
             tracer_payloads: self.tracer_payloads,
@@ -1067,21 +1049,22 @@ mod tests {
         let payload = setup_payload(&header_tags);
         let retry_strategy = RetryStrategy::new(5, 100, RetryBackoffType::Constant, None);
 
-        let send_data_builder = SendDataBuilder::new(
+        let send_data = SendDataBuilder::new(
             100,
             TracerPayloadCollection::V07(vec![payload]),
             header_tags,
             &Endpoint::default(),
         )
+        // Test with_api_key()
         .with_api_key("TEST-KEY")
-        .with_retry_strategy(retry_strategy.clone());
+        // Test with_retry_strategy()
+        .with_retry_strategy(retry_strategy.clone())
+        .build();
 
-        assert_eq!(send_data_builder.len(), 100);
-        assert!(!send_data_builder.is_empty());
         assert_eq!(
-            send_data_builder.target.api_key,
+            send_data.target.api_key,
             Some(std::borrow::Cow::Borrowed("TEST-KEY"))
         );
-        assert_eq!(send_data_builder.retry_strategy, retry_strategy);
+        assert_eq!(send_data.retry_strategy, retry_strategy);
     }
 }

--- a/datadog-trace-utils/src/send_data/mod.rs
+++ b/datadog-trace-utils/src/send_data/mod.rs
@@ -17,7 +17,7 @@ use ddcommon::{
 };
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
-use hyper::header::CONTENT_TYPE;
+use hyper::header::{CONTENT_TYPE, HeaderValue};
 use send_data_result::SendDataResult;
 use std::collections::HashMap;
 #[cfg(feature = "compression")]
@@ -187,15 +187,6 @@ impl SendData {
         &self.target
     }
 
-    /// Returns the target endpoint as mutable.
-    ///
-    /// # Returns
-    ///
-    /// A mutable reference to the target endpoint.
-    pub fn get_target_mut(&mut self) -> &mut Endpoint {
-        &mut self.target
-    }
-
     /// Returns the payloads to be sent.
     ///
     /// # Returns
@@ -224,6 +215,15 @@ impl SendData {
             target: endpoint,
             ..self.clone()
         }
+    }
+
+    /// Overrides the set API key.
+    ///
+    /// # Arguments
+    ///
+    /// * `api_key`: The new API key to be used.
+    pub fn set_api_key(&mut self, api_key: &str) {
+        self.target.api_key = Some(api_key.to_string().into());
     }
 
     /// Sends the data to the target endpoint.

--- a/datadog-trace-utils/src/send_data/mod.rs
+++ b/datadog-trace-utils/src/send_data/mod.rs
@@ -78,7 +78,6 @@ pub enum Compression {
     None,
 }
 
-#[derive(Clone)]
 pub struct SendDataBuilder {
     pub(crate) tracer_payloads: TracerPayloadCollection,
     pub(crate) size: usize,

--- a/datadog-trace-utils/src/send_data/mod.rs
+++ b/datadog-trace-utils/src/send_data/mod.rs
@@ -78,6 +78,7 @@ pub enum Compression {
     None,
 }
 
+#[derive(Clone)]
 pub struct SendDataBuilder {
     pub(crate) tracer_payloads: TracerPayloadCollection,
     pub(crate) size: usize,

--- a/datadog-trace-utils/src/send_data/mod.rs
+++ b/datadog-trace-utils/src/send_data/mod.rs
@@ -119,6 +119,15 @@ impl SendDataBuilder {
         self
     }
 
+    /// Checks if the user defined approximate size of the data to be sent is zero.
+    ///
+    /// # Returns
+    ///
+    /// `true` if size is 0, `false` otherwise.
+    pub fn is_empty(&self) -> bool {
+        self.size == 0
+    }
+
     pub fn build(self) -> SendData {
         SendData {
             tracer_payloads: self.tracer_payloads,

--- a/datadog-trace-utils/src/send_data/mod.rs
+++ b/datadog-trace-utils/src/send_data/mod.rs
@@ -1077,6 +1077,7 @@ mod tests {
         .with_retry_strategy(retry_strategy.clone());
 
         assert_eq!(send_data_builder.len(), 100);
+        assert_eq!(send_data_builder.is_empty(), false);
         assert_eq!(
             send_data_builder.target.api_key,
             Some(std::borrow::Cow::Borrowed("TEST-KEY"))

--- a/datadog-trace-utils/src/send_data/mod.rs
+++ b/datadog-trace-utils/src/send_data/mod.rs
@@ -187,6 +187,15 @@ impl SendData {
         &self.target
     }
 
+    /// Returns the target endpoint as mutable.
+    ///
+    /// # Returns
+    ///
+    /// A mutable reference to the target endpoint.
+    pub fn get_target_mut(&mut self) -> &mut Endpoint {
+        &mut self.target
+    }
+
     /// Returns the payloads to be sent.
     ///
     /// # Returns

--- a/datadog-trace-utils/src/send_data/mod.rs
+++ b/datadog-trace-utils/src/send_data/mod.rs
@@ -119,6 +119,11 @@ impl SendDataBuilder {
         self
     }
 
+    pub fn with_retry_strategy(mut self, retry_strategy: RetryStrategy) -> SendDataBuilder {
+        self.retry_strategy = retry_strategy;
+        self
+    }
+
     /// Checks if the user defined approximate size of the data to be sent is zero.
     ///
     /// # Returns

--- a/datadog-trace-utils/src/send_data/mod.rs
+++ b/datadog-trace-utils/src/send_data/mod.rs
@@ -1077,7 +1077,7 @@ mod tests {
         .with_retry_strategy(retry_strategy.clone());
 
         assert_eq!(send_data_builder.len(), 100);
-        assert_eq!(send_data_builder.is_empty(), false);
+        assert!(!send_data_builder.is_empty());
         assert_eq!(
             send_data_builder.target.api_key,
             Some(std::borrow::Cow::Borrowed("TEST-KEY"))

--- a/datadog-trace-utils/src/send_data/mod.rs
+++ b/datadog-trace-utils/src/send_data/mod.rs
@@ -17,7 +17,7 @@ use ddcommon::{
 };
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
-use hyper::header::{CONTENT_TYPE, HeaderValue};
+use hyper::header::{HeaderValue, CONTENT_TYPE};
 use send_data_result::SendDataResult;
 use std::collections::HashMap;
 #[cfg(feature = "compression")]

--- a/datadog-trace-utils/src/send_data/mod.rs
+++ b/datadog-trace-utils/src/send_data/mod.rs
@@ -124,6 +124,15 @@ impl SendDataBuilder {
         self
     }
 
+    /// Returns the user defined approximate size of the data to be sent in bytes.
+    ///
+    /// # Returns
+    ///
+    /// The size of the data.
+    pub fn len(&self) -> usize {
+        self.size
+    }
+
     /// Checks if the user defined approximate size of the data to be sent is zero.
     ///
     /// # Returns

--- a/datadog-trace-utils/src/send_data/mod.rs
+++ b/datadog-trace-utils/src/send_data/mod.rs
@@ -17,7 +17,7 @@ use ddcommon::{
 };
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
-use hyper::header::{HeaderValue, CONTENT_TYPE};
+use hyper::header::{CONTENT_TYPE};
 use send_data_result::SendDataResult;
 use std::collections::HashMap;
 #[cfg(feature = "compression")]
@@ -111,6 +111,11 @@ impl SendDataBuilder {
     #[cfg(feature = "compression")]
     pub fn with_compression(mut self, compression: Compression) -> SendDataBuilder {
         self.compression = compression;
+        self
+    }
+
+    pub fn with_api_key(mut self, api_key: &str) -> SendDataBuilder {
+        self.target.api_key = Some(api_key.to_string().into());
         self
     }
 
@@ -215,15 +220,6 @@ impl SendData {
             target: endpoint,
             ..self.clone()
         }
-    }
-
-    /// Overrides the set API key.
-    ///
-    /// # Arguments
-    ///
-    /// * `api_key`: The new API key to be used.
-    pub fn set_api_key(&mut self, api_key: &str) {
-        self.target.api_key = Some(api_key.to_string().into());
     }
 
     /// Sends the data to the target endpoint.


### PR DESCRIPTION
# What does this PR do?
Add functions to `SendDataBuilder`:
- `with_api_key()`
- `with_retry_strategy()`

# Motivation

https://github.com/DataDog/datadog-lambda-extension/pull/732 We want to lazily set api key in the `target`, i.e. leave it empty at creation time then set it later.
As a result, we need to pass `SendDataBuilder` around in the codebase, instead of passing `SendData`. Wherever we need to set data on `SendData` right now, we need to do it on `SendDataBuilder` instead.

# How to test the change?

Using the added test