### PR TITLE
fix(ddcommon): fix build on i686

### DIFF
--- a/ddcommon/src/unix_utils/fork.rs
+++ b/ddcommon/src/unix_utils/fork.rs
@@ -64,9 +64,9 @@ pub fn alt_fork() -> libc::pid_t {
     };
 
     // The max value of a PID is configurable, but within an i32, so the failover
-    if res > pid_t::MAX as i64 {
+    if (res as i64) > (pid_t::MAX as i64) {
         pid_t::MAX
-    } else if res < pid_t::MIN as i64 {
+    } else if (res as i64) < (pid_t::MIN as i64) {
         pid_t::MIN
     } else {
         res as pid_t


### PR DESCRIPTION
# What does this PR do?

Build is broken on i686 due to `c_long` (return value from`syscall`) being an i32 instead of a i64 see [this job](https://github.com/DataDog/dd-trace-py/actions/runs/16276305502/job/45955939274?pr=13071#step:6:9216)

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
