### PR TITLE
Bump version in preparation for releasing v19.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "build_common"
-version = "19.0.1"
+version = "19.1.0"
 dependencies = [
  "cbindgen",
  "serde",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "builder"
-version = "19.0.1"
+version = "19.1.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1394,7 +1394,7 @@ checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 
 [[package]]
 name = "data-pipeline"
-version = "19.0.1"
+version = "19.1.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "data-pipeline-ffi"
-version = "19.0.1"
+version = "19.1.0"
 dependencies = [
  "build_common",
  "data-pipeline",
@@ -1441,7 +1441,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-alloc"
-version = "19.0.1"
+version = "19.1.0"
 dependencies = [
  "allocator-api2",
  "bolero",
@@ -1451,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-crashtracker"
-version = "19.0.1"
+version = "19.1.0"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -1484,7 +1484,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-crashtracker-ffi"
-version = "19.0.1"
+version = "19.1.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1503,7 +1503,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-ddsketch"
-version = "19.0.1"
+version = "19.1.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -1616,7 +1616,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-log"
-version = "19.0.1"
+version = "19.1.0"
 dependencies = [
  "chrono",
  "ddcommon-ffi",
@@ -1628,7 +1628,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-log-ffi"
-version = "19.0.1"
+version = "19.1.0"
 dependencies = [
  "build_common",
  "datadog-log",
@@ -1637,7 +1637,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling"
-version = "19.0.1"
+version = "19.1.0"
 dependencies = [
  "anyhow",
  "bitmaps",
@@ -1668,7 +1668,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-ffi"
-version = "19.0.1"
+version = "19.1.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1692,7 +1692,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-protobuf"
-version = "19.0.1"
+version = "19.1.0"
 dependencies = [
  "bolero",
  "datadog-profiling-protobuf",
@@ -1701,7 +1701,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-replayer"
-version = "19.0.1"
+version = "19.1.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1824,7 +1824,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-normalization"
-version = "19.0.1"
+version = "19.1.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1835,7 +1835,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-obfuscation"
-version = "19.0.1"
+version = "19.1.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1853,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-protobuf"
-version = "19.0.1"
+version = "19.1.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -1866,7 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-utils"
-version = "19.0.1"
+version = "19.1.0"
 dependencies = [
  "anyhow",
  "bolero",
@@ -1902,7 +1902,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-tracer-flare"
-version = "19.0.1"
+version = "19.1.0"
 dependencies = [
  "anyhow",
  "datadog-remote-config",
@@ -1917,7 +1917,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon"
-version = "19.0.1"
+version = "19.1.0"
 dependencies = [
  "anyhow",
  "cc",
@@ -1952,7 +1952,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon-ffi"
-version = "19.0.1"
+version = "19.1.0"
 dependencies = [
  "anyhow",
  "bolero",
@@ -1966,7 +1966,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry"
-version = "19.0.1"
+version = "19.1.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1990,7 +1990,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry-ffi"
-version = "19.0.1"
+version = "19.1.0"
 dependencies = [
  "build_common",
  "ddcommon",
@@ -2120,7 +2120,7 @@ dependencies = [
 
 [[package]]
 name = "dogstatsd-client"
-version = "19.0.1"
+version = "19.1.0"
 dependencies = [
  "anyhow",
  "cadence",
@@ -5285,7 +5285,7 @@ dependencies = [
 
 [[package]]
 name = "symbolizer-ffi"
-version = "19.0.1"
+version = "19.1.0"
 dependencies = [
  "blazesym-c",
  "build_common",
@@ -5608,7 +5608,7 @@ dependencies = [
 
 [[package]]
 name = "tinybytes"
-version = "19.0.1"
+version = "19.1.0"
 dependencies = [
  "once_cell",
  "pretty_assertions",
@@ -5823,7 +5823,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "19.0.1"
+version = "19.1.0"
 dependencies = [
  "regex",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.84.1"
 edition = "2021"
-version = "19.0.1"
+version = "19.1.0"
 license = "Apache-2.0"
 
 [profile.dev]


### PR DESCRIPTION
# What does this PR do?

Bump version to v19.1.0

# Additional Notes
No breaking changes as far I could see.
API additions:

- `DDOG_TRACE_EXPORTER_ERROR_CODE_PANIC` to `ddog_TraceExporterErrorCode`
- `ddog_trace_exporter_config_set_rates_payload_version` to data-pipeline.h
- `ddog_trace_exporter_config_set_connection_timeout` to data-pipeline.h
