### PR TITLE
[PROF-12141] Package libdatadog v19.1.0 for Ruby

### DIFF
--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -22,22 +22,22 @@ end
 LIB_GITHUB_RELEASES = [
   {
     file: "libdatadog-aarch64-alpine-linux-musl.tar.gz",
-    sha256: "36ff4cacef2e574e8c97dae02fc02fb9a581dd23448e3a6eba9161e76fca671e",
+    sha256: "7c69a37cb335260610b61ae956192a6dbd104d05a8278c8ff894dbfebc2efd53",
     ruby_platform: "aarch64-linux-musl"
   },
   {
     file: "libdatadog-aarch64-unknown-linux-gnu.tar.gz",
-    sha256: "47258657397a23d625559da180da3d1666083900c2679b1664d0f396c8d0b514",
+    sha256: "606b23f4de7defacd5d4a381816f8d7bfe26112c97fcdf21ec2eb998a6c5fbbd",
     ruby_platform: "aarch64-linux"
   },
   {
     file: "libdatadog-x86_64-alpine-linux-musl.tar.gz",
-    sha256: "ced9376adb75227fe5d8a78a13e3f7ef11e6e156761e4cb57105403bfb024b42",
+    sha256: "2008886021ddee573c0d539626d1d58d41e2a7dbc8deca22b3662da52de6f4d9",
     ruby_platform: "x86_64-linux-musl"
   },
   {
     file: "libdatadog-x86_64-unknown-linux-gnu.tar.gz",
-    sha256: "bd6bbb62b3b29b71dea607b63aac540790aba8456d22328c8a66c20d563546c9",
+    sha256: "4e5b05515ab180aec0819608aa5d277ff710055819654147a9d69caea27a0dbc",
     ruby_platform: "x86_64-linux"
   }
 ]

--- a/ruby/lib/libdatadog/version.rb
+++ b/ruby/lib/libdatadog/version.rb
@@ -2,7 +2,7 @@
 
 module Libdatadog
   # Current libdatadog version
-  LIB_VERSION = "18.1.0"
+  LIB_VERSION = "19.1.0"
 
   GEM_MAJOR_VERSION = "1"
   GEM_MINOR_VERSION = "0"


### PR DESCRIPTION
# What does this PR do?

This PR includes the changes documented in the "Releasing a new version to rubygems.org" part of the README: https://github.com/datadog/libdatadog/tree/main/ruby#releasing-a-new-version-to-rubygemsorg

# Motivation

Enable Ruby to use libdatadog v19.1.0. In particular, this release speeds up crashtracking.

# Additional Notes

N/A

# How to test the change?

I've tested this change locally and did not need to change anything on the Ruby side other than the version bump. Once this version is published, I'll open the Ruby-side PR for the update.

As a reminder, new libdatadog releases don't get automatically picked up by dd-trace-rb, so the PR that bumps the dependency will also test this release against all supported Ruby versions.
