### PR TITLE
fix(datadog-trace-utils): [SVLS-7218] don't hardcode span type on all spans to serverless

### DIFF
--- a/datadog-trace-utils/src/span/trace_utils.rs
+++ b/datadog-trace-utils/src/span/trace_utils.rs
@@ -193,7 +193,6 @@ mod tests {
             span.meta.insert("origin".into(), "cloudfunction".into());
             span.meta
                 .insert("functionname".into(), "dummy_function_name".into());
-            span.r#type = "serverless".into();
         }
         span
     }

--- a/datadog-trace-utils/src/test_utils/mod.rs
+++ b/datadog-trace-utils/src/test_utils/mod.rs
@@ -123,7 +123,6 @@ pub fn create_test_span(
             "functionname".to_string(),
             "dummy_function_name".to_string(),
         );
-        span.r#type = "serverless".to_string();
     }
     span
 }
@@ -185,7 +184,6 @@ pub fn create_test_gcp_span(
             .insert("_dd.origin".to_string(), "cloudfunction".to_string());
         span.meta
             .insert("origin".to_string(), "cloudfunction".to_string());
-        span.r#type = "serverless".to_string();
     }
     span
 }

--- a/datadog-trace-utils/src/trace_utils.rs
+++ b/datadog-trace-utils/src/trace_utils.rs
@@ -436,7 +436,6 @@ pub fn set_serverless_root_span_tags(
     app_name: Option<String>,
     env_type: &EnvironmentType,
 ) {
-    span.r#type = "serverless".to_string();
     let origin_tag = match env_type {
         EnvironmentType::CloudFunction => "cloudfunction",
         EnvironmentType::AzureFunction => "azurefunction",
@@ -1043,7 +1042,6 @@ mod tests {
                 ("service".to_string(), "test-service".to_string())
             ]),
         );
-        assert_eq!(span.r#type, "serverless".to_string())
     }
 
     #[test]
@@ -1068,7 +1066,6 @@ mod tests {
                 ("service".to_string(), "test-service".to_string())
             ]),
         );
-        assert_eq!(span.r#type, "serverless".to_string())
     }
 
     #[test]


### PR DESCRIPTION
# What does this PR do?

Removes hardcoding of span type on all spans to Serverless.

# Motivation

https://datadoghq.atlassian.net/browse/SVLS-7218

While this may have been appropriate at the outset of the project where root spans had to manually be created for Azure Functions, it is no longer necessary due to the automatic instrumentation of http triggers and continuing work to auto instrument other types of triggers.

This also appears to not work correctly as the span type is `serverless` in the flame graph (note the `fx` icon). But the span type is still `custom` (or whatever else it was set to by the tracer) in the trace explorer.

# Additional Notes

# How to test the change?

Deployed to Azure Functions and confirmed that span types set by tracer are not overridden.

Current:

<img width="1208" height="261" alt="Screenshot 2025-07-21 at 5 30 15 PM" src="https://github.com/user-attachments/assets/ac4b2840-ca5e-42f1-b962-2d342181e2ba" />

<img width="529" height="103" alt="Screenshot 2025-07-21 at 5 30 36 PM" src="https://github.com/user-attachments/assets/856c2494-904e-446d-844d-861b5358213c" />


Following this change:

<img width="1210" height="254" alt="Screenshot 2025-07-21 at 5 33 32 PM" src="https://github.com/user-attachments/assets/02cbb937-2a3a-4bfc-aff9-9248b9f87b0f" />

<img width="587" height="156" alt="Screenshot 2025-07-21 at 5 33 38 PM" src="https://github.com/user-attachments/assets/a96c41a7-32a5-42b8-b3eb-7945b0ede5ed" />

