### PR TITLE
[PROFILING] comment update: ensure start time is mentioned as optional

### DIFF
--- a/datadog-profiling-ffi/src/profiles/datatypes.rs
+++ b/datadog-profiling-ffi/src/profiles/datatypes.rs
@@ -730,7 +730,8 @@ pub unsafe extern "C" fn ddog_prof_EncodedProfile_bytes<'a>(
 ///
 /// # Arguments
 /// * `profile` - a reference to the profile being serialized.
-/// * `start_time` - start time for the serialized profile.
+/// * `start_time` - optional start time for the serialized profile. If None/null is passed, the
+///   time of profile creation will be used.
 /// * `end_time` - optional end time of the profile. If None/null is passed, the current time will
 ///   be used.
 ///


### PR DESCRIPTION
# What does this PR do?

- Ensure that the start time is mentioned as an optional field.

# Motivation

Avoid libdatadog users from having to compute a start time.

# Additional Notes

NA

# How to test the change?

This is just a doc change.
