### PR TITLE
Replace DevFlow stale branch auto-closer with MergeGate rule

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -6,5 +6,7 @@ kind: mergequeue
 merge_method: squash
 ---
 schema-version: v1
-kind: stale-branches
-max_age: 2190h  # 3 months
+kind: mergegate
+rules:
+  - require: pull-request-freshness
+    max_age: 10d


### PR DESCRIPTION
# What does this PR do?

We already have a github action that handles stale PRs that we like. The Devflow one isn't as flexible. The intention of the rule was to require branches not be too stale before merging.  This change gets rid of the old definition that auto-closed branches > 3 months old and adds a MergeGate rule that prevents merging branches that haven't been updated within the last 10 days.

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
