### PR TITLE
[Crashtracker] First symbolize if failed, normalize

### DIFF
--- a/datadog-crashtracker-ffi/src/crash_info/api.rs
+++ b/datadog-crashtracker-ffi/src/crash_info/api.rs
@@ -39,28 +39,12 @@ pub unsafe extern "C" fn ddog_crasht_CrashInfo_drop(builder: *mut Handle<CrashIn
 #[must_use]
 #[named]
 #[cfg(unix)]
-pub unsafe extern "C" fn ddog_crasht_CrashInfo_normalize_ips(
+pub unsafe extern "C" fn ddog_crasht_CrashInfo_enrich_stacks(
     mut crash_info: *mut Handle<CrashInfo>,
     pid: u32,
 ) -> VoidResult {
     wrap_with_void_ffi_result!({
-        crash_info.to_inner_mut()?.normalize_ips(pid)?;
-    })
-}
-
-/// # Safety
-/// The `crash_info` can be null, but if non-null it must point to a Builder made by this module,
-/// which has not previously been dropped.
-#[no_mangle]
-#[must_use]
-#[named]
-#[cfg(unix)]
-pub unsafe extern "C" fn ddog_crasht_CrashInfo_resolve_names(
-    mut crash_info: *mut Handle<CrashInfo>,
-    pid: u32,
-) -> VoidResult {
-    wrap_with_void_ffi_result!({
-        crash_info.to_inner_mut()?.resolve_names(pid)?;
+        crash_info.to_inner_mut()?.enrich_stacks(pid)?;
     })
 }
 

--- a/datadog-crashtracker/src/crash_info/mod.rs
+++ b/datadog-crashtracker/src/crash_info/mod.rs
@@ -72,12 +72,8 @@ impl CrashInfo {
 
 #[cfg(unix)]
 impl CrashInfo {
-    pub fn normalize_ips(&mut self, pid: u32) -> anyhow::Result<()> {
-        self.error.normalize_ips(pid)
-    }
-
-    pub fn resolve_names(&mut self, pid: u32) -> anyhow::Result<()> {
-        self.error.resolve_names(pid)
+    pub fn enrich_stacks(&mut self, pid: u32) -> anyhow::Result<()> {
+        self.error.enrich_stacks(pid)
     }
 }
 

--- a/datadog-crashtracker/src/receiver/entry_points.rs
+++ b/datadog-crashtracker/src/receiver/entry_points.rs
@@ -139,12 +139,8 @@ fn resolve_frames(
             .as_ref()
             .context("Unable to resolve frames: No PID specified")?
             .pid;
-        let rval1 = crash_info.resolve_names(pid);
-        let rval2 = crash_info.normalize_ips(pid);
-        anyhow::ensure!(
-            rval1.is_ok() && rval2.is_ok(),
-            "resolve_names: {rval1:?}\tnormalize_ips: {rval2:?}"
-        );
+        let rval = crash_info.enrich_stacks(pid);
+        anyhow::ensure!(rval.is_ok(), "enrich_stacks: {rval:?}");
     }
     Ok(())
 }


### PR DESCRIPTION
# What does this PR do?

This PR refactors how stack frames are enriched.

# Motivation

Before sending the crash report, the call stacks are enriched: symbolized and normalized.

- Symbolization: finding a human-readable name which can be looked up in the code source
- Normalization: Provides enough information to the back (deobfuscation API) to symbolize the frame

After reading the 2 previous bullet points, we understand that we do not need to normalize a frame if it has been symbolized (Normalization is costly).

That's why in this PR, we first try to symbolize. If it failed, we normalize it.

