### PR TITLE
Fix deadlock when calling runtime

### DIFF
--- a/data-pipeline/src/trace_exporter/mod.rs
+++ b/data-pipeline/src/trace_exporter/mod.rs
@@ -2611,6 +2611,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn stop_and_start_runtime() {
         let builder = TraceExporterBuilder::default();
         let exporter = builder.build().unwrap();


### PR DESCRIPTION
# What does this PR do?

Fix a deadlock caused by trying to lock the mutex twice. This also simplifies these methods.

# Motivation

Causing a deadlock in python integration when recreating the runtime.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
