### PR TITLE
feat: Move error log to debug when multiple root spans may exist in a batch

### DIFF
--- a/datadog-trace-utils/src/trace_utils.rs
+++ b/datadog-trace-utils/src/trace_utils.rs
@@ -21,7 +21,7 @@ use rmpv::{Integer, Value};
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::env;
-use tracing::error;
+use tracing::{error, info};
 
 /// The maximum payload size for a single request that can be sent to the trace agent. Payloads
 /// larger than this size will be dropped and the agent will return a 413 error if
@@ -364,7 +364,7 @@ pub fn get_root_span_index(trace: &[pb::Span]) -> anyhow::Result<usize> {
         // If a span's parent is not in the trace, it is a root
         if !span_ids.contains(&span.parent_id) {
             if root_span_id.is_some() {
-                error!(
+                info!(
                     trace_id = &trace[0].trace_id,
                     "trace has multiple root spans"
                 );

--- a/datadog-trace-utils/src/trace_utils.rs
+++ b/datadog-trace-utils/src/trace_utils.rs
@@ -21,7 +21,7 @@ use rmpv::{Integer, Value};
 use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::env;
-use tracing::{error, info};
+use tracing::{debug, error};
 
 /// The maximum payload size for a single request that can be sent to the trace agent. Payloads
 /// larger than this size will be dropped and the agent will return a 413 error if
@@ -364,7 +364,7 @@ pub fn get_root_span_index(trace: &[pb::Span]) -> anyhow::Result<usize> {
         // If a span's parent is not in the trace, it is a root
         if !span_ids.contains(&span.parent_id) {
             if root_span_id.is_some() {
-                info!(
+                debug!(
                     trace_id = &trace[0].trace_id,
                     "trace has multiple root spans"
                 );


### PR DESCRIPTION
# What does this PR do?
Moves an error log to an info log

# Motivation
We use trace-utils as part of our agent pipeline, which means that some partial trace chunks are processed. This log gets noisy as an error log because for many cases it's expected often.

# Additional Notes
Left the log in just moved it to an info level

# How to test the change?
no functional change but we may begin returning the first span instead of the last to be consistent w/ go
