### PR TITLE
Add sidecar transport reconnect functionality

### DIFF
--- a/datadog-ipc-macros/src/lib.rs
+++ b/datadog-ipc-macros/src/lib.rs
@@ -55,7 +55,7 @@ pub fn impl_transfer_handles(_attr: TokenStream, input: TokenStream) -> TokenStr
                                 pat: Box::new(parse_quote! { #ident }),
                             });
                             stmts_move.push(
-                                parse_quote! { __transport.move_handle(#ident.clone().into())?; },
+                                parse_quote! { __transport.copy_handle(#ident.clone().into())?; },
                             );
                             stmts_recv.push(parse_quote! { #ident.receive_handles(__transport)?; });
                         }
@@ -86,7 +86,7 @@ pub fn impl_transfer_handles(_attr: TokenStream, input: TokenStream) -> TokenStr
             });
             if orig_attr_num != func.attrs.len() {
                 arms_res_move.push(parse_quote! {
-                    #res_name::#method(response) => response.move_handles(transport)
+                    #res_name::#method(response) => response.copy_handles(transport)
                 });
                 arms_res_recv.push(parse_quote! {
                     #res_name::#method(response) => response.receive_handles(transport)
@@ -99,7 +99,7 @@ pub fn impl_transfer_handles(_attr: TokenStream, input: TokenStream) -> TokenStr
         #item
 
         impl datadog_ipc::handles::TransferHandles for #req_name {
-            fn move_handles<Transport: datadog_ipc::handles::HandlesTransport>(
+            fn copy_handles<Transport: datadog_ipc::handles::HandlesTransport>(
                 &self,
                 __transport: Transport,
             ) -> Result<(), Transport::Error> {
@@ -125,7 +125,7 @@ pub fn impl_transfer_handles(_attr: TokenStream, input: TokenStream) -> TokenStr
         }
 
         impl datadog_ipc::handles::TransferHandles for #res_name {
-            fn move_handles<Transport: datadog_ipc::handles::HandlesTransport>(
+            fn copy_handles<Transport: datadog_ipc::handles::HandlesTransport>(
                 &self,
                 transport: Transport,
             ) -> Result<(), Transport::Error> {

--- a/datadog-ipc/benches/ipc.rs
+++ b/datadog-ipc/benches/ipc.rs
@@ -39,20 +39,20 @@ fn criterion_benchmark(c: &mut Criterion) {
     transport.set_nonblocking(false).unwrap();
 
     c.bench_function("write only interface", |b| {
-        b.iter(|| transport.send(ExampleInterfaceRequest::Notify {}).unwrap())
+        b.iter(|| transport.send(&ExampleInterfaceRequest::Notify {}).unwrap())
     });
 
     // This consistently blocks on aarch64 (both MacOS and Linux), is there an issue with the
     // optimized code?
     #[cfg(not(target_arch = "aarch64"))]
     c.bench_function("two way interface", |b| {
-        b.iter(|| transport.call(ExampleInterfaceRequest::ReqCnt {}).unwrap())
+        b.iter(|| transport.call(&ExampleInterfaceRequest::ReqCnt {}).unwrap())
     });
 
     // This consistently blocks on aarch64 (both MacOS and Linux), is there an issue with the
     // optimized code?
     #[cfg(not(target_arch = "aarch64"))]
-    match transport.call(ExampleInterfaceRequest::ReqCnt {}).unwrap() {
+    match transport.call(&ExampleInterfaceRequest::ReqCnt {}).unwrap() {
         ExampleInterfaceResponse::ReqCnt(cnt) => {
             println!("Total requests handled: {cnt}");
         }

--- a/datadog-ipc/src/handles.rs
+++ b/datadog-ipc/src/handles.rs
@@ -10,7 +10,7 @@ pub trait HandlesTransport {
     type Error: Error;
 
     /// Move handle out of an object, to send it to remote process
-    fn move_handle<T>(self, handle: PlatformHandle<T>) -> Result<(), Self::Error>;
+    fn copy_handle<T>(self, handle: PlatformHandle<T>) -> Result<(), Self::Error>;
 
     /// Fetch handle received from a remote process based on supplied hint
     fn provide_handle<T>(self, hint: &PlatformHandle<T>) -> Result<PlatformHandle<T>, Self::Error>;
@@ -18,7 +18,7 @@ pub trait HandlesTransport {
 
 /// TransferHandles allows moving PlatformHandles from
 pub trait TransferHandles {
-    fn move_handles<Transport: HandlesTransport>(
+    fn copy_handles<Transport: HandlesTransport>(
         &self,
         transport: Transport,
     ) -> Result<(), Transport::Error>;
@@ -29,6 +29,16 @@ pub trait TransferHandles {
     ) -> Result<(), Transport::Error>;
 }
 
+impl<T: TransferHandles> TransferHandles for &T {
+    fn copy_handles<Transport: HandlesTransport>(&self, transport: Transport) -> Result<(), Transport::Error> {
+        (*self).copy_handles(transport)
+    }
+
+    fn receive_handles<Transport: HandlesTransport>(&mut self, _transport: Transport) -> Result<(), Transport::Error> {
+        unreachable!("receive handles should never be called on a reference (only mut reference)")
+    }
+}
+
 mod transport_impls {
     use super::{HandlesTransport, TransferHandles};
 
@@ -36,12 +46,12 @@ mod transport_impls {
     where
         T: TransferHandles,
     {
-        fn move_handles<Transport>(&self, transport: Transport) -> Result<(), Transport::Error>
+        fn copy_handles<Transport>(&self, transport: Transport) -> Result<(), Transport::Error>
         where
             Transport: HandlesTransport,
         {
             match self {
-                Ok(i) => i.move_handles(transport),
+                Ok(i) => i.copy_handles(transport),
                 Err(_) => Ok(()),
             }
         }
@@ -64,12 +74,12 @@ mod transport_impls {
     where
         T: TransferHandles,
     {
-        fn move_handles<Transport: HandlesTransport>(
+        fn copy_handles<Transport: HandlesTransport>(
             &self,
             transport: Transport,
         ) -> Result<(), Transport::Error> {
             match self {
-                Some(s) => s.move_handles(transport),
+                Some(s) => s.copy_handles(transport),
                 None => Ok(()),
             }
         }
@@ -89,11 +99,11 @@ mod transport_impls {
     use tarpc::{ClientMessage, Request, Response};
 
     impl<T: TransferHandles> TransferHandles for Response<T> {
-        fn move_handles<Transport: HandlesTransport>(
+        fn copy_handles<Transport: HandlesTransport>(
             &self,
             transport: Transport,
         ) -> Result<(), Transport::Error> {
-            self.message.move_handles(transport)
+            self.message.copy_handles(transport)
         }
 
         fn receive_handles<Transport: HandlesTransport>(
@@ -108,12 +118,12 @@ mod transport_impls {
     where
         T: TransferHandles,
     {
-        fn move_handles<M>(&self, mover: M) -> Result<(), M::Error>
+        fn copy_handles<M>(&self, mover: M) -> Result<(), M::Error>
         where
             M: HandlesTransport,
         {
             match self {
-                ClientMessage::Request(r) => r.move_handles(mover),
+                ClientMessage::Request(r) => r.copy_handles(mover),
                 ClientMessage::Cancel {
                     trace_context: _,
                     request_id: _,
@@ -144,11 +154,11 @@ mod transport_impls {
             self.message.receive_handles(provider)
         }
 
-        fn move_handles<M>(&self, mover: M) -> Result<(), M::Error>
+        fn copy_handles<M>(&self, mover: M) -> Result<(), M::Error>
         where
             M: HandlesTransport,
         {
-            self.message.move_handles(mover)
+            self.message.copy_handles(mover)
         }
     }
 }

--- a/datadog-ipc/src/handles.rs
+++ b/datadog-ipc/src/handles.rs
@@ -30,11 +30,17 @@ pub trait TransferHandles {
 }
 
 impl<T: TransferHandles> TransferHandles for &T {
-    fn copy_handles<Transport: HandlesTransport>(&self, transport: Transport) -> Result<(), Transport::Error> {
+    fn copy_handles<Transport: HandlesTransport>(
+        &self,
+        transport: Transport,
+    ) -> Result<(), Transport::Error> {
         (*self).copy_handles(transport)
     }
 
-    fn receive_handles<Transport: HandlesTransport>(&mut self, _transport: Transport) -> Result<(), Transport::Error> {
+    fn receive_handles<Transport: HandlesTransport>(
+        &mut self,
+        _transport: Transport,
+    ) -> Result<(), Transport::Error> {
         unreachable!("receive handles should never be called on a reference (only mut reference)")
     }
 }

--- a/datadog-ipc/src/platform/channel/metadata.rs
+++ b/datadog-ipc/src/platform/channel/metadata.rs
@@ -13,7 +13,7 @@ use std::os::windows::io::AsRawHandle;
 impl HandlesTransport for &mut ChannelMetadata {
     type Error = io::Error;
 
-    fn move_handle<'h, T>(self, handle: PlatformHandle<T>) -> Result<(), Self::Error> {
+    fn copy_handle<'h, T>(self, handle: PlatformHandle<T>) -> Result<(), Self::Error> {
         self.enqueue_for_sending(handle);
 
         Ok(())

--- a/datadog-ipc/src/platform/mem_handle.rs
+++ b/datadog-ipc/src/platform/mem_handle.rs
@@ -185,11 +185,11 @@ where
 }
 
 impl TransferHandles for ShmHandle {
-    fn move_handles<Transport: HandlesTransport>(
+    fn copy_handles<Transport: HandlesTransport>(
         &self,
         transport: Transport,
     ) -> Result<(), Transport::Error> {
-        self.handle.move_handles(transport)
+        self.handle.copy_handles(transport)
     }
 
     fn receive_handles<Transport: HandlesTransport>(

--- a/datadog-ipc/src/platform/message.rs
+++ b/datadog-ipc/src/platform/message.rs
@@ -14,11 +14,11 @@ impl<T> TransferHandles for Message<T>
 where
     T: TransferHandles,
 {
-    fn move_handles<M>(&self, mover: M) -> Result<(), M::Error>
+    fn copy_handles<M>(&self, mover: M) -> Result<(), M::Error>
     where
         M: HandlesTransport,
     {
-        self.item.move_handles(mover)
+        self.item.copy_handles(mover)
     }
 
     fn receive_handles<P>(&mut self, provider: P) -> Result<(), P::Error>

--- a/datadog-ipc/src/platform/platform_handle.rs
+++ b/datadog-ipc/src/platform/platform_handle.rs
@@ -111,11 +111,11 @@ impl<T> PlatformHandle<T> {
 }
 
 impl<T> TransferHandles for PlatformHandle<T> {
-    fn move_handles<Transport: crate::handles::HandlesTransport>(
+    fn copy_handles<Transport: crate::handles::HandlesTransport>(
         &self,
         transport: Transport,
     ) -> Result<(), Transport::Error> {
-        transport.move_handle(self.clone())
+        transport.copy_handle(self.clone())
     }
 
     fn receive_handles<Transport: crate::handles::HandlesTransport>(

--- a/datadog-ipc/src/platform/unix/channel/metadata.rs
+++ b/datadog-ipc/src/platform/unix/channel/metadata.rs
@@ -46,7 +46,7 @@ impl ChannelMetadata {
     where
         T: TransferHandles,
     {
-        item.move_handles(&mut *self)?;
+        item.copy_handles(&mut *self)?;
 
         let message = Message {
             item,

--- a/datadog-ipc/src/platform/windows/channel/metadata.rs
+++ b/datadog-ipc/src/platform/windows/channel/metadata.rs
@@ -117,7 +117,7 @@ impl ChannelMetadata {
     where
         T: TransferHandles,
     {
-        item.move_handles(&mut *self)?;
+        item.copy_handles(&mut *self)?;
 
         let mut handle_map = HashMap::new();
         for handle in self.handles_to_send.drain(..) {

--- a/datadog-ipc/src/transport/blocking.rs
+++ b/datadog-ipc/src/transport/blocking.rs
@@ -4,12 +4,12 @@
 use std::{
     io::{self, Read, Write},
     mem::MaybeUninit,
-    pin::Pin,
     sync::{atomic::AtomicU64, Arc},
     time::Duration,
 };
-
-use bytes::{BufMut, BytesMut};
+use std::marker::PhantomData;
+use std::pin::pin;
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use tarpc::{context::Context, ClientMessage, Request, Response};
 
@@ -19,21 +19,27 @@ use tokio_util::codec::{Decoder, Encoder, LengthDelimitedCodec};
 
 use crate::{
     handles::TransferHandles,
-    platform::{Channel, Message},
+    platform::Channel,
 };
 
 use super::DefaultCodec;
 
 pub struct BlockingTransport<IncomingItem, OutgoingItem> {
     requests_id: Arc<AtomicU64>,
-    transport: FramedBlocking<Response<IncomingItem>, ClientMessage<OutgoingItem>>,
+    codec: LengthDelimitedCodec,
+    read_buffer: BytesMut,
+    channel: Channel,
+    _phantom: PhantomData<(IncomingItem, OutgoingItem)>,
 }
 
 impl<IncomingItem, OutgoingItem> From<Channel> for BlockingTransport<IncomingItem, OutgoingItem> {
-    fn from(c: Channel) -> Self {
+    fn from(channel: Channel) -> Self {
         BlockingTransport {
             requests_id: Arc::from(AtomicU64::new(0)),
-            transport: c.into(),
+            codec: Default::default(),
+            read_buffer: BytesMut::with_capacity(4000),
+            channel,
+            _phantom: Default::default(),
         }
     }
 }
@@ -45,30 +51,26 @@ impl<IncomingItem, OutgoingItem> From<std::os::unix::net::UnixStream>
     fn from(s: std::os::unix::net::UnixStream) -> Self {
         BlockingTransport {
             requests_id: Arc::from(AtomicU64::new(0)),
-            transport: Channel::from(s).into(),
+            codec: Default::default(),
+            read_buffer: BytesMut::with_capacity(4000),
+            channel: Channel::from(s),
+            _phantom: Default::default(),
         }
     }
 }
 
-pub struct FramedBlocking<IncomingItem, OutgoingItem> {
-    codec: LengthDelimitedCodec,
-    read_buffer: BytesMut,
-    channel: Channel,
-    serde_codec: Pin<Box<DefaultCodec<Message<IncomingItem>, Message<OutgoingItem>>>>,
-}
-
-impl<IncomingItem, OutgoingItem> FramedBlocking<IncomingItem, OutgoingItem>
+impl<IncomingItem, OutgoingItem> BlockingTransport<IncomingItem, OutgoingItem>
 where
     IncomingItem: for<'de> Deserialize<'de> + TransferHandles,
     OutgoingItem: Serialize + TransferHandles,
 {
-    pub fn read_item(&mut self) -> Result<IncomingItem, io::Error> {
+    fn read_item(&mut self) -> Result<Response<IncomingItem>, io::Error> {
         let buf = &mut self.read_buffer;
         while buf.has_remaining_mut() {
             buf.reserve(1);
             match self.codec.decode(buf)? {
                 Some(frame) => {
-                    let message = self.serde_codec.as_mut().deserialize(&frame)?;
+                    let message = pin!(DefaultCodec::<_, ()>::default()).deserialize(&frame)?;
                     let item = self.channel.metadata.unwrap_message(message)?;
                     return Ok(item);
                 }
@@ -107,38 +109,22 @@ where
         Err(io::Error::other("couldn't read entire item"))
     }
 
-    fn do_send(&mut self, req: OutgoingItem) -> Result<(), io::Error> {
+    fn do_send(&mut self, req: &ClientMessage<&OutgoingItem>) -> Result<(), io::Error> {
         let msg = self.channel.create_message(req)?;
 
         let mut buf = BytesMut::new();
-        let data = self.serde_codec.as_mut().serialize(&msg)?;
+        let data = pin!(DefaultCodec::<(), _>::default()).serialize(&msg)?;
 
+        // TODO: inefficient, copies the data twice, once to serialize and once with length before
         self.codec.encode(data, &mut buf)?;
         self.channel.write_all(&buf)
     }
-}
 
-impl<IncomingItem, OutgoingItem> From<Channel> for FramedBlocking<IncomingItem, OutgoingItem> {
-    fn from(c: Channel) -> Self {
-        FramedBlocking {
-            codec: Default::default(),
-            read_buffer: BytesMut::with_capacity(4000),
-            channel: c,
-            serde_codec: Box::pin(Default::default()),
-        }
-    }
-}
-
-impl<IncomingItem, OutgoingItem> BlockingTransport<IncomingItem, OutgoingItem>
-where
-    OutgoingItem: Serialize + TransferHandles,
-    IncomingItem: for<'de> Deserialize<'de> + TransferHandles,
-{
-    fn new_client_message(
+    fn new_client_message<'a>(
         &self,
-        item: OutgoingItem,
+        item: &'a OutgoingItem,
         context: Context,
-    ) -> (u64, ClientMessage<OutgoingItem>) {
+    ) -> (u64, ClientMessage<&'a OutgoingItem>) {
         let request_id = self
             .requests_id
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -154,34 +140,34 @@ where
     }
 
     pub fn set_nonblocking(&mut self, nonblocking: bool) -> io::Result<()> {
-        self.transport.channel.set_nonblocking(nonblocking)
+        self.channel.set_nonblocking(nonblocking)
     }
 
     pub fn set_read_timeout(&mut self, timeout: Option<Duration>) -> io::Result<()> {
-        self.transport.channel.set_read_timeout(timeout)
+        self.channel.set_read_timeout(timeout)
     }
 
     pub fn set_write_timeout(&mut self, timeout: Option<Duration>) -> io::Result<()> {
-        self.transport.channel.set_write_timeout(timeout)
+        self.channel.set_write_timeout(timeout)
     }
 
     pub fn is_closed(&self) -> bool {
         // The blocking transport is not supposed to be readable on the client side unless it's a
         // response. So, outside of waiting for a response, it will never be readable unless
         // the server side closed its socket.
-        self.transport.channel.probe_readable()
+        self.channel.probe_readable()
     }
 
-    pub fn send(&mut self, item: OutgoingItem) -> io::Result<()> {
+    pub fn send(&mut self, item: &OutgoingItem) -> io::Result<()> {
         let mut ctx = Context::current();
         ctx.discard_response = true;
         let (_, req) = self.new_client_message(item, ctx);
-        self.transport.do_send(req)
+        self.do_send(&req)
     }
 
-    pub fn call(&mut self, item: OutgoingItem) -> io::Result<IncomingItem> {
+    pub fn call(&mut self, item: &OutgoingItem) -> io::Result<IncomingItem> {
         let (request_id, req) = self.new_client_message(item, Context::current());
-        self.transport.do_send(req)?;
+        self.do_send(&req)?;
 
         for resp in self {
             let resp = resp?;
@@ -190,6 +176,17 @@ where
             }
         }
         Err(io::Error::other("Request is without a response"))
+    }
+    
+    /// This function allows testing a broken pipe
+    pub fn send_garbage(&mut self) -> io::Result<()> {
+        let mut buf = BytesMut::new();
+        self.codec.encode(Bytes::from(vec![1u8; 100]), &mut buf)?;
+        self.channel.write_all(&buf)?;
+        loop {
+            std::thread::sleep(Duration::from_millis(1));
+            self.channel.write_all(&[0])?; // write byte by byte until broken pipe
+        }
     }
 }
 
@@ -201,6 +198,6 @@ where
     type Item = io::Result<Response<IncomingItem>>;
 
     fn next(&mut self) -> Option<io::Result<Response<IncomingItem>>> {
-        Some(self.transport.read_item())
+        Some(self.read_item())
     }
 }

--- a/datadog-ipc/src/transport/blocking.rs
+++ b/datadog-ipc/src/transport/blocking.rs
@@ -1,26 +1,23 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+use bytes::{BufMut, Bytes, BytesMut};
+use serde::{Deserialize, Serialize};
+use std::marker::PhantomData;
+use std::pin::pin;
 use std::{
     io::{self, Read, Write},
     mem::MaybeUninit,
     sync::{atomic::AtomicU64, Arc},
     time::Duration,
 };
-use std::marker::PhantomData;
-use std::pin::pin;
-use bytes::{BufMut, Bytes, BytesMut};
-use serde::{Deserialize, Serialize};
 use tarpc::{context::Context, ClientMessage, Request, Response};
 
 use tokio_serde::{Deserializer, Serializer};
 
 use tokio_util::codec::{Decoder, Encoder, LengthDelimitedCodec};
 
-use crate::{
-    handles::TransferHandles,
-    platform::Channel,
-};
+use crate::{handles::TransferHandles, platform::Channel};
 
 use super::DefaultCodec;
 
@@ -177,7 +174,7 @@ where
         }
         Err(io::Error::other("Request is without a response"))
     }
-    
+
     /// This function allows testing a broken pipe
     pub fn send_garbage(&mut self) -> io::Result<()> {
         let mut buf = BytesMut::new();

--- a/datadog-sidecar-ffi/src/lib.rs
+++ b/datadog-sidecar-ffi/src/lib.rs
@@ -1223,3 +1223,10 @@ pub unsafe extern "C" fn ddog_send_traces_to_sidecar(
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn ddog_drop_agent_info_reader(_: Box<AgentInfoReader>) {}
+
+#[no_mangle]
+#[allow(clippy::missing_safety_doc)]
+pub unsafe extern "C" fn ddog_sidecar_send_garbage(transport: &mut Box<SidecarTransport>) {
+    // This shall fail.
+    let _ = transport.send_garbage();
+}

--- a/datadog-sidecar/src/config.rs
+++ b/datadog-sidecar/src/config.rs
@@ -80,7 +80,7 @@ impl std::fmt::Display for LogMethod {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Config {
     pub ipc_mode: IpcMode,
     pub log_method: LogMethod,

--- a/datadog-sidecar/src/service/blocking.rs
+++ b/datadog-sidecar/src/service/blocking.rs
@@ -12,12 +12,12 @@ use datadog_live_debugger::sender::DebuggerType;
 use ddcommon::tag::Tag;
 use dogstatsd_client::DogStatsDActionOwned;
 use serde::Serialize;
-use std::sync::Mutex;
+use std::sync::{Mutex, MutexGuard};
 use std::{
     io,
     time::{Duration, Instant},
 };
-use tracing::info;
+use tracing::{info, warn};
 
 /// `SidecarTransport` is a wrapper around a BlockingTransport struct from the `datadog_ipc` crate
 /// that handles transparent reconnection.
@@ -28,6 +28,11 @@ use tracing::info;
 /// complete.
 pub struct SidecarTransport {
     pub inner: Mutex<BlockingTransport<SidecarInterfaceResponse, SidecarInterfaceRequest>>,
+    /// If the reconnect_fn is given, whenever a broken pipe is encountered, the connection will be
+    /// attempted to be re-established by calling this function.
+    /// Note that reconnecting only changes the transport (i.e. inner), but keeps the original
+    /// reconnect_fn. 
+    pub reconnect_fn: Option<Box<dyn Fn() -> Option<Box<SidecarTransport>>>>,
 }
 
 impl SidecarTransport {
@@ -76,19 +81,41 @@ impl SidecarTransport {
             Err(_) => true,
         }
     }
-
-    pub fn send(&mut self, item: SidecarInterfaceRequest) -> io::Result<()> {
-        match self.inner.lock() {
-            Ok(mut t) => t.send(item),
-            Err(e) => Err(io::Error::other(e.to_string())),
+    
+    fn with_retry<F: Fn(&mut MutexGuard<BlockingTransport<SidecarInterfaceResponse, SidecarInterfaceRequest>>) -> io::Result<V>, V>(&mut self, f: F) -> io::Result<V> {
+        let mut inner = match self.inner.lock() {
+            Ok(t) => t,
+            Err(e) => return Err(io::Error::other(e.to_string())),
+        };
+        match f(&mut inner) {
+            Ok(ret) => Ok(ret),
+            Err(e) => if e.kind() == io::ErrorKind::BrokenPipe {
+                if let Some(ref reconnect) = self.reconnect_fn {
+                    warn!("The sidecar transport is closed. Reconnecting... This generally indicates a problem with the sidecar, most likely a crash. Check the logs / core dump locations and possibly report a bug.");
+                    *inner = match reconnect() {
+                        None => return Err(e),
+                        Some(n) => n.inner.into_inner().unwrap(),
+                    };
+                    f(&mut inner)
+                } else {
+                    Err(e)
+                }
+            } else {
+                Err(e)
+            }
         }
     }
 
+    pub fn send(&mut self, item: SidecarInterfaceRequest) -> io::Result<()> {
+        self.with_retry(|t| t.send(&item))
+    }
+
     pub fn call(&mut self, item: SidecarInterfaceRequest) -> io::Result<SidecarInterfaceResponse> {
-        match self.inner.lock() {
-            Ok(mut t) => t.call(item),
-            Err(e) => Err(io::Error::other(e.to_string())),
-        }
+        self.with_retry(|t| t.call(&item))
+    }
+    
+    pub fn send_garbage(&mut self) -> io::Result<()> {
+        self.inner.lock().unwrap().send_garbage()
     }
 }
 
@@ -96,6 +123,7 @@ impl From<Channel> for SidecarTransport {
     fn from(c: Channel) -> Self {
         SidecarTransport {
             inner: Mutex::new(c.into()),
+            reconnect_fn: None,
         }
     }
 }


### PR DESCRIPTION
And rename the move_handles to a more appropriate copy_handles, because that's what it does.

blocking.rs was a bit simplified to avoid cloning everything just to possibly reuse it upon reconnect.