### PR TITLE
Return agent response length.

### DIFF
--- a/data-pipeline-ffi/src/response.rs
+++ b/data-pipeline-ffi/src/response.rs
@@ -19,16 +19,19 @@ use std::{
 pub struct ExporterResponse {
     /// The body of the response, which is a string containing the response from the agent.
     pub body: CString,
+    pub body_len: usize,
 }
 
 impl From<AgentResponse> for ExporterResponse {
     fn from(value: AgentResponse) -> Self {
         match value {
             AgentResponse::Changed { body } => ExporterResponse {
+                body_len: body.len(),
                 body: CString::new(body).unwrap_or_default(),
             },
             AgentResponse::Unchanged => ExporterResponse {
                 body: CString::new("").unwrap_or_default(),
+                body_len: 0,
             },
         }
     }
@@ -39,10 +42,14 @@ impl From<AgentResponse> for ExporterResponse {
 #[no_mangle]
 pub unsafe extern "C" fn ddog_trace_exporter_response_get_body(
     response: *const ExporterResponse,
+    out_len: Option<&mut usize>,
 ) -> *const c_char {
     if response.is_null() {
         null()
     } else {
+        if let Some(len) = out_len {
+            *len = (*response).body_len;
+        }
         (*response).body.as_ptr()
     }
 }
@@ -67,20 +74,33 @@ mod tests {
             body: "res".to_string(),
         };
         let response = &ExporterResponse::from(agent_response) as *const ExporterResponse;
+        let mut len = 0;
         let body = unsafe {
-            CStr::from_ptr(ddog_trace_exporter_response_get_body(response)).to_string_lossy()
+            CStr::from_ptr(ddog_trace_exporter_response_get_body(
+                response,
+                Some(&mut len),
+            ))
+            .to_string_lossy()
         };
         assert_eq!(body, "res".to_string());
+        assert_eq!(len, 3);
     }
 
     #[test]
     fn constructor_test_unchanged() {
         let agent_response = AgentResponse::Unchanged;
         let response = Box::into_raw(Box::new(ExporterResponse::from(agent_response)));
+        let mut len = usize::MAX;
         let body = unsafe {
-            CStr::from_ptr(ddog_trace_exporter_response_get_body(response)).to_string_lossy()
+            CStr::from_ptr(ddog_trace_exporter_response_get_body(
+                response,
+                Some(&mut len),
+            ))
+            .to_string_lossy()
         };
         assert_eq!(body, "".to_string());
+        assert_eq!(len, 0);
+
         unsafe {
             ddog_trace_exporter_response_free(response);
         }
@@ -89,7 +109,7 @@ mod tests {
     #[test]
     fn handle_null_test() {
         unsafe {
-            let body = ddog_trace_exporter_response_get_body(null());
+            let body = ddog_trace_exporter_response_get_body(null(), None);
             assert!(body.is_null());
 
             ddog_trace_exporter_response_free(null::<ExporterResponse>() as *mut ExporterResponse);

--- a/data-pipeline-ffi/src/trace_exporter.rs
+++ b/data-pipeline-ffi/src/trace_exporter.rs
@@ -1005,7 +1005,7 @@ mod tests {
             );
             assert_eq!(ret, None);
             assert_eq!(
-                response.assume_init().body.to_string_lossy(),
+                String::from_utf8_lossy(&response.assume_init().body.unwrap()),
                 r#"{
                     "rate_by_service": {
                         "service:foo,env:staging": 1.0,
@@ -1074,7 +1074,10 @@ mod tests {
             );
             mock_traces.assert();
             assert_eq!(ret, None);
-            assert_eq!(response.assume_init().body.to_string_lossy(), response_body);
+            assert_eq!(
+                String::from_utf8_lossy(&response.assume_init().body.unwrap()),
+                response_body
+            );
 
             ddog_trace_exporter_free(exporter);
         }
@@ -1149,7 +1152,10 @@ mod tests {
             );
             mock_traces.assert();
             assert_eq!(ret, None);
-            assert_eq!(response.assume_init().body.to_string_lossy(), response_body);
+            assert_eq!(
+                String::from_utf8_lossy(&response.assume_init().body.unwrap()),
+                response_body
+            );
 
             ddog_trace_exporter_free(exporter);
             // It should receive 1 payloads: metrics


### PR DESCRIPTION
# What does this PR do?

The calling code will need to deserialize the response in order to get the sample rates for that it will need the length of the response which can be computed by iterating over the response looking for the NUL character. This results in extra computation in the calling code and this PR address this situation. Moreover the FFI layer was making an additional copy of the payload to turn it into a CString, this was also removed.

# Motivation

Avoid performance penalties while deserializing the response.