### PR TITLE
Bump version to 20.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "build_common"
-version = "19.1.0"
+version = "20.0.0"
 dependencies = [
  "cbindgen",
  "serde",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "builder"
-version = "19.1.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1394,7 +1394,7 @@ checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 
 [[package]]
 name = "data-pipeline"
-version = "19.1.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1428,7 +1428,7 @@ dependencies = [
 
 [[package]]
 name = "data-pipeline-ffi"
-version = "19.1.0"
+version = "20.0.0"
 dependencies = [
  "build_common",
  "data-pipeline",
@@ -1442,7 +1442,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-alloc"
-version = "19.1.0"
+version = "20.0.0"
 dependencies = [
  "allocator-api2",
  "bolero",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-crashtracker"
-version = "19.1.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-crashtracker-ffi"
-version = "19.1.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1504,7 +1504,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-ddsketch"
-version = "19.1.0"
+version = "20.0.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -1617,7 +1617,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-log"
-version = "19.1.0"
+version = "20.0.0"
 dependencies = [
  "chrono",
  "ddcommon-ffi",
@@ -1629,7 +1629,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-log-ffi"
-version = "19.1.0"
+version = "20.0.0"
 dependencies = [
  "build_common",
  "datadog-log",
@@ -1638,7 +1638,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling"
-version = "19.1.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "bitmaps",
@@ -1669,7 +1669,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-ffi"
-version = "19.1.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-protobuf"
-version = "19.1.0"
+version = "20.0.0"
 dependencies = [
  "bolero",
  "datadog-profiling-protobuf",
@@ -1702,7 +1702,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-replayer"
-version = "19.1.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1830,7 +1830,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-normalization"
-version = "19.1.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-obfuscation"
-version = "19.1.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1859,7 +1859,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-protobuf"
-version = "19.1.0"
+version = "20.0.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -1872,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-utils"
-version = "19.1.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "bolero",
@@ -1908,7 +1908,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-tracer-flare"
-version = "19.1.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "datadog-remote-config",
@@ -1924,7 +1924,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon"
-version = "19.1.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "cc",
@@ -1959,7 +1959,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon-ffi"
-version = "19.1.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "bolero",
@@ -1973,7 +1973,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry"
-version = "19.1.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry-ffi"
-version = "19.1.0"
+version = "20.0.0"
 dependencies = [
  "build_common",
  "ddcommon",
@@ -2127,7 +2127,7 @@ dependencies = [
 
 [[package]]
 name = "dogstatsd-client"
-version = "19.1.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "cadence",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "symbolizer-ffi"
-version = "19.1.0"
+version = "20.0.0"
 dependencies = [
  "blazesym-c",
  "build_common",
@@ -5621,7 +5621,7 @@ dependencies = [
 
 [[package]]
 name = "tinybytes"
-version = "19.1.0"
+version = "20.0.0"
 dependencies = [
  "once_cell",
  "pretty_assertions",
@@ -5836,7 +5836,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "19.1.0"
+version = "20.0.0"
 dependencies = [
  "regex",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.84.1"
 edition = "2021"
-version = "19.1.0"
+version = "20.0.0"
 license = "Apache-2.0"
 
 [profile.dev]


### PR DESCRIPTION
# What does this PR do?

This PR bumps the libdatadog version to 20.0.0 in preparation for release.
This version bumps the major version due to the following changes:

- #1170 
- #1171 

# Motivation

Include new changes in the trace exporter in a release to be integrated in .NET tracer.


