### PR TITLE
Fix clippy warnings for 1.89

### DIFF
--- a/data-pipeline/src/span_concentrator/aggregation.rs
+++ b/data-pipeline/src/span_concentrator/aggregation.rs
@@ -52,11 +52,11 @@ pub(super) struct BorrowedAggregationKey<'a> {
 /// the key type `K` implements `Borrow<Q>`. Since `AggregationKey<'static>` cannot implement
 /// `Borrow<AggregationKey<'a>>` we use `dyn BorrowableAggregationKey` as a placeholder.
 trait BorrowableAggregationKey {
-    fn borrowed_aggregation_key(&self) -> BorrowedAggregationKey;
+    fn borrowed_aggregation_key(&self) -> BorrowedAggregationKey<'_>;
 }
 
 impl BorrowableAggregationKey for AggregationKey<'_> {
-    fn borrowed_aggregation_key(&self) -> BorrowedAggregationKey {
+    fn borrowed_aggregation_key(&self) -> BorrowedAggregationKey<'_> {
         BorrowedAggregationKey {
             resource_name: self.resource_name.borrow(),
             service_name: self.service_name.borrow(),
@@ -76,7 +76,7 @@ impl BorrowableAggregationKey for AggregationKey<'_> {
 }
 
 impl BorrowableAggregationKey for BorrowedAggregationKey<'_> {
-    fn borrowed_aggregation_key(&self) -> BorrowedAggregationKey {
+    fn borrowed_aggregation_key(&self) -> BorrowedAggregationKey<'_> {
         self.clone()
     }
 }

--- a/datadog-crashtracker/src/collector/emitters.rs
+++ b/datadog-crashtracker/src/collector/emitters.rs
@@ -71,31 +71,39 @@ unsafe fn emit_backtrace_by_frames(
         }
         if resolve_frames == StacktraceCollection::EnabledWithInprocessSymbols {
             backtrace::resolve_frame_unsynchronized(frame, |symbol| {
+                #[allow(clippy::unwrap_used)]
                 write!(w, "{{").unwrap();
                 #[allow(clippy::unwrap_used)]
                 emit_absolute_addresses(w, frame).unwrap();
                 if let Some(column) = symbol.colno() {
+                    #[allow(clippy::unwrap_used)]
                     write!(w, ", \"column\": {column}").unwrap();
                 }
                 if let Some(file) = symbol.filename() {
                     // The debug printer for path already wraps it in `"` marks.
+                    #[allow(clippy::unwrap_used)]
                     write!(w, ", \"file\": {file:?}").unwrap();
                 }
                 if let Some(function) = symbol.name() {
+                    #[allow(clippy::unwrap_used)]
                     write!(w, ", \"function\": \"{function}\"").unwrap();
                 }
                 if let Some(line) = symbol.lineno() {
+                    #[allow(clippy::unwrap_used)]
                     write!(w, ", \"line\": {line}").unwrap();
                 }
+                #[allow(clippy::unwrap_used)]
                 writeln!(w, "}}").unwrap();
                 // Flush eagerly to ensure that each frame gets emitted even if the next one fails
                 #[allow(clippy::unwrap_used)]
                 w.flush().unwrap();
             });
         } else {
+            #[allow(clippy::unwrap_used)]
             write!(w, "{{").unwrap();
             #[allow(clippy::unwrap_used)]
             emit_absolute_addresses(w, frame).unwrap();
+            #[allow(clippy::unwrap_used)]
             writeln!(w, "}}").unwrap();
             // Flush eagerly to ensure that each frame gets emitted even if the next one fails
             #[allow(clippy::unwrap_used)]

--- a/datadog-ipc/src/platform/unix/platform_handle.rs
+++ b/datadog-ipc/src/platform/unix/platform_handle.rs
@@ -48,7 +48,7 @@ impl<T> PlatformHandle<T>
 where
     T: SocketlikeViewType,
 {
-    pub fn as_socketlike_view(&self) -> io::Result<SocketlikeView<T>> {
+    pub fn as_socketlike_view(&self) -> io::Result<SocketlikeView<'_, T>> {
         Ok(self.as_owned_fd()?.as_socketlike_view())
     }
 }

--- a/datadog-ipc/src/rate_limiter.rs
+++ b/datadog-ipc/src/rate_limiter.rs
@@ -207,7 +207,7 @@ impl<Inner> Debug for ShmLimiter<Inner> {
 }
 
 impl<Inner> ShmLimiter<Inner> {
-    fn limiter(&self) -> &ShmLimiterData<Inner> {
+    fn limiter(&self) -> &ShmLimiterData<'_, Inner> {
         #[allow(clippy::unwrap_used)]
         unsafe {
             &*self

--- a/datadog-live-debugger-ffi/src/send_data.rs
+++ b/datadog-live-debugger-ffi/src/send_data.rs
@@ -392,7 +392,9 @@ pub extern "C" fn ddog_snapshot_push_stack_frame_with_column<'a, 'b: 'a, 'c: 'a>
 
 #[no_mangle]
 #[allow(clippy::ptr_arg)]
-pub extern "C" fn ddog_evaluation_error_first_msg(vec: &Vec<SnapshotEvaluationError>) -> CharSlice {
+pub extern "C" fn ddog_evaluation_error_first_msg(
+    vec: &Vec<SnapshotEvaluationError>,
+) -> CharSlice<'_> {
     CharSlice::from(vec[0].message.as_str())
 }
 

--- a/datadog-live-debugger/src/expr_defs.rs
+++ b/datadog-live-debugger/src/expr_defs.rs
@@ -141,14 +141,14 @@ impl Display for Condition {
             Condition::Never => f.write_str("false"),
             Condition::Disjunction(b) => {
                 let (x, y) = &**b;
-                fn is_nonassoc(condition: &Condition) -> NonAssocBoolOp {
+                fn is_nonassoc(condition: &Condition) -> NonAssocBoolOp<'_> {
                     NonAssocBoolOp(condition, matches!(condition, Condition::Conjunction(_)))
                 }
                 write!(f, "{} || {}", is_nonassoc(x), is_nonassoc(y))
             }
             Condition::Conjunction(b) => {
                 let (x, y) = &**b;
-                fn is_nonassoc(condition: &Condition) -> NonAssocBoolOp {
+                fn is_nonassoc(condition: &Condition) -> NonAssocBoolOp<'_> {
                     NonAssocBoolOp(condition, matches!(condition, Condition::Disjunction(_)))
                 }
                 write!(f, "{} && {}", is_nonassoc(x), is_nonassoc(y))

--- a/datadog-profiling-ffi/src/profiles/datatypes.rs
+++ b/datadog-profiling-ffi/src/profiles/datatypes.rs
@@ -762,7 +762,7 @@ pub unsafe extern "C" fn ddog_prof_Profile_serialize(
 
 #[must_use]
 #[no_mangle]
-pub unsafe extern "C" fn ddog_Vec_U8_as_slice(vec: &ddcommon_ffi::Vec<u8>) -> Slice<u8> {
+pub unsafe extern "C" fn ddog_Vec_U8_as_slice(vec: &ddcommon_ffi::Vec<u8>) -> Slice<'_, u8> {
     vec.as_slice()
 }
 

--- a/datadog-profiling/src/api.rs
+++ b/datadog-profiling/src/api.rs
@@ -290,7 +290,7 @@ fn string_table_fetch(pprof: &prost_impls::Profile, id: i64) -> anyhow::Result<&
         .ok_or_else(|| anyhow::anyhow!("String {id} was not found."))
 }
 
-fn mapping_fetch(pprof: &prost_impls::Profile, id: u64) -> anyhow::Result<Mapping> {
+fn mapping_fetch(pprof: &prost_impls::Profile, id: u64) -> anyhow::Result<Mapping<'_>> {
     if id == 0 {
         return Ok(Mapping::default());
     }
@@ -307,7 +307,7 @@ fn mapping_fetch(pprof: &prost_impls::Profile, id: u64) -> anyhow::Result<Mappin
     }
 }
 
-fn function_fetch(pprof: &prost_impls::Profile, id: u64) -> anyhow::Result<Function> {
+fn function_fetch(pprof: &prost_impls::Profile, id: u64) -> anyhow::Result<Function<'_>> {
     if id == 0 {
         return Ok(Function::default());
     }
@@ -322,7 +322,7 @@ fn function_fetch(pprof: &prost_impls::Profile, id: u64) -> anyhow::Result<Funct
     }
 }
 
-fn location_fetch(pprof: &prost_impls::Profile, id: u64) -> anyhow::Result<Location> {
+fn location_fetch(pprof: &prost_impls::Profile, id: u64) -> anyhow::Result<Location<'_>> {
     if id == 0 {
         return Ok(Location::default());
     }

--- a/datadog-profiling/src/internal/profile/fuzz_tests.rs
+++ b/datadog-profiling/src/internal/profile/fuzz_tests.rs
@@ -678,12 +678,6 @@ impl From<&FuzzOperation> for Operation {
     }
 }
 
-#[derive(Debug, TypeGenerator)]
-struct ApiFunctionCalls {
-    sample_types: Vec<owned_types::ValueType>,
-    operations: Vec<FuzzOperation>,
-}
-
 #[test]
 #[cfg_attr(miri, ignore)]
 fn fuzz_api_function_calls() {

--- a/datadog-remote-config/src/fetch/fetcher.rs
+++ b/datadog-remote-config/src/fetch/fetcher.rs
@@ -150,7 +150,7 @@ impl<S> ConfigFetcherState<S> {
     /// - This files_lock() must always be called prior to locking any data structure locked within
     ///   FileStorage::store().
     /// - Also, files_lock() must not be called from within FileStorage::store().
-    pub fn files_lock(&self) -> ConfigFetcherFilesLock<S> {
+    pub fn files_lock(&self) -> ConfigFetcherFilesLock<'_, S> {
         assert!(!self.expire_unused_files);
         ConfigFetcherFilesLock {
             inner: self.target_files_by_path.lock_or_panic(),

--- a/datadog-remote-config/src/file_storage.rs
+++ b/datadog-remote-config/src/file_storage.rs
@@ -58,7 +58,7 @@ impl<P> Deref for RawFileContentsGuard<'_, P> {
 
 impl<P> RawFile<P> {
     /// Gets the contents behind a Deref impl (guarding a Mutex).
-    pub fn contents(&self) -> RawFileContentsGuard<P> {
+    pub fn contents(&self) -> RawFileContentsGuard<'_, P> {
         RawFileContentsGuard(self.data.lock_or_panic())
     }
 

--- a/datadog-remote-config/src/path.rs
+++ b/datadog-remote-config/src/path.rs
@@ -59,7 +59,7 @@ pub struct RemoteConfigPathRef<'a> {
 }
 
 impl RemoteConfigPath {
-    pub fn try_parse(path: &str) -> anyhow::Result<RemoteConfigPathRef> {
+    pub fn try_parse(path: &str) -> anyhow::Result<RemoteConfigPathRef<'_>> {
         let parts: Vec<_> = path.split('/').collect();
         Ok(RemoteConfigPathRef {
             source: match parts[0] {

--- a/datadog-sidecar-ffi/src/lib.rs
+++ b/datadog-sidecar-ffi/src/lib.rs
@@ -896,7 +896,7 @@ pub unsafe extern "C" fn ddog_sidecar_set_universal_service_tags(
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn ddog_sidecar_dump(
     transport: &mut Box<SidecarTransport>,
-) -> ffi::CharSlice {
+) -> ffi::CharSlice<'_> {
     let str = match blocking::dump(transport) {
         Ok(dump) => dump,
         Err(e) => format!("{e:?}"),
@@ -913,7 +913,7 @@ pub unsafe extern "C" fn ddog_sidecar_dump(
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn ddog_sidecar_stats(
     transport: &mut Box<SidecarTransport>,
-) -> ffi::CharSlice {
+) -> ffi::CharSlice<'_> {
     let str = match blocking::stats(transport) {
         Ok(stats) => stats,
         Err(e) => format!("{e:?}"),

--- a/datadog-sidecar/src/log.rs
+++ b/datadog-sidecar/src/log.rs
@@ -172,7 +172,7 @@ impl MultiEnvFilter {
         }
     }
 
-    pub fn add(&self, key: String) -> TemporarilyRetainedMapGuard<String, EnvFilter> {
+    pub fn add(&self, key: String) -> TemporarilyRetainedMapGuard<'_, String, EnvFilter> {
         self.map.add(key)
     }
 

--- a/datadog-sidecar/src/service/runtime_info.rs
+++ b/datadog-sidecar/src/service/runtime_info.rs
@@ -58,7 +58,7 @@ impl RuntimeInfo {
     ///
     /// * `MutexGuard<HashMap<QueueId, ActiveApplications>>` - A mutable reference to the
     ///   applications map.
-    pub(crate) fn lock_applications(&self) -> MutexGuard<HashMap<QueueId, ActiveApplication>> {
+    pub(crate) fn lock_applications(&self) -> MutexGuard<'_, HashMap<QueueId, ActiveApplication>> {
         self.applications.lock_or_panic()
     }
 }

--- a/datadog-sidecar/src/service/session_info.rs
+++ b/datadog-sidecar/src/service/session_info.rs
@@ -144,11 +144,13 @@ impl SessionInfo {
         }
     }
 
-    pub(crate) fn lock_runtimes(&self) -> MutexGuard<HashMap<String, RuntimeInfo>> {
+    pub(crate) fn lock_runtimes(&self) -> MutexGuard<'_, HashMap<String, RuntimeInfo>> {
         self.runtimes.lock_or_panic()
     }
 
-    pub(crate) fn get_telemetry_config(&self) -> MutexGuard<Option<ddtelemetry::config::Config>> {
+    pub(crate) fn get_telemetry_config(
+        &self,
+    ) -> MutexGuard<'_, Option<ddtelemetry::config::Config>> {
         let mut cfg = self.session_config.lock_or_panic();
 
         if (*cfg).is_none() {
@@ -167,7 +169,7 @@ impl SessionInfo {
         }
     }
 
-    pub(crate) fn get_trace_config(&self) -> MutexGuard<tracer::Config> {
+    pub(crate) fn get_trace_config(&self) -> MutexGuard<'_, tracer::Config> {
         self.tracer_config.lock_or_panic()
     }
 
@@ -178,7 +180,7 @@ impl SessionInfo {
         f(&mut self.get_trace_config());
     }
 
-    pub(crate) fn get_dogstatsd(&self) -> MutexGuard<Option<dogstatsd_client::Client>> {
+    pub(crate) fn get_dogstatsd(&self) -> MutexGuard<'_, Option<dogstatsd_client::Client>> {
         self.dogstatsd.lock_or_panic()
     }
 
@@ -189,7 +191,7 @@ impl SessionInfo {
         f(&mut self.get_dogstatsd());
     }
 
-    pub fn get_debugger_config(&self) -> MutexGuard<datadog_live_debugger::sender::Config> {
+    pub fn get_debugger_config(&self) -> MutexGuard<'_, datadog_live_debugger::sender::Config> {
         self.debugger_config.lock_or_panic()
     }
 
@@ -204,7 +206,7 @@ impl SessionInfo {
         *self.remote_config_invariants.lock_or_panic() = Some(invariants);
     }
 
-    pub fn get_remote_config_invariants(&self) -> MutexGuard<Option<ConfigInvariants>> {
+    pub fn get_remote_config_invariants(&self) -> MutexGuard<'_, Option<ConfigInvariants>> {
         self.remote_config_invariants.lock_or_panic()
     }
 

--- a/datadog-trace-obfuscation/src/redis_tokenizer.rs
+++ b/datadog-trace-obfuscation/src/redis_tokenizer.rs
@@ -21,7 +21,7 @@ pub struct RedisTokenizerScanResult<'a> {
 }
 
 impl<'a> RedisTokenizer<'a> {
-    pub fn new(query: &str) -> RedisTokenizer {
+    pub fn new(query: &str) -> RedisTokenizer<'_> {
         let mut s = RedisTokenizer {
             data: query,
             offset: 0,

--- a/datadog-trace-utils/src/msgpack_decoder/v04/mod.rs
+++ b/datadog-trace-utils/src/msgpack_decoder/v04/mod.rs
@@ -109,7 +109,7 @@ pub fn from_bytes(data: tinybytes::Bytes) -> Result<(Vec<Vec<SpanBytes>>, usize)
 /// let decoded_span = &decoded_traces[0][0];
 /// assert_eq!("test-span", decoded_span.name);
 /// ```
-pub fn from_slice(mut data: &[u8]) -> Result<(Vec<Vec<SpanSlice>>, usize), DecodeError> {
+pub fn from_slice(mut data: &[u8]) -> Result<(Vec<Vec<SpanSlice<'_>>>, usize), DecodeError> {
     let trace_count = rmp::decode::read_array_len(&mut data).map_err(|_| {
         DecodeError::InvalidFormat("Unable to read array len for trace count".to_owned())
     })?;

--- a/datadog-trace-utils/src/msgpack_decoder/v05/mod.rs
+++ b/datadog-trace-utils/src/msgpack_decoder/v05/mod.rs
@@ -139,7 +139,7 @@ pub fn from_bytes(data: tinybytes::Bytes) -> Result<(Vec<Vec<SpanBytes>>, usize)
 /// let decoded_span = &decoded_traces[0][0];
 /// assert_eq!("", decoded_span.name);
 /// ```
-pub fn from_slice(mut data: &[u8]) -> Result<(Vec<Vec<SpanSlice>>, usize), DecodeError> {
+pub fn from_slice(mut data: &[u8]) -> Result<(Vec<Vec<SpanSlice<'_>>>, usize), DecodeError> {
     let data_elem = rmp::decode::read_array_len(&mut data)
         .map_err(|_| DecodeError::InvalidFormat("Unable to read payload len".to_string()))?;
 

--- a/ddcommon-ffi/src/error.rs
+++ b/ddcommon-ffi/src/error.rs
@@ -96,7 +96,7 @@ pub unsafe extern "C" fn ddog_Error_drop(error: Option<&mut Error>) {
 /// # Safety
 /// Only pass null or a valid reference to a `ddog_Error`.
 #[no_mangle]
-pub unsafe extern "C" fn ddog_Error_message(error: Option<&Error>) -> CharSlice {
+pub unsafe extern "C" fn ddog_Error_message(error: Option<&Error>) -> CharSlice<'_> {
     match error {
         None => CharSlice::empty(),
         Some(err) => CharSlice::from(err.as_ref()),

--- a/ddcommon-ffi/src/string.rs
+++ b/ddcommon-ffi/src/string.rs
@@ -65,7 +65,7 @@ pub unsafe extern "C" fn ddog_StringWrapper_drop(s: Option<&mut StringWrapper>) 
 /// Only pass null or a valid reference to a `ddog_StringWrapper`.
 /// The string should not be mutated nor dropped while the CharSlice is alive.
 #[no_mangle]
-pub unsafe extern "C" fn ddog_StringWrapper_message(s: Option<&StringWrapper>) -> CharSlice {
+pub unsafe extern "C" fn ddog_StringWrapper_message(s: Option<&StringWrapper>) -> CharSlice<'_> {
     match s {
         None => CharSlice::empty(),
         Some(s) => CharSlice::from(s.as_ref()),

--- a/ddcommon-ffi/src/vec.rs
+++ b/ddcommon-ffi/src/vec.rs
@@ -5,7 +5,6 @@ extern crate alloc;
 
 use crate::slice::Slice;
 use core::ops::Deref;
-use std::io::Write;
 use std::marker::PhantomData;
 use std::mem::ManuallyDrop;
 use std::ptr::NonNull;
@@ -74,9 +73,7 @@ impl<T> From<alloc::vec::Vec<T>> for Vec<T> {
 
 impl From<anyhow::Error> for Vec<u8> {
     fn from(err: anyhow::Error) -> Self {
-        let mut vec = vec![];
-        write!(vec, "{err}").expect("write to vec to always succeed");
-        Self::from(vec)
+        Self::from(err.to_string().into_bytes())
     }
 }
 
@@ -105,7 +102,7 @@ impl<T> Vec<T> {
         self.replace(vec);
     }
 
-    pub fn as_slice(&self) -> Slice<T> {
+    pub fn as_slice(&self) -> Slice<'_, T> {
         unsafe { Slice::from_raw_parts(self.ptr, self.len) }
     }
 

--- a/ddcommon/src/unix_utils/file_ops.rs
+++ b/ddcommon/src/unix_utils/file_ops.rs
@@ -161,8 +161,7 @@ mod tests {
         // Test with a path that should cause permission denied
         // This test might not work on all systems, so we'll make it conditional
         let result = open_file_or_quiet(Some("/root/protected_file.txt"));
-        if result.is_err() {
-            let error = result.unwrap_err();
+        if let Err(error) = result {
             // On some systems this might be NotFound, on others PermissionDenied
             assert!(matches!(
                 error.kind(),


### PR DESCRIPTION
# What does this PR do?

Address clippy warnings for Rust 1.89 that dropped today.

Panic macros used within macros will now emit a warning with the latest [clippy update](https://github.com/rust-lang/rust-clippy/pull/14575).

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
