### PR TITLE
feat: Move error log to debug when no root span exists in a batch

### DIFF
--- a/datadog-trace-utils/src/trace_utils.rs
+++ b/datadog-trace-utils/src/trace_utils.rs
@@ -375,7 +375,7 @@ pub fn get_root_span_index(trace: &[pb::Span]) -> anyhow::Result<usize> {
     Ok(match root_span_id {
         Some(i) => i,
         None => {
-            error!(
+            debug!(
                 trace_id = &trace[0].trace_id,
                 "Could not find the root span for trace"
             );


### PR DESCRIPTION
# What does this PR do?

Moves an error log to an info log, similar to https://github.com/DataDog/libdatadog/pull/1167

# Motivation

We use trace-utils as part of our agent pipeline, which means that some partial trace chunks are processed. This log gets noisy as an error log because for many cases it's expected often.

<img width="2388" height="726" alt="image" src="https://github.com/user-attachments/assets/99ec5f25-66eb-4075-9cc3-3788344e9e75" />


# Additional Notes

Left the log in just moved it to an info level

# How to test the change?

no functional change
