### PR TITLE
add mergegate rule to require codeowner approval for data pipeline owned crates

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -10,3 +10,9 @@ kind: mergegate
 rules:
   - require: pull-request-freshness
     max_age: 10d
+  - require: all-files-are-owned
+  - require: reviewers-approval
+    source_patterns:
+      - data-pipeline/**
+      - data-pipeline-ffi/**
+      - datadog-tracer-flare/**


### PR DESCRIPTION
# What does this PR do?

There is not consensus to enforce codeowner approval for all crates, so we don't want to enable the github rule for the entire repo. But the DevFlow MergeGate check supports subfolder enforcement, so team's can opt-in if they so chose. 

Also enabled the requirement that all files have a codeowner. We are already in compliance, so no changes were necessary. 

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
