### PR TITLE
feat(data-pipeline): put https under a feature fate

### DIFF
--- a/data-pipeline/Cargo.toml
+++ b/data-pipeline/Cargo.toml
@@ -28,15 +28,15 @@ tokio = { version = "1.23", features = [
     "test-util",
     "time",
 ], default-features = false }
-
-ddcommon = { path = "../ddcommon" }
-ddtelemetry = { path = "../ddtelemetry" }
-datadog-trace-protobuf = { path = "../datadog-trace-protobuf" }
-datadog-trace-utils = { path = "../datadog-trace-utils" }
-datadog-ddsketch = { path = "../ddsketch" }
-dogstatsd-client = { path = "../dogstatsd-client" }
 uuid = { version = "1.10.0", features = ["v4"] }
 tokio-util = "0.7.11"
+
+ddcommon = { path = "../ddcommon", default-features = false }
+ddtelemetry = { path = "../ddtelemetry", default-features = false }
+datadog-trace-protobuf = { path = "../datadog-trace-protobuf" }
+datadog-trace-utils = { path = "../datadog-trace-utils", default-features = false }
+datadog-ddsketch = { path = "../ddsketch" }
+dogstatsd-client = { path = "../dogstatsd-client", default-features = false }
 tinybytes = { path = "../tinybytes", features = [
     "bytes_string",
     "serialization",
@@ -52,7 +52,9 @@ path = "benches/main.rs"
 
 [dev-dependencies]
 criterion = "0.5.1"
-datadog-trace-utils = { path = "../datadog-trace-utils", features = ["test-utils"] }
+datadog-trace-utils = { path = "../datadog-trace-utils", features = [
+    "test-utils",
+] }
 httpmock = "0.7.0"
 rand = "0.8.5"
 regex = "1.5"
@@ -64,4 +66,11 @@ tokio = { version = "1.23", features = [
 ], default-features = false }
 
 [features]
+default = ["https"]
+https = [
+    "ddcommon/https",
+    "ddtelemetry/https",
+    "datadog-trace-utils/https",
+    "dogstatsd-client/https",
+]
 test-utils = []

--- a/datadog-trace-utils/Cargo.toml
+++ b/datadog-trace-utils/Cargo.toml
@@ -18,21 +18,21 @@ path = "benches/main.rs"
 anyhow = "1.0"
 hyper = { version = "1.6", features = ["http1", "client"] }
 http-body-util = "0.1"
-
 serde = { version = "1.0.145", features = ["derive"] }
 prost = "0.13.5"
 rmp-serde = "1.1.1"
 tracing = { version = "0.1", default-features = false }
 serde_json = "1.0"
 futures = { version = "0.3", default-features = false }
-ddcommon = { path = "../ddcommon" }
-datadog-trace-protobuf = { path = "../datadog-trace-protobuf" }
-datadog-trace-normalization = { path = "../datadog-trace-normalization" }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 rand = "0.8.5"
 bytes = "1.6.0"
 rmpv = { version = "1.3.0", default-features = false }
 rmp = { version = "0.8.14", default-features = false }
+
+ddcommon = { path = "../ddcommon", default-features = false }
+datadog-trace-protobuf = { path = "../datadog-trace-protobuf" }
+datadog-trace-normalization = { path = "../datadog-trace-normalization" }
 tinybytes = { path = "../tinybytes", features = [
     "bytes_string",
     "serialization",
@@ -51,7 +51,7 @@ zstd = { version = "0.13.3", default-features = false, optional = true }
 cargo_metadata = { version = "0.18.1", optional = true }
 # Dependency of cargo metadata, but 0.1.8 requires too new of a rust version.
 cargo-platform = { version = "=0.1.7", optional = true }
-testcontainers = { version = "0.22",features=["http_wait"], optional = true }
+testcontainers = { version = "0.22", features = ["http_wait"], optional = true }
 httpmock = { version = "0.7.0", optional = true }
 urlencoding = { version = "2.1.3", optional = true }
 
@@ -65,6 +65,8 @@ datadog-trace-utils = { path = ".", features = ["test-utils"] }
 tempfile = "3.3.0"
 
 [features]
+default = ["https"]
+https = ["ddcommon/https"]
 mini_agent = ["proxy", "compression", "ddcommon/use_webpki_roots"]
 test-utils = [
     "hyper/server",

--- a/ddtelemetry/Cargo.toml
+++ b/ddtelemetry/Cargo.toml
@@ -12,27 +12,27 @@ bench = false
 [features]
 default = []
 tracing = ["tracing/std"]
+https = ["ddcommon/https"]
 
 [dependencies]
 anyhow = { version = "1.0" }
-ddcommon = { path = "../ddcommon" }
-datadog-ddsketch = { path = "../ddsketch" }
 base64 = "0.22"
 futures = { version = "0.3", default-features = false }
 hyper = { version = "1.6", features = ["http1", "client"] }
 hyper-util = { version = "0.1", features = ["http1", "client", "client-legacy"] }
 http-body-util = "0.1"
 http = "1.0"
-
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 sys-info = { version = "0.9.0" }
 tokio = { version = "1.23", features = ["sync", "io-util"] }
 tokio-util = { version = "0.7", features = ["codec"] }
-
 tracing = { version = "0.1", default-features = false }
 uuid = { version = "1.3", features = ["v4"] }
 hashbrown = "0.15"
+
+ddcommon = { path = "../ddcommon", default-features = false}
+datadog-ddsketch = { path = "../ddsketch" }
 
 [dev-dependencies]
 tracing-subscriber = "0.3.18"

--- a/dogstatsd-client/Cargo.toml
+++ b/dogstatsd-client/Cargo.toml
@@ -10,12 +10,16 @@ license.workspace = true
 bench = false
 
 [dependencies]
-ddcommon = { path = "../ddcommon" }
+ddcommon = { path = "../ddcommon", default-features = false}
 cadence = "1.3.0"
 serde = { version = "1.0", features = ["derive", "rc"] }
 tracing = { version = "0.1", default-features = false }
 anyhow = { version = "1.0" }
 http = "1.0"
+
+[features]
+default = ["https"]
+https = ["ddcommon/https"]
 
 
 [dev-dependencies]


### PR DESCRIPTION
# What does this PR do?

Put https enablement behind a feature gate in the data-pipeline, ddtelemetry and trace-utils crate.
This feature is enabled by default so this should not change anything for current users of the crates.

# Motivation

SInce https support is there to support a very small number of cases (cluster of agents mostly), this would allow us to not ship it by default in dd-trace-rs, reducing the number of dependencies and overall footprint of the library

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
