### PR TITLE
attempt to reduce flakiness of exporter_send_telemetry_test

### DIFF
--- a/data-pipeline-ffi/src/trace_exporter.rs
+++ b/data-pipeline-ffi/src/trace_exporter.rs
@@ -1080,7 +1080,8 @@ mod tests {
             let mock_metrics = server.mock(|when, then| {
                 when.method(POST)
                     .path("/telemetry/proxy/api/v2/apmtelemetry")
-                    .body_contains(r#""runtime_id":"foo""#);
+                    .body_contains(r#""runtime_id":"foo""#)
+                    .body_contains(r#""metric":"trace_api."#);
                 then.status(200)
                     .header("content-type", "application/json")
                     .body("");
@@ -1132,7 +1133,7 @@ mod tests {
             );
 
             ddog_trace_exporter_free(exporter);
-            // It should receive 1 payloads: metrics
+            // It should receive 1 metrics payload (excluding heartbeats)
             mock_metrics.assert_hits(1);
         }
     }


### PR DESCRIPTION
# What does this PR do?

The mock for the telemetry endpoint wasn't scoped to exclude heartbeats, which made it flaky and potentially wrong.

# Motivation

Flakiness

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
