### PR TITLE
re-export ddcommon-ffi types correctly in ddsketch-ffi

### DIFF
--- a/ddsketch-ffi/cbindgen.toml
+++ b/ddsketch-ffi/cbindgen.toml
@@ -23,6 +23,11 @@ include = ["ddsketch-ffi"]
 prefix = "ddsketch_"
 renaming_overrides_prefixing = true
 
+[export.rename]
+"VoidResult" = "ddog_VoidResult"
+"Error" = "ddog_Error"
+"Vec_u8" = "ddog_Vec_U8"
+
 
 [fn]
 must_use = "DDOG_CHECK_RETURN"

--- a/examples/ffi/ddsketch.c
+++ b/examples/ffi/ddsketch.c
@@ -8,8 +8,8 @@
 
 #define TRY(expr)                                                                                  \
   {                                                                                                \
-    struct ddsketch_VoidResult result = expr;                                                     \
-    if (result.tag == DDSKETCH_VOID_RESULT_ERR) {                                                \
+    struct ddog_VoidResult result = expr;                                                         \
+    if (result.tag == DDOG_VOID_RESULT_ERR) {                                                    \
       ddog_CharSlice message = ddog_Error_message((struct ddog_Error*)&result.err);             \
       fprintf(stderr, "ERROR: %.*s\n", (int)message.len, message.ptr);                          \
       ddog_Error_drop((struct ddog_Error*)&result.err);                                         \
@@ -44,7 +44,7 @@ int main(void) {
 
   // Encode the sketch to protobuf format
   printf("Encoding sketch to protobuf...\n");
-  struct ddsketch_Vec_u8 encoded = ddog_ddsketch_encode(&sketch);
+  struct ddog_Vec_U8 encoded = ddog_ddsketch_encode(&sketch);
   
   printf("Encoded sketch size: %zu bytes\n", encoded.len);
   


### PR DESCRIPTION
# What does this PR do?

Update the cbindgen file for ddsketch-ffi to rename 

`ddsketch_VoidResult` -> `ddog_VoidResult`
`ddsketch_Error` -> `ddog_Error`
`ddsketch_Vec_U8` -> `ddog_Vec_U8`

# Motivation

These are types imported from `ddcommon-ffi` and should be named consistently across FFI crates. 

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Example file has been updated
