### PR TITLE
Clear the telemetry cache shm to indicate expiration

### DIFF
--- a/datadog-sidecar/src/service/telemetry.rs
+++ b/datadog-sidecar/src/service/telemetry.rs
@@ -228,6 +228,12 @@ impl TelemetryCachedClient {
     }
 }
 
+impl Drop for TelemetryCachedClient {
+    fn drop(&mut self) {
+        self.shm_writer.write(&[]);
+    }
+}
+
 type ServiceString = String;
 type EnvString = String;
 type TelemetryCachedClientKey = (ServiceString, EnvString);


### PR DESCRIPTION
Otherwise the sidecar clients have no way to realize that it's unlinked now.