### PR TITLE
[crashtracker] Add test to check callstack

### DIFF
--- a/bin_tests/Cargo.toml
+++ b/bin_tests/Cargo.toml
@@ -35,3 +35,7 @@ bench = false
 [[bin]]
 name = "crashtracker_receiver"
 bench = false
+
+[[bin]]
+name = "crashing_test_app"
+bench = false

--- a/bin_tests/src/bin/crashing_test_app.rs
+++ b/bin_tests/src/bin/crashing_test_app.rs
@@ -66,7 +66,7 @@ mod unix {
             true,   // create_alt_stack
             true,   // use_alt_stack
             endpoint,
-            crashtracker::StacktraceCollection::EnabledWithSymbolsInReceiver,
+            crashtracker::StacktraceCollection::WithSymbols,
             crashtracker::default_signals(),
             Some(TEST_COLLECTOR_TIMEOUT),
             Some("".to_string()), // unix_socket_path

--- a/bin_tests/src/bin/crashing_test_app.rs
+++ b/bin_tests/src/bin/crashing_test_app.rs
@@ -1,0 +1,106 @@
+// Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(not(unix))]
+fn main() {}
+
+#[cfg(unix)]
+fn main() -> anyhow::Result<()> {
+    unix::main()
+}
+
+#[cfg(unix)]
+mod unix {
+    use anyhow::ensure;
+    use anyhow::Context;
+    use std::env;
+    use std::time::Duration;
+
+    use datadog_crashtracker::{
+        self as crashtracker, CrashtrackerConfiguration, CrashtrackerReceiverConfig, Metadata,
+    };
+    use ddcommon::{tag, Endpoint};
+
+    const TEST_COLLECTOR_TIMEOUT: Duration = Duration::from_secs(10);
+
+    #[inline(never)]
+    unsafe fn fn3() {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            std::arch::asm!("mov eax, [0]", options(nostack));
+        }
+
+        #[cfg(target_arch = "aarch64")]
+        {
+            std::arch::asm!("mov x0, #0", "ldr x1, [x0]", options(nostack));
+        }
+    }
+
+    #[inline(never)]
+    fn fn2() {
+        unsafe { fn3() }
+    }
+
+    #[inline(never)]
+    fn fn1() {
+        fn2()
+    }
+
+    #[inline(never)]
+    pub fn main() -> anyhow::Result<()> {
+        // init crashtracker
+        let mut args = env::args().skip(1);
+        let output_url = args.next().context("Unexpected number of arguments 1")?;
+        let receiver_binary = args.next().context("Unexpected number of arguments 2")?;
+        let output_dir = args.next().context("Unexpected number of arguments 3")?;
+        anyhow::ensure!(args.next().is_none(), "unexpected extra arguments");
+
+        let stderr_filename = format!("{output_dir}/out.stderr");
+        let stdout_filename = format!("{output_dir}/out.stdout");
+
+        ensure!(!output_url.is_empty(), "output_url must not be empty");
+        let endpoint = Some(Endpoint::from_slice(&output_url));
+
+        let config = CrashtrackerConfiguration::new(
+            vec![], // additional_files
+            true,   // create_alt_stack
+            true,   // use_alt_stack
+            endpoint,
+            crashtracker::StacktraceCollection::EnabledWithSymbolsInReceiver,
+            crashtracker::default_signals(),
+            Some(TEST_COLLECTOR_TIMEOUT),
+            Some("".to_string()), // unix_socket_path
+            true,                 // demangle_names
+        )?;
+
+        let metadata = Metadata {
+            library_name: "libdatadog".to_owned(),
+            library_version: "1.0.0".to_owned(),
+            family: "native".to_owned(),
+            tags: vec![
+                tag!("service", "foo"),
+                tag!("service_version", "bar"),
+                tag!("runtime-id", "xyz"),
+                tag!("language", "native"),
+            ]
+            .into_iter()
+            .map(|x| x.to_string())
+            .collect(),
+        };
+
+        crashtracker::init(
+            config,
+            CrashtrackerReceiverConfig::new(
+                vec![],                // args
+                env::vars().collect(), // env
+                receiver_binary,
+                Some(stderr_filename),
+                Some(stdout_filename),
+            )?,
+            metadata,
+        )?;
+
+        fn1();
+        Ok(())
+    }
+}

--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -129,11 +129,11 @@ fn test_crash_tracking_bin_prechain_sigabrt() {
     test_crash_tracking_bin(BuildProfile::Release, "prechain_abort", "null_deref");
 }
 
-// This test is disabled for now on x86_64 musl.
+// This test is disabled for now on x86_64 musl and macos
 // It seems that on aarch64 musl, libc has CFI which allows
 // unwinding passed the signal frame.
 #[test]
-#[cfg(not(all(target_arch = "x86_64", target_env = "musl")))]
+#[cfg(not(any(all(target_arch = "x86_64", target_env = "musl"), target_os = "macos")))]
 #[cfg_attr(miri, ignore)]
 fn test_crasht_tracking_validate_callstack() {
     test_crash_tracking_callstack()

--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -210,7 +210,9 @@ fn test_crash_tracking_callstack() {
     let crashing_callstack = &crash_payload["error"]["stack"]["frames"];
     assert!(
         crashing_callstack.as_array().unwrap().len() >= expected_functions.len(),
-        "crashing thread callstacks ddddd",
+        "crashing thread callstacks does have less frames than expected. Current: {}, Expected: {}",
+        crashing_callstack.as_array().unwrap().len(),
+        expected_functions.len()
     );
 
     let function_names: Vec<&str> = crashing_callstack

--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -129,6 +129,94 @@ fn test_crash_tracking_bin_prechain_sigabrt() {
     test_crash_tracking_bin(BuildProfile::Release, "prechain_abort", "null_deref");
 }
 
+#[test]
+#[cfg_attr(miri, ignore)]
+fn test_crasht_tracking_validate_callstack() {
+    test_crash_tracking_callstack()
+}
+
+fn test_crash_tracking_callstack() {
+    let (_, crashtracker_receiver) = setup_crashtracking_crates(BuildProfile::Release);
+
+    let crashing_app = ArtifactsBuild {
+        name: "crashing_test_app".to_owned(),
+        // compile in debug so we avoid inlining
+        // and can check the callchain
+        build_profile: BuildProfile::Debug,
+        artifact_type: ArtifactType::Bin,
+        triple_target: None,
+    };
+
+    let fixtures = setup_test_fixtures(&[&crashtracker_receiver, &crashing_app]);
+
+    let mut p = process::Command::new(&fixtures.artifacts[&crashing_app])
+        .arg(format!("file://{}", fixtures.crash_profile_path.display()))
+        .arg(fixtures.artifacts[&crashtracker_receiver].as_os_str())
+        .arg(&fixtures.output_dir)
+        .spawn()
+        .unwrap();
+
+    let exit_status = bin_tests::timeit!("exit after signal", {
+        eprintln!("Waiting for exit");
+        p.wait().unwrap()
+    });
+    assert!(!exit_status.success());
+
+    let stderr_path = format!("{0}/out.stderr", fixtures.output_dir.display());
+    let stderr = fs::read(stderr_path)
+        .context("reading crashtracker stderr")
+        .unwrap();
+    let stdout_path = format!("{0}/out.stdout", fixtures.output_dir.display());
+    let stdout = fs::read(stdout_path)
+        .context("reading crashtracker stdout")
+        .unwrap();
+    let s = String::from_utf8(stderr);
+    assert!(
+        matches!(
+            s.as_deref(),
+            Ok("") | Ok("Failed to fully receive crash.  Exit state was: StackTrace([])\n")
+            | Ok("Failed to fully receive crash.  Exit state was: InternalError(\"{\\\"ip\\\": \\\"\")\n"),
+        ),
+        "got {s:?}"
+    );
+    assert_eq!(Ok(""), String::from_utf8(stdout).as_deref());
+
+    let crash_profile = fs::read(fixtures.crash_profile_path)
+        .context("reading crashtracker profiling payload")
+        .unwrap();
+    let crash_payload = serde_json::from_slice::<serde_json::Value>(&crash_profile)
+        .context("deserializing crashtracker profiling payload to json")
+        .unwrap();
+
+    // Note: in Release, we do not have the crate and module name prepended to the function name
+    // Here we compile the crashing app in Debug.
+    let expected_functions: Vec<&str> = [
+        "crashing_test_app::unix::fn3",
+        "crashing_test_app::unix::fn2",
+        "crashing_test_app::unix::fn1",
+        "crashing_test_app::unix::main",
+        "crashing_test_app::main",
+    ]
+    .to_vec();
+
+    let crashing_callstack = &crash_payload["error"]["stack"]["frames"];
+    assert!(
+        crashing_callstack.as_array().unwrap().len() >= expected_functions.len(),
+        "crashing thread callstacks ddddd",
+    );
+
+    let function_names: Vec<&str> = crashing_callstack
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|f| f["function"].as_str().unwrap_or(""))
+        .collect();
+
+    for (expected, actual) in expected_functions.iter().zip(function_names.iter()) {
+        assert_eq!(expected, actual);
+    }
+}
+
 fn test_crash_tracking_bin(
     crash_tracking_receiver_profile: BuildProfile,
     mode: &str,

--- a/tools/docker/Dockerfile.build
+++ b/tools/docker/Dockerfile.build
@@ -117,6 +117,7 @@ RUN find -name "Cargo.toml" | sed -e s#Cargo.toml#src/lib.rs#g | xargs -n 1 sh -
 RUN echo \
     bin_tests/src/bin/crashtracker_bin_test.rs \
     bin_tests/src/bin/crashtracker_receiver.rs \
+    bin_tests/src/bin/crashing_test_app.rs \
     bin_tests/src/bin/crashtracker_unix_socket_receiver.rs \
     bin_tests/src/bin/test_the_tests.rs \
     builder/src/bin/release.rs \


### PR DESCRIPTION
# What does this PR do?

This PR introduces a `crash_test_app` which does function calls, crashes. The crash tracker will collect the report and make sure that the crashing thread callstack contains certain frames.

# Motivation

Stability and quality: We want to make sure that crash tracker, more specifically the unwinder, accurately collects stack frames.

# Additional Notes

Currently, the test is enabled for:
- x86_64/glibc
- aarch64/glibc
- aarch64/musl-libc

But disabled for:
- x86_64 musl, due to missing CFI (unwinding information) in the libc library.
- macosx: we need to investigate why the report contains messages like `"resolve_names failed with failed to open proc maps file /proc/10282/maps: No such file or directory (os error 2)"`.  It seems that the application already died when we resolve names/normalize ips.

