### PR TITLE
(libraryconfig) LibraryConfig logging instead of console stdout

### DIFF
--- a/datadog-library-config-ffi/src/lib.rs
+++ b/datadog-library-config-ffi/src/lib.rs
@@ -190,4 +190,12 @@ pub extern "C" fn ddog_library_config_local_stable_config_path() -> ffi::CStr<'s
 }
 
 #[no_mangle]
+pub extern "C" fn ddog_library_configurator_get_debug_message(
+    configurator: &Configurator,
+) -> ffi::CString {
+    let messages = configurator.inner.get_debug_messages();
+    ffi::CString::from_std(std::ffi::CString::new(messages.join("\n")).unwrap())
+}
+
+#[no_mangle]
 pub extern "C" fn ddog_library_config_drop(_: ffi::Vec<LibraryConfig>) {}

--- a/datadog-library-config/src/lib.rs
+++ b/datadog-library-config/src/lib.rs
@@ -10,6 +10,7 @@ use std::path::Path;
 use std::{env, fs, io, mem};
 
 use anyhow::Context;
+use std::cell::RefCell;
 
 /// This struct holds maps used to match and template configurations.
 ///
@@ -412,6 +413,7 @@ struct LibraryConfigVal {
 #[derive(Debug)]
 pub struct Configurator {
     debug_logs: bool,
+    debug_messages: RefCell<Vec<String>>
 }
 
 pub enum Target {
@@ -464,37 +466,42 @@ impl Configurator {
     }
 
     pub fn new(debug_logs: bool) -> Self {
-        Self { debug_logs }
+        Self { 
+            debug_logs, 
+            debug_messages: RefCell::new(Vec::new()) 
+        }
     }
 
     fn log_process_info(&self, process_info: &ProcessInfo, source: LibraryConfigSource) {
         if self.debug_logs {
-            eprintln!("Called library_config_common_component:");
-            eprintln!("\tsource: {source:?}");
-            eprintln!("\tconfigurator: {self:?}");
-            eprintln!("\tprocess args:");
-            process_info
-                .args
-                .iter()
-                .map(|arg| String::from_utf8_lossy(arg))
-                .for_each(|e| eprintln!("\t\t{:?}", e.as_ref()));
-
-            eprintln!(
+            let mut debug_mess = self.debug_messages.borrow_mut(); // Borrow once
+            debug_mess.push(format!("Called library_config_common_component:"));
+            debug_mess.push(format!("\tsource: {source:?}"));
+            debug_mess.push(format!("\tconfigurator: {self:?}"));
+            debug_mess.push(format!("\tprocess args:"));
+            
+            for arg in &process_info.args {
+                let arg_str = String::from_utf8_lossy(arg);
+                debug_mess.push(format!("\t\t{:?}", arg_str.as_ref()));
+            }
+            
+            debug_mess.push(format!(
                 "\tprocess language: {:?}",
                 String::from_utf8_lossy(&process_info.language).as_ref()
-            );
+            ));
+            // debug_mess is automatically dropped here, releasing the borrow
         }
     }
 
     fn parse_stable_config_slice(&self, buf: &[u8]) -> anyhow::Result<StableConfig> {
         if buf.is_empty() {
             let stable_config = StableConfig::default();
-            eprintln!("Read the following static config: {stable_config:?}");
+            self.debug_messages.borrow_mut().push(format!("Read the following static config: {stable_config:?}"));
             return Ok(stable_config);
         }
         let stable_config = serde_yaml::from_slice(buf)?;
         if self.debug_logs {
-            eprintln!("Read the following static config: {stable_config:?}");
+            self.debug_messages.borrow_mut().push(format!("Read the following static config: {stable_config:?}"));
         }
         Ok(stable_config)
     }
@@ -512,9 +519,10 @@ impl Configurator {
         process_info: &ProcessInfo,
     ) -> anyhow::Result<Vec<LibraryConfig>> {
         if self.debug_logs {
-            eprintln!("Reading stable configuration from files:");
-            eprintln!("\tlocal: {path_local:?}");
-            eprintln!("\tfleet: {path_managed:?}");
+            let mut debug_mess = self.debug_messages.borrow_mut();
+            debug_mess.push(format!("Reading stable configuration from files:"));
+            debug_mess.push(format!("\tlocal: {path_local:?}"));
+            debug_mess.push(format!("\tfleet: {path_managed:?}"));
         }
         let local_config = match fs::File::open(path_local) {
             Ok(file) => self.parse_stable_config_file(file)?,
@@ -623,7 +631,7 @@ impl Configurator {
         let matcher = Matcher::new(process_info, &stable_config.tags);
         let Some(configs) = matcher.find_stable_config(&stable_config) else {
             if self.debug_logs {
-                eprintln!("No selector matched for source {source:?}");
+                self.debug_messages.borrow_mut().push(format!("No selector matched for source {source:?}"));
             }
             return Ok(());
         };
@@ -641,7 +649,7 @@ impl Configurator {
         }
 
         if self.debug_logs {
-            eprintln!("Will apply the following configuration:\n\tsource {source:?}\n\t{library_config:?}");
+            self.debug_messages.borrow_mut().push(format!("Will apply the following configuration:\n\tsource {source:?}\n\t{library_config:?}"));
         }
         Ok(())
     }
@@ -705,7 +713,8 @@ mod tests {
         let mut actual = configurator
             .get_config_from_bytes(local_cfg, fleet_cfg, process_info)
             .unwrap();
-
+        let debug_messages = configurator.debug_messages.borrow().clone();
+        assert!(!debug_messages.is_empty());
         // Sort by name for determinism
         actual.sort_by_key(|c| c.name.clone());
         assert_eq!(actual, expected);
@@ -731,6 +740,26 @@ mod tests {
             )
             .unwrap();
         assert_eq!(cfg, vec![]);
+        let debug_messages = configurator.debug_messages.borrow().clone();
+        assert_eq!(debug_messages, vec![
+    "Reading stable configuration from files:",
+    "\tlocal: \"/file/is/missing\"",
+    "\tfleet: \"/file/is/missing_too\"",
+    "Called library_config_common_component:",
+    "\tsource: LocalStableConfig",
+    "\tconfigurator: Configurator { debug_logs: true, debug_messages: RefCell { value: <borrowed> } }",
+    "\tprocess args:",
+    "\t\t\"-jar HelloWorld.jar\"",
+    "\tprocess language: \"java\"",
+    "No selector matched for source LocalStableConfig",
+    "Called library_config_common_component:",
+    "\tsource: FleetStableConfig", 
+    "\tconfigurator: Configurator { debug_logs: true, debug_messages: RefCell { value: <borrowed> } }",
+    "\tprocess args:",
+    "\t\t\"-jar HelloWorld.jar\"",
+    "\tprocess language: \"java\"",
+    "No selector matched for source FleetStableConfig"
+]);
     }
 
     #[test]

--- a/datadog-library-config/src/lib.rs
+++ b/datadog-library-config/src/lib.rs
@@ -412,7 +412,7 @@ struct LibraryConfigVal {
 
 pub struct Configurator {
     debug_logs: bool,
-    debug_messages: RefCell<Vec<String>>
+    debug_messages: RefCell<Vec<String>>,
 }
 
 impl std::fmt::Display for Configurator {
@@ -478,14 +478,15 @@ impl Configurator {
     }
 
     pub fn new(debug_logs: bool) -> Self {
-        Self { 
-            debug_logs, 
-            debug_messages: RefCell::new(Vec::new()) 
+        Self {
+            debug_logs,
+            debug_messages: RefCell::new(Vec::new()),
         }
     }
 
     pub fn get_debug_messages(&self) -> Vec<String> {
-        self.debug_messages.try_borrow()
+        self.debug_messages
+            .try_borrow()
             .map(|messages| messages.clone())
             .unwrap_or_else(|_| vec!["Debug messages unavailable (borrow conflict)".to_string()])
     }
@@ -498,12 +499,12 @@ impl Configurator {
                 format!("\tconfigurator: {self:?}"),
                 "\tprocess args:".to_string(),
             ];
-            
+
             for arg in &process_info.args {
                 let arg_str = String::from_utf8_lossy(arg);
                 messages.push(format!("\t\t{:?}", arg_str.as_ref()));
             }
-            
+
             messages.push(format!(
                 "\tprocess language: {:?}",
                 String::from_utf8_lossy(&process_info.language).as_ref()
@@ -516,12 +517,16 @@ impl Configurator {
     fn parse_stable_config_slice(&self, buf: &[u8]) -> anyhow::Result<StableConfig> {
         if buf.is_empty() {
             let stable_config = StableConfig::default();
-            self.push_debug_message(format!("Read the following static config: {stable_config:?}"));
+            self.push_debug_message(format!(
+                "Read the following static config: {stable_config:?}"
+            ));
             return Ok(stable_config);
         }
         let stable_config = serde_yaml::from_slice(buf)?;
         if self.debug_logs {
-            self.push_debug_message(format!("Read the following static config: {stable_config:?}"));
+            self.push_debug_message(format!(
+                "Read the following static config: {stable_config:?}"
+            ));
         }
         Ok(stable_config)
     }
@@ -774,25 +779,28 @@ mod tests {
             .unwrap();
         assert_eq!(cfg, vec![]);
         let debug_messages = configurator.debug_messages.borrow().clone();
-        assert_eq!(debug_messages, vec![
-            "Reading stable configuration from files:",
-            "\tlocal: \"/file/is/missing\"",
-            "\tfleet: \"/file/is/missing_too\"",
-            "Called library_config_common_component:",
-            "\tsource: LocalStableConfig",
-            "\tconfigurator: Configurator { debug_logs: true }",
-            "\tprocess args:",
-            "\t\t\"-jar HelloWorld.jar\"",
-            "\tprocess language: \"java\"",
-            "No selector matched for source LocalStableConfig",
-            "Called library_config_common_component:",
-            "\tsource: FleetStableConfig",
-            "\tconfigurator: Configurator { debug_logs: true }",
-            "\tprocess args:",
-            "\t\t\"-jar HelloWorld.jar\"",
-            "\tprocess language: \"java\"",
-            "No selector matched for source FleetStableConfig"
-        ]);
+        assert_eq!(
+            debug_messages,
+            vec![
+                "Reading stable configuration from files:",
+                "\tlocal: \"/file/is/missing\"",
+                "\tfleet: \"/file/is/missing_too\"",
+                "Called library_config_common_component:",
+                "\tsource: LocalStableConfig",
+                "\tconfigurator: Configurator { debug_logs: true }",
+                "\tprocess args:",
+                "\t\t\"-jar HelloWorld.jar\"",
+                "\tprocess language: \"java\"",
+                "No selector matched for source LocalStableConfig",
+                "Called library_config_common_component:",
+                "\tsource: FleetStableConfig",
+                "\tconfigurator: Configurator { debug_logs: true }",
+                "\tprocess args:",
+                "\t\t\"-jar HelloWorld.jar\"",
+                "\tprocess language: \"java\"",
+                "No selector matched for source FleetStableConfig"
+            ]
+        );
     }
 
     #[test]

--- a/datadog-library-config/src/lib.rs
+++ b/datadog-library-config/src/lib.rs
@@ -484,6 +484,12 @@ impl Configurator {
         }
     }
 
+    pub fn get_debug_messages(&self) -> Vec<String> {
+        self.debug_messages.try_borrow()
+            .map(|messages| messages.clone())
+            .unwrap_or_else(|_| vec!["Debug messages unavailable (borrow conflict)".to_string()])
+    }
+
     fn log_process_info(&self, process_info: &ProcessInfo, source: LibraryConfigSource) {
         if self.debug_logs {
             let mut messages = vec![


### PR DESCRIPTION
# What does this PR do?

Dont print to console but add messages to a list if debug is activated.
Make this list available through FFI

Interrogation: 
I had to use a RefCell to store debug messages to have a mutable field in `Configurator`. I would have preferred these messages directly being available in the Result type when we call Configurator.get() but this would cause breaking changes with libraries already using the API and expecting a Vector of LibraryConfig... 


# Motivation

Tracers should avoid printing to console, but we still want the logs, especially to be able to debug.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
