### PR TITLE
Increase retries from 30 to 45 in all-checks.yml

### DIFF
--- a/.github/workflows/all-checks.yml
+++ b/.github/workflows/all-checks.yml
@@ -14,6 +14,6 @@ jobs:
           - uses: wechuli/allcheckspassed@f4669eca31dbad8fea1a0eb91c419d02c5b42200 # 1.1.1
             with:
                 delay: '3'
-                retries: '30'
+                retries: '45'
                 polling_interval: '1'
                 checks_exclude: 'devflow/merge'


### PR DESCRIPTION
# What does this PR do?

Per title

# Motivation

Some tests can takes ~30mn : https://github.com/DataDog/libdatadog/actions/runs/17307571226

So a 33 minutes timeout may be hit and cause a false positive : https://github.com/DataDog/libdatadog/actions/runs/17308401804/attempts/1 

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
