### PR TITLE
feat(datadog-test-agent): add a method to set the remote config response

### DIFF
--- a/datadog-trace-utils/src/test_utils/datadog_test_agent.rs
+++ b/datadog-trace-utils/src/test_utils/datadog_test_agent.rs
@@ -518,10 +518,7 @@ impl DatadogTestAgent {
 
     pub async fn set_remote_config_response(&self, data: &str, snapshot_token: Option<&str>) {
         let uri = self
-            .get_uri_for_endpoint(
-                SET_REMOTE_CONFIG_RESPONSE_PATH_ENDPOINT,
-                snapshot_token,
-            )
+            .get_uri_for_endpoint(SET_REMOTE_CONFIG_RESPONSE_PATH_ENDPOINT, snapshot_token)
             .await;
 
         let req = Request::builder()

--- a/datadog-trace-utils/src/test_utils/datadog_test_agent.rs
+++ b/datadog-trace-utils/src/test_utils/datadog_test_agent.rs
@@ -516,11 +516,11 @@ impl DatadogTestAgent {
         }
     }
 
-    pub async fn set_remote_config_response(&self, data: &str, snapshot_token: &str) {
+    pub async fn set_remote_config_response(&self, data: &str, snapshot_token: Option<&str>) {
         let uri = self
             .get_uri_for_endpoint(
                 SET_REMOTE_CONFIG_RESPONSE_PATH_ENDPOINT,
-                Some(snapshot_token),
+                snapshot_token,
             )
             .await;
 

--- a/datadog-trace-utils/tests/test_send_data.rs
+++ b/datadog-trace-utils/tests/test_send_data.rs
@@ -351,7 +351,7 @@ mod tracing_integration_tests {
                 ]
             }
         }"##,
-                snapshot_name,
+                Some(snapshot_name),
             )
             .await;
 


### PR DESCRIPTION

# What does this PR do?

Add a method on the test agent client that sets the remote config response for a snapshot.

# Motivation

We'd like to have integration tests in dd-trace-rs for our dynamic sample rates. Thus we'd like to set be able to configure the test agent to answer with a certain rc config

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
