### PR TITLE
Fix spurious truncated debugger payloads

### DIFF
--- a/ddcommon/src/hyper_migration.rs
+++ b/ddcommon/src/hyper_migration.rs
@@ -173,7 +173,7 @@ impl hyper::body::Body for Body {
             Body::Single(body) => body.is_end_stream(),
             Body::Empty(body) => body.is_end_stream(),
             Body::Boxed(body) => body.is_end_stream(),
-            Body::Channel(body) => body.is_closed(),
+            Body::Channel(body) => body.is_closed() && body.is_empty(),
             Body::Incoming(body) => body.is_end_stream(),
         }
     }


### PR DESCRIPTION
The Body wrapper from hyper_migration is only used in debugger code. It very occasionally leads to a state where there's still a pending message on the Body::channel() stream, but the sender was closed. Then hyper will omit that last frame.