### PR TITLE
[HandsOffConfig] Remove eprintln and return debug messages inside Result

### DIFF
--- a/datadog-library-config-ffi/Cargo.toml
+++ b/datadog-library-config-ffi/Cargo.toml
@@ -18,8 +18,9 @@ anyhow = "1.0"
 constcat = "0.4.1"
 
 [features]
-default = ["cbindgen"]
+default = ["cbindgen", "catch_panic"]
 cbindgen = ["build_common/cbindgen", "ddcommon-ffi/cbindgen"]
+catch_panic = []
 
 [build-dependencies]
 build_common = { path = "../build-common" }

--- a/datadog-library-config-ffi/src/lib.rs
+++ b/datadog-library-config-ffi/src/lib.rs
@@ -222,4 +222,12 @@ pub extern "C" fn ddog_library_config_local_stable_config_path() -> ffi::CStr<'s
 }
 
 #[no_mangle]
-pub extern "C" fn ddog_library_config_drop(_: LibraryConfigLoggedResult) {}
+pub extern "C" fn ddog_library_config_drop(mut config_result: LibraryConfigLoggedResult) {
+    match &mut config_result {
+        LibraryConfigLoggedResult::Ok(_) => {}
+        LibraryConfigLoggedResult::Err(err) => {
+            // Use the internal error clearing function for defensive cleanup
+            ddcommon_ffi::clear_error(err);
+        }
+    }
+}

--- a/datadog-library-config/src/lib.rs
+++ b/datadog-library-config/src/lib.rs
@@ -9,8 +9,6 @@ use std::ops::Deref;
 use std::path::Path;
 use std::{env, fs, io, mem};
 
-
-
 /// This struct holds maps used to match and template configurations.
 ///
 /// They are computed lazily so that if the templating feature is not necessary, we don't

--- a/examples/ffi/library_config.c
+++ b/examples/ffi/library_config.c
@@ -98,10 +98,8 @@ int main(int argc, const char *const *argv) {
   if (config_result.tag == DDOG_LIBRARY_CONFIG_LOGGED_RESULT_ERR) {
     ddog_Error err = config_result.err;
     fprintf(stderr, "An error occurred: %.*s", (int)err.message.len, err.message.ptr);    
-
-    // only this one is needed, but calling ddog_Error_drop(&config_result.err) is not going to crash
+    // only this one is needed now, the whole result is dropped by ddog_library_config_drop
     ddog_library_config_drop(config_result);
-    fprintf(stderr, "disposed twice");    
     exit(1);
   }
 

--- a/examples/ffi/library_config.c
+++ b/examples/ffi/library_config.c
@@ -93,16 +93,18 @@ int main(int argc, const char *const *argv) {
     ddog_library_configurator_with_fleet_path(configurator, args.fleet_path);
   }
 
-  ddog_Result_VecLibraryConfig config_result = ddog_library_configurator_get(configurator);
+  ddog_LibraryConfigLoggedResult config_result = ddog_library_configurator_get(configurator);
 
-  if (config_result.tag == DDOG_RESULT_VEC_LIBRARY_CONFIG_ERR_VEC_LIBRARY_CONFIG) {
+  if (config_result.tag == DDOG_LIBRARY_CONFIG_LOGGED_RESULT_ERR) {
     ddog_Error err = config_result.err;
-    fprintf(stderr, "%.*s", (int)err.message.len, err.message.ptr);
-    ddog_Error_drop(&err);
+    fprintf(stderr, "An error occurred: %.*s", (int)err.message.len, err.message.ptr);
+    // NO: ddog_Error_drop(&err);
+    // do not free error, just free the result in any case
+    ddog_library_config_drop(config_result);
     exit(1);
   }
 
-  ddog_Vec_LibraryConfig configs = config_result.ok;
+  ddog_Vec_LibraryConfig configs = config_result.ok.value;
   for (int i = 0; i < configs.len; i++) {
     const ddog_LibraryConfig *cfg = &configs.ptr[i];
 
@@ -110,4 +112,9 @@ int main(int argc, const char *const *argv) {
            ddog_library_config_source_to_string(cfg->source).ptr);
     setenv(cfg->name.ptr, cfg->value.ptr, 1);
   }
+  ddog_CString logs = config_result.ok.logs;
+  printf("Logs are: %s\n", logs.ptr);
+  
+  ddog_library_config_drop(config_result);
+  ddog_library_configurator_drop(configurator);
 }

--- a/examples/ffi/library_config.c
+++ b/examples/ffi/library_config.c
@@ -97,10 +97,11 @@ int main(int argc, const char *const *argv) {
 
   if (config_result.tag == DDOG_LIBRARY_CONFIG_LOGGED_RESULT_ERR) {
     ddog_Error err = config_result.err;
-    fprintf(stderr, "An error occurred: %.*s", (int)err.message.len, err.message.ptr);
-    // NO: ddog_Error_drop(&err);
-    // do not free error, just free the result in any case
+    fprintf(stderr, "An error occurred: %.*s", (int)err.message.len, err.message.ptr);    
+
+    // only this one is needed, but calling ddog_Error_drop(&config_result.err) is not going to crash
     ddog_library_config_drop(config_result);
+    fprintf(stderr, "disposed twice");    
     exit(1);
   }
 


### PR DESCRIPTION
# What does this PR do?

This PR causes some breaking changes with tracers using the FFI, see below.

## Collect debug messages instead of printing directly in library configuration

### Overview

This PR changes the library configuration system to collect debug messages in a buffer and return them with the result, instead of printing them directly using `eprintln!`. This addresses issues where debug output occurs too early in the tracer initialization process, particularly for .NET applications that don't have logging configured yet. So we want to be able to collect log messages that will be treated later on.

### Changes Made

#### Core Library Changes
- **New `LoggedResult<T, E>` type**: A custom result enum that carries both the result data and a `Vec<String>` of debug messages
- **Updated function signatures**: `get_config`, `get_config_from_file`, `parse_stable_config_file`, and related functions now return `LoggedResult` instead of standard `Result`
- **Debug message collection**: All `eprintln!` calls replaced with message collection into a buffer
- **Conditional logging**: Debug messages are only collected when `debug_logs: true` in the `Configurator`

#### FFI Layer Changes
- **New FFI `LoggedResult<T>` type**: FFI-safe enum with `Ok(T, CString)` and `Err(Error)` variants
- **Updated FFI function**: `ddog_library_configurator_get` now returns `ffi::LoggedResult<ffi::Vec<LibraryConfig>>`
- **Helper conversion function**: `logged_result_to_ffi_with_messages` converts Rust `LoggedResult` to FFI format
- **Consolidated drop logic**: Single `ddog_library_config_drop` function handles the new `LoggedResult` type altogether, the error type it can encapsulate doesn't need to be dropped apart anymore

### Breaking Changes ⚠️

**This PR introduces breaking changes for FFI consumers:**

1. **`ddog_library_configurator_get` return type**:
   - **Before**: `ffi::Vec<LibraryConfig>`
   - **After**: `ffi::LoggedResult<ffi::Vec<LibraryConfig>>`

2. **`ddog_library_config_drop` parameter**:
   - **Before**: `ffi::Vec<LibraryConfig>`
   - **After**: `ffi::LoggedResult<ffi::Vec<LibraryConfig>>`

#### Impact on Consumers

**C#/.NET applications** will need to:
- Update P/Invoke signatures to handle the new `LoggedResult` structure
- Call `ddog_library_config_drop` on the entire `LoggedResult` instead of extracted parts, don't call drop on the potential extracted Error
- Handle debug messages from the `CString` logs field in the `Ok` variant

**Other language bindings** will need similar updates to handle the new return type structure.

### Rationale

The primary motivation for this change is that tracers shouldn't have anything logged into console.  And the logging here occurs too early in the tracer initialization process:

- **Timing issue**: Debug output happens before logging systems are properly configured
- **.NET specific problem**: .NET applications haven't initialized their logging infrastructure when library configuration runs
- **Solution**: Collect messages and return them for later processing when logging is available

### Example Usage
 see branch https://github.com/DataDog/dd-trace-dotnet/compare/anna/handsoffconfig-logging-result-change?expand=1

### Testing

- Updated existing tests to handle `LoggedResult` return types
- Fixed `test_missing_files` to expect the new debug message collection behavior
- All tests pass with the new message collection system

### Migration Guide

For FFI consumers upgrading:

1. Update function signatures to handle `LoggedResult` types
2. Extract data and logs from the `Ok` variant
3. Use the consolidated `ddog_library_config_drop` function, don't use drop_error anymore on the Err enum as it would cause a double free
4. Process debug messages when desired
This change improves the reliability of debug output while maintaining the same core functionality.
# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
