### PR TITLE
Revert "[crashtracker] deprecated inprocess symbol resolution"

### DIFF
--- a/datadog-crashtracker/src/collector/api.rs
+++ b/datadog-crashtracker/src/collector/api.rs
@@ -121,7 +121,7 @@ mod tests {
             "/tmp/libdatadog/bin/libdatadog-crashtracking-receiver".to_string();
         let create_alt_stack = true;
         let use_alt_stack = true;
-        let resolve_frames = StacktraceCollection::WithSymbols;
+        let resolve_frames = StacktraceCollection::EnabledWithInprocessSymbols;
         let stderr_filename = Some(format!("{dir}/stderr_{time}.txt"));
         let stdout_filename = Some(format!("{dir}/stdout_{time}.txt"));
         let timeout = Duration::from_secs(10);
@@ -184,7 +184,7 @@ mod tests {
 
         let create_alt_stack = true;
         let use_alt_stack = false;
-        let resolve_frames = StacktraceCollection::WithSymbols;
+        let resolve_frames = StacktraceCollection::EnabledWithInprocessSymbols;
         let timeout = Duration::from_secs(10);
 
         // This should return an error, because we're creating an altstack without using it
@@ -242,7 +242,7 @@ mod tests {
             "/tmp/libdatadog/bin/libdatadog-crashtracking-receiver".to_string();
         let create_alt_stack = true;
         let use_alt_stack = true;
-        let resolve_frames = StacktraceCollection::WithSymbols;
+        let resolve_frames = StacktraceCollection::EnabledWithInprocessSymbols;
         let stderr_filename = Some(format!("{dir}/stderr_{time}.txt"));
         let stdout_filename = Some(format!("{dir}/stdout_{time}.txt"));
         let signals = default_signals();
@@ -364,7 +364,7 @@ mod tests {
             "/tmp/libdatadog/bin/libdatadog-crashtracking-receiver".to_string();
         let create_alt_stack = false; // Use, but do _not_ create
         let use_alt_stack = true;
-        let resolve_frames = StacktraceCollection::WithSymbols;
+        let resolve_frames = StacktraceCollection::EnabledWithInprocessSymbols;
         let stderr_filename = Some(format!("{dir}/stderr_{time}.txt"));
         let stdout_filename = Some(format!("{dir}/stdout_{time}.txt"));
         let signals = default_signals();
@@ -492,7 +492,7 @@ mod tests {
             "/tmp/libdatadog/bin/libdatadog-crashtracking-receiver".to_string();
         let create_alt_stack = false;
         let use_alt_stack = false;
-        let resolve_frames = StacktraceCollection::WithSymbols;
+        let resolve_frames = StacktraceCollection::EnabledWithInprocessSymbols;
         let stderr_filename = Some(format!("{dir}/stderr_{time}.txt"));
         let stdout_filename = Some(format!("{dir}/stdout_{time}.txt"));
         let signals = default_signals();
@@ -656,7 +656,7 @@ mod tests {
             "/tmp/libdatadog/bin/libdatadog-crashtracking-receiver".to_string();
         let create_alt_stack = true; // doesn't matter, but most runtimes use it, so take it
         let use_alt_stack = true;
-        let resolve_frames = StacktraceCollection::WithSymbols;
+        let resolve_frames = StacktraceCollection::EnabledWithInprocessSymbols;
         let stderr_filename = Some(format!("{dir}/stderr_{time}.txt"));
         let stdout_filename = Some(format!("{dir}/stdout_{time}.txt"));
         let signals = default_signals();

--- a/datadog-crashtracker/src/receiver/entry_points.rs
+++ b/datadog-crashtracker/src/receiver/entry_points.rs
@@ -133,7 +133,7 @@ fn resolve_frames(
     config: &CrashtrackerConfiguration,
     crash_info: &mut CrashInfo,
 ) -> anyhow::Result<()> {
-    if config.resolve_frames() == StacktraceCollection::WithSymbols {
+    if config.resolve_frames() == StacktraceCollection::EnabledWithSymbolsInReceiver {
         let pid = crash_info
             .proc_info
             .as_ref()

--- a/datadog-crashtracker/src/shared/configuration.rs
+++ b/datadog-crashtracker/src/shared/configuration.rs
@@ -6,16 +6,22 @@ use serde::{Deserialize, Serialize};
 use std::time::Duration;
 
 /// Stacktrace collection occurs in the context of a crashing process.
-/// If the stack is sufficiently corrupted, it is possible (but unlikely),
+/// If the stack is sufficiently corruputed, it is possible (but unlikely),
 /// for stack trace collection itself to crash.
 /// We recommend fully enabling stacktrace collection, but having an environment
 /// variable to allow downgrading the collector.
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StacktraceCollection {
+    /// Stacktrace collection occurs in the
     Disabled,
     WithoutSymbols,
-    WithSymbols,
+    /// This option uses `backtrace::resolve_frame_unsynchronized()` to gather symbol information
+    /// and also unwind inlined functions. Enabling this feature will not only provide symbolic
+    /// details, but may also yield additional or less stack frames compared to other
+    /// configurations.
+    EnabledWithInprocessSymbols,
+    EnabledWithSymbolsInReceiver,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/examples/ffi/crashtracking.c
+++ b/examples/ffi/crashtracking.c
@@ -62,7 +62,7 @@ int main(int argc, char **argv) {
   ddog_crasht_Config config = {
       .create_alt_stack = false,
       .endpoint = endpoint,
-      .resolve_frames = DDOG_CRASHT_STACKTRACE_COLLECTION_WITH_SYMBOLS,
+      .resolve_frames = DDOG_CRASHT_STACKTRACE_COLLECTION_ENABLED_WITH_INPROCESS_SYMBOLS,
       .signals = INIT_FROM_SLICE(signals),
   };
 


### PR DESCRIPTION
Reverts DataDog/libdatadog#1191
Failing PHP tests
https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-php/-/jobs/1114345312
```
023+                         "comments": [
024+                             "resolve_names failed with proc maps does not contain relevant entries",
025+                             "normalize_ip failed with proc maps does not contain relevant entries"
```