### PR TITLE
fix: handle some allocation failures in profile building

### DIFF
--- a/datadog-profiling-ffi/src/profiles/datatypes.rs
+++ b/datadog-profiling-ffi/src/profiles/datatypes.rs
@@ -496,7 +496,7 @@ pub unsafe extern "C" fn ddog_prof_Profile_add(
         if uses_string_ids {
             profile.add_string_id_sample(sample.into(), timestamp)
         } else {
-            profile.add_sample(sample.try_into()?, timestamp)
+            profile.try_add_sample(sample.try_into()?, timestamp)
         }
     })()
     .context("ddog_prof_Profile_add failed")

--- a/datadog-profiling-replayer/src/main.rs
+++ b/datadog-profiling-replayer/src/main.rs
@@ -209,7 +209,7 @@ fn main() -> anyhow::Result<()> {
 
     let before = Instant::now();
     for (timestamp, sample) in samples {
-        outprof.add_sample(sample, timestamp)?;
+        outprof.try_add_sample(sample, timestamp)?;
     }
     let duration = before.elapsed();
 

--- a/datadog-profiling/examples/profiles.rs
+++ b/datadog-profiling/examples/profiles.rs
@@ -49,7 +49,7 @@ fn main() {
     // Intentionally use the current time.
     let mut profile = Profile::new(&sample_types, Some(period));
 
-    match profile.add_sample(sample, None) {
+    match profile.try_add_sample(sample, None) {
         Ok(_) => {}
         Err(_) => exit(1),
     }

--- a/datadog-profiling/src/collections/string_storage.rs
+++ b/datadog-profiling/src/collections/string_storage.rs
@@ -176,7 +176,7 @@ impl ManagedStringStorage {
         match data.cached_seq_num.get() {
             Some((profile_id, seq_num)) if profile_id.id == cached_profile_id.id => Ok(seq_num),
             _ => {
-                let seq_num = profile_strings.intern(data.str.as_ref());
+                let seq_num = profile_strings.try_intern(data.str.as_ref())?;
                 data.cached_seq_num
                     .set(Some((cached_profile_id.into(), seq_num)));
                 Ok(seq_num)

--- a/datadog-profiling/src/collections/string_table/error.rs
+++ b/datadog-profiling/src/collections/string_table/error.rs
@@ -1,0 +1,38 @@
+// Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum Error {
+    OutOfMemory,
+    StorageFull,
+}
+
+impl core::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let msg = match self {
+            Error::OutOfMemory => "out of memory",
+            Error::StorageFull => "storage full",
+        };
+        std::fmt::Display::fmt(msg, f)
+    }
+}
+
+impl core::error::Error for Error {}
+
+impl From<datadog_alloc::AllocError> for Error {
+    fn from(_: datadog_alloc::AllocError) -> Error {
+        Error::OutOfMemory
+    }
+}
+
+impl From<std::collections::TryReserveError> for Error {
+    fn from(_: std::collections::TryReserveError) -> Error {
+        Error::OutOfMemory
+    }
+}
+
+impl From<indexmap::TryReserveError> for Error {
+    fn from(_: indexmap::TryReserveError) -> Error {
+        Error::OutOfMemory
+    }
+}

--- a/datadog-profiling/src/internal/profile/fuzz_tests.rs
+++ b/datadog-profiling/src/internal/profile/fuzz_tests.rs
@@ -435,7 +435,7 @@ fn fuzz_add_sample<'a>(
     samples_with_timestamps: &mut Vec<&'a Sample>,
     samples_without_timestamps: &mut HashMap<(&'a [Location], &'a [Label]), Vec<i64>>,
 ) {
-    let r = profile.add_sample(sample.into(), *timestamp);
+    let r = profile.try_add_sample(sample.into(), *timestamp);
     if expected_sample_types.len() == sample.values.len() {
         assert!(r.is_ok());
         if timestamp.is_some() {

--- a/datadog-profiling/src/internal/profile/interning_api/mod.rs
+++ b/datadog-profiling/src/internal/profile/interning_api/mod.rs
@@ -161,7 +161,7 @@ impl Profile {
         if s.is_empty() {
             Ok(Self::INTERNED_EMPTY_STRING)
         } else {
-            Ok(GenerationalId::new(self.intern(s), self.generation))
+            Ok(GenerationalId::new(self.try_intern(s)?, self.generation))
         }
     }
 

--- a/datadog-profiling/src/internal/profile/mod.rs
+++ b/datadog-profiling/src/internal/profile/mod.rs
@@ -12,7 +12,7 @@ use crate::api;
 use crate::api::ManagedStringId;
 use crate::collections::identifiable::*;
 use crate::collections::string_storage::{CachedProfileId, ManagedStringStorage};
-use crate::collections::string_table::StringTable;
+use crate::collections::string_table::{self, StringTable};
 use crate::iter::{IntoLendingIterator, LendingIterator};
 use anyhow::Context;
 use datadog_profiling_protobuf::{self as protobuf, Record, Value, NO_OPT_ZERO, OPT_ZERO};
@@ -101,11 +101,11 @@ impl Profile {
         local_root_span_id: u64,
         endpoint: Cow<str>,
     ) -> anyhow::Result<()> {
-        let interned_endpoint = self.intern(endpoint.as_ref());
+        let interned_endpoint = self.try_intern(endpoint.as_ref())?;
 
-        self.endpoints
-            .mappings
-            .insert(local_root_span_id, interned_endpoint);
+        let mappings = &mut self.endpoints.mappings;
+        mappings.try_reserve(1)?;
+        mappings.insert(local_root_span_id, interned_endpoint);
         Ok(())
     }
 
@@ -116,7 +116,7 @@ impl Profile {
         Ok(())
     }
 
-    pub fn add_sample(
+    pub fn try_add_sample(
         &mut self,
         sample: api::Sample,
         timestamp: Option<Timestamp>,
@@ -126,30 +126,35 @@ impl Profile {
             self.validate_sample_labels(&sample)?;
         }
 
-        let labels: Box<_> = sample
-            .labels
-            .iter()
-            .map(|label| {
-                let key = self.intern(label.key);
+        let labels = {
+            let mut lbls = Vec::new();
+            lbls.try_reserve_exact(sample.labels.len())?;
+            for label in &sample.labels {
+                let key = self.try_intern(label.key)?;
                 let internal_label = if !label.str.is_empty() {
-                    let str = self.intern(label.str);
+                    let str = self.try_intern(label.str)?;
                     Label::str(key, str)
                 } else {
                     let num = label.num;
-                    let num_unit = self.intern(label.num_unit);
+                    let num_unit = self.try_intern(label.num_unit)?;
                     Label::num(key, num, num_unit)
                 };
 
-                self.labels.dedup(internal_label)
-            })
-            .collect();
+                let id = self.labels.try_dedup(internal_label)?;
+                lbls.push(id);
+            }
+            lbls.into_boxed_slice()
+        };
 
-        let mut locations = Vec::with_capacity(sample.locations.len());
+        let mut locations = Vec::new();
+        locations
+            .try_reserve_exact(sample.locations.len())
+            .context("failed to reserve memory for sample locations")?;
         for location in &sample.locations {
-            locations.push(self.add_location(location)?);
+            locations.push(self.try_add_location(location)?);
         }
 
-        self.add_sample_internal(sample.values, labels, locations, timestamp)
+        self.try_add_sample_internal(sample.values, labels, locations, timestamp)
     }
 
     pub fn add_string_id_sample(
@@ -178,19 +183,20 @@ impl Profile {
                     Label::num(key, num, num_unit)
                 };
 
-                Ok(self.labels.dedup(internal_label))
+                self.labels.try_dedup(internal_label)
             })
             .collect::<Result<Box<[_]>, _>>()?;
 
-        let mut locations = Vec::with_capacity(sample.locations.len());
+        let mut locations = Vec::new();
+        locations.try_reserve_exact(sample.locations.len())?;
         for location in &sample.locations {
             locations.push(self.add_string_id_location(location)?);
         }
 
-        self.add_sample_internal(sample.values, labels, locations, timestamp)
+        self.try_add_sample_internal(sample.values, labels, locations, timestamp)
     }
 
-    fn add_sample_internal(
+    fn try_add_sample_internal(
         &mut self,
         values: &[i64],
         labels: Box<[LabelId]>,
@@ -204,9 +210,9 @@ impl Profile {
             values.len(),
         );
 
-        let labels = self.label_sets.dedup(LabelSet::new(labels));
+        let labels = self.label_sets.try_dedup(LabelSet::new(labels))?;
 
-        let stacktrace = self.add_stacktrace(locations);
+        let stacktrace = self.try_add_stacktrace(locations)?;
         self.observations
             .add(Sample::new(labels, stacktrace), timestamp, values)?;
         Ok(())
@@ -219,8 +225,8 @@ impl Profile {
         label_value: &str,
         upscaling_info: UpscalingInfo,
     ) -> anyhow::Result<()> {
-        let label_name_id = self.intern(label_name);
-        let label_value_id = self.intern(label_value);
+        let label_name_id = self.try_intern(label_name)?;
+        let label_value_id = self.try_intern(label_value)?;
         self.upscaling_rules.add(
             offset_values,
             (label_name, label_name_id),
@@ -499,12 +505,12 @@ impl Profile {
 
 /// Private helper functions
 impl Profile {
-    fn add_function(&mut self, function: &api::Function) -> FunctionId {
-        let name = self.intern(function.name);
-        let system_name = self.intern(function.system_name);
-        let filename = self.intern(function.filename);
+    fn try_add_function(&mut self, function: &api::Function) -> anyhow::Result<FunctionId> {
+        let name = self.try_intern(function.name)?;
+        let system_name = self.try_intern(function.system_name)?;
+        let filename = self.try_intern(function.filename)?;
 
-        self.functions.dedup(Function {
+        self.functions.try_dedup(Function {
             name,
             system_name,
             filename,
@@ -519,16 +525,16 @@ impl Profile {
         let system_name = self.resolve(function.system_name)?;
         let filename = self.resolve(function.filename)?;
 
-        Ok(self.functions.dedup(Function {
+        self.functions.try_dedup(Function {
             name,
             system_name,
             filename,
-        }))
+        })
     }
 
-    fn add_location(&mut self, location: &api::Location) -> anyhow::Result<LocationId> {
-        let mapping_id = self.add_mapping(&location.mapping);
-        let function_id = self.add_function(&location.function);
+    fn try_add_location(&mut self, location: &api::Location) -> anyhow::Result<LocationId> {
+        let mapping_id = self.try_add_mapping(&location.mapping)?;
+        let function_id = self.try_add_function(&location.function)?;
         self.locations.checked_dedup(Location {
             mapping_id,
             function_id,
@@ -551,7 +557,7 @@ impl Profile {
         })
     }
 
-    fn add_mapping(&mut self, mapping: &api::Mapping) -> Option<MappingId> {
+    fn try_add_mapping(&mut self, mapping: &api::Mapping) -> anyhow::Result<Option<MappingId>> {
         #[inline]
         fn is_zero_mapping(mapping: &api::Mapping) -> bool {
             // - PHP, Python, and Ruby use a mapping only as required.
@@ -572,19 +578,20 @@ impl Profile {
         }
 
         if is_zero_mapping(mapping) {
-            return None;
+            return Ok(None);
         }
 
-        let filename = self.intern(mapping.filename);
-        let build_id = self.intern(mapping.build_id);
+        let filename = self.try_intern(mapping.filename)?;
+        let build_id = self.try_intern(mapping.build_id)?;
 
-        Some(self.mappings.dedup(Mapping {
+        let id = self.mappings.try_dedup(Mapping {
             memory_start: mapping.memory_start,
             memory_limit: mapping.memory_limit,
             file_offset: mapping.file_offset,
             filename,
             build_id,
-        }))
+        })?;
+        Ok(Some(id))
     }
 
     fn add_string_id_mapping(
@@ -610,17 +617,18 @@ impl Profile {
         let filename = self.resolve(mapping.filename)?;
         let build_id = self.resolve(mapping.build_id)?;
 
-        Ok(Some(self.mappings.dedup(Mapping {
+        let id = self.mappings.try_dedup(Mapping {
             memory_start: mapping.memory_start,
             memory_limit: mapping.memory_limit,
             file_offset: mapping.file_offset,
             filename,
             build_id,
-        })))
+        })?;
+        Ok(Some(id))
     }
 
-    fn add_stacktrace(&mut self, locations: Vec<LocationId>) -> StackTraceId {
-        self.stack_traces.dedup(StackTrace { locations })
+    fn try_add_stacktrace(&mut self, locations: Vec<LocationId>) -> anyhow::Result<StackTraceId> {
+        self.stack_traces.try_dedup(StackTrace { locations })
     }
 
     #[inline]
@@ -710,6 +718,13 @@ impl Profile {
     #[inline]
     fn intern(&mut self, item: &str) -> StringId {
         self.strings.intern(item)
+    }
+
+    /// Interns the `str` as a string, returning the id in the string table.
+    /// The empty string is guaranteed to have an id of [StringId::ZERO].
+    #[inline]
+    fn try_intern(&mut self, item: &str) -> Result<StringId, string_table::Error> {
+        self.strings.try_intern(item)
     }
 
     /// Creates a profile from the period, sample types, and start time using
@@ -932,7 +947,7 @@ mod api_tests {
         assert_eq!(profile.only_for_testing_num_aggregated_samples(), 0);
 
         profile
-            .add_sample(
+            .try_add_sample(
                 api::Sample {
                     locations,
                     values: &[1, 10000],
@@ -1010,18 +1025,18 @@ mod api_tests {
         assert_eq!(profile.only_for_testing_num_aggregated_samples(), 0);
 
         profile
-            .add_sample(main_sample, None)
+            .try_add_sample(main_sample, None)
             .expect("profile to not be full");
         assert_eq!(profile.only_for_testing_num_aggregated_samples(), 1);
 
         profile
-            .add_sample(test_sample, None)
+            .try_add_sample(test_sample, None)
             .expect("profile to not be full");
         assert_eq!(profile.only_for_testing_num_aggregated_samples(), 2);
 
         assert_eq!(profile.only_for_testing_num_timestamped_samples(), 0);
         profile
-            .add_sample(timestamp_sample, Timestamp::new(42))
+            .try_add_sample(timestamp_sample, Timestamp::new(42))
             .expect("profile to not be full");
         assert_eq!(profile.only_for_testing_num_timestamped_samples(), 1);
         profile
@@ -1204,7 +1219,7 @@ mod api_tests {
             labels: vec![id_label],
         };
 
-        assert!(profile.add_sample(sample, None).is_err());
+        assert!(profile.try_add_sample(sample, None).is_err());
     }
 
     #[test]
@@ -1249,9 +1264,13 @@ mod api_tests {
             labels: vec![id2_label, other_label],
         };
 
-        profile.add_sample(sample1, None).expect("add to success");
+        profile
+            .try_add_sample(sample1, None)
+            .expect("add to success");
 
-        profile.add_sample(sample2, None).expect("add to success");
+        profile
+            .try_add_sample(sample2, None)
+            .expect("add to success");
 
         profile.add_endpoint(10, Cow::from("my endpoint"))?;
 
@@ -1372,7 +1391,7 @@ mod api_tests {
             labels,
         };
 
-        profile.add_sample(sample, None).unwrap_err();
+        profile.try_add_sample(sample, None).unwrap_err();
     }
 
     #[test]
@@ -1397,7 +1416,9 @@ mod api_tests {
             labels: vec![id_label],
         };
 
-        profile.add_sample(sample1, None).expect("add to success");
+        profile
+            .try_add_sample(sample1, None)
+            .expect("add to success");
 
         let serialized_profile = roundtrip_to_pprof(profile).unwrap();
 
@@ -1437,7 +1458,9 @@ mod api_tests {
             labels: vec![],
         };
 
-        profile.add_sample(sample1, None).expect("add to success");
+        profile
+            .try_add_sample(sample1, None)
+            .expect("add to success");
 
         let upscaling_info = UpscalingInfo::Proportional { scale: 2.0 };
         let values_offset = vec![0];
@@ -1465,7 +1488,9 @@ mod api_tests {
             labels: vec![],
         };
 
-        profile.add_sample(sample1, None).expect("add to success");
+        profile
+            .try_add_sample(sample1, None)
+            .expect("add to success");
 
         let upscaling_info = UpscalingInfo::Proportional { scale: 2.7 };
         let values_offset = vec![0];
@@ -1493,7 +1518,9 @@ mod api_tests {
             labels: vec![],
         };
 
-        profile.add_sample(sample1, None).expect("add to success");
+        profile
+            .try_add_sample(sample1, None)
+            .expect("add to success");
 
         let upscaling_info = UpscalingInfo::Poisson {
             sum_value_offset: 1,
@@ -1525,7 +1552,9 @@ mod api_tests {
             labels: vec![],
         };
 
-        profile.add_sample(sample1, None).expect("add to success");
+        profile
+            .try_add_sample(sample1, None)
+            .expect("add to success");
 
         let upscaling_info = UpscalingInfo::PoissonNonSampleTypeCount {
             sum_value_offset: 1,
@@ -1557,7 +1586,9 @@ mod api_tests {
             labels: vec![],
         };
 
-        profile.add_sample(sample1, None).expect("add to success");
+        profile
+            .try_add_sample(sample1, None)
+            .expect("add to success");
 
         let upscaling_info = UpscalingInfo::Poisson {
             sum_value_offset: 1,
@@ -1589,7 +1620,9 @@ mod api_tests {
             labels: vec![],
         };
 
-        profile.add_sample(sample1, None).expect("add to success");
+        profile
+            .try_add_sample(sample1, None)
+            .expect("add to success");
 
         // invalid sampling_distance value
         let upscaling_info = UpscalingInfo::Poisson {
@@ -1658,8 +1691,12 @@ mod api_tests {
             labels: vec![],
         };
 
-        profile.add_sample(sample1, None).expect("add to success");
-        profile.add_sample(sample2, None).expect("add to success");
+        profile
+            .try_add_sample(sample1, None)
+            .expect("add to success");
+        profile
+            .try_add_sample(sample2, None)
+            .expect("add to success");
 
         // upscale the first value and the last one
         let values_offset: Vec<usize> = vec![0, 2];
@@ -1713,8 +1750,12 @@ mod api_tests {
             labels: vec![],
         };
 
-        profile.add_sample(sample1, None).expect("add to success");
-        profile.add_sample(sample2, None).expect("add to success");
+        profile
+            .try_add_sample(sample1, None)
+            .expect("add to success");
+        profile
+            .try_add_sample(sample2, None)
+            .expect("add to success");
 
         let mut values_offset: Vec<usize> = vec![0];
 
@@ -1758,7 +1799,9 @@ mod api_tests {
             labels: vec![id_label],
         };
 
-        profile.add_sample(sample1, None).expect("add to success");
+        profile
+            .try_add_sample(sample1, None)
+            .expect("add to success");
 
         let values_offset: Vec<usize> = vec![0];
 
@@ -1814,7 +1857,9 @@ mod api_tests {
             labels: vec![id_label],
         };
 
-        profile.add_sample(sample1, None).expect("add to success");
+        profile
+            .try_add_sample(sample1, None)
+            .expect("add to success");
 
         let upscaling_info = UpscalingInfo::Proportional { scale: 2.0 };
         let values_offset: Vec<usize> = vec![0];
@@ -1870,8 +1915,12 @@ mod api_tests {
             labels: vec![],
         };
 
-        profile.add_sample(sample1, None).expect("add to success");
-        profile.add_sample(sample2, None).expect("add to success");
+        profile
+            .try_add_sample(sample1, None)
+            .expect("add to success");
+        profile
+            .try_add_sample(sample2, None)
+            .expect("add to success");
 
         let upscaling_info = UpscalingInfo::Proportional { scale: 2.0 };
         let values_offset: Vec<usize> = vec![0];
@@ -1940,8 +1989,12 @@ mod api_tests {
             labels: vec![id_no_match_label, id_label2],
         };
 
-        profile.add_sample(sample1, None).expect("add to success");
-        profile.add_sample(sample2, None).expect("add to success");
+        profile
+            .try_add_sample(sample1, None)
+            .expect("add to success");
+        profile
+            .try_add_sample(sample2, None)
+            .expect("add to success");
 
         // add rule for the first sample on the 1st value
         let upscaling_info = UpscalingInfo::Proportional { scale: 2.0 };
@@ -1993,7 +2046,9 @@ mod api_tests {
             labels: vec![id_label],
         };
 
-        profile.add_sample(sample1, None).expect("add to success");
+        profile
+            .try_add_sample(sample1, None)
+            .expect("add to success");
 
         // upscale samples and wall-time values
         let values_offset: Vec<usize> = vec![0, 1];
@@ -2029,7 +2084,9 @@ mod api_tests {
             labels: vec![id_label],
         };
 
-        profile.add_sample(sample1, None).expect("add to success");
+        profile
+            .try_add_sample(sample1, None)
+            .expect("add to success");
 
         let upscaling_info = UpscalingInfo::Proportional { scale: 2.0 };
         let mut value_offsets: Vec<usize> = vec![0];
@@ -2301,7 +2358,9 @@ mod api_tests {
             labels: vec![id_label],
         };
 
-        profile.add_sample(sample1, None).expect("add to success");
+        profile
+            .try_add_sample(sample1, None)
+            .expect("add to success");
 
         let mut value_offsets: Vec<usize> = vec![0, 1];
         // Add by-label rule first
@@ -2374,8 +2433,12 @@ mod api_tests {
             labels: vec![id2_label],
         };
 
-        profile.add_sample(sample1, None).expect("add to success");
-        profile.add_sample(sample2, None).expect("add to success");
+        profile
+            .try_add_sample(sample1, None)
+            .expect("add to success");
+        profile
+            .try_add_sample(sample2, None)
+            .expect("add to success");
 
         profile.add_endpoint(10, Cow::from("endpoint 10"))?;
         profile.add_endpoint(large_span_id, Cow::from("large endpoint"))?;


### PR DESCRIPTION
[PROF-11119](https://datadoghq.atlassian.net/browse/PROF-11119)

# What does this PR do?

This PR avoids some panic conditions by gracefully handling some error conditions, such as failing to reserve memory in some places. It does this for:

 - Some public APIs that already return errors, so it wasn't difficult to change plumbing.
 - Some private APIs that were used only in a few places, so again it wasn't difficult to change plumbing.

# Motivation

I was looking through PHP crash reports and found yet-another out-of-memory crash. I noticed that it would not be difficult to fix the specific issue in the PHP crash report and some adjacent ones.

# Additional Notes

This doesn't come close to handling all failed allocations and other error conditions. Doing so would require comprehensive changes including API-breaking changes. I'm already working on a new API for other reasons, so I don't feel it's worth the effort to do those extensive changes--just adopt the new API when it's ready.

# How to test the change?

It should test exactly the same. There are no public API changes.

[PROF-11119]: https://datadoghq.atlassian.net/browse/PROF-11119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ