### PR TITLE
feat!: fallible `AsBytes::try_as_bytes`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2014,6 +2014,7 @@ dependencies = [
  "ddcommon",
  "ddcommon-ffi",
  "ddtelemetry",
+ "function_name",
  "libc",
  "paste",
  "tempfile",

--- a/ddcommon-ffi/src/slice.rs
+++ b/ddcommon-ffi/src/slice.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use core::slice;
+use ddcommon::error::FfiSafeErrorMessage;
 use serde::ser::Error;
 use serde::Serializer;
 use std::borrow::Cow;
@@ -10,6 +11,14 @@ use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use std::os::raw::c_char;
 use std::str::Utf8Error;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug)]
+pub enum SliceConversionError {
+    LargeLength,
+    NullPointer,
+    MisalignedPointer,
+}
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -24,6 +33,25 @@ pub struct Slice<'a, T: 'a> {
     len: usize,
     _marker: PhantomData<&'a [T]>,
 }
+
+/// # Safety
+/// All strings are valid UTF-8 (enforced by using c-str literals in Rust).
+unsafe impl FfiSafeErrorMessage for SliceConversionError {
+    fn as_ffi_str(&self) -> &'static std::ffi::CStr {
+        match self {
+            SliceConversionError::LargeLength => c"length was too large",
+            SliceConversionError::NullPointer => c"null pointer with non-zero length",
+            SliceConversionError::MisalignedPointer => c"pointer was not aligned for the type",
+        }
+    }
+}
+impl Display for SliceConversionError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(self.as_rust_str(), f)
+    }
+}
+
+impl core::error::Error for SliceConversionError {}
 
 impl<'a, T: 'a> core::ops::Deref for Slice<'a, T> {
     type Target = [T];
@@ -55,17 +83,26 @@ pub type ByteSlice<'a> = Slice<'a, u8>;
 
 /// This exists as an intrinsic, but it is private.
 pub fn is_aligned_and_not_null<T>(ptr: *const T) -> bool {
-    !ptr.is_null() && is_aligned(ptr)
-}
-
-#[inline]
-fn is_aligned<T>(ptr: *const T) -> bool {
-    debug_assert!(!ptr.is_null());
-    ptr as usize % std::mem::align_of::<T>() == 0
+    !ptr.is_null() && ptr.is_aligned()
 }
 
 pub trait AsBytes<'a> {
     fn as_bytes(&self) -> &'a [u8];
+
+    /// Tries to interpret the structure as a slice of bytes.
+    ///
+    /// # Errors
+    ///
+    ///  - Returns [`SliceConversionError::NullPointer`] if the slice has a null pointer and a
+    ///    length other than zero. If pointer is null and length is zero, then return `Ok(&[])`
+    ///    instead.
+    ///  - Returns [`SliceConversionError::MisalignedPointer`] if the pointer is non-null and is not
+    ///    aligned correctly for the type (not generally possible with types which are inherently
+    ///    byte oriented, but is if the slice is of some other type which is being safely
+    ///    reinterpreted as bytes).
+    ///  - Returns [`SliceConversionError::LargeLength`] if the length of the slice exceeds
+    ///    [`isize::MAX`].
+    fn try_as_bytes(&self) -> Result<&'a [u8], SliceConversionError>;
 
     #[inline]
     fn try_to_utf8(&self) -> Result<&'a str, Utf8Error> {
@@ -98,12 +135,40 @@ impl<'a> AsBytes<'a> for Slice<'a, u8> {
     fn as_bytes(&self) -> &'a [u8] {
         self.as_slice()
     }
+
+    fn try_as_bytes(&self) -> Result<&'a [u8], SliceConversionError> {
+        self.try_as_slice()
+    }
 }
 
 impl<'a> AsBytes<'a> for Slice<'a, i8> {
     fn as_bytes(&self) -> &'a [u8] {
-        // SAFETY: safe to convert *i8 to *u8 and then read it... I think.
-        unsafe { Slice::from_raw_parts(self.ptr.cast(), self.len) }.as_slice()
+        #[allow(clippy::expect_used)]
+        self.try_as_bytes()
+            .expect("AsBytes::as_bytes failed to convert to a Rust slice")
+    }
+
+    fn try_as_bytes(&self) -> Result<&'a [u8], SliceConversionError> {
+        self.try_as_slice().map(|slice| {
+            // SAFETY: we've gone through a successful try_as_slice, so the
+            // enforceable characteristics such as fitting in isize::MAX are
+            // all good. The rest is safe only if the consumer respects the
+            // inherent safety requirements--doesn't give invalid length,
+            // pointer to invalid memory, etc.
+            unsafe { slice::from_raw_parts(slice.as_ptr().cast(), self.len) }
+        })
+    }
+}
+
+impl<'a> AsBytes<'a> for &'a [c_char] {
+    fn as_bytes(&self) -> &'a [u8] {
+        // SAFETY: We're converting from &[c_char] to &[u8] which is safe since
+        // they have the same layout and c_char has no unused bit patterns.
+        unsafe { slice::from_raw_parts(self.as_ptr().cast(), self.len()) }
+    }
+
+    fn try_as_bytes(&self) -> Result<&'a [u8], SliceConversionError> {
+        Ok(self.as_bytes())
     }
 }
 
@@ -146,15 +211,32 @@ impl<'a, T: 'a> Slice<'a, T> {
     }
 
     pub fn as_slice(&self) -> &'a [T] {
-        if !self.ptr.is_null() {
-            // Crashing immediately is likely better than ignoring these.
-            assert!(is_aligned(self.ptr));
-            assert!(self.len <= isize::MAX as usize);
-            unsafe { slice::from_raw_parts(self.ptr, self.len) }
+        #[allow(clippy::expect_used)]
+        self.try_as_slice()
+            .expect("ffi Slice failed to convert to a Rust slice")
+    }
+
+    /// Tries to convert the FFI slice into a standard slice.
+    ///
+    /// # Errors
+    ///
+    /// 1. Fails if `self.ptr` is null and `self.len` is not zero.
+    /// 2. Fails if `self.ptr` is not null and is unaligned.
+    /// 3. Fails if `self.len` is larger than [`isize::MAX`].
+    pub fn try_as_slice(&self) -> Result<&'a [T], SliceConversionError> {
+        let (ptr, len) = self.as_raw_parts();
+        if !ptr.is_null() {
+            if len > isize::MAX as usize {
+                Err(SliceConversionError::LargeLength)
+            } else if !ptr.is_aligned() {
+                Err(SliceConversionError::MisalignedPointer)
+            } else {
+                Ok(unsafe { slice::from_raw_parts(ptr, len) })
+            }
+        } else if len != 0 {
+            Err(SliceConversionError::NullPointer)
         } else {
-            // Crashing immediately is likely better than ignoring this.
-            assert_eq!(self.len, 0);
-            &[]
+            Ok(&[])
         }
     }
 

--- a/ddcommon/src/error.rs
+++ b/ddcommon/src/error.rs
@@ -1,0 +1,34 @@
+// Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+/// A trait to represent a static error message that is represented by both
+/// the requirements of Rust strings and C strings:
+///
+///  1. It must be a null terminated string with no interior null bytes.
+///  2. It must be valid UTF-8.
+///  3. It must not allocate to achieve the static bounds.
+///
+/// Using a c-str literal in Rust achieves all these requirements:
+///
+/// ```
+/// c"this string is compatible with FfiSafeErrorMessage";
+/// ```
+///
+/// # Safety
+///
+/// The strings returned by `as_ffi_str` must be valid UTF-8.
+pub unsafe trait FfiSafeErrorMessage {
+    /// Returns the error message as a static CStr. It must also be a valid
+    /// Rust string, including being UTF-8.
+    fn as_ffi_str(&self) -> &'static std::ffi::CStr;
+
+    /// Returns the error message as a static Rust str, excluding the null
+    /// terminator. If you need it, use [`FfiSafeErrorMessage::as_ffi_str`].
+    ///
+    /// Do not override this method, it would be marked final if it existed.
+    fn as_rust_str(&self) -> &'static str {
+        // Bytes will not contain the null terminator.
+        let bytes = self.as_ffi_str().to_bytes();
+        unsafe { std::str::from_utf8_unchecked(bytes) }
+    }
+}

--- a/ddcommon/src/lib.rs
+++ b/ddcommon/src/lib.rs
@@ -21,6 +21,7 @@ pub mod entity_id;
 #[macro_use]
 pub mod cstr;
 pub mod config;
+pub mod error;
 pub mod hyper_migration;
 pub mod rate_limiter;
 pub mod tag;

--- a/ddtelemetry-ffi/Cargo.toml
+++ b/ddtelemetry-ffi/Cargo.toml
@@ -24,8 +24,9 @@ build_common = { path = "../build-common" }
 ddtelemetry = { path = "../ddtelemetry" }
 ddcommon = { path = "../ddcommon" }
 ddcommon-ffi = { path = "../ddcommon-ffi", default-features = false }
-paste = "1"
+function_name = "0.3"
 libc = "0.2"
+paste = "1"
 
 [dev-dependencies]
 tempfile = {version = "3.3"}

--- a/ddtelemetry-ffi/src/lib.rs
+++ b/ddtelemetry-ffi/src/lib.rs
@@ -95,7 +95,7 @@ macro_rules! try_c {
     ($failable:expr) => {
         match $failable {
             Ok(o) => o,
-            Err(e) => return ffi::MaybeError::Some(ddcommon_ffi::Error::from(format!("{:?}", e))),
+            Err(e) => return ffi::MaybeError::Some(ddcommon_ffi::Error::from(format!("{e:?}"))),
         }
     };
 }


### PR DESCRIPTION
# What does this PR do?

 1. The `AsBytes` trait has a new method `fn try_as_bytes(&self) -> Result<&'a [u8], SliceConversionError>`. This is a breaking change as adding a new trait method is a breaking change. Generally migrates `as_bytes` to use `self.try_as_bytes().expect()`.
 2. Adds a an `FfiSafeErrorMessage` trait. This is used in this PR but more so in the new profiling API PR. `SliceConversionError` implements `FfiSafeErrorMessage`. 
 3. Adds `try_as_slice` to the FFI `Slice` and `MutSlice` and migrates `as_slice` to use `try_as_slice` with an expect.
 4. Removes `is_aligned` functions to use Rust's `ptr::is_aligned` which stabilized in Rust 1.79.

# Motivation

This gives us another API to use to have fewer panics and more fallible FFI calls. This is used in this PR but is used more heavily in an upcoming profiling PR. That PR will be quite large, so I want to split part of it out.

# How to test the change?

If you implement `AsBytes`, you need to implement `try_as_bytes` now. Probably you should then implement `as_bytes` in terms of `try_as_bytes`. Then it should test the same, unless you are comparing string failures for functions like `ddog_telemetry_handle_add_log`.
