### PR TITLE
Bump version to 21.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "build_common"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "cbindgen",
  "serde",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "builder"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1394,7 +1394,7 @@ checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 
 [[package]]
 name = "data-pipeline"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1428,7 +1428,7 @@ dependencies = [
 
 [[package]]
 name = "data-pipeline-ffi"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "build_common",
  "data-pipeline",
@@ -1442,7 +1442,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-alloc"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "allocator-api2",
  "bolero",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-crashtracker"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-crashtracker-ffi"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-ddsketch"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-log"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "chrono",
  "ddcommon-ffi",
@@ -1631,7 +1631,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-log-ffi"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "build_common",
  "datadog-log",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "anyhow",
  "bitmaps",
@@ -1671,7 +1671,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-ffi"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-protobuf"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "bolero",
  "datadog-profiling-protobuf",
@@ -1705,7 +1705,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-replayer"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1833,7 +1833,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-normalization"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-obfuscation"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1862,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-protobuf"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -1875,7 +1875,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-utils"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "anyhow",
  "bolero",
@@ -1911,7 +1911,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-tracer-flare"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "anyhow",
  "datadog-remote-config",
@@ -1927,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "anyhow",
  "cc",
@@ -1962,7 +1962,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon-ffi"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "anyhow",
  "bolero",
@@ -1976,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "ddsketch-ffi"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "build_common",
  "datadog-ddsketch",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2009,7 +2009,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry-ffi"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "build_common",
  "ddcommon",
@@ -2140,7 +2140,7 @@ dependencies = [
 
 [[package]]
 name = "dogstatsd-client"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "anyhow",
  "cadence",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "symbolizer-ffi"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "blazesym-c",
  "build_common",
@@ -5612,7 +5612,7 @@ dependencies = [
 
 [[package]]
 name = "tinybytes"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "once_cell",
  "pretty_assertions",
@@ -5827,7 +5827,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "20.1.0"
+version = "21.0.0"
 dependencies = [
  "regex",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -794,7 +794,7 @@ dependencies = [
 
 [[package]]
 name = "build_common"
-version = "20.0.0"
+version = "20.1.0"
 dependencies = [
  "cbindgen",
  "serde",
@@ -803,7 +803,7 @@ dependencies = [
 
 [[package]]
 name = "builder"
-version = "20.0.0"
+version = "20.1.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1394,7 +1394,7 @@ checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 
 [[package]]
 name = "data-pipeline"
-version = "20.0.0"
+version = "20.1.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1428,7 +1428,7 @@ dependencies = [
 
 [[package]]
 name = "data-pipeline-ffi"
-version = "20.0.0"
+version = "20.1.0"
 dependencies = [
  "build_common",
  "data-pipeline",
@@ -1442,7 +1442,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-alloc"
-version = "20.0.0"
+version = "20.1.0"
 dependencies = [
  "allocator-api2",
  "bolero",
@@ -1452,7 +1452,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-crashtracker"
-version = "20.0.0"
+version = "20.1.0"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -1487,7 +1487,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-crashtracker-ffi"
-version = "20.0.0"
+version = "20.1.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1506,7 +1506,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-ddsketch"
-version = "20.0.0"
+version = "20.1.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-log"
-version = "20.0.0"
+version = "20.1.0"
 dependencies = [
  "chrono",
  "ddcommon-ffi",
@@ -1631,7 +1631,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-log-ffi"
-version = "20.0.0"
+version = "20.1.0"
 dependencies = [
  "build_common",
  "datadog-log",
@@ -1640,7 +1640,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling"
-version = "20.0.0"
+version = "20.1.0"
 dependencies = [
  "anyhow",
  "bitmaps",
@@ -1671,7 +1671,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-ffi"
-version = "20.0.0"
+version = "20.1.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-protobuf"
-version = "20.0.0"
+version = "20.1.0"
 dependencies = [
  "bolero",
  "datadog-profiling-protobuf",
@@ -1705,7 +1705,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-replayer"
-version = "20.0.0"
+version = "20.1.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1833,7 +1833,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-normalization"
-version = "20.0.0"
+version = "20.1.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-obfuscation"
-version = "20.0.0"
+version = "20.1.0"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1862,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-protobuf"
-version = "20.0.0"
+version = "20.1.0"
 dependencies = [
  "prost",
  "prost-build",
@@ -1875,7 +1875,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-trace-utils"
-version = "20.0.0"
+version = "20.1.0"
 dependencies = [
  "anyhow",
  "bolero",
@@ -1911,7 +1911,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-tracer-flare"
-version = "20.0.0"
+version = "20.1.0"
 dependencies = [
  "anyhow",
  "datadog-remote-config",
@@ -1927,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon"
-version = "20.0.0"
+version = "20.1.0"
 dependencies = [
  "anyhow",
  "cc",
@@ -1962,7 +1962,7 @@ dependencies = [
 
 [[package]]
 name = "ddcommon-ffi"
-version = "20.0.0"
+version = "20.1.0"
 dependencies = [
  "anyhow",
  "bolero",
@@ -1976,7 +1976,7 @@ dependencies = [
 
 [[package]]
 name = "ddsketch-ffi"
-version = "20.0.0"
+version = "20.1.0"
 dependencies = [
  "build_common",
  "datadog-ddsketch",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry"
-version = "20.0.0"
+version = "20.1.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2009,7 +2009,7 @@ dependencies = [
 
 [[package]]
 name = "ddtelemetry-ffi"
-version = "20.0.0"
+version = "20.1.0"
 dependencies = [
  "build_common",
  "ddcommon",
@@ -2140,7 +2140,7 @@ dependencies = [
 
 [[package]]
 name = "dogstatsd-client"
-version = "20.0.0"
+version = "20.1.0"
 dependencies = [
  "anyhow",
  "cadence",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "symbolizer-ffi"
-version = "20.0.0"
+version = "20.1.0"
 dependencies = [
  "blazesym-c",
  "build_common",
@@ -5612,7 +5612,7 @@ dependencies = [
 
 [[package]]
 name = "tinybytes"
-version = "20.0.0"
+version = "20.1.0"
 dependencies = [
  "once_cell",
  "pretty_assertions",
@@ -5827,7 +5827,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "20.0.0"
+version = "20.1.0"
 dependencies = [
  "regex",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.84.1"
 edition = "2021"
-version = "20.1.0"
+version = "21.0.0"
 license = "Apache-2.0"
 
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.84.1"
 edition = "2021"
-version = "20.0.0"
+version = "20.1.0"
 license = "Apache-2.0"
 
 [profile.dev]


### PR DESCRIPTION
# What does this PR do?

This PR bumps the libdatadog version to 21.0.0 in preparation for release.
This version bumps the major version due to the following changes:
https://github.com/DataDog/libdatadog/pull/1201
https://github.com/DataDog/libdatadog/pull/1211

# Motivation

To include `crash_ping` mechanism to track crash reports that fail to be emitted

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
