### PR TITLE
feat(profiling): `ValueType::new` is const and Hash

### DIFF
--- a/datadog-profiling/src/api.rs
+++ b/datadog-profiling/src/api.rs
@@ -5,7 +5,7 @@ use datadog_profiling_protobuf::prost_impls;
 use std::ops::{Add, Sub};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct ValueType<'a> {
     pub r#type: &'a str,
     pub unit: &'a str,
@@ -13,7 +13,7 @@ pub struct ValueType<'a> {
 
 impl<'a> ValueType<'a> {
     #[inline(always)]
-    pub fn new(r#type: &'a str, unit: &'a str) -> Self {
+    pub const fn new(r#type: &'a str, unit: &'a str) -> Self {
         Self { r#type, unit }
     }
 }


### PR DESCRIPTION
# What does this PR do?

`api::ValueType` now derives `Hash` and `api::ValueType::new` is now a `const fn`.

# Motivation

The PHP profiler has its own `ValueType` with two `'static` strs but I realized if I made these changes then PHP could reuse this and have one less conversion. In other words, `const fn new` allows for writing `ValueType<'static>` and `Hash` is because PHP uses it in a hash map (although hopefully that piece will be gone soon).

# Additional Notes

I made these changes in my browser. It's a rare day to make such simple changes.

# How to test the change?

Everything works the same, but you can now have `ValueType<'static>` and you can hash `ValueType`s if you want to.
