### PR TITLE
feat: use docker cli instead of relying on testcontainers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -153,15 +153,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
-name = "ascii-canvas"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
-dependencies = [
- "term",
-]
-
-[[package]]
 name = "assert-json-diff"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -447,8 +438,8 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "itoa",
  "matchit",
@@ -473,8 +464,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -510,17 +501,6 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "basic-cookies"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67bd8fd42c16bdb08688243dc5f0cc117a3ca9efeeaba3a345a18a6159ad96f7"
-dependencies = [
- "lalrpop",
- "lalrpop-util",
- "regex",
-]
 
 [[package]]
 name = "bin_tests"
@@ -565,26 +545,11 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "shlex",
  "syn 2.0.87",
  "which",
 ]
-
-[[package]]
-name = "bit-set"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -740,56 +705,6 @@ checksum = "858dc57c11725c52662501fa79fdbc6f7050339a05ca1bf1e587add0fed40d62"
 dependencies = [
  "bolero-engine",
  "cc",
-]
-
-[[package]]
-name = "bollard"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d41711ad46fda47cd701f6908e59d1bd6b9a2b7464c0d0aeab95c6d37096ff8a"
-dependencies = [
- "base64 0.22.1",
- "bollard-stubs",
- "bytes",
- "futures-core",
- "futures-util",
- "hex",
- "home",
- "http 1.1.0",
- "http-body-util",
- "hyper 1.6.0",
- "hyper-named-pipe",
- "hyper-rustls",
- "hyper-util",
- "hyperlocal",
- "log",
- "pin-project-lite",
- "rustls",
- "rustls-native-certs 0.7.3",
- "rustls-pemfile",
- "rustls-pki-types",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_repr",
- "serde_urlencoded",
- "thiserror",
- "tokio",
- "tokio-util",
- "tower-service",
- "url",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "bollard-stubs"
-version = "1.45.0-rc.26.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7c5415e3a6bc6d3e99eff6268e488fd4ee25e7b28c10f08fa6760bd9de16e4"
-dependencies = [
- "serde",
- "serde_repr",
- "serde_with",
 ]
 
 [[package]]
@@ -1088,7 +1003,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.1.0",
+ "http",
  "mime",
  "mime_guess",
  "rand 0.8.5",
@@ -1174,16 +1089,6 @@ name = "constcat"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5cd0c57ef83705837b1cb872c973eff82b070846d3e23668322b2c0f8246d0"
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "core-foundation"
@@ -1387,12 +1292,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "data-encoding"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
-
-[[package]]
 name = "data-pipeline"
 version = "20.0.0"
 dependencies = [
@@ -1407,10 +1306,10 @@ dependencies = [
  "ddtelemetry",
  "dogstatsd-client",
  "either",
- "http 1.1.0",
+ "http",
  "http-body-util",
  "httpmock",
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "rand 0.8.5",
  "regex",
@@ -1463,7 +1362,7 @@ dependencies = [
  "ddcommon",
  "ddtelemetry",
  "goblin",
- "http 1.1.0",
+ "http",
  "libc",
  "nix",
  "num-derive",
@@ -1588,7 +1487,7 @@ dependencies = [
  "constcat",
  "ddcommon",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "percent-encoding",
  "regex",
  "regex-automata 0.4.8",
@@ -1652,15 +1551,15 @@ dependencies = [
  "datadog-profiling-protobuf",
  "ddcommon",
  "futures",
- "http 1.1.0",
+ "http",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-multipart-rfc7578",
  "indexmap 2.6.0",
  "lz4_flex",
  "mime",
  "prost",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "serde",
  "serde_json",
  "target-triple",
@@ -1686,7 +1585,7 @@ dependencies = [
  "function_name",
  "futures",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "libc",
  "serde_json",
  "symbolizer-ffi",
@@ -1726,9 +1625,9 @@ dependencies = [
  "ddcommon",
  "futures",
  "futures-util",
- "http 1.1.0",
+ "http",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "manual_future",
  "serde",
@@ -1766,10 +1665,10 @@ dependencies = [
  "ddtelemetry",
  "dogstatsd-client",
  "futures",
- "http 1.1.0",
+ "http",
  "http-body-util",
  "httpmock",
- "hyper 1.6.0",
+ "hyper",
  "libc",
  "manual_future",
  "memory-stats",
@@ -1813,7 +1712,7 @@ dependencies = [
  "ddtelemetry",
  "ddtelemetry-ffi",
  "dogstatsd-client",
- "http 1.1.0",
+ "http",
  "libc",
  "paste",
  "rmp-serde",
@@ -1890,7 +1789,7 @@ dependencies = [
  "futures",
  "http-body-util",
  "httpmock",
- "hyper 1.6.0",
+ "hyper",
  "hyper-http-proxy",
  "prost",
  "rand 0.8.5",
@@ -1900,7 +1799,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "testcontainers",
  "tinybytes",
  "tokio",
  "tracing",
@@ -1916,7 +1814,7 @@ dependencies = [
  "datadog-remote-config",
  "datadog-trace-utils",
  "ddcommon",
- "hyper 1.6.0",
+ "hyper",
  "serde_json",
  "tempfile",
  "tokio",
@@ -1935,10 +1833,10 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "http 1.1.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "indexmap 2.6.0",
@@ -1948,7 +1846,7 @@ dependencies = [
  "pin-project",
  "regex",
  "rustls",
- "rustls-native-certs 0.8.1",
+ "rustls-native-certs",
  "serde",
  "static_assertions",
  "tempfile",
@@ -1969,7 +1867,7 @@ dependencies = [
  "chrono",
  "crossbeam-queue",
  "ddcommon",
- "hyper 1.6.0",
+ "hyper",
  "serde",
 ]
 
@@ -1992,9 +1890,9 @@ dependencies = [
  "ddcommon",
  "futures",
  "hashbrown 0.15.1",
- "http 1.1.0",
+ "http",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "serde",
  "serde_json",
@@ -2073,48 +1971,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2126,24 +1982,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "docker_credential"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31951f49556e34d90ed28342e1df7e1cb7a229c4cab0aecc627b5d91edd41d07"
-dependencies = [
- "base64 0.21.7",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "dogstatsd-client"
 version = "20.0.0"
 dependencies = [
  "anyhow",
  "cadence",
  "ddcommon",
- "http 1.1.0",
+ "http",
  "serde",
  "tokio",
  "tracing",
@@ -2188,36 +2033,6 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
-
-[[package]]
-name = "ena"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "enum-as-inner"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.87",
-]
 
 [[package]]
 name = "enum-ordinalize"
@@ -2468,6 +2283,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2588,7 +2409,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.1.0",
+ "http",
  "indexmap 2.6.0",
  "slab",
  "tokio",
@@ -2665,7 +2486,7 @@ dependencies = [
  "base64 0.21.7",
  "bytes",
  "headers-core",
- "http 1.1.0",
+ "http",
  "httpdate",
  "mime",
  "sha1",
@@ -2677,7 +2498,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 1.1.0",
+ "http",
 ]
 
 [[package]]
@@ -2711,51 +2532,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
-name = "hickory-proto"
-version = "0.24.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
-dependencies = [
- "async-trait",
- "cfg-if",
- "data-encoding",
- "enum-as-inner",
- "futures-channel",
- "futures-io",
- "futures-util",
- "idna",
- "ipnet",
- "once_cell",
- "rand 0.8.5",
- "thiserror",
- "tinyvec",
- "tokio",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "hickory-resolver"
-version = "0.24.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
-dependencies = [
- "cfg-if",
- "futures-util",
- "hickory-proto",
- "ipconfig",
- "lru-cache",
- "once_cell",
- "parking_lot",
- "rand 0.8.5",
- "resolv-conf",
- "smallvec",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2774,28 +2550,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hostname"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9c7c7c8ac16c798734b8a24560c1362120597c40d5e1459f09498f8f6c8f2ba"
-dependencies = [
- "cfg-if",
- "libc",
- "windows 0.52.0",
-]
-
-[[package]]
-name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
 name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2808,23 +2562,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.1.0",
+ "http",
 ]
 
 [[package]]
@@ -2835,8 +2578,8 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -2854,28 +2597,36 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "httpmock"
-version = "0.7.0"
+version = "0.8.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ec9586ee0910472dec1a1f0f8acf52f0fdde93aea74d70d4a3107b4be0fd5b"
+checksum = "b9d649264818ad8f19c01f72b4ddf2f0cfcd1183691b956de733673e81d8a51f"
 dependencies = [
  "assert-json-diff",
  "async-object-pool",
  "async-std",
  "async-trait",
- "base64 0.21.7",
- "basic-cookies",
+ "base64 0.22.1",
+ "bytes",
  "crossbeam-utils",
  "form_urlencoded",
+ "futures-timer",
  "futures-util",
- "hyper 0.14.31",
+ "headers",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
  "lazy_static",
- "levenshtein",
  "log",
+ "path-tree",
  "regex",
  "serde",
  "serde_json",
  "serde_regex",
  "similar",
+ "stringmetrics",
+ "tabwriter",
+ "thiserror",
  "tokio",
  "url",
 ]
@@ -2888,29 +2639,6 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
@@ -2919,8 +2647,8 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "h2",
- "http 1.1.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -2939,8 +2667,8 @@ dependencies = [
  "bytes",
  "futures-util",
  "headers",
- "http 1.1.0",
- "hyper 1.6.0",
+ "http",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
@@ -2959,23 +2687,8 @@ dependencies = [
  "bytes",
  "common-multipart-rfc7578",
  "futures-core",
- "http 1.1.0",
- "hyper 1.6.0",
-]
-
-[[package]]
-name = "hyper-named-pipe"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
-dependencies = [
- "hex",
- "hyper 1.6.0",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
- "winapi 0.3.9",
+ "http",
+ "hyper",
 ]
 
 [[package]]
@@ -2985,11 +2698,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
- "http 1.1.0",
- "hyper 1.6.0",
+ "http",
+ "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs 0.8.1",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -3003,7 +2716,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.6.0",
+ "hyper",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -3019,29 +2732,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.1.0",
- "http-body 1.0.1",
- "hyper 1.6.0",
+ "http",
+ "http-body",
+ "hyper",
  "pin-project-lite",
  "socket2",
  "tokio",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "hyperlocal"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
-dependencies = [
- "hex",
- "http-body-util",
- "hyper 1.6.0",
- "hyper-util",
- "pin-project-lite",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
@@ -3261,24 +2959,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ipconfig"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
-dependencies = [
- "socket2",
- "widestring",
- "windows-sys 0.48.0",
- "winreg",
-]
-
-[[package]]
-name = "ipnet"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
-
-[[package]]
 name = "is-terminal"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3358,37 +3038,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lalrpop"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
-dependencies = [
- "ascii-canvas",
- "bit-set",
- "ena",
- "itertools 0.11.0",
- "lalrpop-util",
- "petgraph",
- "pico-args",
- "regex",
- "regex-syntax 0.8.5",
- "string_cache",
- "term",
- "tiny-keccak",
- "unicode-xid",
- "walkdir",
-]
-
-[[package]]
-name = "lalrpop-util"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
-dependencies = [
- "regex-automata 0.4.8",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3399,12 +3048,6 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
-name = "levenshtein"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
@@ -3463,12 +3106,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3497,15 +3134,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 dependencies = [
  "value-bag",
-]
-
-[[package]]
-name = "lru-cache"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]
@@ -3659,12 +3287,6 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
@@ -3847,12 +3469,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
 name = "ordered-float"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3918,35 +3534,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "parse-display"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
-dependencies = [
- "parse-display-derive",
- "regex",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "parse-display-derive"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
-dependencies = [
- "proc-macro2",
- "quote",
- "regex",
- "regex-syntax 0.8.5",
- "structmeta",
- "syn 2.0.87",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "path-tree"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a97453bc21a968f722df730bfe11bd08745cb50d1300b0df2bda131dece136"
+dependencies = [
+ "smallvec",
+]
 
 [[package]]
 name = "pbkdf2"
@@ -3972,15 +3572,6 @@ checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
  "indexmap 2.6.0",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -4120,12 +3711,6 @@ dependencies = [
  "libc",
  "nix",
 ]
-
-[[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "pretty-hex"
@@ -4331,55 +3916,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dc55d7dec32ecaf61e0bd90b3d2392d721a28b95cfd23c3e176eccefbeab2f2"
 
 [[package]]
-name = "quinn"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
-dependencies = [
- "bytes",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash 2.0.0",
- "rustls",
- "socket2",
- "thiserror",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
-dependencies = [
- "bytes",
- "rand 0.8.5",
- "ring",
- "rustc-hash 2.0.0",
- "rustls",
- "slab",
- "thiserror",
- "tinyvec",
- "tracing",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4502,17 +4038,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.15",
- "libredox",
- "thiserror",
-]
-
-[[package]]
 name = "ref-cast"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4575,61 +4100,6 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
-
-[[package]]
-name = "reqwest"
-version = "0.12.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2",
- "hickory-resolver",
- "http 1.1.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.6.0",
- "hyper-rustls",
- "hyper-util",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-native-certs 0.8.1",
- "rustls-pemfile",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
- "windows-registry",
-]
-
-[[package]]
-name = "resolv-conf"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48375394603e3dd4b2d64371f7148fd8c7baa2680e28741f2cb8d23b59e3d4c4"
-dependencies = [
- "hostname",
-]
 
 [[package]]
 name = "ring"
@@ -4699,12 +4169,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
-name = "rustc-hash"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
-
-[[package]]
 name = "rustix"
 version = "0.38.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4734,19 +4198,6 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile",
- "rustls-pki-types",
- "schannel",
- "security-framework 2.11.1",
-]
-
-[[package]]
-name = "rustls-native-certs"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
@@ -4754,16 +4205,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.2.0",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
+ "security-framework",
 ]
 
 [[package]]
@@ -4877,25 +4319,12 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
  "bitflags",
- "core-foundation 0.10.0",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4993,34 +4422,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_repr"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.87",
-]
-
-[[package]]
 name = "serde_spanned"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
  "serde",
 ]
 
@@ -5154,12 +4560,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 
 [[package]]
-name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
-
-[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5170,9 +4570,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
@@ -5214,46 +4614,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "string_cache"
-version = "0.8.7"
+name = "stringmetrics"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
-dependencies = [
- "new_debug_unreachable",
- "once_cell",
- "parking_lot",
- "phf_shared",
- "precomputed-hash",
-]
+checksum = "7b3c8667cd96245cbb600b8dec5680a7319edd719c5aa2b5d23c6bff94f39765"
 
 [[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
-name = "structmeta"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
-dependencies = [
- "proc-macro2",
- "quote",
- "structmeta-derive",
- "syn 2.0.87",
-]
-
-[[package]]
-name = "structmeta-derive"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.87",
-]
 
 [[package]]
 name = "strum"
@@ -5342,9 +4712,6 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
-dependencies = [
- "futures-core",
-]
 
 [[package]]
 name = "synstructure"
@@ -5379,6 +4746,15 @@ dependencies = [
  "ntapi",
  "once_cell",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "tabwriter"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fce91f2f0ec87dff7e6bcbbeb267439aa1188703003c6055193c821487400432"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -5457,17 +4833,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "term"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
-dependencies = [
- "dirs-next",
- "rustversion",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5507,35 +4872,6 @@ dependencies = [
  "libc",
  "spawn_worker",
  "tempfile",
-]
-
-[[package]]
-name = "testcontainers"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef8374cea2c164699681ecc39316c3e1d953831a7a5721e36c7736d974e15fa"
-dependencies = [
- "async-trait",
- "bollard",
- "bollard-stubs",
- "bytes",
- "dirs",
- "docker_credential",
- "either",
- "futures",
- "log",
- "memchr",
- "parse-display",
- "pin-project-lite",
- "reqwest",
- "serde",
- "serde_json",
- "serde_with",
- "thiserror",
- "tokio",
- "tokio-stream",
- "tokio-util",
- "url",
 ]
 
 [[package]]
@@ -5622,15 +4958,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
-]
-
-[[package]]
 name = "tinybytes"
 version = "20.0.0"
 dependencies = [
@@ -5663,21 +4990,6 @@ dependencies = [
  "serde",
  "serde_json",
 ]
-
-[[package]]
-name = "tinyvec"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -5827,10 +5139,10 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "h2",
- "http 1.1.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.6.0",
+ "hyper",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -6054,6 +5366,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6080,7 +5398,6 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
- "serde",
 ]
 
 [[package]]
@@ -6283,12 +5600,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "widestring"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
-
-[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6343,16 +5654,6 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
-dependencies = [
- "windows-core 0.52.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1"
@@ -6387,8 +5688,8 @@ checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-result 0.3.0",
- "windows-strings 0.3.0",
+ "windows-result",
+ "windows-strings",
  "windows-targets 0.53.0",
 ]
 
@@ -6415,42 +5716,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-registry"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
-dependencies = [
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "windows-result"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d08106ce80268c4067c0571ca55a9b4e9516518eaa1a1fe9b37ca403ae1d1a34"
 dependencies = [
  "windows-targets 0.53.0",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
-dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6747,16 +6018,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9fb597c990f03753e08d3c29efbfcf2019a003b4bf4ba19225c158e1549f0f3"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ members = [
   "tinybytes",
   "dogstatsd-client",
   "datadog-log",
-  "datadog-log-ffi"
+  "datadog-log-ffi",
 ]
 
 # https://doc.rust-lang.org/cargo/reference/resolver.html
@@ -64,6 +64,17 @@ rust-version = "1.84.1"
 edition = "2021"
 version = "20.0.0"
 license = "Apache-2.0"
+
+[workspace.dependencies]
+hyper = { version = "1.6", features = [
+  "http1",
+  "client",
+], default-features = false }
+hyper-util = { version = "0.1.10", features = [
+  "http1",
+  "client",
+  "client-legacy",
+] }
 
 [profile.dev]
 debug = 2 # full debug info

--- a/data-pipeline-ffi/Cargo.toml
+++ b/data-pipeline-ffi/Cargo.toml
@@ -23,7 +23,7 @@ cbindgen = ["build_common/cbindgen", "ddcommon-ffi/cbindgen"]
 build_common = { path = "../build-common" }
 
 [dev-dependencies]
-httpmock = "0.7.0"
+httpmock = "0.8.0-alpha.1"
 rmp-serde = "1.1.1"
 datadog-trace-utils = { path = "../datadog-trace-utils" }
 

--- a/data-pipeline-ffi/src/trace_exporter.rs
+++ b/data-pipeline-ffi/src/trace_exporter.rs
@@ -1080,8 +1080,8 @@ mod tests {
             let mock_metrics = server.mock(|when, then| {
                 when.method(POST)
                     .path("/telemetry/proxy/api/v2/apmtelemetry")
-                    .body_contains(r#""runtime_id":"foo""#)
-                    .body_contains(r#""metric":"trace_api."#);
+                    .body_includes(r#""runtime_id":"foo""#)
+                    .body_includes(r#""metric":"trace_api."#);
                 then.status(200)
                     .header("content-type", "application/json")
                     .body("");
@@ -1134,7 +1134,7 @@ mod tests {
 
             ddog_trace_exporter_free(exporter);
             // It should receive 1 metrics payload (excluding heartbeats)
-            mock_metrics.assert_hits(1);
+            mock_metrics.assert_calls(1);
         }
     }
 

--- a/data-pipeline/Cargo.toml
+++ b/data-pipeline/Cargo.toml
@@ -12,8 +12,8 @@ autobenches = false
 [dependencies]
 anyhow = { version = "1.0" }
 arc-swap = "1.7.1"
-hyper = { version = "1.6", features = ["http1", "client"] }
-hyper-util = { version = "0.1", features = ["client", "client-legacy"] }
+hyper = { workspace = true }
+hyper-util = { workspace = true }
 http = "1.0"
 http-body-util = "0.1"
 tracing = { version = "0.1", default-features = false }
@@ -55,7 +55,7 @@ criterion = "0.5.1"
 datadog-trace-utils = { path = "../datadog-trace-utils", features = [
     "test-utils",
 ] }
-httpmock = "0.7.0"
+httpmock = "0.8.0-alpha.1"
 rand = "0.8.5"
 regex = "1.5"
 tempfile = "3.3.0"

--- a/data-pipeline/src/agent_info/fetcher.rs
+++ b/data-pipeline/src/agent_info/fetcher.rs
@@ -382,7 +382,7 @@ mod single_threaded_tests {
             .await
             .unwrap();
 
-        mock.assert_hits(2);
+        mock.assert_calls(2);
         assert!(
             matches!(new_state_info_status, FetchInfoStatus::NewState(info) if *info == AgentInfo {
                         state_hash: TEST_INFO_HASH.to_string(),
@@ -466,7 +466,7 @@ mod single_threaded_tests {
             .await;
 
         // Wait for second fetch
-        while mock_v2.hits_async().await == 0 {
+        while mock_v2.calls_async().await == 0 {
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
 
@@ -533,13 +533,13 @@ mod single_threaded_tests {
         const SLEEP_DURATION_MS: u64 = 10;
 
         let mut attempts = 0;
-        while mock.hits_async().await == 0 && attempts < MAX_ATTEMPTS {
+        while mock.calls_async().await == 0 && attempts < MAX_ATTEMPTS {
             attempts += 1;
             tokio::time::sleep(Duration::from_millis(SLEEP_DURATION_MS)).await;
         }
 
         // Should trigger a fetch since the state is different
-        mock.assert_hits_async(1).await;
+        mock.assert_calls_async(1).await;
 
         // Wait for the cache to be updated with proper timeout
         let mut attempts = 0;
@@ -616,6 +616,6 @@ mod single_threaded_tests {
         tokio::time::sleep(Duration::from_millis(500)).await;
 
         // Should not trigger a fetch since the state is the same
-        mock.assert_hits_async(0).await;
+        mock.assert_calls_async(0).await;
     }
 }

--- a/data-pipeline/src/stats_exporter.rs
+++ b/data-pipeline/src/stats_exporter.rs
@@ -253,7 +253,7 @@ mod tests {
                 when.method(POST)
                     .header("Content-type", "application/msgpack")
                     .path("/v0.6/stats")
-                    .body_contains("libdatadog-test");
+                    .body_includes("libdatadog-test");
                 then.status(200).body("");
             })
             .await;
@@ -312,7 +312,7 @@ mod tests {
                 when.method(POST)
                     .header("Content-type", "application/msgpack")
                     .path("/v0.6/stats")
-                    .body_contains("libdatadog-test");
+                    .body_includes("libdatadog-test");
                 then.status(200).body("");
             })
             .await;
@@ -349,7 +349,7 @@ mod tests {
                 when.method(POST)
                     .header("Content-type", "application/msgpack")
                     .path("/v0.6/stats")
-                    .body_contains("libdatadog-test");
+                    .body_includes("libdatadog-test");
                 then.status(200).body("");
             })
             .await;

--- a/data-pipeline/src/telemetry/mod.rs
+++ b/data-pipeline/src/telemetry/mod.rs
@@ -344,10 +344,10 @@ mod tests {
         client.start().await;
         let _ = client.send(&data);
         client.shutdown().await;
-        while telemetry_srv.hits_async().await == 0 {
+        while telemetry_srv.calls_async().await == 0 {
             sleep(Duration::from_millis(10)).await;
         }
-        telemetry_srv.assert_hits_async(1).await;
+        telemetry_srv.assert_calls_async(1).await;
     }
 
     #[cfg_attr(miri, ignore)]
@@ -373,10 +373,10 @@ mod tests {
         client.start().await;
         let _ = client.send(&data);
         client.shutdown().await;
-        while telemetry_srv.hits_async().await == 0 {
+        while telemetry_srv.calls_async().await == 0 {
             sleep(Duration::from_millis(10)).await;
         }
-        telemetry_srv.assert_hits_async(1).await;
+        telemetry_srv.assert_calls_async(1).await;
     }
 
     #[cfg_attr(miri, ignore)]
@@ -402,10 +402,10 @@ mod tests {
         client.start().await;
         let _ = client.send(&data);
         client.shutdown().await;
-        while telemetry_srv.hits_async().await == 0 {
+        while telemetry_srv.calls_async().await == 0 {
             sleep(Duration::from_millis(10)).await;
         }
-        telemetry_srv.assert_hits_async(1).await;
+        telemetry_srv.assert_calls_async(1).await;
     }
 
     #[cfg_attr(miri, ignore)]
@@ -431,10 +431,10 @@ mod tests {
         client.start().await;
         let _ = client.send(&data);
         client.shutdown().await;
-        while telemetry_srv.hits_async().await == 0 {
+        while telemetry_srv.calls_async().await == 0 {
             sleep(Duration::from_millis(10)).await;
         }
-        telemetry_srv.assert_hits_async(1).await;
+        telemetry_srv.assert_calls_async(1).await;
     }
 
     #[cfg_attr(miri, ignore)]
@@ -460,10 +460,10 @@ mod tests {
         client.start().await;
         let _ = client.send(&data);
         client.shutdown().await;
-        while telemetry_srv.hits_async().await == 0 {
+        while telemetry_srv.calls_async().await == 0 {
             sleep(Duration::from_millis(10)).await;
         }
-        telemetry_srv.assert_hits_async(1).await;
+        telemetry_srv.assert_calls_async(1).await;
     }
 
     #[cfg_attr(miri, ignore)]
@@ -489,10 +489,10 @@ mod tests {
         client.start().await;
         let _ = client.send(&data);
         client.shutdown().await;
-        while telemetry_srv.hits_async().await == 0 {
+        while telemetry_srv.calls_async().await == 0 {
             sleep(Duration::from_millis(10)).await;
         }
-        telemetry_srv.assert_hits_async(1).await;
+        telemetry_srv.assert_calls_async(1).await;
     }
 
     #[cfg_attr(miri, ignore)]
@@ -518,10 +518,10 @@ mod tests {
         client.start().await;
         let _ = client.send(&data);
         client.shutdown().await;
-        while telemetry_srv.hits_async().await == 0 {
+        while telemetry_srv.calls_async().await == 0 {
             sleep(Duration::from_millis(10)).await;
         }
-        telemetry_srv.assert_hits_async(1).await;
+        telemetry_srv.assert_calls_async(1).await;
     }
 
     #[cfg_attr(miri, ignore)]
@@ -547,10 +547,10 @@ mod tests {
         client.start().await;
         let _ = client.send(&data);
         client.shutdown().await;
-        while telemetry_srv.hits_async().await == 0 {
+        while telemetry_srv.calls_async().await == 0 {
             sleep(Duration::from_millis(10)).await;
         }
-        telemetry_srv.assert_hits_async(1).await;
+        telemetry_srv.assert_calls_async(1).await;
     }
 
     #[test]
@@ -674,7 +674,7 @@ mod tests {
 
         let telemetry_srv = server
             .mock_async(|when, then| {
-                when.method(POST).body_contains(r#""runtime_id":"foo""#);
+                when.method(POST).body_includes(r#""runtime_id":"foo""#);
                 then.status(200).body("");
             })
             .await;
@@ -698,10 +698,10 @@ mod tests {
             })
             .unwrap();
         client.shutdown().await;
-        while telemetry_srv.hits_async().await == 0 {
+        while telemetry_srv.calls_async().await == 0 {
             sleep(Duration::from_millis(10)).await;
         }
         // One payload generate-metrics
-        telemetry_srv.assert_hits_async(1).await;
+        telemetry_srv.assert_calls_async(1).await;
     }
 }

--- a/data-pipeline/src/trace_exporter/mod.rs
+++ b/data-pipeline/src/trace_exporter/mod.rs
@@ -1603,7 +1603,7 @@ mod tests {
 
         let metrics_endpoint = server.mock(|when, then| {
             when.method(POST)
-                .body_contains("\"metric\":\"trace_api.bytes\"")
+                .body_includes("\"metric\":\"trace_api.bytes\"")
                 .path("/telemetry/proxy/api/v2/apmtelemetry");
             then.status(200)
                 .header("content-type", "application/json")
@@ -1632,8 +1632,8 @@ mod tests {
         };
         assert_eq!(body, response_body);
 
-        traces_endpoint.assert_hits(1);
-        while metrics_endpoint.hits() == 0 {
+        traces_endpoint.assert_calls(1);
+        while metrics_endpoint.calls() == 0 {
             exporter
                 .runtime
                 .lock()
@@ -1644,7 +1644,7 @@ mod tests {
                     sleep(Duration::from_millis(100)).await;
                 })
         }
-        metrics_endpoint.assert_hits(1);
+        metrics_endpoint.assert_calls(1);
     }
 
     #[test]
@@ -1666,7 +1666,7 @@ mod tests {
 
         let metrics_endpoint = server.mock(|when, then| {
             when.method(POST)
-                .body_contains("\"metric\":\"trace_api.bytes\"")
+                .body_includes("\"metric\":\"trace_api.bytes\"")
                 .path("/telemetry/proxy/api/v2/apmtelemetry");
             then.status(200)
                 .header("content-type", "application/json")
@@ -1690,8 +1690,8 @@ mod tests {
         };
         assert_eq!(body, response_body);
 
-        traces_endpoint.assert_hits(1);
-        while metrics_endpoint.hits() == 0 {
+        traces_endpoint.assert_calls(1);
+        while metrics_endpoint.calls() == 0 {
             exporter
                 .runtime
                 .lock()
@@ -1702,7 +1702,7 @@ mod tests {
                     sleep(Duration::from_millis(100)).await;
                 })
         }
-        metrics_endpoint.assert_hits(1);
+        metrics_endpoint.assert_calls(1);
     }
 
     #[test]
@@ -1716,8 +1716,8 @@ mod tests {
                         }
                     }"#;
         let traces_endpoint = server.mock(|when, then| {
-            when.method(POST).path("/v0.5/traces").matches(|req| {
-                let bytes = tinybytes::Bytes::copy_from_slice(req.body.as_ref().unwrap());
+            when.method(POST).path("/v0.5/traces").is_true(|req| {
+                let bytes = tinybytes::Bytes::copy_from_slice(req.body_ref());
                 bytes.to_vec() == V5_EMPTY
             });
             then.status(200)
@@ -1727,7 +1727,7 @@ mod tests {
 
         let metrics_endpoint = server.mock(|when, then| {
             when.method(POST)
-                .body_contains("\"metric\":\"trace_api.bytes\"")
+                .body_includes("\"metric\":\"trace_api.bytes\"")
                 .path("/telemetry/proxy/api/v2/apmtelemetry");
             then.status(200)
                 .header("content-type", "application/json")
@@ -1759,8 +1759,8 @@ mod tests {
         };
         assert_eq!(body, response_body);
 
-        traces_endpoint.assert_hits(1);
-        while metrics_endpoint.hits() == 0 {
+        traces_endpoint.assert_calls(1);
+        while metrics_endpoint.calls() == 0 {
             exporter
                 .runtime
                 .lock()
@@ -1771,7 +1771,7 @@ mod tests {
                     sleep(Duration::from_millis(100)).await;
                 })
         }
-        metrics_endpoint.assert_hits(1);
+        metrics_endpoint.assert_calls(1);
     }
 
     #[test]
@@ -1805,7 +1805,7 @@ mod tests {
             };
             assert_eq!(body, response_body);
         }
-        traces_endpoint.assert_hits(2);
+        traces_endpoint.assert_calls(2);
     }
 
     #[test]
@@ -1845,7 +1845,7 @@ mod tests {
         let AgentResponse::Unchanged = result else {
             panic!("Expected Unchanged response");
         };
-        traces_endpoint.assert_hits(2);
+        traces_endpoint.assert_calls(2);
         traces_endpoint.delete();
 
         let traces_endpoint = server.mock(|when, then| {
@@ -1865,7 +1865,7 @@ mod tests {
         let AgentResponse::Unchanged = result else {
             panic!("Expected Unchanged response");
         };
-        traces_endpoint.assert_hits(2);
+        traces_endpoint.assert_calls(2);
     }
 
     #[test]
@@ -1943,7 +1943,7 @@ mod tests {
         let data = msgpack_encoder::v04::to_vec(&[trace_chunk]);
 
         // Wait for the info fetcher to get the config
-        while mock_info.hits() == 0 {
+        while mock_info.calls() == 0 {
             exporter
                 .runtime
                 .lock()
@@ -2080,7 +2080,7 @@ mod single_threaded_tests {
 
         // Wait for the mock server to process the stats
         for _ in 0..1000 {
-            if mock_traces.hits() > 0 && mock_stats.hits() > 0 {
+            if mock_traces.calls() > 0 && mock_stats.calls() > 0 {
                 break;
             } else {
                 std::thread::sleep(Duration::from_millis(10));

--- a/datadog-live-debugger/Cargo.toml
+++ b/datadog-live-debugger/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.0.1"
 [dependencies]
 anyhow = "1.0"
 ddcommon = { path = "../ddcommon" }
-hyper = { version = "1.6", features = ["http1", "client"] }
+hyper = { workspace = true}
 http-body-util = "0.1"
 
 regex = "1.9.3"

--- a/datadog-profiling-ffi/Cargo.toml
+++ b/datadog-profiling-ffi/Cargo.toml
@@ -48,7 +48,7 @@ ddsketch-ffi = { path = "../ddsketch-ffi", default-features = false, optional = 
 function_name = "0.3.0"
 futures = { version = "0.3", default-features = false }
 http-body-util = "0.1"
-hyper = { version = "1.6", features = ["http1", "client"] }
+hyper = { workspace = true}
 libc = "0.2"
 serde_json = { version = "1.0" }
 symbolizer-ffi = { path = "../symbolizer-ffi", optional = true, default-features = false }

--- a/datadog-profiling/Cargo.toml
+++ b/datadog-profiling/Cargo.toml
@@ -28,7 +28,7 @@ datadog-profiling-protobuf = { path = "../datadog-profiling-protobuf", features 
 ddcommon = {path = "../ddcommon" }
 futures = { version = "0.3", default-features = false }
 http = "1.0"
-hyper = { version = "1.6", features = ["http1", "client"] }
+hyper = { workspace = true}
 http-body-util = "0.1"
 hyper-multipart-rfc7578 = "0.9.0"
 indexmap = "2.2"

--- a/datadog-remote-config/Cargo.toml
+++ b/datadog-remote-config/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = { version = "1.0" }
 ddcommon = { path = "../ddcommon" }
 datadog-trace-protobuf = { path = "../datadog-trace-protobuf" }
 datadog-live-debugger = { path = "../datadog-live-debugger" }
-hyper = { version = "1.6", features = ["http1", "client"] }
+hyper = { workspace = true }
 http-body-util = "0.1"
 http = "1.0"
 base64 = "0.22.1"
@@ -29,7 +29,7 @@ serde_json = { version = "1.0", features = ["raw_value"] }
 serde_with = "3"
 
 # Test feature
-hyper-util = { version = "0.1", features = ["service"], optional = true }
+hyper-util = { workspace = true, features = ["service"], optional = true }
 
 [dev-dependencies]
 futures = "0.3"

--- a/datadog-sidecar/Cargo.toml
+++ b/datadog-sidecar/Cargo.toml
@@ -31,7 +31,7 @@ tinybytes = { path = "../tinybytes" }
 futures = { version = "0.3", default-features = false }
 manual_future = "0.1.1"
 http = "1.0"
-hyper = { version = "1.6", features = ["http1", "client"] }
+hyper = { workspace = true}
 http-body-util = "0.1"
 
 datadog-ipc = { path = "../datadog-ipc", features = ["tiny-bytes"] }
@@ -99,7 +99,7 @@ microseh = "0.1.1"
 [dev-dependencies]
 libc = { version = "0.2" }
 tempfile = { version = "3.3" }
-httpmock = "0.7.0"
+httpmock = "0.8.0-alpha.1"
 datadog-remote-config = { path = "../datadog-remote-config", features = ["test"] }
 datadog-trace-utils = { path = "../datadog-trace-utils", features = ["test-utils"] }
 

--- a/datadog-trace-utils/Cargo.toml
+++ b/datadog-trace-utils/Cargo.toml
@@ -16,7 +16,7 @@ path = "benches/main.rs"
 
 [dependencies]
 anyhow = "1.0"
-hyper = { version = "1.6", features = ["http1", "client"] }
+hyper = { workspace = true}
 http-body-util = "0.1"
 serde = { version = "1.0.145", features = ["derive"] }
 prost = "0.13.5"
@@ -51,14 +51,13 @@ zstd = { version = "0.13.3", default-features = false, optional = true }
 cargo_metadata = { version = "0.18.1", optional = true }
 # Dependency of cargo metadata, but 0.1.8 requires too new of a rust version.
 cargo-platform = { version = "=0.1.7", optional = true }
-testcontainers = { version = "0.22", features = ["http_wait"], optional = true }
-httpmock = { version = "0.7.0", optional = true }
+httpmock = { version = "0.8.0-alpha.1", optional = true }
 urlencoding = { version = "2.1.3", optional = true }
 
 [dev-dependencies]
 bolero = "0.13"
 criterion = "0.5.1"
-httpmock = { version = "0.7.0" }
+httpmock = { version = "0.8.0-alpha.1" }
 serde_json = "1.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 datadog-trace-utils = { path = ".", features = ["test-utils"] }
@@ -71,7 +70,6 @@ mini_agent = ["proxy", "compression", "ddcommon/use_webpki_roots"]
 test-utils = [
     "hyper/server",
     "httpmock",
-    "testcontainers",
     "cargo_metadata",
     "cargo-platform",
     "urlencoding",

--- a/datadog-trace-utils/src/send_data/mod.rs
+++ b/datadog-trace-utils/src/send_data/mod.rs
@@ -798,7 +798,7 @@ mod tests {
         let data_payload_len = rmp_compute_payload_len(&data.tracer_payloads);
         let res = data.send().await;
 
-        mock.assert_hits_async(2).await;
+        mock.assert_calls_async(2).await;
 
         assert_eq!(res.last_result.unwrap().status(), 200);
         assert_eq!(res.errors_timeout, 0);
@@ -839,7 +839,7 @@ mod tests {
 
         let res = data.send().await;
 
-        mock.assert_hits_async(5).await;
+        mock.assert_calls_async(5).await;
 
         assert!(res.last_result.is_ok());
         assert_eq!(res.last_result.unwrap().status(), 500);
@@ -938,7 +938,7 @@ mod tests {
 
         let res = data.send().await;
 
-        mock.assert_hits_async(5).await;
+        mock.assert_calls_async(5).await;
 
         assert_eq!(res.errors_timeout, 1);
         assert_eq!(res.errors_network, 0);
@@ -980,7 +980,7 @@ mod tests {
 
         let res = data.send().await;
 
-        mock.assert_hits_async(10).await;
+        mock.assert_calls_async(10).await;
 
         assert_eq!(res.errors_timeout, 1);
         assert_eq!(res.errors_network, 0);

--- a/datadog-trace-utils/src/test_utils/mod.rs
+++ b/datadog-trace-utils/src/test_utils/mod.rs
@@ -415,11 +415,11 @@ pub async fn poll_for_mock_hit(
         sleep(Duration::from_millis(sleep_interval_ms)).await;
         mock_observations_remaining -= 1;
         mock_hit = if expected_hits > 0 {
-            mock.hits_async().await == expected_hits
+            mock.calls_async().await == expected_hits
         } else {
             // If we are polling for 0 hits, we need to ensure we do all observations, otherwise
             // this will always be true
-            mock.hits_async().await == 0 && mock_observations_remaining == 0
+            mock.calls_async().await == 0 && mock_observations_remaining == 0
         };
 
         if mock_observations_remaining == 0 || mock_hit {

--- a/datadog-tracer-flare/Cargo.toml
+++ b/datadog-tracer-flare/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0"
 ddcommon = { path = "../ddcommon" }
 datadog-remote-config = { path = "../datadog-remote-config" }
 datadog-trace-utils = { path = "../datadog-trace-utils" }
-hyper = { version = "1.6", features = ["http1", "client"] }
+hyper = { workspace = true}
 tokio = { version = "1.36.0", features = ["time"] }
 serde_json = "1.0"
 zip = "4.0.0"

--- a/ddcommon-ffi/Cargo.toml
+++ b/ddcommon-ffi/Cargo.toml
@@ -23,7 +23,7 @@ anyhow = "1.0"
 chrono = { version = "0.4.38", features = ["std"] }
 crossbeam-queue = "0.3.11"
 ddcommon = { path = "../ddcommon" }
-hyper = { version = "1.6", features = ["http1", "client"] }
+hyper = { workspace = true}
 serde = "1.0"
 
 [dev-dependencies]

--- a/ddcommon/Cargo.toml
+++ b/ddcommon/Cargo.toml
@@ -18,12 +18,8 @@ futures = "0.3"
 futures-core = { version = "0.3.0", default-features = false }
 futures-util = { version = "0.3.0", default-features = false }
 hex = "0.4"
-hyper = { version = "1.6", features = ["http1", "client"] }
-hyper-util = { version = "0.1.10", features = [
-    "http1",
-    "client",
-    "client-legacy",
-] }
+hyper = { workspace = true }
+hyper-util = { workspace = true }
 http = "1.0"
 http-body = "1.0"
 http-body-util = "0.1"

--- a/ddtelemetry/Cargo.toml
+++ b/ddtelemetry/Cargo.toml
@@ -18,8 +18,8 @@ https = ["ddcommon/https"]
 anyhow = { version = "1.0" }
 base64 = "0.22"
 futures = { version = "0.3", default-features = false }
-hyper = { version = "1.6", features = ["http1", "client"] }
-hyper-util = { version = "0.1", features = ["http1", "client", "client-legacy"] }
+hyper = { workspace = true }
+hyper-util = { workspace = true }
 http-body-util = "0.1"
 http = "1.0"
 serde = { version = "1.0", features = ["derive"] }
@@ -31,7 +31,7 @@ tracing = { version = "0.1", default-features = false }
 uuid = { version = "1.3", features = ["v4"] }
 hashbrown = "0.15"
 
-ddcommon = { path = "../ddcommon", default-features = false}
+ddcommon = { path = "../ddcommon", default-features = false }
 datadog-ddsketch = { path = "../ddsketch" }
 
 [dev-dependencies]


### PR DESCRIPTION
# Motivations
Both testcontainers and httpmock have a lot of dependencies which we don't use elsewhere (some of them duplicates with incompatible versions).

This makes building tests quite a bit slower...

Also since testcontainer uses the docker sock, which is not available by default on mac, running the tests on a brand new mac install requires some extra setup.

In total this PR drops 60 tests dependencies on the data-pipeline crare

# What does this PR do?

* testcontainers can be replaced by running a few command with the docker cli directly,
* httpmock has been updated to the latest version, which uses hyper 1.0 instead of 0.14, which means deps are reusable now