### PR TITLE
feat: add support for process tags and container ids.

### DIFF
--- a/datadog-library-config/src/tracer_metadata.rs
+++ b/datadog-library-config/src/tracer_metadata.rs
@@ -1,5 +1,6 @@
 // Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
+use std::default::Default;
 
 /// This struct MUST be backward compatible.
 #[derive(serde::Serialize, Debug)]
@@ -26,6 +27,29 @@ pub struct TracerMetadata {
     /// Version of the service being instrumented.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub service_version: Option<String>,
+    /// Process tags of the application being instrumented.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub process_tags: Option<String>,
+    /// Container id seen by the application.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub container_id: Option<String>,
+}
+
+impl Default for TracerMetadata {
+    fn default() -> Self {
+        TracerMetadata {
+            schema_version: 2,
+            runtime_id: None,
+            tracer_language: String::new(),
+            tracer_version: String::new(),
+            hostname: String::new(),
+            service_name: None,
+            service_env: None,
+            service_version: None,
+            process_tags: None,
+            container_id: None,
+        }
+    }
 }
 
 pub enum AnonymousFileHandle {


### PR DESCRIPTION
This PR introduces support for two new metadata fields:
 - `process_tags`: a comma-separated list of tags that will be used to identify a process.
 - `container_id`: the container id computed by the tracing library.

I also took the opportunity to rework the FFI to be easier to interface with, which also provide ABI stability.

[RFC](https://docs.google.com/document/d/1AFdLUuVk70i0bJd5335-RxqsvwAV9ovAqcO2z5mEMbA/edit?tab=t.0#heading=h.fc4dk46k3lmw)

Changes:
  - Rework the FFI to be easier to use and ABI stability over time.
  - Bump the schema version to v2.

#### Usage Example
```c
void* builder = ddog_tracer_metadata_new();
ddog_tracer_metadata_set(builder, DDOG_METADATA_KIND_TRACER_VERSION, "18.0.0");
ddog_tracer_metadata_set(builder, DDOG_METADATA_KIND_RUNTIME_ID, "my-runtim-id");
ddog_tracer_metadata_set(builder, DDOG_METADATA_KIND_TRACER_LANGUAGE, "c");
ddog_tracer_metadata_set(builder, DDOG_METADATA_KIND_TRACER_VERSION, "0.0.1-rc");
ddog_tracer_metadata_set(builder, DDOG_METADATA_KIND_HOSTNAME, "dmehala-beast-v2");
ddog_tracer_metadata_set(builder, DDOG_METADATA_KIND_SERVICE_NAME, "my-service");
ddog_tracer_metadata_set(builder, DDOG_METADATA_KIND_SERVICE_VERSION, "18.2.4");
ddog_tracer_metadata_set(builder, DDOG_METADATA_KIND_PROCESS_TAGS, "p1,p2,p3");
ddog_tracer_metadata_set(builder, DDOG_METADATA_KIND_CONTAINER_ID, "uuwidhd-djqhdiq-djkdq");

ddog_Result_TracerMemfdHandle handle = ddog_tracer_metadata_store(metadata);
// From there keep a ref on `handle` to keep the memfd alive.
```