### PR TITLE
remove MergeGate codeowner approval requirements

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -11,8 +11,3 @@ rules:
   - require: pull-request-freshness
     max_age: 10d
   - require: all-files-are-owned
-  - require: reviewers-approval
-    source_patterns:
-      - data-pipeline/**
-      - data-pipeline-ffi/**
-      - datadog-tracer-flare/**


### PR DESCRIPTION
# What does this PR do?
We will investigate more flexible options. The rule is too restrictive. It requires codeowner approval for all crates touched in a PR, even though we only want to enforce it for a handful.

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
