### PR TITLE
[APMSP-2299] artifact-size-benchmark from PATs to dd-octo-sts

### DIFF
--- a/.github/chainguard/gitlab.comment-artifact-size-in-pr.sts.yml
+++ b/.github/chainguard/gitlab.comment-artifact-size-in-pr.sts.yml
@@ -1,0 +1,21 @@
+# Runner on gitlab so issuer is the gitlab
+issuer: https://gitlab.ddbuild.io
+
+# We are on the target repo, so we ok things coming from there :downarrow:
+subject: project_path:DataDog/apm-reliability/ddprof-build:ref_type:branch:ref:main
+
+# When exactly are we allowing to get touched (?)
+claim_pattern:
+  project_path: DataDag/apm-reliability/ddprof-build
+  ref: main
+  ref_type: branch
+  ref_path: refs/heads/main
+  job_workflow_ref: gitlab.ddbuild.io/DataDog/apm-reliability/ddprof-build/.gitlab-ci.yml
+
+# What can be done to us (?)
+permission:
+  pull_requests: write
+
+# I don't know what this does, I've seen it done somewhere
+repositories:
+  - libdatadog


### PR DESCRIPTION
# What does this PR do?

Use dd-octo-sts to have fine grained control of github token, instead of relying on github PATs.

https://datadoghq.atlassian.net/browse/APMSP-2299

# Motivation

artifact-size-benchmark gitlab workflow stopped working because the PAT was expired, and general policy change towards having more security and control over these kind of automation by going through dd-octo-sts

https://datadoghq.atlassian.net/browse/APMSP-2299

# Additional Notes

I don't know what I'm doing just yet

# How to test the change?

If gitlab's libddprof-build's artifact-size-benchmark PR manages to automagically post a comment on this PR (I'll try to make it work whilst both PRs are not merged) using dd-octo-sts instead of PAT, we will know it works okay-ish