### PR TITLE
chore: improve logging in telemetry crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1301,6 +1301,7 @@ dependencies = [
  "clap",
  "criterion",
  "datadog-ddsketch",
+ "datadog-log",
  "datadog-trace-protobuf",
  "datadog-trace-utils",
  "ddcommon",

--- a/data-pipeline/Cargo.toml
+++ b/data-pipeline/Cargo.toml
@@ -52,6 +52,7 @@ harness = false
 path = "benches/main.rs"
 
 [dev-dependencies]
+datadog-log = { path = "../datadog-log" }
 clap = { version = "4.0", features = ["derive"] }
 criterion = "0.5.1"
 datadog-trace-utils = { path = "../datadog-trace-utils", features = [

--- a/data-pipeline/src/trace_exporter/builder.rs
+++ b/data-pipeline/src/trace_exporter/builder.rs
@@ -193,12 +193,8 @@ impl TraceExporterBuilder {
     }
 
     /// Enables sending telemetry metrics.
-    pub fn enable_telemetry(&mut self, cfg: Option<TelemetryConfig>) -> &mut Self {
-        if let Some(cfg) = cfg {
-            self.telemetry = Some(cfg);
-        } else {
-            self.telemetry = Some(TelemetryConfig::default());
-        }
+    pub fn enable_telemetry(&mut self, cfg: TelemetryConfig) -> &mut Self {
+        self.telemetry = Some(cfg);
         self
     }
 
@@ -381,11 +377,11 @@ mod tests {
             .set_input_format(TraceExporterInputFormat::Proxy)
             .set_output_format(TraceExporterOutputFormat::V04)
             .set_client_computed_stats()
-            .enable_telemetry(Some(TelemetryConfig {
+            .enable_telemetry(TelemetryConfig {
                 heartbeat: 1000,
                 runtime_id: None,
                 debug_enabled: false,
-            }));
+            });
         let exporter = builder.build().unwrap();
 
         assert_eq!(

--- a/data-pipeline/src/trace_exporter/mod.rs
+++ b/data-pipeline/src/trace_exporter/mod.rs
@@ -1080,10 +1080,10 @@ mod tests {
         };
 
         if enable_telemetry {
-            builder.enable_telemetry(Some(TelemetryConfig {
+            builder.enable_telemetry(TelemetryConfig {
                 heartbeat: 100,
                 ..Default::default()
-            }));
+            });
         }
 
         builder.build().unwrap()
@@ -1619,10 +1619,10 @@ mod tests {
             .set_language("nodejs")
             .set_language_version("1.0")
             .set_language_interpreter("v8")
-            .enable_telemetry(Some(TelemetryConfig {
+            .enable_telemetry(TelemetryConfig {
                 heartbeat: 100,
                 ..Default::default()
-            }));
+            });
         let exporter = builder.build().unwrap();
 
         let traces = vec![0x90];
@@ -1743,10 +1743,10 @@ mod tests {
             .set_language("nodejs")
             .set_language_version("1.0")
             .set_language_interpreter("v8")
-            .enable_telemetry(Some(TelemetryConfig {
+            .enable_telemetry(TelemetryConfig {
                 heartbeat: 100,
                 ..Default::default()
-            }))
+            })
             .set_input_format(TraceExporterInputFormat::V04)
             .set_output_format(TraceExporterOutputFormat::V05);
 

--- a/ddtelemetry/Cargo.toml
+++ b/ddtelemetry/Cargo.toml
@@ -10,7 +10,7 @@ license.workspace = true
 bench = false
 
 [features]
-default = []
+default = ["tracing"]
 tracing = ["tracing/std"]
 https = ["ddcommon/https"]
 

--- a/ddtelemetry/src/config.rs
+++ b/ddtelemetry/src/config.rs
@@ -4,6 +4,7 @@
 use ddcommon::{config::parse_env, parse_uri, Endpoint};
 use http::{uri::PathAndQuery, Uri};
 use std::{borrow::Cow, time::Duration};
+use tracing::debug;
 
 pub const DEFAULT_DD_SITE: &str = "datadoghq.com";
 pub const PROD_INTAKE_SUBDOMAIN: &str = "instrumentation-telemetry-intake";
@@ -119,6 +120,10 @@ impl Settings {
     const _DD_SHARED_LIB_DEBUG: &'static str = "_DD_SHARED_LIB_DEBUG";
 
     pub fn from_env() -> Self {
+        debug!(
+            config.source = "environment",
+            "Loading telemetry settings from environment variables"
+        );
         let default = Self::default();
         Self {
             agent_host: parse_env::str_not_empty(Self::DD_AGENT_HOST),

--- a/ddtelemetry/src/lib.rs
+++ b/ddtelemetry/src/lib.rs
@@ -10,6 +10,7 @@
 #![cfg_attr(not(test), deny(clippy::unimplemented))]
 
 use ddcommon::entity_id;
+use tracing::debug;
 
 pub mod config;
 pub mod data;
@@ -18,11 +19,24 @@ pub mod metrics;
 pub mod worker;
 
 pub fn build_host() -> data::Host {
+    debug!("Building telemetry host information");
+    let hostname = info::os::real_hostname().unwrap_or_else(|_| String::from("unknown_hostname"));
+    let container_id = entity_id::get_container_id().map(|f| f.to_string());
+    let os_version = info::os::os_version().ok();
+
+    debug!(
+        host.hostname = %hostname,
+        host.container_id = ?container_id,
+        host.os = info::os::os_name(),
+        host.os_version = ?os_version,
+        "Built telemetry host information"
+    );
+
     data::Host {
-        hostname: info::os::real_hostname().unwrap_or_else(|_| String::from("unknown_hostname")),
-        container_id: entity_id::get_container_id().map(|f| f.to_string()),
+        hostname,
+        container_id,
         os: Some(String::from(info::os::os_name())),
-        os_version: info::os::os_version().ok(),
+        os_version,
         kernel_name: None,
         kernel_release: None,
         kernel_version: None,

--- a/examples/ffi/README.md
+++ b/examples/ffi/README.md
@@ -26,5 +26,6 @@ The build command will create executables in the examples/ffi/build folder. You 
 ./examples/ffi/build/ddsketch
 ./examples/ffi/build/telemetry
 ./examples/ffi/build/crashtracker
+./examples/ffi/build/trace_exporter
 # ... etc
 ```

--- a/examples/ffi/trace_exporter.c
+++ b/examples/ffi/trace_exporter.c
@@ -92,6 +92,18 @@ int main(int argc, char** argv)
     ddog_trace_exporter_config_set_tracer_version(config, tracer_version);
     ddog_trace_exporter_config_set_language(config, language);
 
+    ddog_TelemetryClientConfig telemetry_config = {
+        .interval = 60000,
+        .runtime_id = DDOG_CHARSLICE_C("12345678-1234-1234-1234-123456789abc"),
+        .debug_enabled = true
+    };
+
+    ret = ddog_trace_exporter_config_enable_telemetry(config, &telemetry_config);
+    if (ret) {
+        handle_error(ret);
+        goto error;
+    }
+
     ret = ddog_trace_exporter_new(&trace_exporter, config);
 
     assert(ret == NULL);


### PR DESCRIPTION
# What does this PR do?

- introduces improved logging and debugging capabilities across the telemetry and trace exporter modules
- refactors telemetry API for clarity

# Motivation

We don't get to see what happens in the telemetry crate.

# Additional Notes

None

# How to test the change?

- updated tests
- updated example apps (rust and C)
