### PR TITLE
chore(remote-config): make live debugger optional feature

### DIFF
--- a/datadog-remote-config/Cargo.toml
+++ b/datadog-remote-config/Cargo.toml
@@ -5,13 +5,15 @@ name = "datadog-remote-config"
 version = "0.0.1"
 
 [features]
+default = []
+live-debugger = ["datadog-live-debugger"]
 test = ["hyper/server", "hyper-util"]
 
 [dependencies]
 anyhow = { version = "1.0" }
 ddcommon = { path = "../ddcommon" }
 datadog-trace-protobuf = { path = "../datadog-trace-protobuf" }
-datadog-live-debugger = { path = "../datadog-live-debugger" }
+datadog-live-debugger = { path = "../datadog-live-debugger", optional = true }
 hyper = { workspace = true }
 http-body-util = "0.1"
 http = "1.0"

--- a/datadog-remote-config/src/fetch/fetcher.rs
+++ b/datadog-remote-config/src/fetch/fetcher.rs
@@ -696,7 +696,7 @@ pub mod tests {
             endpoint: server.endpoint.clone(),
             products: vec![
                 RemoteConfigProduct::ApmTracing,
-                RemoteConfigProduct::LiveDebugger,
+                RemoteConfigProduct::AgentConfig,
             ],
             capabilities: vec![RemoteConfigCapabilities::ApmTracingCustomTags],
         };
@@ -727,7 +727,7 @@ pub mod tests {
 
             let client = req.client.as_ref().unwrap();
             assert_eq!(client.capabilities, &[128, 0]);
-            assert_eq!(client.products, &["APM_TRACING", "LIVE_DEBUGGING"]);
+            assert_eq!(client.products, &["APM_TRACING", "AGENT_CONFIG"]);
             assert!(client.is_tracer);
             assert!(!client.is_agent);
             assert_eq!(client.id, "foo");
@@ -779,7 +779,7 @@ pub mod tests {
 
             let client = req.client.as_ref().unwrap();
             assert_eq!(client.capabilities, &[128, 0]);
-            assert_eq!(client.products, &["APM_TRACING", "LIVE_DEBUGGING"]);
+            assert_eq!(client.products, &["APM_TRACING", "AGENT_CONFIG"]);
             assert!(client.is_tracer);
             assert!(!client.is_agent);
             assert_eq!(client.id, "foo");

--- a/datadog-remote-config/src/fetch/test_server.rs
+++ b/datadog-remote-config/src/fetch/test_server.rs
@@ -216,6 +216,9 @@ impl RemoteConfigServer {
             language: "php".to_string(),
             tracer_version: "1.2.3".to_string(),
             endpoint: self.endpoint.clone(),
+            #[cfg(not(feature = "live-debugger"))]
+            products: vec![RemoteConfigProduct::ApmTracing],
+            #[cfg(feature = "live-debugger")]
             products: vec![
                 RemoteConfigProduct::ApmTracing,
                 RemoteConfigProduct::LiveDebugger,

--- a/datadog-remote-config/src/parse.rs
+++ b/datadog-remote-config/src/parse.rs
@@ -7,11 +7,13 @@ use crate::{
     },
     RemoteConfigPath, RemoteConfigProduct, RemoteConfigSource,
 };
+#[cfg(feature = "live-debugger")]
 use datadog_live_debugger::LiveDebuggingData;
 
 #[derive(Debug)]
 pub enum RemoteConfigData {
     DynamicConfig(DynamicConfigFile),
+    #[cfg(feature = "live-debugger")]
     LiveDebugger(LiveDebuggingData),
     TracerFlareConfig(AgentConfigFile),
     TracerFlareTask(AgentTaskFile),
@@ -33,6 +35,7 @@ impl RemoteConfigData {
             RemoteConfigProduct::ApmTracing => {
                 RemoteConfigData::DynamicConfig(config::dynamic::parse_json(data)?)
             }
+            #[cfg(feature = "live-debugger")]
             RemoteConfigProduct::LiveDebugger => {
                 let parsed = datadog_live_debugger::parse_json(&String::from_utf8_lossy(data))?;
                 RemoteConfigData::LiveDebugger(parsed)
@@ -46,6 +49,7 @@ impl From<&RemoteConfigData> for RemoteConfigProduct {
     fn from(value: &RemoteConfigData) -> Self {
         match value {
             RemoteConfigData::DynamicConfig(_) => RemoteConfigProduct::ApmTracing,
+            #[cfg(feature = "live-debugger")]
             RemoteConfigData::LiveDebugger(_) => RemoteConfigProduct::LiveDebugger,
             RemoteConfigData::TracerFlareConfig(_) => RemoteConfigProduct::AgentConfig,
             RemoteConfigData::TracerFlareTask(_) => RemoteConfigProduct::AgentTask,

--- a/datadog-remote-config/src/path.rs
+++ b/datadog-remote-config/src/path.rs
@@ -23,6 +23,7 @@ pub enum RemoteConfigProduct {
     AsmData,
     AsmDD,
     AsmFeatures,
+    #[cfg(feature = "live-debugger")]
     LiveDebugger,
 }
 
@@ -36,6 +37,7 @@ impl Display for RemoteConfigProduct {
             RemoteConfigProduct::AsmData => "ASM_DATA",
             RemoteConfigProduct::AsmDD => "ASM_DD",
             RemoteConfigProduct::AsmFeatures => "ASM_FEATURES",
+            #[cfg(feature = "live-debugger")]
             RemoteConfigProduct::LiveDebugger => "LIVE_DEBUGGING",
         };
         write!(f, "{str}")
@@ -85,6 +87,7 @@ impl RemoteConfigPath {
                 "ASM_DATA" => RemoteConfigProduct::AsmData,
                 "ASM_DD" => RemoteConfigProduct::AsmDD,
                 "ASM_FEATURES" => RemoteConfigProduct::AsmFeatures,
+                #[cfg(feature = "live-debugger")]
                 "LIVE_DEBUGGING" => RemoteConfigProduct::LiveDebugger,
                 product => anyhow::bail!("Unknown product {}", product),
             },

--- a/datadog-sidecar/Cargo.toml
+++ b/datadog-sidecar/Cargo.toml
@@ -22,7 +22,7 @@ datadog-sidecar-macros = { path = "../datadog-sidecar-macros" }
 ddtelemetry = { path = "../ddtelemetry", features = ["tracing"] }
 data-pipeline = { path = "../data-pipeline" }
 datadog-trace-utils = { path = "../datadog-trace-utils" }
-datadog-remote-config = { path = "../datadog-remote-config" }
+datadog-remote-config = { path = "../datadog-remote-config" , features = ["live-debugger"]}
 datadog-live-debugger = { path = "../datadog-live-debugger" }
 datadog-crashtracker = { path = "../datadog-crashtracker" }
 dogstatsd-client = { path = "../dogstatsd-client" }


### PR DESCRIPTION
# What does this PR do?

Move live debugger remote configuration functionality behind a feature flag.

# Motivation

Avoid pulling in unnecessary dependencies for users that don't need live debugging.
