### PR TITLE
chore(chainguard): removed obsolete/wrong local policy

### DIFF
--- a/.github/chainguard/gitlab.libddprof-comment-pr.sts.yaml
+++ b/.github/chainguard/gitlab.libddprof-comment-pr.sts.yaml
@@ -1,7 +1,0 @@
-issuer: https://token.actions.githubusercontent.com
-
-subject: repo:DataDog/libdatadog
-
-permissions:
-  metadata: read
-  pull_requests: write

--- a/.github/chainguard/gitlab.libddprof-draft-release.sts.yaml
+++ b/.github/chainguard/gitlab.libddprof-draft-release.sts.yaml
@@ -1,7 +1,0 @@
-issuer: https://token.actions.githubusercontent.com
-
-subject: repo:DataDog/libdatadog
-
-permissions:
-  contents: write
-  metadata: read


### PR DESCRIPTION
# What does this PR do?

Removing local policy chainguard that *should* not be in use.

# Motivation

It might be confusing to someone to see these here when they should not, and more generally keeping trashfiles is not advised

# Additional Notes

Correct policy chainguards are on the org-wide repository as per the dd-octo-sts documentation.

# How to test the change?

I don't know if you can test these are indeed useless in the PR, it's a local policy chainguard so you can make sure these names don't exist in the current repository...