### PR TITLE
[APMAPI-1625] Package libdatadog v22.0.0 for Ruby

### DIFF
--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -22,22 +22,22 @@ end
 LIB_GITHUB_RELEASES = [
   {
     file: "libdatadog-aarch64-alpine-linux-musl.tar.gz",
-    sha256: "5cf54178ec492b0a44ad82d41eb2099ed412a9a7d56a49d7e7af7139ee1f985c",
+    sha256: "250bf6011a1ab3c177ed6743faf64457f8dd7ed4ed1a97af4683327407dd13ab",
     ruby_platform: "aarch64-linux-musl"
   },
   {
     file: "libdatadog-aarch64-unknown-linux-gnu.tar.gz",
-    sha256: "c9aa49fe7a6b80e354ee5134736431ff61139ea1bab516b63a48a2bce3bebeca",
+    sha256: "47367657799c6273315a25a70c5f9d7b3258fbd46bd3b6e74a85d509b3d3679c",
     ruby_platform: "aarch64-linux"
   },
   {
     file: "libdatadog-x86_64-alpine-linux-musl.tar.gz",
-    sha256: "7b21231bb9c61993d425a45b6ae8ecede0cdac4a24c551b5bedebc0520721706",
+    sha256: "433d2d274543dbcccf055d708d93f7b07927ddca2273a87aedb82971e02f1e64",
     ruby_platform: "x86_64-linux-musl"
   },
   {
     file: "libdatadog-x86_64-unknown-linux-gnu.tar.gz",
-    sha256: "3daf4bbac975e440c6e93f6ca39df5f96777a7eaee63ff974c89b2180daf58c5",
+    sha256: "65a92ae10f264775082e67b29067d0d4712f0c24e600d6d4f819c5ef2ca8d257",
     ruby_platform: "x86_64-linux"
   }
 ]
@@ -202,7 +202,7 @@ module Helpers
     excluded_files: [
       "datadog_profiling.pc", # we use the datadog_profiling_with_rpath.pc variant
       "libdatadog_profiling.a", "datadog_profiling-static.pc", # We don't use the static library
-      "libdatadog_profiling.so.debug", # We don't include debug info
+      "libdatadog_profiling.debug", # We don't include debug info
       "DatadogConfig.cmake" # We don't compile using cmake
     ]
   )

--- a/ruby/lib/libdatadog/version.rb
+++ b/ruby/lib/libdatadog/version.rb
@@ -2,7 +2,7 @@
 
 module Libdatadog
   # Current libdatadog version
-  LIB_VERSION = "21.0.0"
+  LIB_VERSION = "22.0.0"
 
   GEM_MAJOR_VERSION = "1"
   GEM_MINOR_VERSION = "0"


### PR DESCRIPTION
What does this PR do?
This PR includes the changes documented in the "Releasing a new version to rubygems.org" part of the README: [datadog/libdatadog@main/ruby#releasing-a-new-version-to-rubygemsorg](https://github.com/datadog/libdatadog/tree/main/ruby?rgh-link-date=2025-07-17T09%3A09%3A43Z#releasing-a-new-version-to-rubygemsorg)
It also changes one of the filtered file from libdatadog_profiling.so.debug to libdatadog_profiling.debug

Motivation
Enable Ruby to use libdatadog v22.0.0. In particular, this release includes DSM and updates to Stable config and Process Discovery.

Additional Notes
N/A

How to test the change?
I've tested this change locally with updates to the API. Once this version is published, I'll open the Ruby-side PR for the update.

As a reminder, new libdatadog releases don't get automatically picked up by dd-trace-rb, so the PR that bumps the dependency will also test this release against all supported Ruby versions.
