### PR TITLE
[build] Fix soname on musl

### DIFF
--- a/builder/src/arch/musl.rs
+++ b/builder/src/arch/musl.rs
@@ -64,7 +64,7 @@ pub fn fix_soname(lib_path: &str) {
     let mut patch_soname = Command::new("patchelf")
         .arg("--set-soname")
         .arg(PROF_DYNAMIC_LIB)
-        .arg(lib_path)
+        .arg(lib_path.to_owned() + "/" + PROF_DYNAMIC_LIB)
         .spawn()
         .expect("failed to spawn patchelf");
 


### PR DESCRIPTION
# What does this PR do?

Fix the missing `SONAME` on musl.

# Motivation

There might have been a change in version of patchelf but starting v20 of libdatadog, sofile does not have a `SONAME` which prevents (ex: .NET profiler/tracer ) linking to libdatadog.

Starting v21
```
 readelf -d libdatadog-x86_64-alpine-linux-musl/lib/libdatadog_profiling.so

Dynamic section at offset 0x88c460 contains 27 entries:
  Tag        Type                         Name/Value
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.musl-x86_64.so.1]
```

before v21
```
 readelf -d libdatadog-x86_64-alpine-linux-musl/lib/libdatadog_profiling.so

Dynamic section at offset 0x877340 contains 28 entries:
  Tag        Type                         Name/Value
 0x000000000000000e (SONAME)             Library soname: [libdatadog_profiling.so]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.musl-x86_64.so.1]
```


# Check
Download https://gitlab.ddbuild.io/DataDog/apm-reliability/libddprof-build/-/jobs/1161933649/artifacts/file/x86_64-alpine-linux-musl/lib/libdatadog_profiling.so and run `readelf -d libdatadog_profiling.so`
```
Dynamic section at offset 0x892548 contains 28 entries:
  Tag        Type                         Name/Value
 0x000000000000000e (SONAME)             Library soname: [libdatadog_profiling.so]
 0x0000000000000001 (NEEDED)             Shared library: [libgcc_s.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libc.musl-x86_64.so.1]
```
