### PR TITLE
feat(profiling): OTel style API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1833,6 +1833,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "enum-ordinalize"
 version = "3.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3250,6 +3270,7 @@ dependencies = [
  "crossbeam-utils",
  "cxx",
  "cxx-build",
+ "enum-map",
  "futures",
  "hashbrown 0.16.1",
  "http",
@@ -4460,7 +4481,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "059a34f111a9dee2ce1ac2826a68b24601c4298cfeb1a587c3cb493d5ab46f52"
 dependencies = [
  "libc",
- "nix 0.29.0",
+ "nix 0.30.1",
 ]
 
 [[package]]

--- a/examples/ffi/profiles.c
+++ b/examples/ffi/profiles.c
@@ -145,6 +145,22 @@ int main(void) {
     }
   }
 
+  // New API add2_otel: single value with sample type (OpenTelemetry-style)
+  // This is more convenient when you have one value per sample type
+  const ddog_prof_Slice_Location2 locations_slice = {&location2, 1};
+  for (int i = 0; i < NUM_SAMPLES; i++) {
+    label2.num = i;
+    int64_t otel_value = 10 + i;
+    const ddog_prof_Slice_Label2 labels_slice = {&label2, 1};
+
+    ddog_prof_Status add2_otel_status = ddog_prof_Profile_add2_otel(
+        &profile, locations_slice, otel_value, wall_time, labels_slice, 0);
+    if (add2_otel_status.err != NULL) {
+      fprintf(stderr, "add2_otel error: %s\n", add2_otel_status.err);
+      ddog_prof_Status_drop(&add2_otel_status);
+    }
+  }
+
   //   printf("Press any key to reset and drop...");
   //   getchar();
 

--- a/libdd-profiling/Cargo.toml
+++ b/libdd-profiling/Cargo.toml
@@ -35,6 +35,7 @@ chrono = {version = "0.4", default-features = false, features = ["std", "clock"]
 crossbeam-channel = "0.5.15"
 crossbeam-utils = { version = "0.8.21" }
 cxx = { version = "1.0", optional = true }
+enum-map = "2.7.3"
 futures = { version = "0.3", default-features = false }
 hashbrown = { version = "0.16", default-features = false }
 http = "1.0"

--- a/libdd-profiling/src/api/sample_type.rs
+++ b/libdd-profiling/src/api/sample_type.rs
@@ -14,7 +14,7 @@ use super::ValueType;
 /// - **pprof-nodejs**: `profile-serializer.ts` (value type functions)
 #[cfg_attr(test, derive(bolero::generator::TypeGenerator, strum::EnumIter))]
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, enum_map::Enum)]
 pub enum SampleType {
     AllocSamples,
     AllocSamplesUnscaled,

--- a/libdd-profiling/src/profiles/datatypes/function.rs
+++ b/libdd-profiling/src/profiles/datatypes/function.rs
@@ -61,7 +61,7 @@ impl From<Function2> for Function {
 /// implementation detail.
 #[derive(Clone, Copy, Debug)]
 #[repr(transparent)]
-pub struct FunctionId2(pub(crate) *mut Function2);
+pub struct FunctionId2(pub *mut Function2);
 
 // todo: when MSRV is 1.88.0+, derive Default
 impl Default for FunctionId2 {

--- a/libdd-profiling/src/profiles/datatypes/mapping.rs
+++ b/libdd-profiling/src/profiles/datatypes/mapping.rs
@@ -69,7 +69,7 @@ impl From<Mapping> for Mapping2 {
 /// implementation detail.
 #[derive(Clone, Copy, Debug)]
 #[repr(transparent)]
-pub struct MappingId2(pub(crate) *mut Mapping2);
+pub struct MappingId2(pub *mut Mapping2);
 
 // todo: when MSRV is 1.88.0+, derive Default
 impl Default for MappingId2 {

--- a/libdd-profiling/src/profiles/datatypes/string.rs
+++ b/libdd-profiling/src/profiles/datatypes/string.rs
@@ -14,7 +14,7 @@ use crate::profiles::collections::StringRef;
 /// string set.
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
-pub struct StringId2(*mut StringHeader);
+pub struct StringId2(pub *mut StringHeader);
 
 /// Represents what StringIds point to. Its definition is intentionally
 /// obscured; the actual layout is being hidden. This is here so that


### PR DESCRIPTION
# What does this PR do?

Adds a new API which takes a single sample type by enum along with a single value.  Currently, we just forward to the existing API, once we're happy with this we can start changing the underlying data model.

# Motivation

1. This matches what OTel expects, first step towards making libdatadog match otel
2. The current vector of values is sparse, we're storing a bunch of zeros.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
