### PR TITLE
feat: change cargo patch approach to generic annotations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1568,6 +1568,7 @@ dependencies = [
  "http-body-util",
  "httpmock",
  "libc",
+ "libdd-capabilities-impl",
  "libdd-common",
  "libdd-common-ffi",
  "libdd-crashtracker",
@@ -3146,6 +3147,7 @@ version = "28.0.0"
 dependencies = [
  "build_common",
  "httpmock",
+ "libdd-capabilities-impl",
  "libdd-common-ffi",
  "libdd-data-pipeline",
  "libdd-tinybytes",

--- a/datadog-sidecar/Cargo.toml
+++ b/datadog-sidecar/Cargo.toml
@@ -17,6 +17,7 @@ tokio-console = ["tokio/full", "tokio/tracing", "console-subscriber"]
 anyhow = { version = "1.0" }
 arrayref = "0.3.7"
 priority-queue = "2.1.1"
+libdd-capabilities-impl = "0.1.0"
 libdd-common = { path = "../libdd-common" }
 datadog-sidecar-macros = { path = "../datadog-sidecar-macros" }
 

--- a/datadog-sidecar/src/service/agent_info.rs
+++ b/datadog-sidecar/src/service/agent_info.rs
@@ -16,6 +16,7 @@ use datadog_ipc::platform::NamedShmHandle;
 use futures::future::Shared;
 use futures::FutureExt;
 use http::uri::PathAndQuery;
+use libdd_capabilities_impl::DefaultHttpClient;
 use libdd_common::{Endpoint, MutexExt};
 use libdd_data_pipeline::agent_info::schema::AgentInfoStruct;
 use libdd_data_pipeline::agent_info::{fetch_info_with_state, FetchInfoStatus};
@@ -101,7 +102,9 @@ impl AgentInfoFetcher {
             parts.path_and_query = Some(PathAndQuery::from_static("/info"));
             fetch_endpoint.url = http::Uri::from_parts(parts).unwrap();
             loop {
-                let fetched = fetch_info_with_state(&fetch_endpoint, state.as_deref()).await;
+                let fetched =
+                    fetch_info_with_state::<DefaultHttpClient>(&fetch_endpoint, state.as_deref())
+                        .await;
                 let mut complete_fut = None;
                 {
                     let mut infos_guard = agent_infos.0.lock_or_panic();

--- a/datadog-sidecar/src/service/tracing/trace_flusher.rs
+++ b/datadog-sidecar/src/service/tracing/trace_flusher.rs
@@ -5,6 +5,7 @@ use super::TraceSendData;
 use crate::agent_remote_config::AgentRemoteConfigWriter;
 use datadog_ipc::platform::NamedShmHandle;
 use futures::future::join_all;
+use libdd_capabilities_impl::DefaultHttpClient;
 use libdd_common::{Endpoint, MutexExt};
 use libdd_trace_utils::trace_utils;
 use libdd_trace_utils::trace_utils::SendData;
@@ -245,7 +246,7 @@ impl TraceFlusher {
 
     async fn send_and_handle_trace(&self, send_data: SendData) {
         let endpoint = send_data.get_target().clone();
-        let response = send_data.send().await;
+        let response = send_data.send::<DefaultHttpClient>().await;
         self.metrics.lock_or_panic().update(&response);
         match response.last_result {
             Ok(response) => {

--- a/libdd-data-pipeline-ffi/Cargo.toml
+++ b/libdd-data-pipeline-ffi/Cargo.toml
@@ -29,6 +29,7 @@ rmp-serde = "1.1.1"
 libdd-trace-utils = { path = "../libdd-trace-utils" }
 
 [dependencies]
+libdd-capabilities-impl = "0.1.0"
 libdd-data-pipeline = { path = "../libdd-data-pipeline" }
 libdd-common-ffi = { path = "../libdd-common-ffi", default-features = false }
 libdd-tinybytes = { path = "../libdd-tinybytes" }

--- a/libdd-data-pipeline-ffi/src/trace_exporter.rs
+++ b/libdd-data-pipeline-ffi/src/trace_exporter.rs
@@ -479,7 +479,7 @@ pub unsafe extern "C" fn ddog_trace_exporter_new(
                 builder.enable_health_metrics();
             }
 
-            match builder.build::<DefaultHttpClient>() {
+            match builder.build() {
                 Ok(exporter) => {
                     out_handle.as_ptr().write(Box::new(exporter));
                     None

--- a/libdd-data-pipeline/Cargo.toml
+++ b/libdd-data-pipeline/Cargo.toml
@@ -35,7 +35,6 @@ libdd-telemetry = { version = "2.0.0", path = "../libdd-telemetry", default-feat
 libdd-trace-protobuf = { version = "1.0.0", path = "../libdd-trace-protobuf" }
 libdd-trace-stats = { version = "1.0.0", path = "../libdd-trace-stats" }
 libdd-capabilities = { path = "../libdd-capabilities" }
-libdd-capabilities-impl = "0.1.0"
 libdd-trace-utils = { version = "1.0.0", path = "../libdd-trace-utils", default-features = false }
 libdd-ddsketch = { version = "1.0.0", path = "../libdd-ddsketch" }
 libdd-dogstatsd-client = { version = "1.0.0", path = "../libdd-dogstatsd-client", default-features = false }
@@ -48,6 +47,7 @@ libdd-tinybytes = { version = "1.1.0", path = "../libdd-tinybytes", features = [
 bench = false
 
 [dev-dependencies]
+libdd-capabilities-impl = "0.1.0"
 libdd-log = { path = "../libdd-log" }
 clap = { version = "4.0", features = ["derive"] }
 criterion = "0.5.1"

--- a/libdd-data-pipeline/examples/send-traces-with-stats.rs
+++ b/libdd-data-pipeline/examples/send-traces-with-stats.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use clap::Parser;
+use libdd_capabilities_impl::DefaultHttpClient;
 use libdd_data_pipeline::trace_exporter::{
     TelemetryConfig, TraceExporter, TraceExporterInputFormat, TraceExporterOutputFormat,
 };
@@ -55,7 +56,7 @@ fn main() {
 
     let args = Args::parse();
     let telemetry_cfg = TelemetryConfig::default();
-    let mut builder = TraceExporter::builder();
+    let mut builder = TraceExporter::<DefaultHttpClient>::builder();
     builder
         .set_url(&args.url)
         .set_hostname("test")
@@ -69,7 +70,9 @@ fn main() {
         .set_output_format(TraceExporterOutputFormat::V04)
         .enable_telemetry(telemetry_cfg)
         .enable_stats(Duration::from_secs(10));
-    let exporter = builder.build().expect("Failed to build TraceExporter");
+    let exporter = builder
+        .build::<DefaultHttpClient>()
+        .expect("Failed to build TraceExporter");
     let now = UNIX_EPOCH
         .elapsed()
         .expect("Failed to get time since UNIX_EPOCH")

--- a/libdd-data-pipeline/examples/send-traces-with-stats.rs
+++ b/libdd-data-pipeline/examples/send-traces-with-stats.rs
@@ -71,7 +71,7 @@ fn main() {
         .enable_telemetry(telemetry_cfg)
         .enable_stats(Duration::from_secs(10));
     let exporter = builder
-        .build::<DefaultHttpClient>()
+        .build()
         .expect("Failed to build TraceExporter");
     let now = UNIX_EPOCH
         .elapsed()

--- a/libdd-data-pipeline/src/trace_exporter/builder.rs
+++ b/libdd-data-pipeline/src/trace_exporter/builder.rs
@@ -22,8 +22,8 @@ use std::time::Duration;
 const DEFAULT_AGENT_URL: &str = "http://127.0.0.1:8126";
 
 #[allow(missing_docs)]
-#[derive(Default, Debug)]
-pub struct TraceExporterBuilder {
+#[derive(Debug)]
+pub struct TraceExporterBuilder<H> {
     url: Option<String>,
     hostname: String,
     env: String,
@@ -51,9 +51,43 @@ pub struct TraceExporterBuilder {
     test_session_token: Option<String>,
     agent_rates_payload_version_enabled: bool,
     connection_timeout: Option<u64>,
+    _phantom: PhantomData<H>,
 }
 
-impl TraceExporterBuilder {
+impl<H> Default for TraceExporterBuilder<H> {
+    fn default() -> Self {
+        Self {
+            url: None,
+            hostname: String::new(),
+            env: String::new(),
+            app_version: String::new(),
+            service: String::new(),
+            tracer_version: String::new(),
+            language: String::new(),
+            language_version: String::new(),
+            language_interpreter: String::new(),
+            language_interpreter_vendor: String::new(),
+            git_commit_sha: String::new(),
+            input_format: TraceExporterInputFormat::default(),
+            output_format: TraceExporterOutputFormat::default(),
+            dogstatsd_url: None,
+            client_computed_stats: false,
+            client_computed_top_level: false,
+            stats_bucket_size: None,
+            peer_tags_aggregation: false,
+            compute_stats_by_span_kind: false,
+            peer_tags: Vec::new(),
+            telemetry: None,
+            health_metrics_enabled: false,
+            test_session_token: None,
+            agent_rates_payload_version_enabled: false,
+            connection_timeout: None,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<H: HttpClientTrait + Send + Sync + 'static> TraceExporterBuilder<H> {
     /// Sets the URL of the agent.
     ///
     /// The agent supports the following URL schemes:
@@ -219,9 +253,7 @@ impl TraceExporterBuilder {
     }
 
     #[allow(missing_docs)]
-    pub fn build<H: HttpClientTrait + Send + Sync + 'static>(
-        self,
-    ) -> Result<TraceExporter<H>, TraceExporterError> {
+    pub fn build(self) -> Result<TraceExporter<H>, TraceExporterError> {
         if !Self::is_inputs_outputs_formats_compatible(self.input_format, self.output_format) {
             return Err(TraceExporterError::Builder(
                 BuilderErrorKind::InvalidConfiguration(
@@ -367,7 +399,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     #[test]
     fn test_new() {
-        let mut builder = TraceExporterBuilder::default();
+        let mut builder = TraceExporterBuilder::<DefaultHttpClient>::default();
         builder
             .set_url("http://192.168.1.1:8127/")
             .set_tracer_version("v0.1")
@@ -384,7 +416,7 @@ mod tests {
                 runtime_id: None,
                 debug_enabled: false,
             });
-        let exporter = builder.build::<DefaultHttpClient>().unwrap();
+        let exporter = builder.build().unwrap();
 
         assert_eq!(
             exporter
@@ -407,8 +439,8 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     #[test]
     fn test_new_defaults() {
-        let builder = TraceExporterBuilder::default();
-        let exporter = builder.build::<DefaultHttpClient>().unwrap();
+        let builder = TraceExporterBuilder::<DefaultHttpClient>::default();
+        let exporter = builder.build().unwrap();
 
         assert_eq!(
             exporter
@@ -429,7 +461,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn test_builder_error() {
-        let mut builder = TraceExporterBuilder::default();
+        let mut builder = TraceExporterBuilder::<DefaultHttpClient>::default();
         builder
             .set_url("")
             .set_service("foo")
@@ -439,7 +471,7 @@ mod tests {
             .set_language_version("1.0")
             .set_language_interpreter("v8");
 
-        let exporter = builder.build::<DefaultHttpClient>();
+        let exporter = builder.build();
 
         assert!(exporter.is_err());
 

--- a/libdd-data-pipeline/src/trace_exporter/mod.rs
+++ b/libdd-data-pipeline/src/trace_exporter/mod.rs
@@ -208,7 +208,7 @@ pub struct TraceExporter<H: HttpClientTrait + Send + Sync + 'static> {
 
 impl<H: HttpClientTrait + Send + Sync + 'static> TraceExporter<H> {
     #[allow(missing_docs)]
-    pub fn builder() -> TraceExporterBuilder {
+    pub fn builder() -> TraceExporterBuilder<H> {
         TraceExporterBuilder::default()
     }
 
@@ -909,7 +909,7 @@ mod tests {
         enable_telemetry: bool,
         enable_health_metrics: bool,
     ) -> TraceExporter<DefaultHttpClient> {
-        let mut builder = TraceExporterBuilder::default();
+        let mut builder = TraceExporter::<DefaultHttpClient>::builder();
         builder
             .set_url(&url)
             .set_service("test")
@@ -936,7 +936,7 @@ mod tests {
             });
         }
 
-        builder.build::<DefaultHttpClient>().unwrap()
+        builder.build().unwrap()
     }
 
     #[test]
@@ -1328,7 +1328,7 @@ mod tests {
                 );
         });
 
-        let mut builder = TraceExporterBuilder::default();
+        let mut builder = TraceExporter::<DefaultHttpClient>::builder();
         builder
             .set_url(&server.url("/"))
             .set_service("foo")
@@ -1337,7 +1337,7 @@ mod tests {
             .set_language("nodejs")
             .set_language_version("1.0")
             .set_language_interpreter("v8");
-        let exporter = builder.build::<DefaultHttpClient>().unwrap();
+        let exporter = builder.build().unwrap();
 
         let traces: Vec<Vec<SpanBytes>> = vec![vec![SpanBytes {
             name: BytesString::from_slice(b"test").unwrap(),
@@ -1370,7 +1370,7 @@ mod tests {
                 .body(r#"{ "error": "Unavailable" }"#);
         });
 
-        let mut builder = TraceExporterBuilder::default();
+        let mut builder = TraceExporter::<DefaultHttpClient>::builder();
         builder
             .set_url(&server.url("/"))
             .set_service("foo")
@@ -1379,7 +1379,7 @@ mod tests {
             .set_language("nodejs")
             .set_language_version("1.0")
             .set_language_interpreter("v8");
-        let exporter = builder.build::<DefaultHttpClient>().unwrap();
+        let exporter = builder.build().unwrap();
 
         let traces: Vec<Vec<SpanBytes>> = vec![vec![SpanBytes {
             name: BytesString::from_slice(b"test").unwrap(),
@@ -1405,7 +1405,7 @@ mod tests {
                 .body("");
         });
 
-        let mut builder = TraceExporterBuilder::default();
+        let mut builder = TraceExporter::<DefaultHttpClient>::builder();
         builder
             .set_url(&server.url("/"))
             .set_service("foo")
@@ -1414,7 +1414,7 @@ mod tests {
             .set_language("nodejs")
             .set_language_version("1.0")
             .set_language_interpreter("v8");
-        let exporter = builder.build::<DefaultHttpClient>().unwrap();
+        let exporter = builder.build().unwrap();
 
         let traces: Vec<Vec<SpanBytes>> = vec![vec![SpanBytes {
             name: BytesString::from_slice(b"test").unwrap(),
@@ -1459,7 +1459,7 @@ mod tests {
                 .body("");
         });
 
-        let mut builder = TraceExporterBuilder::default();
+        let mut builder = TraceExporter::<DefaultHttpClient>::builder();
         builder
             .set_url(&server.url("/"))
             .set_service("foo")
@@ -1472,7 +1472,7 @@ mod tests {
                 heartbeat: 100,
                 ..Default::default()
             });
-        let exporter = builder.build::<DefaultHttpClient>().unwrap();
+        let exporter = builder.build().unwrap();
 
         let traces = vec![0x90];
         let result = exporter.send(traces.as_ref()).unwrap();
@@ -1583,7 +1583,7 @@ mod tests {
                 .body("");
         });
 
-        let mut builder = TraceExporterBuilder::default();
+        let mut builder = TraceExporter::<DefaultHttpClient>::builder();
         builder
             .set_url(&server.url("/"))
             .set_service("foo")
@@ -1599,7 +1599,7 @@ mod tests {
             .set_input_format(TraceExporterInputFormat::V04)
             .set_output_format(TraceExporterOutputFormat::V05);
 
-        let exporter = builder.build::<DefaultHttpClient>().unwrap();
+        let exporter = builder.build().unwrap();
 
         let traces = vec![0x90];
         let result = exporter.send(traces.as_ref()).unwrap();
@@ -1643,9 +1643,9 @@ mod tests {
                 .body(response_body);
         });
 
-        let mut builder = TraceExporterBuilder::default();
+        let mut builder = TraceExporter::<DefaultHttpClient>::builder();
         builder.set_url(&server.url("/"));
-        let exporter = builder.build::<DefaultHttpClient>().unwrap();
+        let exporter = builder.build().unwrap();
         let traces = vec![0x90];
         for _ in 0..2 {
             let result = exporter.send(traces.as_ref()).unwrap();
@@ -1678,11 +1678,11 @@ mod tests {
                 .body(response_body);
         });
 
-        let mut builder = TraceExporterBuilder::default();
+        let mut builder = TraceExporter::<DefaultHttpClient>::builder();
         builder
             .set_url(&server.url("/"))
             .enable_agent_rates_payload_version();
-        let exporter = builder.build::<DefaultHttpClient>().unwrap();
+        let exporter = builder.build().unwrap();
         let traces = vec![0x90];
         let result = exporter.send(traces.as_ref()).unwrap();
         let AgentResponse::Changed { body } = result else {
@@ -1770,7 +1770,7 @@ mod tests {
             then.delay(delay).status(status).body(response);
         });
 
-        let mut builder = TraceExporterBuilder::default();
+        let mut builder = TraceExporter::<DefaultHttpClient>::builder();
         builder
             .set_url(&server.url("/"))
             .set_service("test")
@@ -1782,7 +1782,7 @@ mod tests {
             .set_input_format(TraceExporterInputFormat::V04)
             .set_output_format(TraceExporterOutputFormat::V04)
             .enable_stats(Duration::from_secs(10));
-        let exporter = builder.build::<DefaultHttpClient>().unwrap();
+        let exporter = builder.build().unwrap();
 
         let trace_chunk = vec![SpanBytes {
             duration: 10,
@@ -1814,17 +1814,17 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn test_connection_timeout() {
-        let exporter = TraceExporterBuilder::default()
-            .build::<DefaultHttpClient>()
+        let exporter = TraceExporter::<DefaultHttpClient>::builder()
+            .build()
             .unwrap();
 
         assert_eq!(exporter.endpoint.timeout_ms, Endpoint::default().timeout_ms);
 
         let timeout = Some(42);
-        let mut builder = TraceExporterBuilder::default();
+        let mut builder = TraceExporter::<DefaultHttpClient>::builder();
         builder.set_connection_timeout(timeout);
 
-        let exporter = builder.build::<DefaultHttpClient>().unwrap();
+        let exporter = builder.build().unwrap();
 
         assert_eq!(exporter.endpoint.timeout_ms, 42);
     }
@@ -1832,8 +1832,8 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn stop_and_start_runtime() {
-        let builder = TraceExporterBuilder::default();
-        let exporter = builder.build::<DefaultHttpClient>().unwrap();
+        let builder = TraceExporter::<DefaultHttpClient>::builder();
+        let exporter = builder.build().unwrap();
         exporter.stop_worker();
         exporter.run_worker().unwrap();
     }
@@ -1880,7 +1880,7 @@ mod single_threaded_tests {
                 .body(r#"{"version":"1","client_drop_p0s":true,"endpoints":["/v0.4/traces","/v0.6/stats"]}"#);
         });
 
-        let mut builder = TraceExporterBuilder::default();
+        let mut builder = TraceExporter::<DefaultHttpClient>::builder();
         builder
             .set_url(&server.url("/"))
             .set_service("test")
@@ -1892,7 +1892,7 @@ mod single_threaded_tests {
             .set_input_format(TraceExporterInputFormat::V04)
             .set_output_format(TraceExporterOutputFormat::V04)
             .enable_stats(Duration::from_secs(10));
-        let exporter = builder.build::<DefaultHttpClient>().unwrap();
+        let exporter = builder.build().unwrap();
 
         let trace_chunk = vec![SpanBytes {
             duration: 10,
@@ -1980,7 +1980,7 @@ mod single_threaded_tests {
                 .body(r#"{"version":"1","client_drop_p0s":true,"endpoints":["/v0.4/traces","/v0.6/stats"]}"#);
         });
 
-        let mut builder = TraceExporterBuilder::default();
+        let mut builder = TraceExporter::<DefaultHttpClient>::builder();
         builder
             .set_url(&server.url("/"))
             .set_service("test")
@@ -1992,7 +1992,7 @@ mod single_threaded_tests {
             .set_input_format(TraceExporterInputFormat::V04)
             .set_output_format(TraceExporterOutputFormat::V04)
             .enable_stats(Duration::from_secs(10));
-        let exporter = builder.build::<DefaultHttpClient>().unwrap();
+        let exporter = builder.build().unwrap();
 
         let trace_chunk = vec![SpanBytes {
             service: "test".into(),

--- a/libdd-data-pipeline/tests/test_fetch_info.rs
+++ b/libdd-data-pipeline/tests/test_fetch_info.rs
@@ -3,6 +3,7 @@
 
 #[cfg(test)]
 mod tracing_integration_tests {
+    use libdd_capabilities_impl::DefaultHttpClient;
     use libdd_common::{worker::Worker, Endpoint};
     use libdd_data_pipeline::agent_info;
     use libdd_data_pipeline::agent_info::{fetch_info, AgentInfoFetcher};
@@ -14,7 +15,7 @@ mod tracing_integration_tests {
     async fn test_fetch_info_from_test_agent() {
         let test_agent = DatadogTestAgent::new(None, None, &[]).await;
         let endpoint = Endpoint::from_url(test_agent.get_uri_for_endpoint("info", None).await);
-        let info = fetch_info(&endpoint)
+        let info = fetch_info::<DefaultHttpClient>(&endpoint)
             .await
             .expect("Failed to fetch agent info");
         assert!(
@@ -31,7 +32,7 @@ mod tracing_integration_tests {
         let test_agent = DatadogTestAgent::new(None, None, &[]).await;
         let endpoint = Endpoint::from_url(test_agent.get_uri_for_endpoint("info", None).await);
         let (mut fetcher, _response_observer) =
-            AgentInfoFetcher::new(endpoint, Duration::from_secs(1));
+            AgentInfoFetcher::<DefaultHttpClient>::new(endpoint, Duration::from_secs(1));
         tokio::spawn(async move { fetcher.run().await });
         let info_received = async {
             while agent_info::get_agent_info().is_none() {

--- a/libdd-data-pipeline/tests/test_trace_exporter.rs
+++ b/libdd-data-pipeline/tests/test_trace_exporter.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #[cfg(test)]
 mod tracing_integration_tests {
+    use libdd_capabilities_impl::DefaultHttpClient;
     use libdd_data_pipeline::trace_exporter::agent_response::AgentResponse;
     use libdd_data_pipeline::trace_exporter::{
         TraceExporter, TraceExporterInputFormat, TraceExporterOutputFormat,
@@ -112,7 +113,7 @@ mod tracing_integration_tests {
             .await;
 
         let task_result = task::spawn_blocking(move || {
-            let mut builder = TraceExporter::builder();
+            let mut builder = TraceExporter::<DefaultHttpClient>::builder();
             builder
                 .set_url(url.to_string().as_ref())
                 .set_language("test-lang")
@@ -124,7 +125,9 @@ mod tracing_integration_tests {
                 .set_service("test")
                 .set_test_session_token(snapshot_name);
 
-            let trace_exporter = builder.build().expect("Unable to build TraceExporter");
+            let trace_exporter = builder
+                .build::<DefaultHttpClient>()
+                .expect("Unable to build TraceExporter");
 
             let data = get_v04_trace_snapshot_test_payload("test_exporter_v04_snapshot");
 
@@ -164,7 +167,7 @@ mod tracing_integration_tests {
             .await;
 
         let task_result = task::spawn_blocking(move || {
-            let mut builder = TraceExporter::builder();
+            let mut builder = TraceExporter::<DefaultHttpClient>::builder();
             builder
                 .set_url(url.to_string().as_ref())
                 .set_language("test-lang")
@@ -177,7 +180,9 @@ mod tracing_integration_tests {
                 .set_test_session_token(snapshot_name)
                 .set_input_format(TraceExporterInputFormat::V04)
                 .set_output_format(TraceExporterOutputFormat::V05);
-            let trace_exporter = builder.build().expect("Unable to build TraceExporter");
+            let trace_exporter = builder
+                .build::<DefaultHttpClient>()
+                .expect("Unable to build TraceExporter");
 
             let data = get_v04_trace_snapshot_test_payload("test_exporter_v04_v05_snapshot");
 
@@ -210,7 +215,7 @@ mod tracing_integration_tests {
             .await;
 
         let task_result = task::spawn_blocking(move || {
-            let mut builder = TraceExporter::builder();
+            let mut builder = TraceExporter::<DefaultHttpClient>::builder();
             builder
                 .set_url(url.to_string().as_ref())
                 .set_language("test-lang")
@@ -223,7 +228,9 @@ mod tracing_integration_tests {
                 .set_test_session_token(snapshot_name)
                 .set_input_format(TraceExporterInputFormat::V05)
                 .set_output_format(TraceExporterOutputFormat::V05);
-            let trace_exporter = builder.build().expect("Unable to build TraceExporter");
+            let trace_exporter = builder
+                .build::<DefaultHttpClient>()
+                .expect("Unable to build TraceExporter");
 
             let data = get_v05_trace_snapshot_test_payload();
 
@@ -287,7 +294,7 @@ mod tracing_integration_tests {
             .await;
 
         let task_result = task::spawn_blocking(move || {
-            let mut builder = TraceExporter::builder();
+            let mut builder = TraceExporter::<DefaultHttpClient>::builder();
             builder
                 .set_url(url.to_string().as_ref())
                 .set_language("test-lang")
@@ -299,7 +306,9 @@ mod tracing_integration_tests {
                 .set_test_session_token(snapshot_name)
                 .set_service("test");
 
-            let trace_exporter = builder.build().expect("Unable to build TraceExporter");
+            let trace_exporter = builder
+                .build::<DefaultHttpClient>()
+                .expect("Unable to build TraceExporter");
 
             let data = get_v04_trace_snapshot_test_payload("test_exporter_v04_snapshot_uds");
 

--- a/libdd-data-pipeline/tests/test_trace_exporter.rs
+++ b/libdd-data-pipeline/tests/test_trace_exporter.rs
@@ -126,7 +126,7 @@ mod tracing_integration_tests {
                 .set_test_session_token(snapshot_name);
 
             let trace_exporter = builder
-                .build::<DefaultHttpClient>()
+                .build()
                 .expect("Unable to build TraceExporter");
 
             let data = get_v04_trace_snapshot_test_payload("test_exporter_v04_snapshot");
@@ -181,7 +181,7 @@ mod tracing_integration_tests {
                 .set_input_format(TraceExporterInputFormat::V04)
                 .set_output_format(TraceExporterOutputFormat::V05);
             let trace_exporter = builder
-                .build::<DefaultHttpClient>()
+                .build()
                 .expect("Unable to build TraceExporter");
 
             let data = get_v04_trace_snapshot_test_payload("test_exporter_v04_v05_snapshot");
@@ -229,7 +229,7 @@ mod tracing_integration_tests {
                 .set_input_format(TraceExporterInputFormat::V05)
                 .set_output_format(TraceExporterOutputFormat::V05);
             let trace_exporter = builder
-                .build::<DefaultHttpClient>()
+                .build()
                 .expect("Unable to build TraceExporter");
 
             let data = get_v05_trace_snapshot_test_payload();
@@ -307,7 +307,7 @@ mod tracing_integration_tests {
                 .set_service("test");
 
             let trace_exporter = builder
-                .build::<DefaultHttpClient>()
+                .build()
                 .expect("Unable to build TraceExporter");
 
             let data = get_v04_trace_snapshot_test_payload("test_exporter_v04_snapshot_uds");

--- a/libdd-trace-utils/Cargo.toml
+++ b/libdd-trace-utils/Cargo.toml
@@ -37,7 +37,6 @@ rmp = { version = "0.8.14", default-features = false }
 
 libdd-common = { version = "1.1.0", path = "../libdd-common", default-features = false }
 libdd-capabilities = { path = "../libdd-capabilities" }
-libdd-capabilities-impl = "0.1.0"
 libdd-trace-protobuf = { version = "1.0.0", path = "../libdd-trace-protobuf" }
 libdd-trace-normalization = { version = "1.0.0", path = "../libdd-trace-normalization" }
 libdd-tinybytes = { version = "1.1.0", path = "../libdd-tinybytes", features = [
@@ -58,6 +57,7 @@ urlencoding = { version = "2.1.3", optional = true }
 indexmap = "2.11"
 
 [dev-dependencies]
+libdd-capabilities-impl = "0.1.0"
 bolero = "0.13"
 criterion = "0.5.1"
 httpmock = { version = "0.8.0-alpha.1" }

--- a/libdd-trace-utils/tests/test_send_data.rs
+++ b/libdd-trace-utils/tests/test_send_data.rs
@@ -6,6 +6,7 @@ mod tracing_integration_tests {
     use http_body_util::BodyExt;
     #[cfg(target_os = "linux")]
     use hyper::Uri;
+    use libdd_capabilities_impl::DefaultHttpClient;
     #[cfg(target_os = "linux")]
     use libdd_common::connector::uds::socket_path_to_uri;
     use libdd_common::{http_common, Endpoint};
@@ -116,7 +117,7 @@ mod tracing_integration_tests {
             &endpoint,
         );
 
-        let _result = data.send().await;
+        let _result = data.send::<DefaultHttpClient>().await;
 
         test_agent.assert_snapshot(snapshot_name).await;
     }
@@ -208,7 +209,7 @@ mod tracing_integration_tests {
             &endpoint,
         );
 
-        let _result = data.send().await;
+        let _result = data.send::<DefaultHttpClient>().await;
 
         test_agent.assert_snapshot(snapshot_name).await;
     }
@@ -245,7 +246,7 @@ mod tracing_integration_tests {
             &endpoint,
         );
 
-        let result = data.send().await;
+        let result = data.send::<DefaultHttpClient>().await;
 
         assert!(result.last_result.is_ok());
     }
@@ -326,7 +327,7 @@ mod tracing_integration_tests {
             &endpoint,
         );
 
-        let _result = data.send().await;
+        let _result = data.send::<DefaultHttpClient>().await;
 
         test_agent.assert_snapshot(snapshot_name).await;
     }


### PR DESCRIPTION
# What does this PR do?

Change cargo patch approach to generic annotations

# Motivation

Discussions with the team about the best approach.

# Additional Notes

Currently this is for 1 (one) capability, when we have 2, 3, or more capabilities, all these annations should either:
- Be bundled up into one
- Take multiple generics (that actually will always be all correlated together)

In the former option, we lose the main gain of this approach: explicit denotation of the aspect that can change. In the latter, it's just more ugly than it already is.

But functionally, I agree this is still static dispatch for statically known information, so that's fine by me.

# How to test the change?

For now this is mostly demonstrative, not actually something that ought be merged.