### PR TITLE
Remove obsolete `ref_protected` from STS trust policies

### DIFF
--- a/.github/chainguard/self.read.members.sts.yaml
+++ b/.github/chainguard/self.read.members.sts.yaml
@@ -4,7 +4,6 @@ subject_pattern: "repo:DataDog/libdatadog.*"
 
 claim_pattern:
   ref: "refs/heads/(main|release)"
-  ref_protected: "true"
 
 permissions:
   members: read

--- a/.github/chainguard/self.write.pr.sts.yaml
+++ b/.github/chainguard/self.write.pr.sts.yaml
@@ -4,7 +4,6 @@ subject_pattern: "repo:DataDog/libdatadog.*"
 
 claim_pattern:
   ref: "refs/heads/(main|release)"
-  ref_protected: "true"
   job_workflow_ref: DataDog/libdatadog/\.github/workflows/release-proposal-dispatch\.yml@.+
 
 permissions:


### PR DESCRIPTION
## Summary

- Remove `ref_protected: "true"` from dd-octo-sts trust policy claim patterns

The `ref_protected` OIDC claim is now obsolete in the DataDog org:

- **GitHub**: The org-level "incompatible file paths on windows" push ruleset causes ALL branches to report `ref_protected: true` in OIDC tokens, making it useless as a security signal
- **GitLab**: All branches on `gitlab.ddbuild.io` report `ref_protected: true` due to org-level `pushAccessLevels: 40` config

Since the claim is universally `true`, it provides no actual filtering — only a false sense of security. Removing it has zero functional impact on policy enforcement.

All other constraints (subject, ref, job_workflow_ref, project_path, pipeline_source, etc.) remain unchanged and continue to provide the real security boundaries.

Ticket: https://datadoghq.atlassian.net/browse/SINT-4732

## Test plan

- [ ] Verify that the remaining policy constraints are sufficient (ref, job_workflow_ref, etc. are unchanged)
- [ ] No functional change expected since ref_protected was already always true

🤖 Generated with [Claude Code](https://claude.com/claude-code)
