### PR TITLE
refactor(profiling): split upload function

### DIFF
--- a/examples/ffi/exporter.cpp
+++ b/examples/ffi/exporter.cpp
@@ -146,6 +146,18 @@ int main(int argc, char *argv[]) {
   auto cancel = ddog_CancellationToken_new();
   auto cancel_for_background_thread = ddog_CancellationToken_clone(&cancel);
 
+  // Eagerly initialize the tokio runtime. This is optional, but required
+  // to avoid race conditions if another thread might be using the
+  // the cancellation token at the same time as the profile is being sent
+  // (as is the case here).
+  ddog_VoidResult init_result = ddog_prof_Exporter_init_runtime(exporter);
+  if (init_result.tag != DDOG_VOID_RESULT_OK) {
+    print_error("Failed to initialize exporter runtime: ", init_result.err);
+    ddog_Error_drop(&init_result.err);
+    ddog_prof_Exporter_drop(exporter);
+    return 1;
+  }
+
   // As an example of CancellationToken usage, here we create a background
   // thread that sleeps for some time and then cancels a request early (e.g.
   // before the timeout in ddog_prof_Exporter_send_blocking is hit).

--- a/libdd-profiling-ffi/src/exporter.rs
+++ b/libdd-profiling-ffi/src/exporter.rs
@@ -222,7 +222,37 @@ unsafe fn parse_json(
     }
 }
 
+/// Initializes the tokio runtime for the exporter.
+///
+/// This function creates the tokio runtime used by `ddog_prof_Exporter_send_blocking`.
+/// It can be called ahead of time to ensure the runtime is ready before sending.
+///
+/// # Thread Affinity
+///
+/// **Important**: The runtime has thread affinity. This function should be called from
+/// the same thread that will later call `ddog_prof_Exporter_send_blocking`.
+///
+/// # Arguments
+/// * `exporter` - Borrows the exporter.
+///
+/// # Safety
+/// The `exporter` must point to a valid ProfileExporter that has not been dropped.
+#[no_mangle]
+#[must_use]
+#[named]
+pub unsafe extern "C" fn ddog_prof_Exporter_init_runtime(
+    mut exporter: *mut Handle<ProfileExporter>,
+) -> VoidResult {
+    wrap_with_void_ffi_result!({
+        let exporter = exporter.to_inner_mut()?;
+        exporter.init_runtime()?
+    })
+}
+
 /// Builds a request and sends it, returning the HttpStatus.
+///
+/// Note: If the runtime has not been initialized via `ddog_prof_Exporter_init_runtime`,
+/// it will be lazily initialized on first call.
 ///
 /// # Arguments
 /// * `exporter` - Borrows the exporter.

--- a/libdd-profiling/src/exporter/profile_exporter.rs
+++ b/libdd-profiling/src/exporter/profile_exporter.rs
@@ -161,6 +161,26 @@ impl ProfileExporter {
     /// - Using the async [`send`] method directly from within a tokio runtime
     ///
     /// [`send`]: ProfileExporter::send
+    /// Initializes the tokio runtime for blocking operations.
+    ///
+    /// This method lazily creates a single-threaded tokio runtime. It can be called
+    /// before `send_blocking` to ensure the runtime is ready ahead of time.
+    ///
+    /// # Thread Affinity
+    ///
+    /// **Important**: The runtime uses `new_current_thread()`, which has thread affinity.
+    /// This method should be called from the same thread that will later call `send_blocking`.
+    pub fn init_runtime(&mut self) -> anyhow::Result<()> {
+        if self.runtime.is_none() {
+            self.runtime = Some(
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()?,
+            );
+        }
+        Ok(())
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn send_blocking(
         &mut self,
@@ -172,13 +192,7 @@ impl ProfileExporter {
         process_tags: Option<&str>,
         cancel: Option<&CancellationToken>,
     ) -> anyhow::Result<reqwest::StatusCode> {
-        if self.runtime.is_none() {
-            self.runtime = Some(
-                tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()?,
-            );
-        }
+        self.init_runtime()?;
 
         Ok(self
             .runtime


### PR DESCRIPTION
## What does this PR do?

This PR splits the Exporter creation process into two steps (two functions to call):
1. Create the Tokio runtime with `init_runtime`
2. Upload the Profile with `send_blocking` (`send_blocking` calls `init_runtime` if it hasn't been initialised from the outside)

This fixes a TSan-detected race condition where we try to cancel the Upload request (using the Cancellation Token) at the same time the runtime is being initialised.   
Example runtime Profiler fix PR: https://github.com/DataDog/dd-trace-py/pull/16467/s

The PR also updates the existing `exporter.cpp` example to use the new function (tested with `cargo ffi-test --filter exporter`).

## Open questions

Currently, the PR maintains compatibility with existing usages -- not explicitly calling `init_runtime` will make `send_blocking` call it when it needs it. However, this is risky (for the reasons that made us make this PR in the first place).
* Should we prevent people from doing this? _Doing so will break compatibility with current usages._
* ... Or should we instead keep the race? _Doing so will guarantee backwards compatibility but also not force usages to be fixed._

--- We ended up going for the second, keeping the race so that we don't have a breaking API change. 