### PR TITLE
chore(telemetry): use weaker mem ordering for SEQ_ID

### DIFF
--- a/libdd-telemetry/examples/tm-ping.rs
+++ b/libdd-telemetry/examples/tm-ping.rs
@@ -22,7 +22,7 @@ fn build_app_started_payload() -> AppStarted {
 
 fn seq_id() -> u64 {
     static SEQ_ID: AtomicU64 = AtomicU64::new(0);
-    SEQ_ID.fetch_add(1, Ordering::SeqCst)
+    SEQ_ID.fetch_add(1, Ordering::Relaxed)
 }
 
 fn build_request<'a>(

--- a/libdd-telemetry/examples/tm-send-sketch.rs
+++ b/libdd-telemetry/examples/tm-send-sketch.rs
@@ -20,7 +20,7 @@ use libdd_telemetry::{
 
 fn seq_id() -> u64 {
     static SEQ_ID: AtomicU64 = AtomicU64::new(1);
-    SEQ_ID.fetch_add(1, Ordering::SeqCst)
+    SEQ_ID.fetch_add(1, Ordering::Relaxed)
 }
 
 fn build_request<'a>(


### PR DESCRIPTION
# What does this PR do?

This PR replaces a bunch of sequentially consistent atomic accesses on id generator by weaker relaxed accesses.

# Motivation

The motivation to use the weakest memory ordering applicable is two folds:

1. Performance: relaxed accesses compile to normal, non-atomic loads and stores on standard platforms (x86_64 and arm64 in particular). Whether this particular change has any performance impact is less obvious.
2. Readability: I think my main motivation is that I find it _easier_, at least as a reader, to reason about weaker orderings. For example, a relaxed access indicates that there's no other unsynchronized data that this atomic protect or interact with, which enables local reasoning (you don't have to care about what other threads might be doing). A sequentially consistent access is the converse: they lead to a global order which involves all other seqcst accesses to this atomic, which is a strong and far-reaching assumption.

# Additional Notes

This atomic is a counter, which is the poster child for `Relaxed` ordering (you usually only need the atomicity). This counter doesn't protect or interact with unsynchronized memory, so there's no reason to use a stronger ordering. Although this is just in an example, so it's mostly cosmetic.

# How to test the change?

Should see no difference in behavior except maybe for performance.