### PR TITLE
refactor(profiling)!: switch profile exporter to ureq

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6266,9 +6266,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.3.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+checksum = "fdc97a28575b85cfedf2a7e7d3cc64b3e11bd8ac766666318003abbacc7a21fc"
 dependencies = [
  "base64 0.22.1",
  "log",
@@ -6277,14 +6277,14 @@ dependencies = [
  "rustls-pki-types",
  "rustls-platform-verifier",
  "ureq-proto",
- "utf8-zero",
+ "utf-8",
 ]
 
 [[package]]
 name = "ureq-proto"
-version = "0.6.0"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
 dependencies = [
  "base64 0.22.1",
  "http",
@@ -6310,16 +6310,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf16_iter"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
-name = "utf8-zero"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3195,7 +3195,6 @@ dependencies = [
  "proptest",
  "prost",
  "rand 0.8.5",
- "reqwest",
  "rustc-hash",
  "rustls",
  "rustls-platform-verifier",
@@ -3205,8 +3204,7 @@ dependencies = [
  "target-triple",
  "tempfile",
  "thiserror 2.0.17",
- "tokio",
- "tokio-util",
+ "ureq",
  "zstd",
 ]
 
@@ -3236,7 +3234,6 @@ dependencies = [
  "serde_json",
  "symbolizer-ffi",
  "thiserror 2.0.17",
- "tokio-util",
 ]
 
 [[package]]
@@ -4904,6 +4901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -6267,6 +6265,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "ureq-proto",
+ "utf8-zero",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6288,6 +6314,12 @@ name = "utf16_iter"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -472,8 +472,11 @@ unicode-width,https://github.com/unicode-rs/unicode-width,MIT OR Apache-2.0,"kwa
 unicode-xid,https://github.com/unicode-rs/unicode-xid,MIT OR Apache-2.0,"erick.tryzelaar <erick.tryzelaar@gmail.com>, kwantam <kwantam@gmail.com>, Manish Goregaokar <manishsmail@gmail.com>"
 unsafe-libyaml,https://github.com/dtolnay/unsafe-libyaml,MIT,David Tolnay <dtolnay@gmail.com>
 untrusted,https://github.com/briansmith/untrusted,ISC,Brian Smith <brian@briansmith.org>
+ureq,https://github.com/algesten/ureq,MIT OR Apache-2.0,"Martin Algesten <martin@algesten.se>, Jacob Hoffman-Andrews <ureq@hoffman-andrews.com>"
+ureq-proto,https://github.com/algesten/ureq-proto,MIT OR Apache-2.0,Martin Algesten <martin@algesten.se>
 url,https://github.com/servo/rust-url,MIT OR Apache-2.0,The rust-url developers
 urlencoding,https://github.com/kornelski/rust_urlencoding,MIT,"Kornel <kornel@geekhood.net>, Bertram Truong <b@bertramtruong.com>"
+utf-8,https://github.com/SimonSapin/rust-utf8,MIT OR Apache-2.0,Simon Sapin <simon.sapin@exyr.org>
 utf16_iter,https://github.com/hsivonen/utf16_iter,Apache-2.0 OR MIT,Henri Sivonen <hsivonen@hsivonen.fi>
 utf8_iter,https://github.com/hsivonen/utf8_iter,Apache-2.0 OR MIT,Henri Sivonen <hsivonen@hsivonen.fi>
 utf8parse,https://github.com/alacritty/vte,Apache-2.0 OR MIT,"Joe Wilm <joe@jwilm.com>, Christian Duerr <contact@christianduerr.com>"

--- a/examples/cxx/profiling.cpp
+++ b/examples/cxx/profiling.cpp
@@ -229,12 +229,7 @@ int main() {
                 );
             }
             std::cout << "✅ Exporter created" << std::endl;
-            
-            // Create a cancellation token for the export
-            // In a real application, you could clone this and cancel from another thread
-            // Example: auto token_clone = cancel_token->clone_token(); token_clone->cancel();
-            auto cancel_token = new_cancellation_token();
-            
+
             // Prepare metadata (same for all export modes)
             std::string app_metadata = R"({
     "app_version": "1.2.3",
@@ -246,7 +241,7 @@ int main() {
             
             // Export the profile (unified code path)
             std::cout << "Exporting profile with additional metadata..." << std::endl;
-            (*exporter)->send_profile_with_cancellation(
+            (*exporter)->send_profile(
                 *profile,
                 // Files to compress and attach
                 {AttachmentFile{
@@ -263,8 +258,7 @@ int main() {
                 // Internal metadata (JSON string)
                 R"({"profiler_version": "1.0", "custom_field": "demo"})",
                 // System info (JSON string)
-                R"({"os": "macos", "arch": "arm64", "cores": 8})",
-                *cancel_token
+                R"({"os": "macos", "arch": "arm64", "cores": 8})"
             );
             std::cout << "✅ Profile exported successfully!" << std::endl;
             

--- a/examples/ffi/exporter.cpp
+++ b/examples/ffi/exporter.cpp
@@ -5,7 +5,6 @@
 #include <datadog/common.h>
 #include <datadog/profiling.h>
 #include <memory>
-#include <thread>
 
 static ddog_CharSlice to_slice_c_char(const char *s) { return {.ptr = s, .len = strlen(s)}; }
 
@@ -143,43 +142,10 @@ int main(int argc, char *argv[]) {
       DDOG_CHARSLICE_C_BARE("{\"application\": {\"start_time\": \"2024-01-24T11:17:22+0000\"}, "
                             "\"platform\": {\"kernel\": \"Darwin Kernel 22.5.0\"}}");
 
-  auto cancel = ddog_CancellationToken_new();
-  auto cancel_for_background_thread = ddog_CancellationToken_clone(&cancel);
-
-  // Eagerly initialize the tokio runtime. This is optional, but required
-  // to avoid race conditions if another thread might be using the
-  // the cancellation token at the same time as the profile is being sent
-  // (as is the case here).
-  ddog_VoidResult init_result = ddog_prof_Exporter_init_runtime(exporter);
-  if (init_result.tag != DDOG_VOID_RESULT_OK) {
-    print_error("Failed to initialize exporter runtime: ", init_result.err);
-    ddog_Error_drop(&init_result.err);
-    ddog_prof_Exporter_drop(exporter);
-    return 1;
-  }
-
-  // As an example of CancellationToken usage, here we create a background
-  // thread that sleeps for some time and then cancels a request early (e.g.
-  // before the timeout in ddog_prof_Exporter_send_blocking is hit).
-  //
-  // If the request is faster than the sleep time, no cancellation takes place.
-  std::thread trigger_cancel_if_request_takes_too_long_thread(
-      [](ddog_CancellationToken cancel_for_background_thread) {
-        int timeout_ms = 5000;
-        std::this_thread::sleep_for(std::chrono::milliseconds(timeout_ms));
-        printf("Request took longer than %d ms, triggering asynchronous "
-               "cancellation\n",
-               timeout_ms);
-        ddog_CancellationToken_cancel(&cancel_for_background_thread);
-        ddog_CancellationToken_drop(&cancel_for_background_thread);
-      },
-      cancel_for_background_thread);
-  trigger_cancel_if_request_takes_too_long_thread.detach();
-
   int exit_code = 0;
   auto send_result = ddog_prof_Exporter_send_blocking(
-      exporter, encoded_profile, files_to_compress_and_export, 
-      nullptr, nullptr, &internal_metadata_example, &info_example, &cancel);
+      exporter, encoded_profile, files_to_compress_and_export, nullptr, nullptr,
+      &internal_metadata_example, &info_example);
   if (send_result.tag == DDOG_PROF_RESULT_HTTP_STATUS_ERR_HTTP_STATUS) {
     print_error("Failed to send profile: ", send_result.err);
     exit_code = 1;
@@ -189,6 +155,5 @@ int main(int argc, char *argv[]) {
   }
 
   ddog_prof_Exporter_drop(exporter);
-  ddog_CancellationToken_drop(&cancel);
   return exit_code;
 }

--- a/libdd-common/Cargo.toml
+++ b/libdd-common/Cargo.toml
@@ -21,13 +21,13 @@ futures = "0.3"
 futures-core = { version = "0.3.0", default-features = false }
 futures-util = { version = "0.3.0", default-features = false }
 hex = "0.4"
-httparse = { version = "1.9", optional = true }
+httparse = "1.9"
 http = "1"
 mime = { version = "0.3.16", optional = true }
 multer = { version = "3.1", optional = true }
 bytes = { version = "1.11.1" }
 pin-project = "1"
-rand = { version = "0.8", optional = true }
+rand = "0.8"
 regex = "1.5"
 regex-lite = { version = "0.1", optional = true }
 # Use hickory-dns instead of the default system DNS resolver to avoid fork safety issues.
@@ -109,7 +109,7 @@ fips = ["tls-core", "hyper-rustls/fips"]
 # Enable reqwest client builder support with file dump debugging
 reqwest = ["dep:reqwest", "test-utils"]
 # Enable test utilities for use in other crates
-test-utils = ["dep:httparse", "dep:rand", "dep:mime", "dep:multer"]
+test-utils = ["dep:mime", "dep:multer"]
 # Enable benchmark utilities (ReportingAllocator, Criterion allocation measurement)
 bench-utils = ["dep:criterion"]
 

--- a/libdd-common/src/endpoint_resolved.rs
+++ b/libdd-common/src/endpoint_resolved.rs
@@ -1,0 +1,26 @@
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResolvedEndpoint {
+    pub kind: ResolvedEndpointKind,
+    pub request_url: String,
+    pub timeout: Duration,
+    pub use_system_resolver: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ResolvedEndpointKind {
+    Tcp,
+    #[cfg(unix)]
+    UnixSocket {
+        path: PathBuf,
+    },
+    #[cfg(windows)]
+    WindowsNamedPipe {
+        path: PathBuf,
+    },
+}

--- a/libdd-common/src/endpoint_resolved.rs
+++ b/libdd-common/src/endpoint_resolved.rs
@@ -1,6 +1,7 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(any(unix, windows))]
 use std::path::PathBuf;
 use std::time::Duration;
 

--- a/libdd-common/src/lib.rs
+++ b/libdd-common/src/lib.rs
@@ -18,8 +18,8 @@ pub mod azure_app_services;
 pub mod cc_utils;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod connector;
-#[cfg(feature = "reqwest")]
 pub mod dump_server;
+mod endpoint_resolved;
 pub mod entity_id;
 pub mod regex_engine;
 #[macro_use]
@@ -40,6 +40,8 @@ pub mod threading;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod timeout;
 pub mod unix_utils;
+
+pub use endpoint_resolved::{ResolvedEndpoint, ResolvedEndpointKind};
 
 /// Extension trait for `Mutex` to provide a method that acquires a lock, panicking if the lock is
 /// poisoned.
@@ -422,8 +424,10 @@ impl Endpoint {
         self
     }
 
-    /// Use the system DNS resolver when building the reqwest client. Only has effect for
-    /// HTTP(S) endpoints.
+    /// Use the system DNS resolver when building an HTTP client.
+    ///
+    /// This only has an effect for transports that support selecting between resolver
+    /// implementations.
     pub fn with_system_resolver(mut self, use_system_resolver: bool) -> Self {
         self.use_system_resolver = use_system_resolver;
         self
@@ -511,5 +515,87 @@ impl Endpoint {
         };
 
         Ok((builder, request_url))
+    }
+
+    /// Resolves this endpoint into a transport-neutral model for HTTP clients.
+    ///
+    /// This method handles various endpoint schemes:
+    /// - `http`/`https`: Standard HTTP(S) endpoints
+    /// - `unix`: Unix domain sockets (Unix only)
+    /// - `windows`: Windows named pipes (Windows only)
+    /// - `file`: File dump endpoints for debugging (spawns a local server to capture requests)
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// - The endpoint scheme is unsupported
+    /// - Path decoding fails
+    /// - The dump server fails to start (for file:// scheme)
+    pub fn resolve_for_http(&self) -> anyhow::Result<ResolvedEndpoint> {
+        use anyhow::Context;
+
+        let timeout = std::time::Duration::from_millis(self.timeout_ms);
+
+        let (kind, request_url) = match self.url.scheme_str() {
+            // HTTP/HTTPS endpoints
+            Some("http") | Some("https") => (ResolvedEndpointKind::Tcp, self.url.to_string()),
+
+            // File dump endpoint (debugging) - uses platform-specific local transport
+            Some("file") => {
+                let output_path = decode_uri_path_in_authority(&self.url)
+                    .context("Failed to decode file path from URI")?;
+                let socket_or_pipe_path = dump_server::spawn_dump_server(output_path)?;
+
+                #[cfg(unix)]
+                {
+                    (
+                        ResolvedEndpointKind::UnixSocket {
+                            path: socket_or_pipe_path,
+                        },
+                        "http://localhost/".to_string(),
+                    )
+                }
+                #[cfg(windows)]
+                {
+                    (
+                        ResolvedEndpointKind::WindowsNamedPipe {
+                            path: socket_or_pipe_path,
+                        },
+                        "http://localhost/".to_string(),
+                    )
+                }
+            }
+
+            // Unix domain sockets
+            #[cfg(unix)]
+            Some("unix") => {
+                use connector::uds::socket_path_from_uri;
+                let socket_path = socket_path_from_uri(&self.url)?;
+                (
+                    ResolvedEndpointKind::UnixSocket { path: socket_path },
+                    format!("http://localhost{}", self.url.path()),
+                )
+            }
+
+            // Windows named pipes
+            #[cfg(windows)]
+            Some("windows") => {
+                use connector::named_pipe::named_pipe_path_from_uri;
+                let pipe_path = named_pipe_path_from_uri(&self.url)?;
+                (
+                    ResolvedEndpointKind::WindowsNamedPipe { path: pipe_path },
+                    format!("http://localhost{}", self.url.path()),
+                )
+            }
+
+            // Unsupported schemes
+            scheme => anyhow::bail!("Unsupported endpoint scheme: {:?}", scheme),
+        };
+
+        Ok(ResolvedEndpoint {
+            kind,
+            request_url,
+            timeout,
+            use_system_resolver: self.use_system_resolver,
+        })
     }
 }

--- a/libdd-common/src/lib.rs
+++ b/libdd-common/src/lib.rs
@@ -18,6 +18,7 @@ pub mod azure_app_services;
 pub mod cc_utils;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod connector;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod dump_server;
 mod endpoint_resolved;
 pub mod entity_id;
@@ -455,7 +456,7 @@ impl Endpoint {
     /// - The endpoint scheme is unsupported
     /// - Path decoding fails
     /// - The dump server fails to start (for file:// scheme)
-    #[cfg(feature = "reqwest")]
+    #[cfg(all(feature = "reqwest", not(target_arch = "wasm32")))]
     pub fn to_reqwest_client_builder(&self) -> anyhow::Result<(reqwest::ClientBuilder, String)> {
         use anyhow::Context;
 
@@ -530,6 +531,7 @@ impl Endpoint {
     /// - The endpoint scheme is unsupported
     /// - Path decoding fails
     /// - The dump server fails to start (for file:// scheme)
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn resolve_for_http(&self) -> anyhow::Result<ResolvedEndpoint> {
         use anyhow::Context;
 

--- a/libdd-common/tests/reqwest_builder_test.rs
+++ b/libdd-common/tests/reqwest_builder_test.rs
@@ -152,7 +152,6 @@ mod reqwest_tests {
 
 #[cfg(feature = "test-utils")]
 mod resolve_tests {
-    use libdd_common::test_utils::{create_temp_file_path, parse_http_request_sync};
     use libdd_common::{Endpoint, ResolvedEndpointKind};
 
     #[test]
@@ -188,6 +187,7 @@ mod resolve_tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn test_file_dump_captures_http_request() {
+        use libdd_common::test_utils::{create_temp_file_path, parse_http_request_sync};
         use std::io::{Read, Write};
         use std::os::unix::net::UnixStream;
 

--- a/libdd-common/tests/reqwest_builder_test.rs
+++ b/libdd-common/tests/reqwest_builder_test.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[cfg(feature = "reqwest")]
-mod tests {
+mod reqwest_tests {
     use libdd_common::test_utils::{
         count_active_threads, create_temp_file_path, parse_http_request,
     };
@@ -35,16 +35,12 @@ mod tests {
         ensure_crypto_provider();
         let file_path = create_temp_file_path("libdd_common_test", "http");
 
-        // Create endpoint with file:// scheme
         let endpoint = Endpoint::from_slice(&format!("file://{}", file_path.display()));
-
-        // Build reqwest client
         let (builder, url) = endpoint
             .to_reqwest_client_builder()
             .expect("should build client");
         let client = builder.build().expect("should create client");
 
-        // Send a simple request
         let test_body = "Hello from test!";
         let response = send_request(client, &url, test_body)
             .await
@@ -52,19 +48,13 @@ mod tests {
 
         assert_eq!(response.status(), 200);
 
-        // Read the captured request
-        // No sleep needed - the server only sends 200 after file.sync_all() completes
         let captured = std::fs::read(&*file_path).expect("should read dump file");
-
-        // Parse and validate
         let request = parse_http_request(&captured)
             .await
             .expect("should parse captured request");
 
         assert_eq!(request.method, "POST");
         assert_eq!(request.path, "/");
-
-        // Find our custom headers
         assert_eq!(
             request.headers.get("content-type").map(|s| s.as_str()),
             Some("text/plain")
@@ -73,8 +63,6 @@ mod tests {
             request.headers.get("x-test-header").map(|s| s.as_str()),
             Some("test-value")
         );
-
-        // Validate body
         assert_eq!(request.body, test_body.as_bytes());
     }
 
@@ -90,9 +78,6 @@ mod tests {
         assert!(err.to_string().contains("Unsupported endpoint scheme"));
     }
 
-    /// Both resolver configs produce a buildable reqwest client. Does not send a request (no
-    /// network). Does not verify which resolver is actually used; that is done by
-    /// test_system_resolver_uses_extra_thread.
     #[test]
     #[cfg_attr(miri, ignore)]
     fn test_both_resolver_configs_build_client() {
@@ -107,18 +92,9 @@ mod tests {
         }
     }
 
-    /// Verifies that the two resolver configs actually use different resolvers (default uses
-    /// fewer threads than system). With the default (in-process) resolver, no extra thread is
-    /// used for DNS; with the system resolver, reqwest uses a threadpool thread. Each phase
-    /// runs in its own single-threaded tokio runtime (started then dropped). Requires network.
-    /// Only runs on platforms where count_active_threads is implemented.
-    ///
-    /// TODO: Even the in-process resolver can lead to long-lived threads that outlast the
-    /// runtime (e.g. on OSX the "Grand Central Dispatch" thread). This should be
-    /// investigated so we can tighten or simplify the assertions.
     #[test]
     #[allow(dead_code)]
-    #[ignore] // This test is too flaky for now.  Leaving it in place since it's useful for debugging.
+    #[ignore]
     #[cfg_attr(miri, ignore)]
     #[cfg(any(target_os = "linux", target_os = "macos", windows))]
     fn test_system_resolver_uses_extra_thread() {
@@ -141,7 +117,7 @@ mod tests {
         );
         assert!(
             threads_default_after_drop <= initial + 2,
-            "More threads survived than expected.  See TODO on this test. {}",
+            "More threads survived than expected. {}",
             msg
         );
         assert!(
@@ -149,14 +125,8 @@ mod tests {
             "We expect the system resolver to use at least one more thread than the in-process resolver while the client is alive. {}",
             msg
         );
-        // After dropping the runtime, the system resolver's thread may or may not be reclaimed
-        // depending on platform and timing; we only assert on the "alive" counts above.
     }
 
-    /// Runs one resolver phase in a fresh single-threaded tokio runtime (started then dropped):
-    /// build client with the given resolver setting, send one request, count threads with client
-    /// alive, drop client, drop runtime, then count threads after drop. Returns (threads_alive,
-    /// threads_after_drop).
     fn run_resolver_phase(url_slice: &str, use_system_resolver: bool) -> (usize, usize) {
         ensure_crypto_provider();
         let rt = tokio::runtime::Builder::new_current_thread()
@@ -177,5 +147,85 @@ mod tests {
         let after_drop =
             count_active_threads().expect("count_active_threads not supported on this platform");
         (alive, after_drop)
+    }
+}
+
+#[cfg(feature = "test-utils")]
+mod resolve_tests {
+    use libdd_common::test_utils::{create_temp_file_path, parse_http_request_sync};
+    use libdd_common::{Endpoint, ResolvedEndpointKind};
+
+    #[test]
+    fn test_http_endpoint_resolution_preserves_settings() {
+        for use_system_resolver in [false, true] {
+            let endpoint = Endpoint::from_slice("http://example.com/")
+                .with_timeout(1234)
+                .with_system_resolver(use_system_resolver);
+
+            let resolved = endpoint
+                .resolve_for_http()
+                .expect("should resolve endpoint");
+
+            assert!(matches!(resolved.kind, ResolvedEndpointKind::Tcp));
+            assert_eq!(resolved.request_url, "http://example.com/");
+            assert_eq!(resolved.timeout, std::time::Duration::from_millis(1234));
+            assert_eq!(resolved.use_system_resolver, use_system_resolver);
+        }
+    }
+
+    #[test]
+    fn test_unsupported_scheme_returns_error() {
+        let endpoint = Endpoint::from_slice("ftp://example.com/file");
+
+        let result = endpoint.resolve_for_http();
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("Unsupported endpoint scheme"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_file_dump_captures_http_request() {
+        use std::io::{Read, Write};
+        use std::os::unix::net::UnixStream;
+
+        let file_path = create_temp_file_path("libdd_common_test", "http");
+        let endpoint = Endpoint::from_slice(&format!("file://{}", file_path.display()));
+
+        let resolved = endpoint
+            .resolve_for_http()
+            .expect("should resolve endpoint");
+        assert_eq!(resolved.request_url, "http://localhost/");
+
+        let socket_path = match resolved.kind {
+            ResolvedEndpointKind::UnixSocket { path } => path,
+            other => panic!("unexpected resolved endpoint kind: {:?}", other),
+        };
+
+        let mut stream = UnixStream::connect(socket_path).expect("connect to dump server");
+        let request = b"POST / HTTP/1.1\r\nHost: localhost\r\nContent-Type: text/plain\r\nX-Test-Header: test-value\r\nContent-Length: 16\r\n\r\nHello from test!";
+        stream.write_all(request).expect("write request");
+        stream.shutdown(std::net::Shutdown::Write).ok();
+
+        let mut response = Vec::new();
+        stream.read_to_end(&mut response).expect("read response");
+        assert!(response.starts_with(b"HTTP/1.1 200 OK"));
+
+        let captured = std::fs::read(&*file_path).expect("should read dump file");
+        let parsed = parse_http_request_sync(&captured).expect("should parse captured request");
+
+        assert_eq!(parsed.method, "POST");
+        assert_eq!(parsed.path, "/");
+        assert_eq!(
+            parsed.headers.get("content-type").map(String::as_str),
+            Some("text/plain")
+        );
+        assert_eq!(
+            parsed.headers.get("x-test-header").map(String::as_str),
+            Some("test-value")
+        );
+        assert_eq!(parsed.body, b"Hello from test!");
     }
 }

--- a/libdd-profiling-ffi/Cargo.toml
+++ b/libdd-profiling-ffi/Cargo.toml
@@ -59,6 +59,5 @@ libc = "0.2"
 serde_json = { version = "1.0" }
 symbolizer-ffi = { path = "../symbolizer-ffi", optional = true, default-features = false }
 thiserror = "2"
-tokio-util = "0.7.1"
 datadog-ffe-ffi = { path = "../datadog-ffe-ffi", default-features = false, optional = true }
 libdd-shared-runtime-ffi = { path = "../libdd-shared-runtime-ffi", default-features = false, optional = true }

--- a/libdd-profiling-ffi/src/exporter.rs
+++ b/libdd-profiling-ffi/src/exporter.rs
@@ -16,8 +16,6 @@ use libdd_profiling::internal::EncodedProfile;
 use std::borrow::Cow;
 use std::str::FromStr;
 
-type TokioCancellationToken = tokio_util::sync::CancellationToken;
-
 #[allow(dead_code)]
 #[repr(C)]
 pub enum ProfilingEndpoint<'a> {
@@ -231,37 +229,7 @@ unsafe fn parse_json(
     }
 }
 
-/// Initializes the tokio runtime for the exporter.
-///
-/// This function creates the tokio runtime used by `ddog_prof_Exporter_send_blocking`.
-/// It can be called ahead of time to ensure the runtime is ready before sending.
-///
-/// # Thread Affinity
-///
-/// **Important**: The runtime has thread affinity. This function should be called from
-/// the same thread that will later call `ddog_prof_Exporter_send_blocking`.
-///
-/// # Arguments
-/// * `exporter` - Borrows the exporter.
-///
-/// # Safety
-/// The `exporter` must point to a valid ProfileExporter that has not been dropped.
-#[no_mangle]
-#[must_use]
-#[named]
-pub unsafe extern "C" fn ddog_prof_Exporter_init_runtime(
-    mut exporter: *mut Handle<ProfileExporter>,
-) -> VoidResult {
-    wrap_with_void_ffi_result!({
-        let exporter = exporter.to_inner_mut()?;
-        exporter.init_runtime()?
-    })
-}
-
 /// Builds a request and sends it, returning the HttpStatus.
-///
-/// Note: If the runtime has not been initialized via `ddog_prof_Exporter_init_runtime`,
-/// it will be lazily initialized on first call.
 ///
 /// # Arguments
 /// * `exporter` - Borrows the exporter.
@@ -271,7 +239,6 @@ pub unsafe extern "C" fn ddog_prof_Exporter_init_runtime(
 /// * `optional_process_tags` - Process-level tags as a comma-separated string.
 /// * `optional_internal_metadata_json` - Internal metadata as a JSON string.
 /// * `optional_info_json` - System info as a JSON string.
-/// * `cancel` - Optional cancellation token.
 ///
 /// # Safety
 /// All non-null arguments MUST have been created by APIs in this module.
@@ -286,7 +253,6 @@ pub unsafe extern "C" fn ddog_prof_Exporter_send_blocking(
     optional_process_tags: Option<&CharSlice>,
     optional_internal_metadata_json: Option<&CharSlice>,
     optional_info_json: Option<&CharSlice>,
-    mut cancel: *mut Handle<TokioCancellationToken>,
 ) -> Result<HttpStatus> {
     wrap_with_ffi_result!({
         let exporter = exporter.to_inner_mut()?;
@@ -299,7 +265,6 @@ pub unsafe extern "C" fn ddog_prof_Exporter_send_blocking(
         let internal_metadata = parse_json("internal_metadata", optional_internal_metadata_json)?;
         let info = parse_json("info", optional_info_json)?;
 
-        let cancel = cancel.to_inner_mut().ok();
         let status = exporter.send_blocking(
             profile,
             files_to_compress_and_export.as_slice(),
@@ -307,83 +272,10 @@ pub unsafe extern "C" fn ddog_prof_Exporter_send_blocking(
             internal_metadata,
             info,
             process_tags_str,
-            cancel.as_deref(),
         )?;
 
         anyhow::Ok(HttpStatus(status.as_u16()))
     })
-}
-
-/// Can be passed as an argument to send and then be used to asynchronously cancel it from a
-/// different thread.
-#[no_mangle]
-#[must_use]
-pub extern "C" fn ddog_CancellationToken_new() -> Handle<TokioCancellationToken> {
-    TokioCancellationToken::new().into()
-}
-
-/// A cloned TokioCancellationToken is connected to the TokioCancellationToken it was created from.
-/// Either the cloned or the original token can be used to cancel or provided as arguments to send.
-/// The useful part is that they have independent lifetimes and can be dropped separately.
-///
-/// Thus, it's possible to do something like:
-/// ```c
-/// cancel_t1 = ddog_CancellationToken_new();
-/// cancel_t2 = ddog_CancellationToken_clone(cancel_t1);
-///
-/// // On thread t1:
-///     ddog_prof_Exporter_send(..., cancel_t1);
-///     ddog_CancellationToken_drop(cancel_t1);
-///
-/// // On thread t2:
-///     ddog_CancellationToken_cancel(cancel_t2);
-///     ddog_CancellationToken_drop(cancel_t2);
-/// ```
-///
-/// Without clone, both t1 and t2 would need to synchronize to make sure neither was using the
-/// cancel before it could be dropped. With clone, there is no need for such synchronization, both
-/// threads have their own cancel and should drop that cancel after they are done with it.
-///
-/// # Safety
-/// If the `token` is non-null, it must point to a valid object.
-#[no_mangle]
-#[must_use]
-pub unsafe extern "C" fn ddog_CancellationToken_clone(
-    mut token: *mut Handle<TokioCancellationToken>,
-) -> Handle<TokioCancellationToken> {
-    if let Ok(token) = token.to_inner_mut() {
-        token.clone().into()
-    } else {
-        Handle::empty()
-    }
-}
-
-/// Cancel send that is being called in another thread with the given token.
-/// Note that cancellation is a terminal state; cancelling a token more than once does nothing.
-/// Returns `true` if token was successfully cancelled.
-#[no_mangle]
-pub unsafe extern "C" fn ddog_CancellationToken_cancel(
-    mut cancel: *mut Handle<TokioCancellationToken>,
-) -> bool {
-    if let Ok(token) = cancel.to_inner_mut() {
-        let will_cancel = !token.is_cancelled();
-        if will_cancel {
-            token.cancel();
-        }
-        will_cancel
-    } else {
-        false
-    }
-}
-
-/// # Safety
-/// The `token` can be null, but non-null values must be created by the Rust
-/// Global allocator and must have not been dropped already.
-#[no_mangle]
-pub unsafe extern "C" fn ddog_CancellationToken_drop(
-    mut token: *mut Handle<TokioCancellationToken>,
-) {
-    drop(token.take())
 }
 
 // ============================================================================
@@ -619,7 +511,6 @@ mod tests {
                 None,
                 None,
                 None,
-                &mut Handle::empty(),
             )
         };
 
@@ -757,7 +648,6 @@ mod tests {
                 Some(&process_tags),
                 Some(&raw_internal_metadata),
                 Some(&raw_info),
-                &mut Handle::empty(),
             )
         };
 

--- a/libdd-profiling/Cargo.toml
+++ b/libdd-profiling/Cargo.toml
@@ -55,7 +55,7 @@ serde = {version = "1.0", features = ["derive"]}
 serde_json = {version = "1.0"}
 target-triple = "0.1.4"
 thiserror = "2"
-ureq = { version = "3.2", default-features = false, features = ["rustls-no-provider", "platform-verifier"] }
+ureq = { version = "=3.2.0", default-features = false, features = ["rustls-no-provider", "platform-verifier"] }
 zstd = { version = "0.13", default-features = false }
 # ring is the crypto provider for non-FIPS builds on all platforms.
 # FIPS builds activate aws-lc-rs via the rustls/fips feature instead.

--- a/libdd-profiling/Cargo.toml
+++ b/libdd-profiling/Cargo.toml
@@ -42,28 +42,20 @@ http-body-util = "0.1"
 httparse = "1.9"
 indexmap = "2.11"
 libdd-alloc = { version = "1.0.0", path = "../libdd-alloc" }
-libdd-common = { version = "4.2.0", path = "../libdd-common", default-features = false, features = ["reqwest", "test-utils"] }
+libdd-common = { version = "4.2.0", path = "../libdd-common", default-features = false }
 libdd-profiling-protobuf = { version = "2.0.0", path = "../libdd-profiling-protobuf", features = ["prost_impls"] }
 mime = "0.3.16"
 parking_lot = { version = "0.12", default-features = false }
 prost = "0.14.1"
 rand = "0.8"
-# Use rustls to align with the rest of the workspace (libdd-common, libdd-telemetry, etc.)
-# Non-FIPS builds use ring as the crypto provider; FIPS builds use aws-lc-rs.
-# Use hickory-dns instead of the default system DNS resolver to avoid fork safety issues.
-# The default resolver can hold locks or other global state that can cause deadlocks
-# or corruption when the process forks (e.g., in PHP-FPM or other forking environments).
-# Use rustls-no-provider instead of rustls to avoid reqwest forcing aws-lc-rs as the crypto
-# backend. We install the ring provider explicitly via tls.rs / libdd-common instead.
-reqwest = { version = "0.13.2", features = ["multipart", "rustls-no-provider", "hickory-dns"], default-features = false}
+
 rustls-platform-verifier = "0.6"
 rustc-hash = { version = "2.1", default-features = false }
 serde = {version = "1.0", features = ["derive"]}
 serde_json = {version = "1.0"}
 target-triple = "0.1.4"
 thiserror = "2"
-tokio = {version = "1.23", features = ["rt", "macros", "net", "io-util", "fs"]}
-tokio-util = { version = "0.7.1", default-features = false }
+ureq = { version = "3.2", default-features = false, features = ["rustls-no-provider", "platform-verifier"] }
 zstd = { version = "0.13", default-features = false }
 # ring is the crypto provider for non-FIPS builds on all platforms.
 # FIPS builds activate aws-lc-rs via the rustls/fips feature instead.

--- a/libdd-profiling/src/cxx.rs
+++ b/libdd-profiling/src/cxx.rs
@@ -148,13 +148,6 @@ pub mod ffi {
         type Profile;
         type ProfileExporter;
         type ExporterManager;
-        type CancellationToken;
-
-        // CancellationToken factory and methods
-        fn new_cancellation_token() -> Box<CancellationToken>;
-        fn clone_token(self: &CancellationToken) -> Box<CancellationToken>;
-        fn cancel(self: &CancellationToken);
-        fn is_cancelled(self: &CancellationToken) -> bool;
 
         // Static factory methods for Profile
         #[Self = "Profile"]
@@ -257,39 +250,6 @@ pub mod ffi {
             process_tags: &str,
             internal_metadata: &str,
             info: &str,
-        ) -> Result<()>;
-
-        /// Sends a profile to Datadog with cancellation support.
-        ///
-        /// This is the same as `send_profile`, but allows cancelling the operation from another
-        /// thread using a cancellation token.
-        ///
-        /// **Important**: This method resets the profile and sends the *previous* profile data.
-        /// After calling this, the profile will be empty and ready for new samples.
-        ///
-        /// # Arguments
-        /// * `profile` - Profile to send (will be consumed/reset, previous data is sent)
-        /// * `files_to_compress` - Additional files to compress and attach (e.g., heap dumps)
-        /// * `additional_tags` - Per-profile tags (in addition to exporter-level tags)
-        /// * `process_tags` - Process-level tags as comma-separated string (e.g.,
-        ///   "runtime:native,profiler_version:1.0") Pass empty string "" if not needed
-        /// * `internal_metadata` - Internal metadata as JSON string (e.g., `{"key": "value"}`) See
-        ///   Datadog-internal "RFC: Attaching internal metadata to pprof profiles" Pass empty
-        ///   string "" if not needed
-        /// * `info` - System/environment info as JSON string (e.g., `{"os": "linux", "arch":
-        ///   "x86_64"}`) See Datadog-internal "RFC: Pprof System Info Support" Pass empty string ""
-        ///   if not needed
-        /// * `cancel` - Cancellation token to cancel the send operation
-        #[allow(clippy::too_many_arguments)]
-        fn send_profile_with_cancellation(
-            self: &mut ProfileExporter,
-            profile: &mut Profile,
-            files_to_compress: Vec<AttachmentFile>,
-            additional_tags: Vec<Tag>,
-            process_tags: &str,
-            internal_metadata: &str,
-            info: &str,
-            cancel: &CancellationToken,
         ) -> Result<()>;
 
         // ExporterManager methods
@@ -468,50 +428,6 @@ impl<'a> TryFrom<&ffi::Tag<'a>> for libdd_common::tag::Tag {
 
     fn try_from(tag: &ffi::Tag<'a>) -> Result<Self, Self::Error> {
         libdd_common::tag::Tag::new(tag.key, tag.value)
-    }
-}
-
-// ============================================================================
-// CancellationToken - Wrapper around tokio_util::sync::CancellationToken
-// ============================================================================
-
-pub struct CancellationToken {
-    inner: tokio_util::sync::CancellationToken,
-}
-
-/// Creates a new cancellation token.
-pub fn new_cancellation_token() -> Box<CancellationToken> {
-    Box::new(CancellationToken {
-        inner: tokio_util::sync::CancellationToken::new(),
-    })
-}
-
-impl CancellationToken {
-    /// Clones the cancellation token.
-    ///
-    /// A cloned token is connected to the original token - either can be used
-    /// to cancel or check cancellation status. The useful part is that they have
-    /// independent lifetimes and can be dropped separately.
-    ///
-    /// This is useful for multi-threaded scenarios where one thread performs the
-    /// send operation while another thread can cancel it.
-    pub fn clone_token(&self) -> Box<CancellationToken> {
-        Box::new(CancellationToken {
-            inner: self.inner.clone(),
-        })
-    }
-
-    /// Cancels the token.
-    ///
-    /// Note that cancellation is a terminal state; calling cancel multiple times
-    /// has no additional effect.
-    pub fn cancel(&self) {
-        self.inner.cancel();
-    }
-
-    /// Returns true if the token has been cancelled.
-    pub fn is_cancelled(&self) -> bool {
-        self.inner.is_cancelled()
     }
 }
 
@@ -818,49 +734,9 @@ impl ProfileExporter {
             process_tags,
             internal_metadata,
             info,
-            None,
         )
     }
 
-    /// Sends a profile to Datadog with cancellation support.
-    ///
-    /// # Arguments
-    /// * `profile` - Profile to send (will be reset after sending)
-    /// * `files_to_compress` - Additional files to compress and attach
-    /// * `additional_tags` - Per-profile tags (in addition to exporter-level tags)
-    /// * `process_tags` - Process-level tags as comma-separated string. Empty string if not needed.
-    /// * `internal_metadata` - Internal metadata as JSON string. Empty string if not needed.
-    ///   Example: `{"custom_field": "value", "version": "1.0"}`
-    /// * `info` - System/environment info as JSON string. Empty string if not needed. Example:
-    ///   `{"os": "linux", "arch": "x86_64", "kernel": "5.15.0"}`
-    /// * `cancel` - Cancellation token to cancel the send operation
-    #[allow(clippy::too_many_arguments)]
-    pub fn send_profile_with_cancellation(
-        &mut self,
-        profile: &mut Profile,
-        files_to_compress: Vec<ffi::AttachmentFile>,
-        additional_tags: Vec<ffi::Tag>,
-        process_tags: &str,
-        internal_metadata: &str,
-        info: &str,
-        cancel: &CancellationToken,
-    ) -> anyhow::Result<()> {
-        self.send_profile_impl(
-            profile,
-            files_to_compress,
-            additional_tags,
-            process_tags,
-            internal_metadata,
-            info,
-            Some(&cancel.inner),
-        )
-    }
-
-    /// Internal implementation shared by send_profile and send_profile_with_cancellation
-    ///
-    /// Resets the profile and sends the previous profile data. This allows continuous
-    /// profiling where you keep adding samples to the current profile while the previous
-    /// period's data is being sent.
     #[allow(clippy::too_many_arguments)]
     fn send_profile_impl(
         &mut self,
@@ -870,7 +746,6 @@ impl ProfileExporter {
         process_tags: &str,
         internal_metadata: &str,
         info: &str,
-        cancel: Option<&tokio_util::sync::CancellationToken>,
     ) -> anyhow::Result<()> {
         let (
             encoded,
@@ -895,7 +770,6 @@ impl ProfileExporter {
             internal_metadata_json,
             info_json,
             process_tags_opt,
-            cancel,
         )?;
 
         anyhow::ensure!(

--- a/libdd-profiling/src/cxx.rs
+++ b/libdd-profiling/src/cxx.rs
@@ -790,6 +790,7 @@ pub struct ExporterManager {
 }
 
 impl ExporterManager {
+    #[allow(clippy::boxed_local)]
     pub fn new_manager(exporter: Box<ProfileExporter>) -> anyhow::Result<Box<ExporterManager>> {
         let inner = exporter::ExporterManager::new(exporter.inner)?;
         Ok(Box::new(ExporterManager { inner }))

--- a/libdd-profiling/src/exporter/errors.rs
+++ b/libdd-profiling/src/exporter/errors.rs
@@ -1,37 +1,13 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use std::error;
-use std::fmt;
 use thiserror::Error;
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-#[allow(dead_code)]
-pub(crate) enum Error {
-    InvalidUrl,
-    OperationTimedOut,
-    UserRequestedCancellation,
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(match self {
-            Self::InvalidUrl => "invalid url",
-            Self::OperationTimedOut => "operation timed out",
-            Self::UserRequestedCancellation => "operation cancelled by user",
-        })
-    }
-}
-impl error::Error for Error {}
 
 #[derive(Debug, Error)]
 pub enum SendError {
     #[error("Failed to build request")]
     BuildFailed(#[from] anyhow::Error),
 
-    #[error("Operation cancelled by user")]
-    Cancelled,
-
     #[error("Failed to send HTTP request")]
-    RequestFailed(#[from] reqwest::Error),
+    RequestFailed(#[source] anyhow::Error),
 }

--- a/libdd-profiling/src/exporter/exporter_manager.rs
+++ b/libdd-profiling/src/exporter/exporter_manager.rs
@@ -6,22 +6,22 @@ use crate::{exporter::File, internal::EncodedProfile};
 use anyhow::Context;
 use crossbeam_channel::{Receiver, Sender};
 use libdd_common::tag::Tag;
-use reqwest::RequestBuilder;
-use std::thread::JoinHandle;
-use tokio_util::sync::CancellationToken;
 
+use super::transport::PreparedRequest;
+use std::thread::JoinHandle;
+
+#[allow(private_interfaces)]
 #[derive(Debug)]
 pub enum ExporterManager {
     Active {
-        cancel: CancellationToken,
         exporter: ProfileExporter,
         handle: JoinHandle<anyhow::Result<()>>,
-        sender: Sender<RequestBuilder>,
-        receiver: Receiver<RequestBuilder>,
+        sender: Sender<PreparedRequest>,
+        receiver: Receiver<PreparedRequest>,
     },
     Suspended {
         exporter: ProfileExporter,
-        inflight: Vec<RequestBuilder>,
+        inflight: Vec<PreparedRequest>,
     },
     /// Temporary state used during transitions between Active and Suspended.
     /// The manager should never be left in this state.
@@ -31,32 +31,18 @@ pub enum ExporterManager {
 impl ExporterManager {
     pub fn new(exporter: ProfileExporter) -> anyhow::Result<Self> {
         let (sender, receiver) = crossbeam_channel::bounded(2);
-        let cancel = CancellationToken::new();
-        let cloned_receiver: Receiver<RequestBuilder> = receiver.clone();
-        let cloned_cancel = cancel.clone();
+        let cloned_receiver: Receiver<PreparedRequest> = receiver.clone();
+        let worker_exporter = exporter.clone();
         let handle = std::thread::spawn(move || {
-            let runtime = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()?;
-            runtime.block_on(async {
-                loop {
-                    let Ok(msg) = cloned_receiver.recv() else {
-                        return;
-                    };
-                    if cloned_cancel
-                        .run_until_cancelled(msg.send())
-                        .await
-                        .is_none()
-                    {
-                        return;
-                    }
-                    // TODO: Add logging for failed uploads.
-                }
-            });
-            Ok(())
+            loop {
+                let Ok(msg) = cloned_receiver.recv() else {
+                    return Ok(());
+                };
+                let _ = worker_exporter.send_prepared(msg);
+                // TODO: Add logging for failed uploads.
+            }
         });
         Ok(Self::Active {
-            cancel,
             exporter,
             handle,
             sender,
@@ -68,7 +54,6 @@ impl ExporterManager {
         let old = std::mem::replace(self, Self::Transitioning);
 
         let Self::Active {
-            cancel,
             exporter,
             handle,
             sender,
@@ -79,7 +64,6 @@ impl ExporterManager {
             anyhow::bail!("Cannot abort manager in state: {:?}", self);
         };
 
-        cancel.cancel();
         let inflight: Vec<_> = receiver.try_iter().collect();
         drop(sender);
 

--- a/libdd-profiling/src/exporter/exporter_manager.rs
+++ b/libdd-profiling/src/exporter/exporter_manager.rs
@@ -185,7 +185,7 @@ impl ExporterManager {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use crate::exporter::config;

--- a/libdd-profiling/src/exporter/mod.rs
+++ b/libdd-profiling/src/exporter/mod.rs
@@ -4,8 +4,11 @@
 pub mod config;
 mod errors;
 pub mod exporter_manager;
+mod multipart;
 mod profile_exporter;
 mod tls;
+mod transport;
+mod ureq_client;
 
 pub use errors::SendError;
 pub use exporter_manager::ExporterManager;

--- a/libdd-profiling/src/exporter/multipart.rs
+++ b/libdd-profiling/src/exporter/multipart.rs
@@ -1,0 +1,103 @@
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::Write;
+
+use anyhow::Context;
+
+use super::profile_exporter::File;
+use crate::internal::{EncodedProfile, Profile};
+use crate::profiles::{Compressor, DefaultProfileCodec};
+
+#[derive(Debug)]
+pub(crate) struct PreparedMultipart {
+    pub(crate) content_type: String,
+    pub(crate) body: Vec<u8>,
+}
+
+pub(crate) fn build_multipart(
+    event: &serde_json::Value,
+    profile: EncodedProfile,
+    additional_files: &[File<'_>],
+) -> anyhow::Result<PreparedMultipart> {
+    let boundary = format!(
+        "------------------------{:016x}{:016x}",
+        rand::random::<u64>(),
+        rand::random::<u64>()
+    );
+
+    let event_bytes = serde_json::to_vec(event)?;
+    let mut body = Vec::with_capacity(
+        event_bytes.len()
+            + profile.buffer.len()
+            + additional_files
+                .iter()
+                .map(|f| f.bytes.len())
+                .sum::<usize>(),
+    );
+
+    append_part(
+        &mut body,
+        &boundary,
+        "event",
+        "event.json",
+        Some("application/json"),
+        &event_bytes,
+    );
+
+    for file in additional_files {
+        let mut encoder = Compressor::<DefaultProfileCodec>::try_new(
+            (file.bytes.len() >> 3).next_power_of_two(),
+            10 * 1024 * 1024,
+            Profile::COMPRESSION_LEVEL,
+        )
+        .context("failed to create compressor")?;
+        encoder.write_all(file.bytes)?;
+        let compressed = encoder.finish()?;
+
+        append_part(
+            &mut body,
+            &boundary,
+            file.name,
+            file.name,
+            None,
+            &compressed,
+        );
+    }
+
+    append_part(
+        &mut body,
+        &boundary,
+        "profile.pprof",
+        "profile.pprof",
+        None,
+        &profile.buffer,
+    );
+    body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+
+    Ok(PreparedMultipart {
+        content_type: format!("multipart/form-data; boundary={boundary}"),
+        body,
+    })
+}
+
+fn append_part(
+    body: &mut Vec<u8>,
+    boundary: &str,
+    name: &str,
+    filename: &str,
+    content_type: Option<&str>,
+    content: &[u8],
+) {
+    body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+    body.extend_from_slice(
+        format!("Content-Disposition: form-data; name=\"{name}\"; filename=\"{filename}\"\r\n")
+            .as_bytes(),
+    );
+    if let Some(content_type) = content_type {
+        body.extend_from_slice(format!("Content-Type: {content_type}\r\n").as_bytes());
+    }
+    body.extend_from_slice(b"\r\n");
+    body.extend_from_slice(content);
+    body.extend_from_slice(b"\r\n");
+}

--- a/libdd-profiling/src/exporter/profile_exporter.rs
+++ b/libdd-profiling/src/exporter/profile_exporter.rs
@@ -1,9 +1,7 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-//! Reqwest-based profiling exporter
-//!
-//! This is a simplified async implementation using reqwest.
+//! ureq-based profiling exporter.
 //!
 //! ## Debugging with File Dumps
 //!
@@ -25,26 +23,20 @@
 //! which can be useful for debugging or replaying requests.
 
 use super::errors::SendError;
-use anyhow::Context;
+use super::multipart::build_multipart;
+use super::transport::{PreparedRequest, ProfileTransport};
 use libdd_common::tag::Tag;
 use libdd_common::{azure_app_services, tag, Endpoint};
-use reqwest::RequestBuilder;
 use serde_json::json;
-use std::io::Write;
-use tokio::runtime::Runtime;
-use tokio_util::sync::CancellationToken;
 
-use crate::internal::{EncodedProfile, Profile};
-use crate::profiles::{Compressor, DefaultProfileCodec};
+use crate::internal::EncodedProfile;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ProfileExporter {
-    client: reqwest::Client,
+    transport: ProfileTransport,
     family: String,
     base_tags_string: String,
-    request_url: String,
-    headers: reqwest::header::HeaderMap,
-    runtime: Option<Runtime>,
+    headers: Vec<(String, String)>,
 }
 
 pub struct File<'a> {
@@ -55,22 +47,8 @@ pub struct File<'a> {
 impl ProfileExporter {
     /// Creates a new exporter to be used to report profiling data.
     ///
-    /// Note: Reqwest v0.12.23+ includes automatic retry support for transient failures.
-    /// The default configuration automatically retries safe errors and low-level protocol NACKs.
-    /// For custom retry policies, users can configure the reqwest client before creating the
-    /// exporter.
-    ///
-    /// # Thread Safety
-    ///
-    /// The exporter can be used from any thread, but if using `send_blocking()`, the exporter
-    /// should remain on the same thread for all blocking calls. See [`send_blocking`] for details.
-    ///
-    /// # Performance
-    ///
     /// TLS configuration is cached globally and reused across exporter
     /// instances, avoiding repeated root store loading on Linux.
-    ///
-    /// [`send_blocking`]: ProfileExporter::send_blocking
     pub fn new(
         profiling_library_name: &str,
         profiling_library_version: &str,
@@ -78,109 +56,54 @@ impl ProfileExporter {
         mut tags: Vec<Tag>,
         endpoint: Endpoint,
     ) -> anyhow::Result<Self> {
-        // For HTTPS, use the cached platform TLS config (loads system CA certs).
-        // For all other schemes (http, unix, windows, file), provide a minimal
-        // config with an empty root store so reqwest doesn't attempt to load
-        // system CA certificates itself — which fails in minimal container
-        // environments. TLS will never be negotiated on those transports anyway.
-        let tls_config = if endpoint.url.scheme_str() == Some("https") {
-            super::tls::cached_tls_config()?
-        } else {
-            super::tls::empty_tls_config()?
-        };
-        // Pre-build all static headers
-        let mut headers = reqwest::header::HeaderMap::new();
+        let mut headers = Vec::with_capacity(8);
+        headers.push(("Connection".to_string(), "close".to_string()));
+        headers.push((
+            "DD-EVP-ORIGIN".to_string(),
+            profiling_library_name.to_string(),
+        ));
+        headers.push((
+            "DD-EVP-ORIGIN-VERSION".to_string(),
+            profiling_library_version.to_string(),
+        ));
+        headers.push((
+            "User-Agent".to_string(),
+            format!("DDProf/{}", env!("CARGO_PKG_VERSION")),
+        ));
 
-        headers.insert(
-            "Connection",
-            reqwest::header::HeaderValue::from_static("close"),
-        );
-        headers.insert(
-            "DD-EVP-ORIGIN",
-            reqwest::header::HeaderValue::from_str(profiling_library_name)?,
-        );
-        headers.insert(
-            "DD-EVP-ORIGIN-VERSION",
-            reqwest::header::HeaderValue::from_str(profiling_library_version)?,
-        );
-        headers.insert(
-            "User-Agent",
-            reqwest::header::HeaderValue::from_str(&format!(
-                "DDProf/{}",
-                env!("CARGO_PKG_VERSION")
-            ))?,
-        );
-
-        // Add optional endpoint headers (api-key, test-token)
         for (name, value) in endpoint.get_optional_headers() {
-            headers.insert(name, reqwest::header::HeaderValue::from_str(value)?);
+            headers.push((name.to_string(), value.to_string()));
         }
 
-        // Add entity-related headers (container-id, entity-id, external-env)
         for (name, value) in libdd_common::entity_id::get_entity_headers() {
-            headers.insert(name, reqwest::header::HeaderValue::from_static(value));
+            headers.push((name.to_string(), value.to_string()));
         }
 
-        // Add Azure App Services tags if available
         if let Some(aas) = &*azure_app_services::AAS_METADATA {
             let aas_tags_iter = aas.get_app_service_tags();
             tags.try_reserve(aas_tags_iter.len())?;
             tags.extend(aas_tags_iter.filter_map(|(name, value)| Tag::new(name, value).ok()));
         }
 
-        // Precompute the base tags string (includes configured tags + Azure App Services tags)
         let base_tags_string: String = tags.iter().flat_map(|tag| [tag.as_ref(), ","]).collect();
 
-        let (builder, request_url) = endpoint.to_reqwest_client_builder()?;
-        let builder = builder.tls_backend_preconfigured(tls_config.0);
+        let resolved = endpoint.resolve_for_http()?;
+        let tls_config = resolved
+            .request_url
+            .starts_with("https://")
+            .then(|| super::tls::cached_tls_config().map(|config| config.0))
+            .transpose()?;
+        let transport = ProfileTransport::new(resolved, tls_config)?;
 
         Ok(Self {
-            client: builder.build()?,
+            transport,
             family: family.to_string(),
             base_tags_string,
-            request_url,
             headers,
-            runtime: None,
         })
     }
 
     /// Synchronously sends a profile to the configured endpoint.
-    ///
-    /// This is a blocking wrapper around the async [`send`] method. It lazily creates and caches
-    /// a single-threaded tokio runtime on first use.
-    ///
-    /// # Thread Affinity
-    ///
-    /// **Important**: The cached runtime uses `new_current_thread()`, which has thread affinity.
-    /// For best results, all calls to `send_blocking()` on the same exporter instance should be
-    /// made from the same thread. Moving the exporter across threads between blocking calls may
-    /// cause issues.
-    ///
-    /// If you need to use the exporter from multiple threads, consider either:
-    /// - Creating a separate exporter instance per thread
-    /// - Using the async [`send`] method directly from within a tokio runtime
-    ///
-    /// [`send`]: ProfileExporter::send
-    /// Initializes the tokio runtime for blocking operations.
-    ///
-    /// This method lazily creates a single-threaded tokio runtime. It can be called
-    /// before `send_blocking` to ensure the runtime is ready ahead of time.
-    ///
-    /// # Thread Affinity
-    ///
-    /// **Important**: The runtime uses `new_current_thread()`, which has thread affinity.
-    /// This method should be called from the same thread that will later call `send_blocking`.
-    pub fn init_runtime(&mut self) -> anyhow::Result<()> {
-        if self.runtime.is_none() {
-            self.runtime = Some(
-                tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()?,
-            );
-        }
-        Ok(())
-    }
-
     #[allow(clippy::too_many_arguments)]
     pub fn send_blocking(
         &mut self,
@@ -190,26 +113,19 @@ impl ProfileExporter {
         internal_metadata: Option<serde_json::Value>,
         info: Option<serde_json::Value>,
         process_tags: Option<&str>,
-        cancel: Option<&CancellationToken>,
-    ) -> anyhow::Result<reqwest::StatusCode> {
-        self.init_runtime()?;
-
-        Ok(self
-            .runtime
-            .as_ref()
-            .context("Missing runtime")?
-            .block_on(self.send(
-                profile,
-                additional_files,
-                additional_tags,
-                internal_metadata,
-                info,
-                process_tags,
-                cancel,
-            ))?
-            .status())
+    ) -> anyhow::Result<http::StatusCode> {
+        self.send_status(
+            profile,
+            additional_files,
+            additional_tags,
+            internal_metadata,
+            info,
+            process_tags,
+        )
+        .map_err(anyhow::Error::from)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn build(
         &self,
         profile: EncodedProfile,
@@ -218,7 +134,7 @@ impl ProfileExporter {
         internal_metadata: Option<serde_json::Value>,
         info: Option<serde_json::Value>,
         process_tags: Option<&str>,
-    ) -> anyhow::Result<RequestBuilder> {
+    ) -> Result<PreparedRequest, SendError> {
         let tags_profiler = self.build_tags_string(additional_tags)?;
         let event = self.build_event_json(
             &profile,
@@ -229,18 +145,25 @@ impl ProfileExporter {
             process_tags,
         );
 
-        let form = self.build_multipart_form(event, profile, additional_files)?;
+        let multipart =
+            build_multipart(&event, profile, additional_files).map_err(SendError::BuildFailed)?;
 
-        Ok(self
-            .client
-            .post(&self.request_url)
-            .headers(self.headers.clone())
-            .multipart(form))
+        let mut headers = self.headers.clone();
+        headers.push(("Content-Type".to_string(), multipart.content_type));
+        headers.push((
+            "Content-Length".to_string(),
+            multipart.body.len().to_string(),
+        ));
+
+        Ok(PreparedRequest {
+            headers,
+            body: multipart.body,
+        })
     }
 
-    #[allow(clippy::too_many_arguments)]
     /// Build and send a profile. Returns the HTTP status code.
-    pub async fn send(
+    #[allow(clippy::too_many_arguments)]
+    fn send_status(
         &self,
         profile: EncodedProfile,
         additional_files: &[File<'_>],
@@ -248,9 +171,8 @@ impl ProfileExporter {
         internal_metadata: Option<serde_json::Value>,
         info: Option<serde_json::Value>,
         process_tags: Option<&str>,
-        cancel: Option<&CancellationToken>,
-    ) -> Result<reqwest::Response, SendError> {
-        let request_builder = self.build(
+    ) -> Result<http::StatusCode, SendError> {
+        let request = self.build(
             profile,
             additional_files,
             additional_tags,
@@ -259,28 +181,20 @@ impl ProfileExporter {
             process_tags,
         )?;
 
-        // Send request with optional cancellation support
-        if let Some(token) = cancel {
-            token
-                .run_until_cancelled(request_builder.send())
-                .await
-                .ok_or(SendError::Cancelled)?
-                .map_err(SendError::RequestFailed)
-        } else {
-            request_builder
-                .send()
-                .await
-                .map_err(SendError::RequestFailed)
-        }
+        self.send_prepared(request)
+            .map_err(SendError::RequestFailed)
     }
 
-    // Helper methods
+    pub(crate) fn send_prepared(
+        &self,
+        request: PreparedRequest,
+    ) -> anyhow::Result<http::StatusCode> {
+        self.transport.send(request)
+    }
 
     fn build_tags_string(&self, additional_tags: &[Tag]) -> anyhow::Result<String> {
-        // Start with precomputed base tags (includes configured tags + Azure App Services tags)
         let mut tags = self.base_tags_string.clone();
 
-        // Add additional tags with try_reserve to avoid OOM
         for tag in additional_tags {
             let t = tag.as_ref();
             tags.try_reserve(t.len() + ','.len_utf8())?;
@@ -288,20 +202,16 @@ impl ProfileExporter {
             tags.push(',');
         }
 
-        // Add runtime platform tag (last, no trailing comma)
-        {
-            let t = tag!("runtime_platform", target_triple::TARGET);
-            // Using try_reserve_exact since this is the last tag
-            tags.try_reserve_exact(t.as_ref().len())?;
-            tags.push_str(t.as_ref());
-        }
+        let t = tag!("runtime_platform", target_triple::TARGET);
+        tags.try_reserve_exact(t.as_ref().len())?;
+        tags.push_str(t.as_ref());
         Ok(tags)
     }
 
     fn build_event_json(
         &self,
         profile: &EncodedProfile,
-        additional_files: &[File],
+        additional_files: &[File<'_>],
         tags_profiler: &str,
         internal_metadata: Option<serde_json::Value>,
         info: Option<serde_json::Value>,
@@ -330,48 +240,5 @@ impl ProfileExporter {
             "internal": internal,
             "info": info.unwrap_or_else(|| json!({})),
         })
-    }
-
-    fn build_multipart_form(
-        &self,
-        event: serde_json::Value,
-        profile: EncodedProfile,
-        additional_files: &[File],
-    ) -> anyhow::Result<reqwest::multipart::Form> {
-        // Note: We don't set Content-Type for file attachments in the multipart form.
-        // The intake backend treats all attachments as raw bytes (application/octet-stream)
-        // and detects compression by reading magic bytes (gzip/zstd/etc headers).
-        // Content-Type is only meaningful for the main "event" part (set to application/json).
-        // Attachments are not forwarded beyond intake, so their MIME types are not needed.
-        let event_bytes = serde_json::to_vec(&event)?;
-
-        let mut form = reqwest::multipart::Form::new().part(
-            "event",
-            reqwest::multipart::Part::bytes(event_bytes)
-                .file_name("event.json")
-                .mime_str("application/json")?,
-        );
-
-        // Add additional files (compressed)
-        for file in additional_files {
-            let mut encoder = Compressor::<DefaultProfileCodec>::try_new(
-                (file.bytes.len() >> 3).next_power_of_two(),
-                10 * 1024 * 1024,
-                Profile::COMPRESSION_LEVEL,
-            )
-            .context("failed to create compressor")?;
-            encoder.write_all(file.bytes)?;
-
-            form = form.part(
-                file.name.to_string(),
-                reqwest::multipart::Part::bytes(encoder.finish()?).file_name(file.name.to_string()),
-            );
-        }
-
-        // Add profile
-        Ok(form.part(
-            "profile.pprof",
-            reqwest::multipart::Part::bytes(profile.buffer).file_name("profile.pprof"),
-        ))
     }
 }

--- a/libdd-profiling/src/exporter/tls.rs
+++ b/libdd-profiling/src/exporter/tls.rs
@@ -1,42 +1,18 @@
 // Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-//! Pre-initialized TLS configuration for high-performance profile export.
+//! Shared TLS configuration for the profiling exporter.
 //!
-//! On Linux, [`TlsConfig::new`] eagerly loads native root certificates via the
-//! platform verifier, avoiding repeated expensive disk I/O on every
-//! [`ProfileExporter`] creation.
-//!
-//! On macOS, the platform verifier's `Verifier::new()` is cheap (no cert
-//! loading), but the actual Security.framework work happens lazily during each
-//! TLS handshake. Creating a [`TlsConfig`] still avoids redundant `reqwest`
-//! client setup on every exporter creation.
-//!
-//! # Fork Safety
-//!
-//! `TlsConfig` does **not** call Security.framework APIs directly, so it is
-//! safe to create before `fork()`. Security.framework work is deferred to
-//! each child's first TLS handshake.
-//!
-//! [`ProfileExporter`]: super::ProfileExporter
+//! The exporter uses `ureq` for synchronous HTTPS requests and configures it to
+//! use rustls with the platform verifier plus the workspace's preferred crypto
+//! provider.
 
-/// Wraps a [`rustls::ClientConfig`] that has been pre-configured with the
-/// platform certificate verifier. Clone is cheap (inner `Arc`).
+/// Wraps a [`ureq::tls::TlsConfig`] prepared for the profiling exporter.
 #[derive(Clone)]
-pub(crate) struct TlsConfig(pub(crate) rustls::ClientConfig);
+pub(crate) struct TlsConfig(pub(crate) ureq::tls::TlsConfig);
 
 impl TlsConfig {
-    /// Create a new TLS configuration using the platform certificate verifier.
-    ///
-    /// On Linux, this eagerly loads the native root certificate store, which is
-    /// the expensive operation that was previously repeated on every
-    /// `ProfileExporter::new` call.
-    ///
-    /// On macOS, this is lightweight; the platform verifier defers
-    /// Security.framework calls to the first TLS handshake.
-    pub fn new() -> Result<Self, rustls::Error> {
-        use rustls_platform_verifier::BuilderVerifierExt;
-
+    pub fn new() -> Self {
         // Use an explicit CryptoProvider rather than relying on
         // `CryptoProvider::get_default_or_install_from_crate_features()`.
         // Feature unification may enable multiple crypto backends in the same
@@ -45,56 +21,27 @@ impl TlsConfig {
             .cloned()
             .unwrap_or_else(|| std::sync::Arc::new(Self::default_crypto_provider()));
 
-        let config = rustls::ClientConfig::builder_with_provider(provider)
-            .with_safe_default_protocol_versions()?
-            .with_platform_verifier()?
-            .with_no_client_auth();
-        Ok(Self(config))
+        let config = ureq::tls::TlsConfig::builder()
+            .provider(ureq::tls::TlsProvider::Rustls)
+            .root_certs(ureq::tls::RootCerts::PlatformVerifier)
+            .unversioned_rustls_crypto_provider(provider)
+            .build();
+
+        Self(config)
     }
 
     /// Returns the default crypto provider (ring for non-FIPS builds).
-    ///
-    /// Matches the convention used by `libdd-common`: ring on all platforms
-    /// for non-FIPS. FIPS builds install the aws-lc-rs FIPS provider externally.
     fn default_crypto_provider() -> rustls::crypto::CryptoProvider {
         rustls::crypto::ring::default_provider()
     }
 }
 
-impl TlsConfig {
-    /// Create a minimal TLS configuration with an empty root store.
-    ///
-    /// Used for non-HTTPS endpoints (HTTP, unix sockets, named pipes) where TLS
-    /// will never actually be negotiated. Providing this to reqwest prevents it
-    /// from attempting to load system CA certificates on its own, which fails in
-    /// minimal container environments that have no CA certificates installed.
-    pub fn new_empty() -> Result<Self, rustls::Error> {
-        let provider = rustls::crypto::CryptoProvider::get_default()
-            .cloned()
-            .unwrap_or_else(|| std::sync::Arc::new(Self::default_crypto_provider()));
-
-        let config = rustls::ClientConfig::builder_with_provider(provider)
-            .with_safe_default_protocol_versions()?
-            .with_root_certificates(rustls::RootCertStore::empty())
-            .with_no_client_auth();
-        Ok(Self(config))
-    }
-}
-
 static TLS_CONFIG: std::sync::LazyLock<Result<TlsConfig, String>> =
-    std::sync::LazyLock::new(|| {
-        TlsConfig::new().map_err(|err| format!("failed to initialize TLS configuration: {err}"))
-    });
+    std::sync::LazyLock::new(|| Ok(TlsConfig::new()));
 
 pub(crate) fn cached_tls_config() -> anyhow::Result<TlsConfig> {
     TLS_CONFIG
         .as_ref()
         .map(Clone::clone)
         .map_err(|err| anyhow::anyhow!("{err}"))
-}
-
-/// Returns a TLS config with an empty root store, for use with non-HTTPS endpoints.
-/// Never fails — no system cert loading is attempted.
-pub(crate) fn empty_tls_config() -> anyhow::Result<TlsConfig> {
-    TlsConfig::new_empty().map_err(|err| anyhow::anyhow!("failed to build TLS config: {err}"))
 }

--- a/libdd-profiling/src/exporter/transport.rs
+++ b/libdd-profiling/src/exporter/transport.rs
@@ -1,0 +1,37 @@
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+use super::ureq_client::UreqClient;
+use http::StatusCode;
+
+#[derive(Debug)]
+pub(crate) struct PreparedRequest {
+    pub(crate) headers: Vec<(String, String)>,
+    pub(crate) body: Vec<u8>,
+}
+
+#[derive(Clone)]
+pub(crate) struct ProfileTransport {
+    client: UreqClient,
+}
+
+impl ProfileTransport {
+    pub(crate) fn new(
+        endpoint: libdd_common::ResolvedEndpoint,
+        tls_config: Option<ureq::tls::TlsConfig>,
+    ) -> anyhow::Result<Self> {
+        let client = UreqClient::new(endpoint, tls_config)?;
+        Ok(Self { client })
+    }
+
+    pub(crate) fn send(&self, request: PreparedRequest) -> anyhow::Result<StatusCode> {
+        let status = self.client.send(request)?;
+        Ok(status)
+    }
+}
+
+impl std::fmt::Debug for ProfileTransport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ProfileTransport").finish()
+    }
+}

--- a/libdd-profiling/src/exporter/ureq_client.rs
+++ b/libdd-profiling/src/exporter/ureq_client.rs
@@ -1,0 +1,280 @@
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt;
+use std::sync::Arc;
+
+use anyhow::Context;
+use http::StatusCode;
+use libdd_common::{ResolvedEndpoint, ResolvedEndpointKind};
+use ureq::unversioned::transport::Buffers;
+
+use super::transport::PreparedRequest;
+
+#[derive(Clone)]
+pub(crate) struct UreqClient {
+    agent: ureq::Agent,
+    request_url: String,
+}
+
+impl UreqClient {
+    pub(crate) fn new(
+        resolved: ResolvedEndpoint,
+        tls_config: Option<ureq::tls::TlsConfig>,
+    ) -> anyhow::Result<Self> {
+        let _ = resolved.use_system_resolver;
+
+        let config = base_config_builder(resolved.timeout, tls_config).build();
+
+        match resolved.kind {
+            ResolvedEndpointKind::Tcp => Ok(Self {
+                agent: config.new_agent(),
+                request_url: resolved.request_url,
+            }),
+            #[cfg(unix)]
+            ResolvedEndpointKind::UnixSocket { path } => Ok(Self {
+                agent: ureq::Agent::with_parts(config, UnixConnector::new(path), UnixResolver),
+                request_url: resolved.request_url,
+            }),
+            #[cfg(windows)]
+            ResolvedEndpointKind::WindowsNamedPipe { .. } => {
+                anyhow::bail!("Windows named pipes are not supported by the ureq-based exporter")
+            }
+        }
+    }
+
+    pub(crate) fn send(&self, request: PreparedRequest) -> anyhow::Result<StatusCode> {
+        let mut builder = self.agent.post(&self.request_url);
+        for (name, value) in &request.headers {
+            builder = builder.header(name, value);
+        }
+
+        let response = builder
+            .send(request.body.as_slice())
+            .with_context(|| format!("failed to send profiling request to {}", self.request_url))?;
+        Ok(response.status())
+    }
+}
+
+fn base_config_builder(
+    timeout: std::time::Duration,
+    tls_config: Option<ureq::tls::TlsConfig>,
+) -> ureq::config::ConfigBuilder<ureq::typestate::AgentScope> {
+    let builder = ureq::Agent::config_builder()
+        .http_status_as_error(false)
+        .timeout_global(Some(timeout))
+        .timeout_connect(Some(timeout))
+        .timeout_send_request(Some(timeout))
+        .timeout_send_body(Some(timeout))
+        .timeout_recv_response(Some(timeout))
+        .timeout_recv_body(Some(timeout));
+
+    match tls_config {
+        Some(tls_config) => builder.tls_config(tls_config),
+        None => builder,
+    }
+}
+
+#[cfg(unix)]
+#[derive(Debug)]
+struct UnixResolver;
+
+#[cfg(unix)]
+impl ureq::unversioned::resolver::Resolver for UnixResolver {
+    fn resolve(
+        &self,
+        _uri: &http::Uri,
+        _config: &ureq::config::Config,
+        _timeout: ureq::unversioned::transport::NextTimeout,
+    ) -> Result<ureq::unversioned::resolver::ResolvedSocketAddrs, ureq::Error> {
+        let mut addrs = ureq::unversioned::resolver::ArrayVec::from_fn(|_| {
+            std::net::SocketAddr::from(([127, 0, 0, 1], 0))
+        });
+        addrs.push(std::net::SocketAddr::from(([127, 0, 0, 1], 0)));
+        Ok(addrs)
+    }
+}
+
+#[cfg(unix)]
+#[derive(Clone)]
+struct UnixConnector {
+    path: Arc<std::path::PathBuf>,
+}
+
+#[cfg(unix)]
+impl UnixConnector {
+    fn new(path: std::path::PathBuf) -> Self {
+        Self {
+            path: Arc::new(path),
+        }
+    }
+}
+
+#[cfg(unix)]
+impl fmt::Debug for UnixConnector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UnixConnector")
+            .field("path", &self.path)
+            .finish()
+    }
+}
+
+#[cfg(unix)]
+impl<In: ureq::unversioned::transport::Transport> ureq::unversioned::transport::Connector<In>
+    for UnixConnector
+{
+    type Out = ureq::unversioned::transport::Either<In, UnixTransport>;
+
+    fn connect(
+        &self,
+        _details: &ureq::unversioned::transport::ConnectionDetails,
+        chained: Option<In>,
+    ) -> Result<Option<Self::Out>, ureq::Error> {
+        if chained.is_some() {
+            return Ok(chained.map(ureq::unversioned::transport::Either::A));
+        }
+
+        let stream = std::os::unix::net::UnixStream::connect(&*self.path).map_err(|err| {
+            std::io::Error::new(
+                err.kind(),
+                format!("failed to connect to UDS {}: {err}", self.path.display()),
+            )
+        })?;
+
+        let buffers = ureq::unversioned::transport::LazyBuffers::new(128 * 1024, 128 * 1024);
+        Ok(Some(ureq::unversioned::transport::Either::B(
+            UnixTransport::new(stream, buffers),
+        )))
+    }
+}
+
+#[cfg(unix)]
+struct UnixTransport {
+    stream: std::os::unix::net::UnixStream,
+    buffers: ureq::unversioned::transport::LazyBuffers,
+    timeout_write: Option<ureq::unversioned::transport::time::Duration>,
+    timeout_read: Option<ureq::unversioned::transport::time::Duration>,
+}
+
+#[cfg(unix)]
+impl UnixTransport {
+    fn new(
+        stream: std::os::unix::net::UnixStream,
+        buffers: ureq::unversioned::transport::LazyBuffers,
+    ) -> Self {
+        Self {
+            stream,
+            buffers,
+            timeout_read: None,
+            timeout_write: None,
+        }
+    }
+}
+
+#[cfg(unix)]
+impl ureq::unversioned::transport::Transport for UnixTransport {
+    fn buffers(&mut self) -> &mut dyn ureq::unversioned::transport::Buffers {
+        &mut self.buffers
+    }
+
+    fn transmit_output(
+        &mut self,
+        amount: usize,
+        timeout: ureq::unversioned::transport::NextTimeout,
+    ) -> Result<(), ureq::Error> {
+        use std::io::Write;
+
+        maybe_update_timeout(
+            timeout,
+            &mut self.timeout_write,
+            &self.stream,
+            std::os::unix::net::UnixStream::set_write_timeout,
+        )?;
+
+        let output = &self.buffers.output()[..amount];
+        match self.stream.write_all(output) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::TimedOut => {
+                Err(ureq::Error::Timeout(timeout.reason))
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                Err(ureq::Error::Timeout(timeout.reason))
+            }
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    fn await_input(
+        &mut self,
+        timeout: ureq::unversioned::transport::NextTimeout,
+    ) -> Result<bool, ureq::Error> {
+        use std::io::Read;
+
+        maybe_update_timeout(
+            timeout,
+            &mut self.timeout_read,
+            &self.stream,
+            std::os::unix::net::UnixStream::set_read_timeout,
+        )?;
+
+        let input = self.buffers.input_append_buf();
+        let amount = match self.stream.read(input) {
+            Ok(amount) => Ok(amount),
+            Err(err) if err.kind() == std::io::ErrorKind::TimedOut => {
+                Err(ureq::Error::Timeout(timeout.reason))
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                Err(ureq::Error::Timeout(timeout.reason))
+            }
+            Err(err) => Err(err.into()),
+        }?;
+        self.buffers.input_appended(amount);
+
+        Ok(amount > 0)
+    }
+
+    fn is_open(&mut self) -> bool {
+        probe_unix_stream(&mut self.stream).unwrap_or(false)
+    }
+}
+
+#[cfg(unix)]
+fn maybe_update_timeout(
+    timeout: ureq::unversioned::transport::NextTimeout,
+    previous: &mut Option<ureq::unversioned::transport::time::Duration>,
+    stream: &std::os::unix::net::UnixStream,
+    f: impl Fn(&std::os::unix::net::UnixStream, Option<std::time::Duration>) -> std::io::Result<()>,
+) -> std::io::Result<()> {
+    let maybe_timeout = timeout.not_zero();
+
+    if maybe_timeout != *previous {
+        (f)(stream, maybe_timeout.map(|t| *t))?;
+        *previous = maybe_timeout;
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn probe_unix_stream(stream: &mut std::os::unix::net::UnixStream) -> Result<bool, ureq::Error> {
+    use std::io::Read;
+
+    stream.set_nonblocking(true)?;
+
+    let mut buf = [0];
+    let result = match stream.read(&mut buf) {
+        Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => Ok(true),
+        Ok(_) => Ok(false),
+        Err(_) => Ok(false),
+    };
+
+    stream.set_nonblocking(false)?;
+    result
+}
+
+#[cfg(unix)]
+impl fmt::Debug for UnixTransport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("UnixTransport").finish()
+    }
+}

--- a/libdd-profiling/src/exporter/ureq_client.rs
+++ b/libdd-profiling/src/exporter/ureq_client.rs
@@ -1,12 +1,15 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(unix)]
 use std::fmt;
+#[cfg(unix)]
 use std::sync::Arc;
 
 use anyhow::Context;
 use http::StatusCode;
 use libdd_common::{ResolvedEndpoint, ResolvedEndpointKind};
+#[cfg(unix)]
 use ureq::unversioned::transport::Buffers;
 
 use super::transport::PreparedRequest;

--- a/libdd-profiling/tests/exporter_e2e.rs
+++ b/libdd-profiling/tests/exporter_e2e.rs
@@ -1,21 +1,22 @@
 // Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-//! End-to-end tests for ProfileExporter
+//! End-to-end tests for ProfileExporter.
 //!
 //! These tests validate the full export flow across different endpoint types.
 
 mod common;
 
-use libdd_common::test_utils::{parse_http_request, parse_http_request_sync};
+use libdd_common::test_utils::parse_http_request_sync;
 use libdd_profiling::exporter::config;
 use libdd_profiling::exporter::{File, ProfileExporter};
 use libdd_profiling::internal::EncodedProfile;
 use std::collections::HashMap;
+use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
-/// Shared state for test HTTP servers
+/// Shared state for test HTTP servers.
 #[derive(Debug, Clone)]
 struct ReceivedRequest {
     method: String,
@@ -24,7 +25,7 @@ struct ReceivedRequest {
     body: Vec<u8>,
 }
 
-/// Helper to create a unique temp file path
+/// Helper to create a unique temp file path.
 fn create_temp_file_path(extension: &str) -> PathBuf {
     std::env::temp_dir().join(format!(
         "libdd_test_{}_{:x}.{}",
@@ -34,7 +35,7 @@ fn create_temp_file_path(extension: &str) -> PathBuf {
     ))
 }
 
-/// Transport type for endpoint tests
+/// Transport type for endpoint tests.
 enum Transport {
     Tcp,
     #[cfg(unix)]
@@ -43,7 +44,7 @@ enum Transport {
     NamedPipe,
 }
 
-/// Server info returned from spawning a test server
+/// Server info returned from spawning a test server.
 struct ServerInfo {
     port: Option<u16>,
     #[cfg(unix)]
@@ -53,21 +54,19 @@ struct ServerInfo {
     received_requests: Arc<Mutex<Vec<ReceivedRequest>>>,
 }
 
-/// Spawn an async HTTP server with the specified transport
-async fn spawn_server(transport: Transport) -> anyhow::Result<ServerInfo> {
+/// Spawn an HTTP server with the specified transport.
+fn spawn_server(transport: Transport) -> anyhow::Result<ServerInfo> {
     let received_requests = Arc::new(Mutex::new(Vec::new()));
     let requests_clone = received_requests.clone();
 
     match transport {
         Transport::Tcp => {
-            use tokio::net::TcpListener;
-
-            let listener = TcpListener::bind("127.0.0.1:0").await?;
+            let listener = std::net::TcpListener::bind("127.0.0.1:0")?;
             let port = listener.local_addr()?.port();
 
-            tokio::spawn(async move {
-                if let Ok((stream, _)) = listener.accept().await {
-                    read_and_capture_request(stream, requests_clone).await;
+            std::thread::spawn(move || {
+                if let Ok((stream, _)) = listener.accept() {
+                    read_and_capture_request(stream, requests_clone);
                 }
             });
 
@@ -80,18 +79,15 @@ async fn spawn_server(transport: Transport) -> anyhow::Result<ServerInfo> {
                 received_requests,
             })
         }
-
         #[cfg(unix)]
         Transport::UnixSocket => {
-            use tokio::net::UnixListener;
-
             let socket_path = create_temp_file_path("sock");
             let _ = std::fs::remove_file(&socket_path);
-            let listener = UnixListener::bind(&socket_path)?;
+            let listener = std::os::unix::net::UnixListener::bind(&socket_path)?;
 
-            tokio::spawn(async move {
-                if let Ok((stream, _)) = listener.accept().await {
-                    read_and_capture_request(stream, requests_clone).await;
+            std::thread::spawn(move || {
+                if let Ok((stream, _)) = listener.accept() {
+                    read_and_capture_request(stream, requests_clone);
                 }
             });
 
@@ -103,50 +99,17 @@ async fn spawn_server(transport: Transport) -> anyhow::Result<ServerInfo> {
                 received_requests,
             })
         }
-
         #[cfg(windows)]
         Transport::NamedPipe => {
-            use tokio::net::windows::named_pipe::ServerOptions;
-
-            // Create a unique named pipe name
-            let pipe_name = format!(
-                r"\\.\pipe\dd_test_{}_{:x}",
-                std::process::id(),
-                rand::random::<u64>()
-            );
-            let pipe_path = PathBuf::from(&pipe_name);
-
-            // Create server endpoint
-            let server = ServerOptions::new()
-                .first_pipe_instance(true)
-                .create(&pipe_name)?;
-
-            tokio::spawn(async move {
-                // Wait for a client to connect
-                if server.connect().await.is_ok() {
-                    read_and_capture_request(server, requests_clone).await;
-                }
-            });
-
-            // No sleep needed - create() synchronously creates the pipe and makes it ready,
-            // just like bind() for TCP/UDS
-            Ok(ServerInfo {
-                port: None,
-                #[cfg(unix)]
-                socket_path: None,
-                pipe_path: Some(pipe_path),
-                received_requests,
-            })
+            anyhow::bail!("named pipe E2E tests are not implemented without tokio")
         }
     }
 }
 
-/// Read HTTP request from an async stream and capture it
-async fn read_and_capture_request<S>(
-    mut stream: S,
-    received_requests: Arc<Mutex<Vec<ReceivedRequest>>>,
-) where
-    S: tokio::io::AsyncReadExt + tokio::io::AsyncWriteExt + Unpin,
+/// Read an HTTP request from a blocking stream and capture it.
+fn read_and_capture_request<S>(mut stream: S, received_requests: Arc<Mutex<Vec<ReceivedRequest>>>)
+where
+    S: Read + Write,
 {
     let mut buffer = Vec::new();
     let mut temp_buf = [0u8; 8192];
@@ -155,7 +118,7 @@ async fn read_and_capture_request<S>(
     let mut headers_end_pos: Option<usize> = None;
 
     loop {
-        match stream.read(&mut temp_buf).await {
+        match stream.read(&mut temp_buf) {
             Ok(0) => break,
             Ok(n) => {
                 buffer.extend_from_slice(&temp_buf[..n]);
@@ -187,7 +150,7 @@ async fn read_and_capture_request<S>(
         }
     }
 
-    if let Ok(req) = parse_http_request(&buffer).await {
+    if let Ok(req) = parse_http_request_sync(&buffer) {
         received_requests.lock().unwrap().push(ReceivedRequest {
             method: req.method,
             path: req.path,
@@ -197,21 +160,22 @@ async fn read_and_capture_request<S>(
     }
 
     let response = b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n";
-    let _ = stream.write_all(response).await;
+    let _ = stream.write_all(response);
+    let _ = stream.flush();
 }
 
-/// Result source for capturing the HTTP request
+/// Result source for capturing the HTTP request.
 enum RequestSource {
     File(PathBuf),
     Captured(Arc<Mutex<Vec<ReceivedRequest>>>),
 }
 
-/// Export a comprehensive profile with all features and capture the HTTP request
-async fn export_full_profile(
+/// Export a comprehensive profile with all features and capture the HTTP request.
+fn export_full_profile(
     endpoint: libdd_common::Endpoint,
     source: RequestSource,
 ) -> anyhow::Result<ReceivedRequest> {
-    // Build tags
+    // Build tags.
     let tags = vec![
         libdd_common::tag::Tag::new("service", "test-service")?,
         libdd_common::tag::Tag::new("env", "test")?,
@@ -222,7 +186,7 @@ async fn export_full_profile(
         libdd_common::tag::Tag::new("version", "1.0")?,
     ];
 
-    // Build additional files
+    // Build additional files.
     let additional_files = vec![
         File {
             name: "jit.pprof",
@@ -234,7 +198,7 @@ async fn export_full_profile(
         },
     ];
 
-    // Build metadata
+    // Build metadata.
     let internal_metadata = serde_json::json!({
         "no_signals_workaround_enabled": "true",
         "execution_trace_enabled": "false",
@@ -256,28 +220,25 @@ async fn export_full_profile(
         }
     });
 
-    // Create exporter and send
-    let exporter = ProfileExporter::new("test-lib", "1.0.0", "native", tags, endpoint)?;
+    // Create exporter and send.
+    let mut exporter = ProfileExporter::new("test-lib", "1.0.0", "native", tags, endpoint)?;
     let profile = EncodedProfile::test_instance()?;
 
-    exporter
-        .send(
-            profile,
-            &additional_files,
-            &additional_tags,
-            Some(internal_metadata),
-            Some(info),
-            Some("entrypoint.name:main,pid:12345"),
-            None,
-        )
-        .await?;
+    exporter.send_blocking(
+        profile,
+        &additional_files,
+        &additional_tags,
+        Some(internal_metadata),
+        Some(info),
+        Some("entrypoint.name:main,pid:12345"),
+    )?;
 
-    // Get the request from the appropriate source
+    // Get the request from the appropriate source.
     match source {
         RequestSource::File(path) => {
-            // No sleep needed - send_blocking() waits for file to be synced
+            // No sleep needed: send_blocking() waits until the dump file is written.
             let request_bytes = std::fs::read(&path)?;
-            let req = parse_http_request(&request_bytes).await?;
+            let req = parse_http_request_sync(&request_bytes)?;
             Ok(ReceivedRequest {
                 method: req.method,
                 path: req.path,
@@ -286,8 +247,7 @@ async fn export_full_profile(
             })
         }
         RequestSource::Captured(requests) => {
-            // No sleep needed - send().await waits until HTTP response is received,
-            // which means the server has already captured the request
+            // No sleep needed: send_blocking() only returns after the server has replied.
             let reqs = requests.lock().unwrap();
             if reqs.is_empty() {
                 anyhow::bail!("No request captured");
@@ -297,17 +257,16 @@ async fn export_full_profile(
     }
 }
 
-/// Validate the full export result
+/// Validate the full export result.
 fn validate_full_export(req: &ReceivedRequest, expected_path: &str) -> anyhow::Result<()> {
-    // Verify request basics
+    // Verify request basics.
     assert_eq!(req.method, "POST");
     assert_eq!(req.path, expected_path);
 
-    // Check for entity headers and validate their values match what libdd_common provides
+    // Check for entity headers and validate their values match what libdd_common provides.
     common::assert_entity_headers_match(&req.headers);
 
-    // Parse the request to get multipart parts
-    // We need to reconstruct a minimal HTTP request to parse
+    // Reconstruct a minimal HTTP request so the multipart parser can consume it.
     let mut http_request_bytes = Vec::new();
     http_request_bytes
         .extend_from_slice(format!("{} {} HTTP/1.1\r\n", req.method, req.path).as_bytes());
@@ -320,18 +279,18 @@ fn validate_full_export(req: &ReceivedRequest, expected_path: &str) -> anyhow::R
     let parsed_req = parse_http_request_sync(&http_request_bytes)?;
     let parts = &parsed_req.multipart_parts;
 
-    // Find event JSON
+    // Find event JSON.
     let event_part = parts
         .iter()
         .find(|p| p.name == "event")
         .ok_or_else(|| anyhow::anyhow!("Missing event part"))?;
     let event_json: serde_json::Value = serde_json::from_slice(&event_part.content)?;
 
-    // Verify basic event fields
+    // Verify basic event fields.
     assert_eq!(event_json["family"], "native");
     assert_eq!(event_json["version"], "4");
 
-    // Verify tags (base + additional)
+    // Verify tags (base + additional).
     let tags_profiler = event_json["tags_profiler"]
         .as_str()
         .ok_or_else(|| anyhow::anyhow!("Missing tags_profiler"))?;
@@ -344,10 +303,10 @@ fn validate_full_export(req: &ReceivedRequest, expected_path: &str) -> anyhow::R
         assert!(tags_profiler.contains(tag), "Missing tag: {}", tag);
     }
 
-    // Verify process_tags
+    // Verify process_tags.
     assert_eq!(event_json["process_tags"], "entrypoint.name:main,pid:12345");
 
-    // Verify attachments
+    // Verify attachments.
     let attachments = event_json["attachments"]
         .as_array()
         .ok_or_else(|| anyhow::anyhow!("Missing attachments"))?;
@@ -360,7 +319,7 @@ fn validate_full_export(req: &ReceivedRequest, expected_path: &str) -> anyhow::R
         );
     }
 
-    // Verify internal metadata was merged
+    // Verify internal metadata was merged.
     let internal = event_json["internal"]
         .as_object()
         .ok_or_else(|| anyhow::anyhow!("Missing internal metadata"))?;
@@ -369,12 +328,12 @@ fn validate_full_export(req: &ReceivedRequest, expected_path: &str) -> anyhow::R
     assert_eq!(internal["custom_field"], "custom_value");
     assert!(internal.contains_key("libdatadog_version"));
 
-    // Verify info was included
+    // Verify info was included.
     assert_eq!(event_json["info"]["application"]["env"], "production");
     assert_eq!(event_json["info"]["platform"]["hostname"], "test-host");
     assert_eq!(event_json["info"]["runtime"]["engine"], "rust");
 
-    // Verify parts exist (files are compressed, just check non-empty)
+    // Verify parts exist. Attachments are compressed, so only check for presence and bytes.
     for part_name in &["profile.pprof", "jit.pprof", "metadata.json"] {
         let part = parts
             .iter()
@@ -390,11 +349,11 @@ fn validate_full_export(req: &ReceivedRequest, expected_path: &str) -> anyhow::R
     Ok(())
 }
 
-/// Helper to test agent endpoint with a specific transport
-async fn test_agent_with_transport(transport: Transport) -> anyhow::Result<()> {
-    let server = spawn_server(transport).await?;
+/// Helper to test agent endpoint with a specific transport.
+fn test_agent_with_transport(transport: Transport) -> anyhow::Result<()> {
+    let server = spawn_server(transport)?;
 
-    // Configure agent endpoint based on transport
+    // Configure agent endpoint based on transport.
     let endpoint = if let Some(port) = server.port {
         let endpoint_url = format!("http://127.0.0.1:{}", port).parse()?;
         config::agent(endpoint_url)?
@@ -413,14 +372,13 @@ async fn test_agent_with_transport(transport: Transport) -> anyhow::Result<()> {
         anyhow::bail!("No port, socket path, or pipe path available")
     };
 
-    // Run the full export test
-    let req =
-        export_full_profile(endpoint, RequestSource::Captured(server.received_requests)).await?;
+    // Run the full export test.
+    let req = export_full_profile(endpoint, RequestSource::Captured(server.received_requests))?;
 
-    // Validate
+    // Validate.
     validate_full_export(&req, "/profiling/v1/input")?;
 
-    // Cleanup if needed
+    // Cleanup if needed.
     #[cfg(unix)]
     if let Some(path) = server.socket_path {
         let _ = std::fs::remove_file(&path);
@@ -429,11 +387,11 @@ async fn test_agent_with_transport(transport: Transport) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Helper to test agentless endpoint with a specific transport
-async fn test_agentless_with_transport(transport: Transport) -> anyhow::Result<()> {
-    let server = spawn_server(transport).await?;
+/// Helper to test agentless endpoint with a specific transport.
+fn test_agentless_with_transport(transport: Transport) -> anyhow::Result<()> {
+    let server = spawn_server(transport)?;
 
-    // Configure agentless endpoint based on transport
+    // Configure agentless endpoint based on transport.
     let endpoint = if let Some(port) = server.port {
         let endpoint_url = format!("http://127.0.0.1:{}/api/v2/profile", port).parse()?;
         let mut endpoint = libdd_common::Endpoint::from_url(endpoint_url);
@@ -443,7 +401,7 @@ async fn test_agentless_with_transport(transport: Transport) -> anyhow::Result<(
         #[cfg(unix)]
         {
             let socket_path = server.socket_path.as_ref().unwrap();
-            // For Unix sockets, we need to create endpoint manually
+            // For Unix sockets, we need to create the full intake path manually.
             let endpoint_url = libdd_common::connector::uds::socket_path_to_uri(socket_path)?;
             let mut parts = endpoint_url.into_parts();
             parts.path_and_query = Some("/api/v2/profile".parse()?);
@@ -454,35 +412,25 @@ async fn test_agentless_with_transport(transport: Transport) -> anyhow::Result<(
         }
         #[cfg(windows)]
         {
-            let pipe_path = server.pipe_path.as_ref().unwrap();
-            // For named pipes, we need to create endpoint manually
-            let endpoint_url =
-                libdd_common::connector::named_pipe::named_pipe_path_to_uri(pipe_path)?;
-            let mut parts = endpoint_url.into_parts();
-            parts.path_and_query = Some("/api/v2/profile".parse()?);
-            let url = http::Uri::from_parts(parts)?;
-            let mut endpoint = libdd_common::Endpoint::from_url(url);
-            endpoint.api_key = Some("test-api-key-12345".into());
-            endpoint
+            anyhow::bail!("named pipe E2E tests are not implemented without tokio")
         }
         #[cfg(not(any(unix, windows)))]
         anyhow::bail!("No port, socket path, or pipe path available")
     };
 
-    // Run the full export test
-    let req =
-        export_full_profile(endpoint, RequestSource::Captured(server.received_requests)).await?;
+    // Run the full export test.
+    let req = export_full_profile(endpoint, RequestSource::Captured(server.received_requests))?;
 
-    // Validate - agentless uses /api/v2/profile path
+    // Validate. Agentless uses the intake path directly.
     validate_full_export(&req, "/api/v2/profile")?;
 
-    // Verify API key header is present
+    // Verify API key header is present.
     assert!(
         req.headers.contains_key("dd-api-key"),
         "DD-API-KEY header should be present for agentless"
     );
 
-    // Cleanup if needed
+    // Cleanup if needed.
     #[cfg(unix)]
     if let Some(path) = server.socket_path {
         let _ = std::fs::remove_file(&path);
@@ -491,60 +439,59 @@ async fn test_agentless_with_transport(transport: Transport) -> anyhow::Result<(
     Ok(())
 }
 
-#[tokio::test]
+#[test]
 #[cfg_attr(miri, ignore)]
-async fn test_export_agent_tcp() -> anyhow::Result<()> {
-    test_agent_with_transport(Transport::Tcp).await
+fn test_export_agent_tcp() -> anyhow::Result<()> {
+    test_agent_with_transport(Transport::Tcp)
 }
 
 #[cfg(unix)]
-#[tokio::test]
+#[test]
 #[cfg_attr(miri, ignore)]
-async fn test_export_agent_uds() -> anyhow::Result<()> {
-    test_agent_with_transport(Transport::UnixSocket).await
+fn test_export_agent_uds() -> anyhow::Result<()> {
+    test_agent_with_transport(Transport::UnixSocket)
 }
 
-#[tokio::test]
+#[test]
 #[cfg_attr(miri, ignore)]
-async fn test_export_agentless_tcp() -> anyhow::Result<()> {
-    test_agentless_with_transport(Transport::Tcp).await
+fn test_export_agentless_tcp() -> anyhow::Result<()> {
+    test_agentless_with_transport(Transport::Tcp)
 }
 
 #[cfg(unix)]
-#[tokio::test]
+#[test]
 #[cfg_attr(miri, ignore)]
-async fn test_export_agentless_uds() -> anyhow::Result<()> {
-    test_agentless_with_transport(Transport::UnixSocket).await
+fn test_export_agentless_uds() -> anyhow::Result<()> {
+    test_agentless_with_transport(Transport::UnixSocket)
 }
 
 #[cfg(windows)]
-#[tokio::test]
+#[test]
 #[cfg_attr(miri, ignore)]
-async fn test_export_agent_named_pipe() -> anyhow::Result<()> {
-    test_agent_with_transport(Transport::NamedPipe).await
+fn test_export_agent_named_pipe() -> anyhow::Result<()> {
+    test_agent_with_transport(Transport::NamedPipe)
 }
 
 #[cfg(windows)]
-#[tokio::test]
+#[test]
 #[cfg_attr(miri, ignore)]
-async fn test_export_agentless_named_pipe() -> anyhow::Result<()> {
-    test_agentless_with_transport(Transport::NamedPipe).await
+fn test_export_agentless_named_pipe() -> anyhow::Result<()> {
+    test_agentless_with_transport(Transport::NamedPipe)
 }
 
-#[tokio::test]
+#[test]
 #[cfg_attr(miri, ignore)]
-async fn test_export_file() -> anyhow::Result<()> {
+fn test_export_file() -> anyhow::Result<()> {
     let file_path = create_temp_file_path("http");
     let endpoint = config::file(file_path.to_string_lossy().as_ref())?;
 
-    // Test and capture
-    let req = export_full_profile(endpoint, RequestSource::File(file_path.clone())).await?;
+    // Test and capture.
+    let req = export_full_profile(endpoint, RequestSource::File(file_path.clone()))?;
 
-    // Validate
+    // Validate.
     validate_full_export(&req, "/")?;
 
-    // Cleanup
+    // Cleanup.
     let _ = std::fs::remove_file(&file_path);
-
     Ok(())
 }

--- a/libdd-profiling/tests/exporter_e2e.rs
+++ b/libdd-profiling/tests/exporter_e2e.rs
@@ -26,6 +26,7 @@ struct ReceivedRequest {
 }
 
 /// Helper to create a unique temp file path.
+#[cfg(unix)]
 fn create_temp_file_path(extension: &str) -> PathBuf {
     std::env::temp_dir().join(format!(
         "libdd_test_{}_{:x}.{}",
@@ -166,6 +167,7 @@ where
 
 /// Result source for capturing the HTTP request.
 enum RequestSource {
+    #[cfg(unix)]
     File(PathBuf),
     Captured(Arc<Mutex<Vec<ReceivedRequest>>>),
 }
@@ -235,6 +237,7 @@ fn export_full_profile(
 
     // Get the request from the appropriate source.
     match source {
+        #[cfg(unix)]
         RequestSource::File(path) => {
             // No sleep needed: send_blocking() waits until the dump file is written.
             let request_bytes = std::fs::read(&path)?;

--- a/libdd-profiling/tests/exporter_e2e.rs
+++ b/libdd-profiling/tests/exporter_e2e.rs
@@ -467,6 +467,7 @@ fn test_export_agentless_uds() -> anyhow::Result<()> {
 
 #[cfg(windows)]
 #[test]
+#[ignore = "ureq transport does not support Windows named pipes"]
 #[cfg_attr(miri, ignore)]
 fn test_export_agent_named_pipe() -> anyhow::Result<()> {
     test_agent_with_transport(Transport::NamedPipe)
@@ -474,11 +475,13 @@ fn test_export_agent_named_pipe() -> anyhow::Result<()> {
 
 #[cfg(windows)]
 #[test]
+#[ignore = "ureq transport does not support Windows named pipes"]
 #[cfg_attr(miri, ignore)]
 fn test_export_agentless_named_pipe() -> anyhow::Result<()> {
     test_agentless_with_transport(Transport::NamedPipe)
 }
 
+#[cfg(unix)]
 #[test]
 #[cfg_attr(miri, ignore)]
 fn test_export_file() -> anyhow::Result<()> {

--- a/libdd-profiling/tests/file_exporter_test.rs
+++ b/libdd-profiling/tests/file_exporter_test.rs
@@ -64,7 +64,7 @@ mod tests {
         // Build and send profile
         let profile = EncodedProfile::test_instance().expect("test profile");
         exporter
-            .send_blocking(profile, &[], &[], None, None, None, None)
+            .send_blocking(profile, &[], &[], None, None, None)
             .expect("send to succeed");
 
         // Read the dump file
@@ -173,7 +173,6 @@ mod tests {
                 Some(internal_metadata.clone()),
                 None,
                 None,
-                None,
             )
             .expect("send to succeed");
 
@@ -215,15 +214,7 @@ mod tests {
         // Build and send profile
         let profile = EncodedProfile::test_instance().expect("test profile");
         exporter
-            .send_blocking(
-                profile,
-                &[],
-                &[],
-                None,
-                None,
-                Some(expected_process_tags),
-                None,
-            )
+            .send_blocking(profile, &[], &[], None, None, Some(expected_process_tags))
             .expect("send to succeed");
 
         // Read the dump file
@@ -279,7 +270,7 @@ mod tests {
         // Build and send profile
         let profile = EncodedProfile::test_instance().expect("test profile");
         exporter
-            .send_blocking(profile, &[], &[], None, Some(info.clone()), None, None)
+            .send_blocking(profile, &[], &[], None, Some(info.clone()), None)
             .expect("send to succeed");
 
         // Read the dump file
@@ -319,7 +310,7 @@ mod tests {
         // Build and send profile
         let profile = EncodedProfile::test_instance().expect("test profile");
         exporter
-            .send_blocking(profile, &[], &[], None, None, None, None)
+            .send_blocking(profile, &[], &[], None, None, None)
             .expect("send to succeed");
 
         // Read the dump file

--- a/libdd-profiling/tests/file_exporter_test.rs
+++ b/libdd-profiling/tests/file_exporter_test.rs
@@ -1,13 +1,20 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+#![cfg(unix)]
+
+#[cfg(unix)]
 mod common;
 
+#[cfg(unix)]
 use libdd_common::test_utils::{create_temp_file_path, parse_http_request_sync, TempFileGuard};
+#[cfg(unix)]
 use libdd_profiling::exporter::ProfileExporter;
+#[cfg(unix)]
 use libdd_profiling::internal::EncodedProfile;
 
 /// Create a file-based exporter and return the temp file path with auto-cleanup
+#[cfg(unix)]
 fn create_file_exporter(
     profiling_library_name: &str,
     profiling_library_version: &str,

--- a/libdd-profiling/tests/file_exporter_test.rs
+++ b/libdd-profiling/tests/file_exporter_test.rs
@@ -36,7 +36,7 @@ fn create_file_exporter(
     Ok((exporter, file_path))
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use libdd_common::tag;


### PR DESCRIPTION
> [!WARNING]
> This is vibe coded and I have not spend a second checking the code. I gave it a try in https://github.com/DataDog/dd-trace-php/tree/florian/ureq and it works, so thats something :-D

# What does this PR do?

A brief description of the change being made with this pull request.

# Motivation

Brings PHP Profiler binary size down by ~2.5 MB (from 16 to 13.3 on amd64 and from 14.5 to 12 on aarch64).

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
