### PR TITLE
feat(stats)!: implement span derived primary tags in libdd-trace-stats

### DIFF
--- a/libdd-data-pipeline/src/stats_exporter.rs
+++ b/libdd-data-pipeline/src/stats_exporter.rs
@@ -232,6 +232,7 @@ mod tests {
             SystemTime::now() - BUCKETS_DURATION * 3,
             vec![],
             vec![],
+            vec![],
         );
         let mut trace = vec![];
 

--- a/libdd-data-pipeline/src/trace_exporter/stats.rs
+++ b/libdd-data-pipeline/src/trace_exporter/stats.rs
@@ -72,6 +72,7 @@ pub(crate) fn start_stats_computation(
             std::time::SystemTime::now(),
             span_kinds,
             peer_tags,
+            vec![], // TODO: Add span-derived primary tags
         )));
         let cancellation_token = CancellationToken::new();
         create_and_start_stats_worker(

--- a/libdd-trace-stats/README.md
+++ b/libdd-trace-stats/README.md
@@ -53,6 +53,7 @@ let mut concentrator = SpanConcentrator::new(
     SystemTime::now(),
     vec!["client".to_string(), "server".to_string()], // eligible span kinds
     vec!["peer.service".to_string()], // peer tag keys
+    vec!["example.key".to_string()], // span derived primary tag keys
 );
 
 // Add spans

--- a/libdd-trace-stats/benches/span_concentrator_bench.rs
+++ b/libdd-trace-stats/benches/span_concentrator_bench.rs
@@ -47,6 +47,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         now,
         vec![],
         vec!["db_name".into(), "bucket_s3".into()],
+        vec![],
     );
     let mut spans = vec![];
     for trace_id in 1..100 {

--- a/libdd-trace-stats/src/span_concentrator/aggregation.rs
+++ b/libdd-trace-stats/src/span_concentrator/aggregation.rs
@@ -268,7 +268,10 @@ impl<'a> BorrowedAggregationKey<'a> {
 
         let span_derived_primary_tags: Vec<(&'a str, &'a str)> = span_derived_primary_tag_keys
             .iter()
-            .filter_map(|key| Some((key.as_str(), span.get_meta(key.as_str())?)))
+            .filter_map(|key| match span.get_meta(key.as_str()) {
+                Some(v) if !v.is_empty() => Some((key.as_str(), v)),
+                _ => None,
+            })
             .collect();
 
         Self {
@@ -891,6 +894,25 @@ mod tests {
                     span_id: 1,
                     parent_id: 0,
                     meta: HashMap::from([("region", "us1")]),
+                    ..Default::default()
+                },
+                OwnedAggregationKey {
+                    service_name: "service".into(),
+                    operation_name: "op".into(),
+                    resource_name: "res".into(),
+                    is_trace_root: true,
+                    span_derived_primary_tags: vec![("region".into(), "us1".into())],
+                    ..Default::default()
+                },
+            ),
+            (
+                SpanSlice {
+                    service: "service",
+                    name: "op",
+                    resource: "res",
+                    span_id: 1,
+                    parent_id: 0,
+                    meta: HashMap::from([("region", "us1"), ("env", "")]),
                     ..Default::default()
                 },
                 OwnedAggregationKey {

--- a/libdd-trace-stats/src/span_concentrator/aggregation.rs
+++ b/libdd-trace-stats/src/span_concentrator/aggregation.rs
@@ -238,7 +238,7 @@ impl<'a> BorrowedAggregationKey<'a> {
             // of `peer_tag_keys`
             peer_tag_keys
                 .iter()
-                .filter_map(|key| Some(((key.as_str()), (span.get_meta(key.as_str())?))))
+                .filter_map(|key| Some((key.as_str(), span.get_meta(key.as_str())?)))
                 .collect()
         } else if let Some(base_service) = span.get_meta("_dd.base_service") {
             // Internal spans with a base service override use only _dd.base_service as peer tag
@@ -268,7 +268,7 @@ impl<'a> BorrowedAggregationKey<'a> {
 
         let span_derived_primary_tags: Vec<(&'a str, &'a str)> = span_derived_primary_tag_keys
             .iter()
-            .filter_map(|key| Some(((key.as_str()), (span.get_meta(key.as_str())?))))
+            .filter_map(|key| Some((key.as_str(), span.get_meta(key.as_str())?)))
             .collect();
 
         Self {

--- a/libdd-trace-stats/src/span_concentrator/aggregation.rs
+++ b/libdd-trace-stats/src/span_concentrator/aggregation.rs
@@ -39,6 +39,7 @@ pub(super) struct BorrowedAggregationKey<'a> {
     http_endpoint: &'a str,
     grpc_status_code: Option<u8>,
     service_source: &'a str,
+    span_derived_primary_tags: Vec<(&'a str, &'a str)>,
 }
 
 impl hashbrown::Equivalent<OwnedAggregationKey> for BorrowedAggregationKey<'_> {
@@ -59,6 +60,7 @@ impl hashbrown::Equivalent<OwnedAggregationKey> for BorrowedAggregationKey<'_> {
             http_endpoint,
             grpc_status_code,
             service_source,
+            span_derived_primary_tags,
         }: &OwnedAggregationKey,
     ) -> bool {
         self.resource_name == resource_name
@@ -79,6 +81,12 @@ impl hashbrown::Equivalent<OwnedAggregationKey> for BorrowedAggregationKey<'_> {
             && self.http_endpoint == http_endpoint
             && self.grpc_status_code == *grpc_status_code
             && self.service_source == service_source
+            && self.span_derived_primary_tags.len() == span_derived_primary_tags.len()
+            && self
+                .span_derived_primary_tags
+                .iter()
+                .zip(span_derived_primary_tags.iter())
+                .all(|((k1, v1), (k2, v2))| k1 == k2 && v1 == v2)
     }
 }
 
@@ -104,6 +112,7 @@ pub(super) struct OwnedAggregationKey {
     http_endpoint: String,
     grpc_status_code: Option<u8>,
     service_source: String,
+    span_derived_primary_tags: Vec<(String, String)>,
 }
 
 impl From<&BorrowedAggregationKey<'_>> for OwnedAggregationKey {
@@ -126,6 +135,11 @@ impl From<&BorrowedAggregationKey<'_>> for OwnedAggregationKey {
             http_endpoint: value.http_endpoint.to_owned(),
             grpc_status_code: value.grpc_status_code,
             service_source: value.service_source.to_owned(),
+            span_derived_primary_tags: value
+                .span_derived_primary_tags
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
         }
     }
 }
@@ -208,9 +222,16 @@ fn grpc_status_str_to_int_value(v: &str) -> Option<u8> {
 impl<'a> BorrowedAggregationKey<'a> {
     /// Return an AggregationKey matching the given span.
     ///
-    /// If `peer_tags_keys` is not empty then the peer tags of the span will be included in the
+    /// If `peer_tag_keys` is not empty then the peer tags of the span will be included in the
     /// key.
-    pub(super) fn from_span<T: StatSpan<'a>>(span: &'a T, peer_tag_keys: &'a [String]) -> Self {
+    ///
+    /// If `span_derived_primary_tag_keys` is not empty then matching span tags keys are included
+    /// in the key.
+    pub(super) fn from_span<T: StatSpan<'a>>(
+        span: &'a T,
+        peer_tag_keys: &'a [String],
+        span_derived_primary_tag_keys: &'a [String],
+    ) -> Self {
         let span_kind = span.get_meta(TAG_SPANKIND).unwrap_or_default();
         let peer_tags = if should_track_peer_tags(span_kind) {
             // Parse the meta tags of the span and return a list of the peer tags based on the list
@@ -245,6 +266,11 @@ impl<'a> BorrowedAggregationKey<'a> {
 
         let service_source = span.get_meta(TAG_SVC_SRC).unwrap_or_default();
 
+        let span_derived_primary_tags: Vec<(&'a str, &'a str)> = span_derived_primary_tag_keys
+            .iter()
+            .filter_map(|key| Some(((key.as_str()), (span.get_meta(key.as_str())?))))
+            .collect();
+
         Self {
             resource_name: span.resource(),
             service_name: span.service(),
@@ -261,6 +287,7 @@ impl<'a> BorrowedAggregationKey<'a> {
             http_endpoint,
             grpc_status_code,
             service_source,
+            span_derived_primary_tags,
         }
     }
 }
@@ -288,6 +315,14 @@ impl From<pb::ClientGroupedStats> for OwnedAggregationKey {
             http_endpoint: value.http_endpoint,
             grpc_status_code: value.grpc_status_code.parse().ok(),
             service_source: value.service_source,
+            span_derived_primary_tags: value
+                .span_derived_primary_tags
+                .into_iter()
+                .filter_map(|t| {
+                    let (key, value) = t.split_once(':')?;
+                    Some((key.to_string(), value.to_string()))
+                })
+                .collect(),
         }
     }
 }
@@ -418,7 +453,11 @@ fn encode_grouped_stats(key: OwnedAggregationKey, group: GroupedStats) -> pb::Cl
             .map(|c| c.to_string())
             .unwrap_or_default(),
         service_source: key.service_source,
-        span_derived_primary_tags: vec![], // Todo
+        span_derived_primary_tags: key
+            .span_derived_primary_tags
+            .into_iter()
+            .map(|(k, v)| format!("{k}:{v}"))
+            .collect(),
     }
 }
 
@@ -820,6 +859,51 @@ mod tests {
             ),
         ];
 
+        let test_primary_tag_keys = vec!["region".to_string(), "env".to_string()];
+        let test_cases_primary_tags: Vec<(SpanSlice, OwnedAggregationKey)> = vec![
+            (
+                SpanSlice {
+                    service: "service",
+                    name: "op",
+                    resource: "res",
+                    span_id: 1,
+                    parent_id: 0,
+                    meta: HashMap::from([("region", "us1"), ("env", "prod")]),
+                    ..Default::default()
+                },
+                OwnedAggregationKey {
+                    service_name: "service".into(),
+                    operation_name: "op".into(),
+                    resource_name: "res".into(),
+                    is_trace_root: true,
+                    span_derived_primary_tags: vec![
+                        ("region".into(), "us1".into()),
+                        ("env".into(), "prod".into()),
+                    ],
+                    ..Default::default()
+                },
+            ),
+            (
+                SpanSlice {
+                    service: "service",
+                    name: "op",
+                    resource: "res",
+                    span_id: 1,
+                    parent_id: 0,
+                    meta: HashMap::from([("region", "us1")]),
+                    ..Default::default()
+                },
+                OwnedAggregationKey {
+                    service_name: "service".into(),
+                    operation_name: "op".into(),
+                    resource_name: "res".into(),
+                    is_trace_root: true,
+                    span_derived_primary_tags: vec![("region".into(), "us1".into())],
+                    ..Default::default()
+                },
+            ),
+        ];
+
         let test_peer_tags = vec![
             "aws.s3.bucket".to_string(),
             "db.instance".to_string(),
@@ -907,7 +991,7 @@ mod tests {
         ];
 
         for (span, expected_key) in test_cases {
-            let borrowed_key = BorrowedAggregationKey::from_span(&span, &[]);
+            let borrowed_key = BorrowedAggregationKey::from_span(&span, &[], &[]);
             assert_eq!(
                 OwnedAggregationKey::from(&borrowed_key),
                 expected_key,
@@ -919,8 +1003,19 @@ mod tests {
             );
         }
 
+        for (span, expected_key) in test_cases_primary_tags {
+            let borrowed_key =
+                BorrowedAggregationKey::from_span(&span, &[], test_primary_tag_keys.as_slice());
+            assert_eq!(OwnedAggregationKey::from(&borrowed_key), expected_key);
+            assert_eq!(
+                get_hash(&borrowed_key),
+                get_hash(&OwnedAggregationKey::from(&borrowed_key))
+            );
+        }
+
         for (span, expected_key) in test_cases_with_peer_tags {
-            let borrowed_key = BorrowedAggregationKey::from_span(&span, test_peer_tags.as_slice());
+            let borrowed_key =
+                BorrowedAggregationKey::from_span(&span, test_peer_tags.as_slice(), &[]);
             assert_eq!(OwnedAggregationKey::from(&borrowed_key), expected_key);
             assert_eq!(
                 get_hash(&borrowed_key),

--- a/libdd-trace-stats/src/span_concentrator/mod.rs
+++ b/libdd-trace-stats/src/span_concentrator/mod.rs
@@ -66,6 +66,8 @@ pub struct SpanConcentrator {
     span_kinds_stats_computed: Vec<String>,
     /// keys for supplementary tags that describe peer.service entities
     peer_tag_keys: Vec<String>,
+    /// keys for second primary tags on trace stats
+    span_derived_primary_tag_keys: Vec<String>,
 }
 
 impl SpanConcentrator {
@@ -73,12 +75,15 @@ impl SpanConcentrator {
     /// - `bucket_size` is the size of the time buckets
     /// - `now` the current system time, used to define the oldest bucket
     /// - `span_kinds_stats_computed` list of span kinds eligible for stats computation
-    /// - `peer_tags_keys` list of keys considered as peer tags for aggregation
+    /// - `peer_tag_keys` list of keys considered as peer tags for aggregation
+    /// - `span_derived_primary_tag_keys` list of keys considered as second primary tags for
+    ///   aggregation
     pub fn new(
         bucket_size: Duration,
         now: SystemTime,
         span_kinds_stats_computed: Vec<String>,
         peer_tag_keys: Vec<String>,
+        span_derived_primary_tag_keys: Vec<String>,
     ) -> SpanConcentrator {
         SpanConcentrator {
             bucket_size: bucket_size.as_nanos() as u64,
@@ -90,6 +95,7 @@ impl SpanConcentrator {
             buffer_len: 2,
             span_kinds_stats_computed,
             peer_tag_keys,
+            span_derived_primary_tag_keys,
         }
     }
 
@@ -101,6 +107,11 @@ impl SpanConcentrator {
     /// Set the list of keys considered as peer_tags for aggregation
     pub fn set_peer_tags(&mut self, peer_tags: Vec<String>) {
         self.peer_tag_keys = peer_tags;
+    }
+
+    /// Set the list of keys considered as span_derived_primary_tag_keys for aggregation
+    pub fn set_span_derived_primary_tags(&mut self, tag_keys: Vec<String>) {
+        self.span_derived_primary_tag_keys = tag_keys;
     }
 
     /// Return the bucket size used for aggregation
@@ -124,7 +135,11 @@ impl SpanConcentrator {
                 bucket_timestamp = self.oldest_timestamp;
             }
 
-            let agg_key = BorrowedAggregationKey::from_span(span, self.peer_tag_keys.as_slice());
+            let agg_key = BorrowedAggregationKey::from_span(
+                span,
+                self.peer_tag_keys.as_slice(),
+                self.span_derived_primary_tag_keys.as_slice(),
+            );
 
             self.buckets
                 .entry(bucket_timestamp)

--- a/libdd-trace-stats/src/span_concentrator/tests.rs
+++ b/libdd-trace-stats/src/span_concentrator/tests.rs
@@ -99,8 +99,13 @@ fn assert_counts_equal(expected: Vec<pb::ClientGroupedStats>, actual: Vec<pb::Cl
 #[test]
 fn test_concentrator_oldest_timestamp_cold() {
     let now = SystemTime::now();
-    let mut concentrator =
-        SpanConcentrator::new(Duration::from_nanos(BUCKET_SIZE), now, vec![], vec![]);
+    let mut concentrator = SpanConcentrator::new(
+        Duration::from_nanos(BUCKET_SIZE),
+        now,
+        vec![],
+        vec![],
+        vec![],
+    );
     let mut spans = vec![
         get_test_span(now, 1, 0, 50, 5, "A1", "resource1", 0),
         get_test_span(now, 1, 0, 40, 4, "A1", "resource1", 0),
@@ -149,8 +154,13 @@ fn test_concentrator_oldest_timestamp_cold() {
 #[test]
 fn test_concentrator_oldest_timestamp_hot() {
     let now = SystemTime::now();
-    let mut concentrator =
-        SpanConcentrator::new(Duration::from_nanos(BUCKET_SIZE), now, vec![], vec![]);
+    let mut concentrator = SpanConcentrator::new(
+        Duration::from_nanos(BUCKET_SIZE),
+        now,
+        vec![],
+        vec![],
+        vec![],
+    );
     let mut spans = vec![
         get_test_span(now, 1, 0, 50, 5, "A1", "resource1", 0),
         get_test_span(now, 1, 0, 40, 4, "A1", "resource1", 0),
@@ -222,8 +232,13 @@ fn test_concentrator_oldest_timestamp_hot() {
 #[test]
 fn test_concentrator_stats_totals() {
     let now = SystemTime::now();
-    let mut concentrator =
-        SpanConcentrator::new(Duration::from_nanos(BUCKET_SIZE), now, vec![], vec![]);
+    let mut concentrator = SpanConcentrator::new(
+        Duration::from_nanos(BUCKET_SIZE),
+        now,
+        vec![],
+        vec![],
+        vec![],
+    );
     let aligned_now = align_timestamp(
         system_time_to_unix_duration(now).as_nanos() as u64,
         concentrator.bucket_size,
@@ -282,8 +297,13 @@ fn test_concentrator_stats_totals() {
 /// buckets.
 fn test_concentrator_stats_counts() {
     let now = SystemTime::now();
-    let mut concentrator =
-        SpanConcentrator::new(Duration::from_nanos(BUCKET_SIZE), now, vec![], vec![]);
+    let mut concentrator = SpanConcentrator::new(
+        Duration::from_nanos(BUCKET_SIZE),
+        now,
+        vec![],
+        vec![],
+        vec![],
+    );
     let aligned_now = align_timestamp(
         system_time_to_unix_duration(now).as_nanos() as u64,
         concentrator.bucket_size,
@@ -578,6 +598,7 @@ fn test_span_should_be_included_in_stats() {
         now,
         get_span_kinds(),
         vec![],
+        vec![],
     );
     for span in &spans {
         concentrator.add_span(span);
@@ -656,6 +677,7 @@ fn test_ignore_partial_spans() {
         now,
         get_span_kinds(),
         vec![],
+        vec![],
     );
     for span in &spans {
         concentrator.add_span(span);
@@ -678,6 +700,7 @@ fn test_force_flush() {
         Duration::from_nanos(BUCKET_SIZE),
         now,
         get_span_kinds(),
+        vec![],
         vec![],
     );
     for span in &spans {
@@ -760,12 +783,14 @@ fn test_peer_tags_aggregation() {
         now,
         get_span_kinds(),
         vec![],
+        vec![],
     );
     let mut concentrator_with_peer_tags = SpanConcentrator::new(
         Duration::from_nanos(BUCKET_SIZE),
         now,
         get_span_kinds(),
         vec!["db.instance".to_string(), "db.system".to_string()],
+        vec![],
     );
     for span in &spans {
         concentrator_without_peer_tags.add_span(span);
@@ -877,6 +902,125 @@ fn test_peer_tags_aggregation() {
     );
 }
 
+/// Test the span derived primary tags aggregation
+#[test]
+fn test_span_derived_primary_tags_aggregation() {
+    let now = SystemTime::now();
+    let mut spans = vec![
+        get_test_span_with_meta(
+            now,
+            1,
+            0,
+            100,
+            5,
+            "A1",
+            "GET /objects",
+            0,
+            &[("custom.primary", "a")],
+            &[("_dd.measured", 1.0)],
+        ),
+        get_test_span_with_meta(
+            now,
+            2,
+            0,
+            100,
+            5,
+            "A1",
+            "GET /objects",
+            0,
+            &[("custom.primary", "b")],
+            &[("_dd.measured", 1.0)],
+        ),
+    ];
+    compute_top_level_span(spans.as_mut_slice());
+
+    let mut concentrator_without_span_derived_primary_tags = SpanConcentrator::new(
+        Duration::from_nanos(BUCKET_SIZE),
+        now,
+        get_span_kinds(),
+        vec![],
+        vec![],
+    );
+    let mut concentrator_with_span_derived_primary_tags = SpanConcentrator::new(
+        Duration::from_nanos(BUCKET_SIZE),
+        now,
+        get_span_kinds(),
+        vec![],
+        vec!["custom.primary".to_string()],
+    );
+    for span in &spans {
+        concentrator_without_span_derived_primary_tags.add_span(span);
+        concentrator_with_span_derived_primary_tags.add_span(span);
+    }
+
+    let flushtime = now
+        + Duration::from_nanos(
+            concentrator_with_span_derived_primary_tags.bucket_size
+                * concentrator_with_span_derived_primary_tags.buffer_len as u64,
+        );
+
+    let expected_without_span_derived_primary_tags = vec![pb::ClientGroupedStats {
+        service: "A1".to_string(),
+        resource: "GET /objects".to_string(),
+        r#type: "db".to_string(),
+        name: "query".to_string(),
+        duration: 200,
+        hits: 2,
+        top_level_hits: 2,
+        errors: 0,
+        is_trace_root: pb::Trilean::True.into(),
+        ..Default::default()
+    }];
+
+    let expected_with_span_derived_primary_tags = vec![
+        pb::ClientGroupedStats {
+            service: "A1".to_string(),
+            resource: "GET /objects".to_string(),
+            r#type: "db".to_string(),
+            name: "query".to_string(),
+            span_derived_primary_tags: vec!["custom.primary:a".to_string()],
+            duration: 100,
+            hits: 1,
+            top_level_hits: 1,
+            errors: 0,
+            is_trace_root: pb::Trilean::True.into(),
+            ..Default::default()
+        },
+        pb::ClientGroupedStats {
+            service: "A1".to_string(),
+            resource: "GET /objects".to_string(),
+            r#type: "db".to_string(),
+            name: "query".to_string(),
+            span_derived_primary_tags: vec!["custom.primary:b".to_string()],
+            duration: 100,
+            hits: 1,
+            top_level_hits: 1,
+            errors: 0,
+            is_trace_root: pb::Trilean::True.into(),
+            ..Default::default()
+        },
+    ];
+
+    assert_counts_equal(
+        expected_without_span_derived_primary_tags,
+        concentrator_without_span_derived_primary_tags
+            .flush(flushtime, false)
+            .first()
+            .expect("There should be at least one time bucket")
+            .stats
+            .clone(),
+    );
+    assert_counts_equal(
+        expected_with_span_derived_primary_tags,
+        concentrator_with_span_derived_primary_tags
+            .flush(flushtime, false)
+            .first()
+            .expect("There should be at least one time bucket")
+            .stats
+            .clone(),
+    );
+}
+
 /// Test that internal spans with _dd.base_service use it as their sole peer tag
 #[test]
 fn test_base_service_peer_tag() {
@@ -961,6 +1105,7 @@ fn test_base_service_peer_tag() {
         now,
         get_span_kinds(),
         vec!["db.instance".to_string(), "db.system".to_string()],
+        vec![],
     );
 
     for span in &spans {
@@ -1181,6 +1326,7 @@ fn test_pb_span() {
         now,
         get_span_kinds(),
         vec!["db.instance".to_string(), "db.system".to_string()],
+        vec![],
     );
     let aligned_now = align_timestamp(
         system_time_to_unix_duration(now).as_nanos() as u64,


### PR DESCRIPTION
# What does this PR do?

Add span derived primary tags to the stats aggregation key and populate `ClientGroupedStats.span_derived_primary_tags` with the related key/value pairs when the span derived primary tag keys are provided.

# Motivation

Support span derived primary tags for Serverless.

- https://datadoghq.atlassian.net/browse/SVLS-8032
- https://github.com/DataDog/serverless-components/pull/51

# Additional Notes

Span derived primary tags still needs to be implemented in `libdd-data-pipeline`. Omitted from this PR since the goal of this PR is to support span derived primary tags for Serverless without affecting other teams.

https://github.com/DataDog/libdatadog/blob/62181a8a2a766419a07cbecd7d6f87ef05dd166f/libdd-data-pipeline/src/trace_exporter/stats.rs#L75

# How to test the change?

- Unit test for aggregating by span derived primary tags
- Deployed to Azure Function with `DD_APM_SPAN_DERIVED_PRIMARY_TAGS` configured and confirmed the configured tags appear on trace metrics.
