### PR TITLE
chore(libdd-common-ffi): remove unneded dependency version

### DIFF
--- a/libdd-common-ffi/Cargo.toml
+++ b/libdd-common-ffi/Cargo.toml
@@ -23,7 +23,7 @@ build_common = { path = "../build-common" }
 anyhow = "1.0"
 chrono = { version = "0.4.38", features = ["std"] }
 crossbeam-queue = "0.3.11"
-libdd-common = { version = "3.0.2", path = "../libdd-common" }
+libdd-common = { path = "../libdd-common" }
 hyper = { workspace = true}
 serde = "1.0"
 


### PR DESCRIPTION
# What does this PR do?

Removes dependency version for libdd-common.

# Motivation

Since libdd-common-ffi is not published the dependency version is not needed. Having it there was causing some addiotional computation in the publishing workflows.

