### PR TITLE
ci(libdd-shared-runtime): downgrade version so publish workflow succeeds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3219,7 +3219,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-shared-runtime"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "async-trait",
  "futures",

--- a/libdd-data-pipeline-ffi/Cargo.toml
+++ b/libdd-data-pipeline-ffi/Cargo.toml
@@ -31,7 +31,7 @@ libdd-trace-utils = { path = "../libdd-trace-utils" }
 [dependencies]
 libdd-capabilities-impl = { version = "0.1.0", path = "../libdd-capabilities-impl" }
 libdd-data-pipeline = { path = "../libdd-data-pipeline" }
-libdd-shared-runtime = { version = "1.0.0", path = "../libdd-shared-runtime" }
+libdd-shared-runtime = { version = "0.1.0", path = "../libdd-shared-runtime" }
 libdd-common-ffi = { path = "../libdd-common-ffi", default-features = false }
 libdd-tinybytes = { path = "../libdd-tinybytes" }
 tracing = { version = "0.1", default-features = false }

--- a/libdd-data-pipeline/Cargo.toml
+++ b/libdd-data-pipeline/Cargo.toml
@@ -31,7 +31,7 @@ uuid = { version = "1.10.0", features = ["v4"] }
 tokio-util = "0.7.11"
 libdd-capabilities = { path = "../libdd-capabilities", version = "0.1.0" }
 libdd-common = { version = "3.0.2", path = "../libdd-common", default-features = false }
-libdd-shared-runtime = { version = "1.0.0", path = "../libdd-shared-runtime" }
+libdd-shared-runtime = { version = "0.1.0", path = "../libdd-shared-runtime" }
 libdd-telemetry = { version = "4.0.0", path = "../libdd-telemetry", default-features = false, optional = true}
 libdd-trace-protobuf = { version = "3.0.1", path = "../libdd-trace-protobuf" }
 libdd-trace-stats = { version = "2.0.0", path = "../libdd-trace-stats" }

--- a/libdd-shared-runtime-ffi/Cargo.toml
+++ b/libdd-shared-runtime-ffi/Cargo.toml
@@ -22,5 +22,5 @@ cbindgen = ["build_common/cbindgen"]
 build_common = { path = "../build-common" }
 
 [dependencies]
-libdd-shared-runtime = { version = "1.0.0", path = "../libdd-shared-runtime" }
+libdd-shared-runtime = { version = "0.1.0", path = "../libdd-shared-runtime" }
 tracing = { version = "0.1", default-features = false }

--- a/libdd-shared-runtime/Cargo.toml
+++ b/libdd-shared-runtime/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "libdd-shared-runtime"
-version = "1.0.0"
+version = "0.1.0"
 description = "Shared tokio runtime with fork-safe worker management for Datadog libraries"
 homepage = "https://github.com/DataDog/libdatadog/tree/main/libdd-shared-runtime"
 repository = "https://github.com/DataDog/libdatadog/tree/main/libdd-shared-runtime"

--- a/libdd-telemetry/Cargo.toml
+++ b/libdd-telemetry/Cargo.toml
@@ -32,7 +32,7 @@ uuid = { version = "1.3", features = ["v4"] }
 hashbrown = "0.15"
 bytes = "1.4"
 libdd-common = { version = "3.0.2", path = "../libdd-common", default-features = false }
-libdd-shared-runtime = { version = "1.0.0", path = "../libdd-shared-runtime" }
+libdd-shared-runtime = { version = "0.1.0", path = "../libdd-shared-runtime" }
 libdd-ddsketch = { version = "1.0.1", path = "../libdd-ddsketch" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]


### PR DESCRIPTION
# What does this PR do?

Downgrade the version to `0.1.0` so the publish workflow can make progress.

# Motivation

CI workflow on publication will perform a major bump to initial releases in order to prevent libdatadog packages to be on beta versions. This PR will prevent a `2.0.0` is published right away.
