### PR TITLE
fix(crypto): gate libdd-common TLS features in obfuscation and capabilities-impl

### DIFF
--- a/libdd-capabilities-impl/Cargo.toml
+++ b/libdd-capabilities-impl/Cargo.toml
@@ -19,4 +19,9 @@ bench = false
 bytes = "1"
 http = "1"
 libdd-capabilities = { path = "../libdd-capabilities", version = "0.1.0" }
-libdd-common = { path = "../libdd-common", version = "3.0.2" }
+libdd-common = { path = "../libdd-common", version = "3.0.2", default-features = false }
+
+[features]
+default = ["https"]
+https = ["libdd-common/https"]
+fips = ["libdd-common/fips"]

--- a/libdd-trace-obfuscation/Cargo.toml
+++ b/libdd-trace-obfuscation/Cargo.toml
@@ -18,8 +18,13 @@ percent-encoding = "2.1"
 log = "0.4"
 fluent-uri = "0.4.1"
 libdd-trace-protobuf = { version = "3.0.1", path = "../libdd-trace-protobuf" }
-libdd-trace-utils = { version = "3.0.1", path = "../libdd-trace-utils" }
-libdd-common = { version = "3.0.2", path = "../libdd-common" }
+libdd-trace-utils = { version = "3.0.1", path = "../libdd-trace-utils", default-features = false }
+libdd-common = { version = "3.0.2", path = "../libdd-common", default-features = false }
+
+[features]
+default = ["https"]
+https = ["libdd-common/https", "libdd-trace-utils/https"]
+fips = ["libdd-common/fips", "libdd-trace-utils/fips"]
 
 [dev-dependencies]
 duplicate = "0.4.1"

--- a/libdd-trace-utils/Cargo.toml
+++ b/libdd-trace-utils/Cargo.toml
@@ -59,7 +59,7 @@ urlencoding = { version = "2.1.3", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", features = ["time", "rt-multi-thread"] }
-libdd-capabilities-impl = { version = "0.1.0", path = "../libdd-capabilities-impl" }
+libdd-capabilities-impl = { version = "0.1.0", path = "../libdd-capabilities-impl", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
@@ -76,7 +76,7 @@ tempfile = "3.3.0"
 
 [features]
 default = ["https"]
-https = ["libdd-common/https"]
+https = ["libdd-common/https", "libdd-capabilities-impl/https"]
 mini_agent = ["compression", "libdd-common/use_webpki_roots"]
 test-utils = [
     "hyper/server",
@@ -87,4 +87,4 @@ test-utils = [
 ]
 compression = ["zstd", "flate2"]
 # FIPS mode uses the FIPS-compliant cryptographic provider (Unix only)
-fips = ["libdd-common/fips"]
+fips = ["libdd-common/fips", "libdd-capabilities-impl/fips"]


### PR DESCRIPTION
## What does this PR do?

Follows up on #1816 by gating `libdd-common`'s TLS features behind `https`/`fips` feature flags in the three internal crates that were still pulling in `libdd-common` with default features. Without this, downstream consumers that build with `--no-default-features --features fips` still get `ring` in the dependency tree via transitive default feature activation, breaking FIPS compliance checks.

### Changes:
- `libdd-trace-obfuscation/Cargo.toml`: Added `default-features = false` on both `libdd-common` and `libdd-trace-utils`. Added `[features]` section with `default = ["https"]`, `https` (forwarding to `libdd-common/https` and `libdd-trace-utils/https`), and `fips` (forwarding to `libdd-common/fips` and `libdd-trace-utils/fips`).
- `libdd-capabilities-impl/Cargo.toml`: Added `default-features = false` on `libdd-common`. Added `[features]` section with `default = ["https"]`, `https` (forwarding to `libdd-common/https`), and `fips` (forwarding to `libdd-common/fips`).
- `libdd-trace-utils/Cargo.toml`: Added `default-features = false` on `libdd-capabilities-impl` in `[target.'cfg(not(target_arch = "wasm32"))'.dependencies]`. Updated `https` and `fips` features to also forward to `libdd-capabilities-impl/https` and `libdd-capabilities-impl/fips` respectively.

## Motivation

PR #1816 moved `ring` behind `libdd-common`'s `https` feature and introduced a separate `fips` feature that uses `aws-lc-rs` without pulling in `ring`. However, three internal crates (`libdd-trace-obfuscation`, `libdd-capabilities-impl`, and `libdd-trace-utils` via `libdd-capabilities-impl`) still depended on `libdd-common` with default features enabled. Since Cargo features are additive, this caused `libdd-common/default` → `https` → `rustls/ring` to be activated regardless of what the downstream consumer configured.

In `datadog-lambda-extension`, the FIPS build (`cargo clippy --no-default-features --features fips`) was failing because the build.rs FIPS compliance check detected `ring` in the dependency tree through these transitive paths:

```
ring v0.17.14
└── rustls
    └── libdd-common (feature "https", activated by "default")
        ├── libdd-trace-obfuscation (default features)
        ├── libdd-capabilities-impl (default features, via libdd-trace-utils)
        └── libdd-trace-utils (default features, via libdd-trace-obfuscation)
```

This PR applies the same pattern already used by `libdd-trace-utils` for its `libdd-common` dependency (`default-features = false` + explicit `https`/`fips` forwarding) to all internal crates in the dependency chain.

## Additional Notes

- `libdd-trace-utils` already had `default-features = false` on `libdd-common` and proper `https`/`fips` feature gates. The only change to `libdd-trace-utils` is adding the same treatment for its `libdd-capabilities-impl` dependency.
- Default builds are unchanged — the `default = ["https"]` feature on each crate preserves the existing behavior where `ring` is used as the crypto backend.
- Downstream consumers that need FIPS must set `default-features = false` on these crates and activate the `fips` feature explicitly. For example, in `datadog-lambda-extension`:
  ```toml
  libdd-common = { ..., default-features = false }
  libdd-trace-utils = { ..., default-features = false, features = ["mini_agent"] }
  libdd-trace-obfuscation = { ..., default-features = false }

  [features]
  default = ["libdd-common/default", "libdd-trace-utils/default", "libdd-trace-obfuscation/default", ...]
  fips = ["libdd-common/fips", "libdd-trace-utils/fips", "libdd-trace-obfuscation/fips", ...]
  ```

## How to test the change?

- Verify default build compiles (ring path unchanged):
  ```
  cargo check --workspace
  ```

- Verify ring is absent from a FIPS feature build of affected crates:
  ```
  cargo tree -p libdd-trace-obfuscation --no-default-features --features fips -i ring
  # Expected: "error: package ID specification `ring` did not match any packages"
  ```

- Verify aws-lc-rs is present in FIPS builds:
  ```
  cargo tree -p libdd-trace-obfuscation --no-default-features --features fips -i aws-lc-rs
  # Expected: aws-lc-rs present via hyper-rustls/fips
  ```

- Verify ring is still present in default builds:
  ```
  cargo tree -p libdd-trace-obfuscation -i ring
  # Expected: ring present via libdd-common/https
  ```