### PR TITLE
chore(libdd-crashtracker): remove path reference for libdd-libunwind-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3101,6 +3101,8 @@ dependencies = [
 [[package]]
 name = "libdd-libunwind-sys"
 version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eecc52581f5ccbcced4e2264fb7dd95112dba55f47d217c859420dd64e62c43a"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ members = [
   "libdd-dogstatsd-client",
   "libdd-http-client",
   "libdd-log",
-  "libdd-log-ffi", "libdd-libunwind-sys",
+  "libdd-log-ffi",
 ]
 
 # https://doc.rust-lang.org/cargo/reference/resolver.html

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -219,6 +219,7 @@ kernel32-sys,https://github.com/retep998/winapi-rs,MIT,Peter Atashian <retep998@
 kv-log-macro,https://github.com/yoshuawuyts/kv-log-macro,MIT OR Apache-2.0,Yoshua Wuyts <yoshuawuyts@gmail.com>
 lazy_static,https://github.com/rust-lang-nursery/lazy-static.rs,MIT OR Apache-2.0,Marvin Löbel <loebel.marvin@gmail.com>
 libc,https://github.com/rust-lang/libc,MIT OR Apache-2.0,The Rust Project Developers
+libdd-libunwind-sys,https://github.com/DataDog/libdatadog/tree/main/libdd-libunwind-sys,Apache-2.0,The libdd-libunwind-sys Authors
 libloading,https://github.com/nagisa/rust_libloading,ISC,Simonas Kazlauskas <libloading@kazlauskas.me>
 libredox,https://gitlab.redox-os.org/redox-os/libredox,MIT,4lDO2 <4lDO2@protonmail.com>
 libz-rs-sys,https://github.com/trifectatechfoundation/zlib-rs,Zlib,The libz-rs-sys Authors

--- a/libdd-crashtracker/Cargo.toml
+++ b/libdd-crashtracker/Cargo.toml
@@ -42,7 +42,7 @@ cxx = ["dep:cxx", "dep:cxx-build"]
 blazesym = "=0.2.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-libdd-libunwind-sys = { version = "1.0.0", path = "../libdd-libunwind-sys" }
+libdd-libunwind-sys = { version = "1.0.0" }
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
# What does this PR do?

Remove `libdd-libunwind-sys` path reference.

# Motivation

Since libdd-libunwind-sys is being moved to another repo the path reference is no longer needed.