### PR TITLE
feat(profiling-ffi): ProfilesDictionary_get_func

### DIFF
--- a/libdd-profiling-ffi/src/profiles/profiles_dictionary.rs
+++ b/libdd-profiling-ffi/src/profiles/profiles_dictionary.rs
@@ -242,15 +242,35 @@ pub unsafe extern "C" fn ddog_prof_ProfilesDictionary_get_str(
     let Some(dict) = dict else {
         return ProfileStatus::from(NULL_PROFILES_DICTIONARY);
     };
-    let string_ref = StringRef::from(string_id);
     // SAFETY: It's not actually safe--as indicated in the docs
     // for this function, the caller needs to be sure the string
     // set in the dictionary outlives the slice.
     result.write(unsafe {
         std::mem::transmute::<CharSlice<'_>, CharSlice<'static>>(CharSlice::from(
-            dict.strings().get(string_ref),
+            dict.get_str(string_id),
         ))
     });
+    ProfileStatus::OK
+}
+
+/// Tries to get the function value associated with the function id.
+///
+/// # Safety
+///
+///  1. The `function_id` should belong to this dictionary.
+///  2. The dictionary must be live for the duration of the call.
+///  3. The result pointer must be valid for [`core::ptr::write`].
+#[no_mangle]
+pub unsafe extern "C" fn ddog_prof_ProfilesDictionary_get_func(
+    result: *mut Function2,
+    dict: Option<&ProfilesDictionary>,
+    function_id: FunctionId2,
+) -> ProfileStatus {
+    ensure_non_null_out_parameter!(result);
+    let Some(dict) = dict else {
+        return ProfileStatus::from(NULL_PROFILES_DICTIONARY);
+    };
+    unsafe { result.write(dict.get_func(function_id)) };
     ProfileStatus::OK
 }
 

--- a/libdd-profiling/src/profiles/datatypes/function.rs
+++ b/libdd-profiling/src/profiles/datatypes/function.rs
@@ -23,8 +23,12 @@ pub struct Function {
 
 /// An FFI-safe version of the Function which allows null. Be sure to maintain
 /// layout-compatibility with it, except that StringId2 may be null.
+///
+/// Equality and hashing are defined by pointer identity, so they are only
+/// meaningful when comparing ids that originate from the same
+/// `ProfilesDictionary`.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash)]
 pub struct Function2 {
     pub name: StringId2,
     pub system_name: StringId2,

--- a/libdd-profiling/src/profiles/datatypes/profiles_dictionary.rs
+++ b/libdd-profiling/src/profiles/datatypes/profiles_dictionary.rs
@@ -1,7 +1,7 @@
 // Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::profiles::collections::{ParallelSet, ParallelStringSet, SetError};
+use crate::profiles::collections::{ParallelSet, ParallelStringSet, SetError, StringRef};
 use crate::profiles::datatypes::{
     Function, Function2, FunctionId2, Mapping, Mapping2, MappingId2, StringId2,
 };
@@ -75,6 +75,24 @@ impl ProfilesDictionary {
         Ok(string_ref.into())
     }
 
+    /// Returns the string for the given id.
+    ///
+    /// # Safety
+    /// The `id` must belong to this dictionary's string set. The returned
+    /// `&str` borrows from the dictionary's internal storage and must not
+    /// outlive it.
+    pub unsafe fn get_str(&self, id: StringId2) -> &str {
+        unsafe { self.strings.get(StringRef::from(id)) }
+    }
+
+    /// Returns the function for the given id, or `Function2::default()` if the id is empty.
+    ///
+    /// # Safety
+    /// The `id` must belong to this dictionary.
+    pub unsafe fn get_func(&self, id: FunctionId2) -> Function2 {
+        unsafe { id.read() }.unwrap_or_default()
+    }
+
     pub fn functions(&self) -> &FunctionSet {
         &self.functions
     }
@@ -103,6 +121,46 @@ mod tests {
         unsafe {
             assert_eq!(dict.strings().get(id.into()), expected);
         }
+    }
+
+    #[test]
+    fn get_str_round_trip() {
+        let dict = ProfilesDictionary::try_new().unwrap();
+        let id = dict.try_insert_str2("hello").unwrap();
+        assert_eq!(unsafe { dict.get_str(id) }, "hello");
+    }
+
+    #[test]
+    fn get_str_empty_id() {
+        let dict = ProfilesDictionary::try_new().unwrap();
+        assert_eq!(unsafe { dict.get_str(StringId2::EMPTY) }, "");
+    }
+
+    #[test]
+    fn get_func_round_trip() {
+        let dict = ProfilesDictionary::try_new().unwrap();
+        let name_id = dict.try_insert_str2("my_func").unwrap();
+        let system_name_id = dict.try_insert_str2("_my_func").unwrap();
+        let file_name_id = dict.try_insert_str2("lib.rs").unwrap();
+        let function = Function2 {
+            name: name_id,
+            system_name: system_name_id,
+            file_name: file_name_id,
+        };
+        let id = dict.try_insert_function2(function).unwrap();
+        let got = unsafe { dict.get_func(id) };
+        assert_string_id_eq(got.name, name_id);
+        assert_string_id_eq(got.system_name, system_name_id);
+        assert_string_id_eq(got.file_name, file_name_id);
+    }
+
+    #[test]
+    fn get_func_empty_id() {
+        let dict = ProfilesDictionary::try_new().unwrap();
+        let got = unsafe { dict.get_func(FunctionId2::default()) };
+        assert!(got.name.is_empty());
+        assert!(got.system_name.is_empty());
+        assert!(got.file_name.is_empty());
     }
 
     proptest! {

--- a/libdd-profiling/src/profiles/datatypes/string.rs
+++ b/libdd-profiling/src/profiles/datatypes/string.rs
@@ -12,8 +12,12 @@ use crate::profiles::collections::StringRef;
 /// another, even if it happens to work by implementation detail. There is an
 /// exception is for well-known strings, which are considered present in every
 /// string set.
+///
+/// Equality and hashing are defined by pointer identity, so they are only
+/// meaningful when comparing ids that originate from the same
+/// `ProfilesDictionary`.
 #[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct StringId2(*mut StringHeader);
 
 /// Represents what StringIds point to. Its definition is intentionally


### PR DESCRIPTION
# What does this PR do?

Adds a `ddog_pprof_ProfilesDictionary_get_func` so you can go from a `FunctionId2` to `Function2`. This capability was already available in the Rust component, just missing from FFI.

# Motivation

I may need this in Ruby to adopt `FunctionId2` efficiently.

# Additional Notes

The tests were written with AI, please scrutinize them.

There was already `ddog_pprof_ProfilesDictionary_get_str`, this mirrors that for functions.

# How to test the change?

Regular tests apply, something like `cargo nextest run -p libdd-profiling -p libdd-profiling-ffi`.