### PR TITLE
chore(release): proposal for libdd-profiling-protobuf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3218,7 +3218,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-profiling-protobuf"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "bolero",
  "libdd-profiling-protobuf",

--- a/libdd-profiling-protobuf/CHANGELOG.md
+++ b/libdd-profiling-protobuf/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+
+
+## [2.0.0](https://github.com/datadog/libdatadog/compare/libdd-profiling-protobuf-v1.0.0..libdd-profiling-protobuf-v2.0.0) - 2026-04-15
+
+### Changed
+
+- bumped prost dependency from 0.13 to 0.14 ([#1426](https://github.com/datadog/libdatadog/issues/1700)) - ([14bab865c](https://github.com/datadog/libdatadog/commit/14bab865c))
+
+
+
 ## 1.0.0 - 2025-11-17
 
 Initial release.

--- a/libdd-profiling-protobuf/Cargo.toml
+++ b/libdd-profiling-protobuf/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "libdd-profiling-protobuf"
-version = "1.0.0"
+version = "2.0.0"
 description = "Protobuf utils for Datadog's continuous profiling library"
 homepage = "https://github.com/DataDog/libdatadog/tree/main/libdd-profiling-protobuf"
 repository = "https://github.com/DataDog/libdatadog/tree/main/libdd-profiling-protobuf"

--- a/libdd-profiling/Cargo.toml
+++ b/libdd-profiling/Cargo.toml
@@ -43,7 +43,7 @@ httparse = "1.9"
 indexmap = "2.11"
 libdd-alloc = { version = "1.0.0", path = "../libdd-alloc" }
 libdd-common = { version = "3.0.2", path = "../libdd-common", default-features = false, features = ["reqwest", "test-utils"] }
-libdd-profiling-protobuf = { version = "1.0.0", path = "../libdd-profiling-protobuf", features = ["prost_impls"] }
+libdd-profiling-protobuf = { version = "2.0.0", path = "../libdd-profiling-protobuf", features = ["prost_impls"] }
 mime = "0.3.16"
 parking_lot = { version = "0.12", default-features = false }
 prost = "0.14.1"


### PR DESCRIPTION
# Release proposal for libdd-profiling-protobuf and its dependencies

This PR contains version bumps based on public API changes and commits since last release.

## libdd-profiling-protobuf
**Next version:** `2.0.0`
**Semver bump:** `major`
**Tag:** `libdd-profiling-protobuf-v2.0.0`
