### PR TITLE
chore(crashtracking): default bin_tests to symbolicate in receiver

### DIFF
--- a/bin_tests/src/bin/crashtracker_bin_test.rs
+++ b/bin_tests/src/bin/crashtracker_bin_test.rs
@@ -86,9 +86,9 @@ mod unix {
                 "receiver_symbols" => {
                     crashtracker::StacktraceCollection::EnabledWithSymbolsInReceiver
                 }
-                _ => crashtracker::StacktraceCollection::WithoutSymbols,
+                _ => crashtracker::StacktraceCollection::EnabledWithSymbolsInReceiver,
             },
-            Err(_) => crashtracker::StacktraceCollection::WithoutSymbols,
+            Err(_) => crashtracker::StacktraceCollection::EnabledWithSymbolsInReceiver,
         };
 
         // Ensure the receiver gets a timeout consistent with the collector's.


### PR DESCRIPTION
# What does this PR do?

We want customers and users of this library to lean towards symbolicating in the receiver. Our bin_tests should also just default for that for parity and ease of quick validations for devs like me, who like to quickly run a e2e crash using the bin tests

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
