### PR TITLE
chore(license): use same version of dd-rust-license-tool

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -72,6 +72,7 @@ scripts/publication-order.sh         @DataDog/libdatadog-core
 scripts/reformat_copyright.sh        @DataDog/libdatadog-core
 scripts/semver-level.sh              @DataDog/libdatadog-core
 scripts/update_license_3rdparty.sh   @DataDog/libdatadog-core
+scripts/Dockerfile.license           @DataDog/libdatadog-core
 spawn_worker/                        @DataDog/libdatadog-php @DataDog/libdatadog-apm
 symbolizer-ffi                       @DataDog/libdatadog-profiling
 tests/run-package-tests.ps1          @DataDog/apm-common-components-core

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -81,16 +81,38 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+      # Keep version in sync with: scripts/update_license_3rdparty.sh (TOOL_VERSION) and scripts/Dockerfile.license (ARG TOOL_VERSION)
       - name: Cache dd-rust-license-tool
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # 4.2.2
         with:
           path: |
+            ~/.cargo/registry/
+            ~/.cargo/git/db/
             ~/.cargo/bin/dd-rust-license-tool
             ~/.cargo/.crates.toml
             ~/.cargo/.crates2.json
-          key: dd-rust-license-tool-1.0.6
-      - run: cargo install dd-rust-license-tool --version "1.0.6" --locked
-      - run: dd-rust-license-tool check
+          key: dd-rust-license-tool-1.0.6-v2
+      - run: cargo install --list | grep -qF "dd-rust-license-tool v1.0.6" || cargo install dd-rust-license-tool --version "1.0.6" --locked
+      - name: Generate new LICENSE-3rdparty.csv and check against the previous
+        run: |
+          if ! dd-rust-license-tool dump > /tmp/CI.csv 2> /tmp/CI.error; then
+            echo "ERROR: dd-rust-license-tool dump failed! See error output below:"
+            cat /tmp/CI.error
+            exit 1
+          fi
+          if ! diff /tmp/CI.csv LICENSE-3rdparty.csv; then
+            echo "Differences detected in LICENSE-3rdparty.csv."
+            echo "Please run './scripts/update_license_3rdparty.sh' to update the file and commit the changes."
+            exit 1
+          fi
+          echo "No differences found."
+      - name: Export generated license file on failure
+        if: failure()
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: LICENSE-3rdparty.csv
+          path: /tmp/CI.csv
+          overwrite: true
 
   codeowners-validator:
     runs-on: ubuntu-latest

--- a/scripts/Dockerfile.license
+++ b/scripts/Dockerfile.license
@@ -1,0 +1,17 @@
+# Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+
+FROM rust:1.84-slim
+
+# Keep in sync with: scripts/update_license_3rdparty.sh (TOOL_VERSION) and .github/workflows/lint.yml (cache key + install step)
+ARG TOOL_VERSION=1.0.6
+
+RUN cargo install dd-rust-license-tool --version "${TOOL_VERSION}" --locked
+
+WORKDIR /build
+
+COPY . .
+
+RUN dd-rust-license-tool dump > /licenses.csv
+
+ENTRYPOINT ["cat", "/licenses.csv"]

--- a/scripts/update_license_3rdparty.sh
+++ b/scripts/update_license_3rdparty.sh
@@ -1,12 +1,84 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 # SPDX-License-Identifier: Apache-2.0
 
-set -eu
+set -euo pipefail
 
-# If you're missing dd-rust-license-tool, install it with:
-# cargo install dd-rust-license-tool
+# Keep in sync with: scripts/Dockerfile.license (ARG TOOL_VERSION) and .github/workflows/lint.yml (cache key + install step)
+TOOL_VERSION="1.0.6"
+INSTALL_CMD="cargo install dd-rust-license-tool --version \"${TOOL_VERSION}\" --locked"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)"
 
-cd "$(dirname "$0")"/..
-dd-rust-license-tool write
+run_native() {
+    cd "${ROOT_DIR}"
+    echo "Running dd-rust-license-tool dump..."
+    dd-rust-license-tool dump > LICENSE-3rdparty.csv
+}
+
+run_docker() {
+    if ! command -v docker &> /dev/null || ! docker info &> /dev/null; then
+        echo "ERROR: Docker is not running. Please start the Docker daemon and try again."
+        exit 1
+    fi
+    export DOCKER_BUILDKIT=1
+    echo "Building license tool container..."
+    docker build \
+        --progress=plain \
+        -t libdatadog-dd-license-tool \
+        -f "${ROOT_DIR}/scripts/Dockerfile.license" \
+        "${ROOT_DIR}"
+    echo "Generating LICENSE-3rdparty.csv..."
+    docker run --rm libdatadog-dd-license-tool > "${ROOT_DIR}/LICENSE-3rdparty.csv"
+}
+
+if cargo install --list 2>/dev/null | grep -qF "dd-rust-license-tool v${TOOL_VERSION}"; then
+    run_native
+else
+    INSTALLED_VERSION=$(cargo install --list 2>/dev/null | grep "^dd-rust-license-tool v" | awk '{print $2}' | tr -d ':' || true)
+
+    echo "dd-rust-license-tool v${TOOL_VERSION} is not installed."
+    if [ -n "${INSTALLED_VERSION}" ]; then
+        echo "Found installed version: ${INSTALLED_VERSION}"
+    fi
+    echo ""
+    echo "To install v${TOOL_VERSION} locally, run:"
+    echo "  ${INSTALL_CMD}"
+    echo ""
+    echo "How would you like to proceed?"
+    echo "  1) Install dd-rust-license-tool v${TOOL_VERSION} locally and run"
+    echo "  2) Use Docker (requires Docker daemon to be running)"
+    if [ -n "${INSTALLED_VERSION}" ]; then
+        echo "  3) Run with the installed version (${INSTALLED_VERSION})"
+        read -rp "Enter 1, 2, or 3: " choice
+    else
+        read -rp "Enter 1 or 2: " choice
+    fi
+
+    case "${choice}" in
+        1)
+            echo "Installing dd-rust-license-tool v${TOOL_VERSION}..."
+            eval "${INSTALL_CMD}"
+            run_native
+            ;;
+        2)
+            run_docker
+            ;;
+        3)
+            if [ -n "${INSTALLED_VERSION}" ]; then
+                run_native
+            else
+                echo "Invalid choice. Exiting."
+                exit 1
+            fi
+            ;;
+        *)
+            echo "Invalid choice. Exiting."
+            exit 1
+            ;;
+    esac
+fi
+
+echo ""
+echo "Successfully generated LICENSE-3rdparty.csv."
+echo "Please review and commit the changes."


### PR DESCRIPTION
# What does this PR do?

Changes the script for generating the `LICENSE-3rdparty.csv` to use the same version of `dd-rust-license-tool` as CI. Also changes CI to cache more things to speed up the check.

# Motivation

Different versions of `dd-rust-license-tool` in different repos mess things up.

# Additional Notes

The script and docker file is ported from `dd-trace-rs`.

There is also an option to run the license update in a Docker container if you don't want to install `dd-rust-license-tool` or have another version installed locally.

# How to test the change?

I've run both paths locally.