### PR TITLE
fix(libdd-telemetry-ffi): logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3272,6 +3272,7 @@ dependencies = [
  "libdd-common-ffi",
  "libdd-telemetry",
  "paste",
+ "serde_json",
  "tempfile",
 ]
 

--- a/libdd-telemetry-ffi/Cargo.toml
+++ b/libdd-telemetry-ffi/Cargo.toml
@@ -31,3 +31,4 @@ paste = "1"
 
 [dev-dependencies]
 tempfile = {version = "3.3"}
+serde_json = {version = "1.0"}

--- a/libdd-telemetry-ffi/src/lib.rs
+++ b/libdd-telemetry-ffi/src/lib.rs
@@ -119,6 +119,35 @@ mod tests {
     };
     use std::{mem::MaybeUninit, ptr::NonNull};
 
+    /// Spins up a worker backed by a file:// endpoint, returns (handle, temp_file).
+    /// The caller is responsible for stopping the worker and reading the file.
+    unsafe fn start_file_backed_worker() -> (Box<TelemetryWorkerHandle>, tempfile::NamedTempFile) {
+        let mut builder: MaybeUninit<Box<TelemetryWorkerBuilder>> = MaybeUninit::uninit();
+        ddog_telemetry_builder_instantiate(
+            NonNull::new(&mut builder).unwrap().cast(),
+            ffi::CharSlice::from("test-service"),
+            ffi::CharSlice::from("rust"),
+            ffi::CharSlice::from("1.0"),
+            ffi::CharSlice::from("0.0.1"),
+        )
+        .unwrap_none();
+        let mut builder = builder.assume_init();
+
+        let f = tempfile::NamedTempFile::new().unwrap();
+        ddog_telemetry_builder_with_endpoint_config_endpoint(
+            &mut builder,
+            &Endpoint::from_slice(&format!("file://{}", f.path().to_str().unwrap())),
+        )
+        .unwrap_none();
+
+        let mut handle: MaybeUninit<Box<TelemetryWorkerHandle>> = MaybeUninit::uninit();
+        ddog_telemetry_builder_run(builder, NonNull::new(&mut handle).unwrap().cast())
+            .unwrap_none();
+        let handle = handle.assume_init();
+        ddog_telemetry_handle_start(&handle).unwrap_none();
+        (handle, f)
+    }
+
     #[test]
     #[cfg_attr(miri, ignore)]
     fn test_set_builder_str_param() {
@@ -370,6 +399,158 @@ mod tests {
 
             assert_eq!(ddog_telemetry_handle_stop(&handle), MaybeError::None);
             ddog_telemetry_handle_wait_for_shutdown(handle);
+        }
+    }
+
+    /// Finds all sub-payloads with the given request_type in a file endpoint output.
+    /// Handles both top-level payloads and those nested inside message-batch.
+    fn find_sub_payloads(output: &str, request_type: &str) -> Vec<serde_json::Value> {
+        let mut results = Vec::new();
+        for line in output.lines() {
+            let Ok(parsed) = serde_json::from_str::<serde_json::Value>(line) else {
+                continue;
+            };
+            collect_payloads_recursive(&parsed, request_type, &mut results);
+        }
+        results
+    }
+
+    fn collect_payloads_recursive(
+        value: &serde_json::Value,
+        target_type: &str,
+        results: &mut Vec<serde_json::Value>,
+    ) {
+        if value["request_type"].as_str() == Some(target_type) {
+            results.push(value.clone());
+        }
+        if value["request_type"].as_str() == Some("message-batch") {
+            if let Some(batch) = value["payload"].as_array() {
+                for item in batch {
+                    collect_payloads_recursive(item, target_type, results);
+                }
+            }
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_add_dependency_preserves_version() {
+        unsafe {
+            let (handle, f) = start_file_backed_worker();
+
+            ddog_telemetry_handle_add_dependency(
+                &handle,
+                ffi::CharSlice::from("my-test-crate"),
+                ffi::CharSlice::from("1.2.3"),
+            )
+            .unwrap_none();
+
+            ddog_telemetry_handle_add_dependency(
+                &handle,
+                ffi::CharSlice::from("versionless-crate"),
+                ffi::CharSlice::from(""),
+            )
+            .unwrap_none();
+
+            ddog_telemetry_handle_stop(&handle).unwrap_none();
+            ddog_telemetry_handle_wait_for_shutdown(handle);
+
+            let output = std::fs::read_to_string(f.path()).unwrap();
+            let dep_payloads = find_sub_payloads(&output, "app-dependencies-loaded");
+            assert!(
+                !dep_payloads.is_empty(),
+                "expected at least one app-dependencies-loaded payload in output:\n{output}"
+            );
+
+            let deps: Vec<&serde_json::Value> = dep_payloads
+                .iter()
+                .filter_map(|p| p["payload"]["dependencies"].as_array())
+                .flatten()
+                .collect();
+
+            let versioned = deps
+                .iter()
+                .find(|d| d["name"] == "my-test-crate")
+                .expect("expected my-test-crate in dependencies");
+            assert_eq!(
+                versioned["version"].as_str(),
+                Some("1.2.3"),
+                "Non-empty version must be preserved through the FFI layer"
+            );
+
+            let versionless = deps
+                .iter()
+                .find(|d| d["name"] == "versionless-crate")
+                .expect("expected versionless-crate in dependencies");
+            assert!(
+                versionless["version"].is_null(),
+                "Empty version string should map to null/None, got {:?}",
+                versionless["version"]
+            );
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_add_integration_preserves_version() {
+        unsafe {
+            let (handle, f) = start_file_backed_worker();
+
+            ddog_telemetry_handle_add_integration(
+                &handle,
+                ffi::CharSlice::from("http-framework"),
+                ffi::CharSlice::from("2.0.0"),
+                true,
+                ffi::Option::<bool>::None,
+                ffi::Option::<bool>::None,
+            )
+            .unwrap_none();
+
+            ddog_telemetry_handle_add_integration(
+                &handle,
+                ffi::CharSlice::from("versionless-integration"),
+                ffi::CharSlice::from(""),
+                true,
+                ffi::Option::<bool>::None,
+                ffi::Option::<bool>::None,
+            )
+            .unwrap_none();
+
+            ddog_telemetry_handle_stop(&handle).unwrap_none();
+            ddog_telemetry_handle_wait_for_shutdown(handle);
+
+            let output = std::fs::read_to_string(f.path()).unwrap();
+            let int_payloads = find_sub_payloads(&output, "app-integrations-change");
+            assert!(
+                !int_payloads.is_empty(),
+                "expected at least one app-integrations-change payload in output:\n{output}"
+            );
+
+            let integrations: Vec<&serde_json::Value> = int_payloads
+                .iter()
+                .filter_map(|p| p["payload"]["integrations"].as_array())
+                .flatten()
+                .collect();
+
+            let versioned = integrations
+                .iter()
+                .find(|i| i["name"] == "http-framework")
+                .expect("expected http-framework in integrations");
+            assert_eq!(
+                versioned["version"].as_str(),
+                Some("2.0.0"),
+                "Non-empty version must be preserved through the FFI layer"
+            );
+
+            let versionless = integrations
+                .iter()
+                .find(|i| i["name"] == "versionless-integration")
+                .expect("expected versionless-integration in integrations");
+            assert!(
+                versionless["version"].is_null(),
+                "Empty version string should map to null/None, got {:?}",
+                versionless["version"]
+            );
         }
     }
 }

--- a/libdd-telemetry-ffi/src/lib.rs
+++ b/libdd-telemetry-ffi/src/lib.rs
@@ -423,10 +423,11 @@ mod tests {
         target_type: &str,
         results: &mut Vec<serde_json::Value>,
     ) {
-        if value["request_type"].as_str() == Some(target_type) {
+        let request_type = value["request_type"].as_str();
+        if request_type == Some(target_type) {
             results.push(value.clone());
         }
-        if value["request_type"].as_str() == Some("message-batch") {
+        if request_type == Some("message-batch") {
             if let Some(batch) = value["payload"].as_array() {
                 for item in batch {
                     collect_payloads_recursive(item, target_type, results);

--- a/libdd-telemetry-ffi/src/lib.rs
+++ b/libdd-telemetry-ffi/src/lib.rs
@@ -114,7 +114,10 @@ mod tests {
     use libdd_common::Endpoint;
     use libdd_common_ffi as ffi;
     use libdd_telemetry::{
-        data::metrics::{MetricNamespace, MetricType},
+        data::{
+            metrics::{MetricNamespace, MetricType},
+            LogLevel,
+        },
         worker::{TelemetryWorkerBuilder, TelemetryWorkerHandle},
     };
     use std::{mem::MaybeUninit, ptr::NonNull};
@@ -550,6 +553,68 @@ mod tests {
                 versionless["version"].is_null(),
                 "Empty version string should map to null/None, got {:?}",
                 versionless["version"]
+            );
+        }
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_add_log_preserves_stack_trace() {
+        unsafe {
+            let (handle, f) = start_file_backed_worker();
+
+            ddog_telemetry_handle_add_log(
+                &handle,
+                ffi::CharSlice::from("log-with-trace"),
+                ffi::CharSlice::from("something went wrong"),
+                LogLevel::Error,
+                ffi::CharSlice::from("frame1\nframe2\nframe3"),
+            )
+            .unwrap_none();
+
+            ddog_telemetry_handle_add_log(
+                &handle,
+                ffi::CharSlice::from("log-without-trace"),
+                ffi::CharSlice::from("just a warning"),
+                LogLevel::Warn,
+                ffi::CharSlice::from(""),
+            )
+            .unwrap_none();
+
+            ddog_telemetry_handle_stop(&handle).unwrap_none();
+            ddog_telemetry_handle_wait_for_shutdown(handle);
+
+            let output = std::fs::read_to_string(f.path()).unwrap();
+            let log_payloads = find_sub_payloads(&output, "logs");
+            assert!(
+                !log_payloads.is_empty(),
+                "expected at least one logs payload in output:\n{output}"
+            );
+
+            let logs: Vec<&serde_json::Value> = log_payloads
+                .iter()
+                .filter_map(|p| p["payload"]["logs"].as_array())
+                .flatten()
+                .collect();
+
+            let with_trace = logs
+                .iter()
+                .find(|l| l["message"] == "something went wrong")
+                .expect("expected log with message 'something went wrong'");
+            assert_eq!(
+                with_trace["stack_trace"].as_str(),
+                Some("frame1\nframe2\nframe3"),
+                "Non-empty stack_trace must be preserved through the FFI layer"
+            );
+
+            let without_trace = logs
+                .iter()
+                .find(|l| l["message"] == "just a warning")
+                .expect("expected log with message 'just a warning'");
+            assert!(
+                without_trace["stack_trace"].is_null(),
+                "Empty stack_trace string should map to null/None, got {:?}",
+                without_trace["stack_trace"]
             );
         }
     }

--- a/libdd-telemetry-ffi/src/worker_handle.rs
+++ b/libdd-telemetry-ffi/src/worker_handle.rs
@@ -20,8 +20,8 @@ pub unsafe extern "C" fn ddog_telemetry_handle_add_dependency(
     dependency_version: ffi::CharSlice,
 ) -> MaybeError {
     let name = dependency_name.to_utf8_lossy().into_owned();
-    let version = (!dependency_version.is_empty())
-        .then(|| dependency_version.to_utf8_lossy().into_owned());
+    let version =
+        (!dependency_version.is_empty()).then(|| dependency_version.to_utf8_lossy().into_owned());
     crate::try_c!(handle.add_dependency(name, version));
     MaybeError::None
 }
@@ -37,8 +37,8 @@ pub unsafe extern "C" fn ddog_telemetry_handle_add_integration(
     auto_enabled: ffi::Option<bool>,
 ) -> MaybeError {
     let name = dependency_name.to_utf8_lossy().into_owned();
-    let version = (!dependency_version.is_empty())
-        .then(|| dependency_version.to_utf8_lossy().into_owned());
+    let version =
+        (!dependency_version.is_empty()).then(|| dependency_version.to_utf8_lossy().into_owned());
     crate::try_c!(handle.add_integration(
         name,
         enabled,
@@ -71,8 +71,7 @@ pub unsafe extern "C" fn ddog_telemetry_handle_add_log(
         id,
         message.to_utf8_lossy().into_owned(),
         level,
-        (!stack_trace.is_empty())
-            .then(|| stack_trace.to_utf8_lossy().into_owned()),
+        (!stack_trace.is_empty()).then(|| stack_trace.to_utf8_lossy().into_owned()),
     ));
     MaybeError::None
 }

--- a/libdd-telemetry-ffi/src/worker_handle.rs
+++ b/libdd-telemetry-ffi/src/worker_handle.rs
@@ -20,8 +20,7 @@ pub unsafe extern "C" fn ddog_telemetry_handle_add_dependency(
     dependency_version: ffi::CharSlice,
 ) -> MaybeError {
     let name = dependency_name.to_utf8_lossy().into_owned();
-    let version = dependency_version
-        .is_empty()
+    let version = (!dependency_version.is_empty())
         .then(|| dependency_version.to_utf8_lossy().into_owned());
     crate::try_c!(handle.add_dependency(name, version));
     MaybeError::None
@@ -38,8 +37,7 @@ pub unsafe extern "C" fn ddog_telemetry_handle_add_integration(
     auto_enabled: ffi::Option<bool>,
 ) -> MaybeError {
     let name = dependency_name.to_utf8_lossy().into_owned();
-    let version = dependency_version
-        .is_empty()
+    let version = (!dependency_version.is_empty())
         .then(|| dependency_version.to_utf8_lossy().into_owned());
     crate::try_c!(handle.add_integration(
         name,
@@ -73,8 +71,7 @@ pub unsafe extern "C" fn ddog_telemetry_handle_add_log(
         id,
         message.to_utf8_lossy().into_owned(),
         level,
-        stack_trace
-            .is_empty()
+        (!stack_trace.is_empty())
             .then(|| stack_trace.to_utf8_lossy().into_owned()),
     ));
     MaybeError::None

--- a/libdd-telemetry-ffi/src/worker_handle.rs
+++ b/libdd-telemetry-ffi/src/worker_handle.rs
@@ -19,9 +19,8 @@ pub unsafe extern "C" fn ddog_telemetry_handle_add_dependency(
     dependency_name: ffi::CharSlice,
     dependency_version: ffi::CharSlice,
 ) -> MaybeError {
-    let name = dependency_name.to_utf8_lossy().into_owned();
-    let version =
-        (!dependency_version.is_empty()).then(|| dependency_version.to_utf8_lossy().into_owned());
+    let name = crate::try_c!(dependency_name.try_to_string());
+    let version = crate::try_c!(dependency_version.try_to_string_option());
     crate::try_c!(handle.add_dependency(name, version));
     MaybeError::None
 }
@@ -36,9 +35,8 @@ pub unsafe extern "C" fn ddog_telemetry_handle_add_integration(
     compatible: ffi::Option<bool>,
     auto_enabled: ffi::Option<bool>,
 ) -> MaybeError {
-    let name = dependency_name.to_utf8_lossy().into_owned();
-    let version =
-        (!dependency_version.is_empty()).then(|| dependency_version.to_utf8_lossy().into_owned());
+    let name = crate::try_c!(dependency_name.try_to_string());
+    let version = crate::try_c!(dependency_version.try_to_string_option());
     crate::try_c!(handle.add_integration(
         name,
         enabled,
@@ -69,9 +67,9 @@ pub unsafe extern "C" fn ddog_telemetry_handle_add_log(
     }));
     crate::try_c!(handle.add_log(
         id,
-        message.to_utf8_lossy().into_owned(),
+        crate::try_c!(message.try_to_string()),
         level,
-        (!stack_trace.is_empty()).then(|| stack_trace.to_utf8_lossy().into_owned()),
+        crate::try_c!(stack_trace.try_to_string_option()),
     ));
     MaybeError::None
 }


### PR DESCRIPTION
# Bug

The FFI functions ddog_telemetry_handle_add_dependency, ddog_telemetry_handle_add_integration, and ddog_telemetry_handle_add_log had an inverted condition when converting optional string fields (version, stack_trace) from C slices to Rust Option<String>.

The code was using .is_empty().then(|| ...), which would populate the Option only when the input was empty — the exact opposite of the intended behavior. Non-empty values were silently dropped, and empty strings were incorrectly converted and passed through.

# Fix

Changed the condition to (!slice.is_empty()).then(|| ...) so that the Option is Some(...) when the input is non-empty and None when it is empty, as intended.

# Additional Notes

Addresses APMSP-2937

# How to test the change?

96844c851a894dd7528dd5ae30bf914c5e16ceb2 show tests with failing stuff, 14b6d1e2b79522274525625515dbc2a04bd27091 show the fix and the tests passing
