### PR TITLE
feat(data-pipeline): propagate session ids through telemetry FFI

### DIFF
--- a/libdd-data-pipeline-ffi/src/trace_exporter.rs
+++ b/libdd-data-pipeline-ffi/src/trace_exporter.rs
@@ -48,6 +48,22 @@ pub struct TelemetryClientConfig<'a> {
     /// When enabled, sets the DD-Telemetry-Debug-Enabled header to true.
     /// Defaults to false.
     pub debug_enabled: bool,
+
+    /// Stable session identifier. Sent as the `DD-Session-ID` HTTP header on
+    /// telemetry requests. An empty `CharSlice` is treated as unset.
+    pub session_id: CharSlice<'a>,
+
+    /// Identifier of the root process in a hierarchy of instrumented
+    /// processes. Sent as the `DD-Root-Session-ID` HTTP header on telemetry
+    /// requests when distinct from the session id. An empty `CharSlice` is
+    /// treated as unset.
+    pub root_session_id: CharSlice<'a>,
+
+    /// Identifier of the immediate parent process. Sent as the
+    /// `DD-Parent-Session-ID` HTTP header on telemetry requests when
+    /// distinct from the session id. An empty `CharSlice` is treated as
+    /// unset.
+    pub parent_session_id: CharSlice<'a>,
 }
 
 /// The TraceExporterConfig object will hold the configuration properties for the TraceExporter.
@@ -300,6 +316,19 @@ pub unsafe extern "C" fn ddog_trace_exporter_config_enable_telemetry(
     catch_panic!(
         if let Option::Some(config) = config {
             if let Option::Some(telemetry_cfg) = telemetry_cfg {
+                let session_id = match telemetry_cfg.session_id.try_to_string_option() {
+                    Ok(s) => s,
+                    Err(_) => return gen_error!(ErrorCode::InvalidInput),
+                };
+                let root_session_id = match telemetry_cfg.root_session_id.try_to_string_option() {
+                    Ok(s) => s,
+                    Err(_) => return gen_error!(ErrorCode::InvalidInput),
+                };
+                let parent_session_id = match telemetry_cfg.parent_session_id.try_to_string_option()
+                {
+                    Ok(s) => s,
+                    Err(_) => return gen_error!(ErrorCode::InvalidInput),
+                };
                 let cfg = TelemetryConfig {
                     heartbeat: telemetry_cfg.interval,
                     runtime_id: match sanitize_string(telemetry_cfg.runtime_id) {
@@ -307,6 +336,9 @@ pub unsafe extern "C" fn ddog_trace_exporter_config_enable_telemetry(
                         Err(e) => return Some(e),
                     },
                     debug_enabled: telemetry_cfg.debug_enabled,
+                    session_id,
+                    root_session_id,
+                    parent_session_id,
                 };
                 debug!(telemetry_cfg = ?cfg, "Configuring telemetry");
                 config.telemetry_cfg = Some(cfg);
@@ -871,6 +903,9 @@ mod tests {
                     interval: 1000,
                     runtime_id: CharSlice::from("id"),
                     debug_enabled: false,
+                    session_id: CharSlice::default(),
+                    root_session_id: CharSlice::default(),
+                    parent_session_id: CharSlice::default(),
                 }),
             );
             assert_eq!(error.as_ref().unwrap().code, ErrorCode::InvalidArgument);
@@ -888,6 +923,9 @@ mod tests {
                     interval: 1000,
                     runtime_id: CharSlice::from("foo"),
                     debug_enabled: true,
+                    session_id: CharSlice::default(),
+                    root_session_id: CharSlice::default(),
+                    parent_session_id: CharSlice::default(),
                 }),
             );
             assert!(error.is_none());
@@ -903,6 +941,46 @@ mod tests {
                 "foo"
             );
             assert!(cfg.telemetry_cfg.as_ref().unwrap().debug_enabled);
+            // Empty session CharSlices must be treated as unset.
+            assert!(cfg.telemetry_cfg.as_ref().unwrap().session_id.is_none());
+            assert!(cfg
+                .telemetry_cfg
+                .as_ref()
+                .unwrap()
+                .root_session_id
+                .is_none());
+            assert!(cfg
+                .telemetry_cfg
+                .as_ref()
+                .unwrap()
+                .parent_session_id
+                .is_none());
+        }
+    }
+
+    #[test]
+    fn config_telemetry_session_ids_test() {
+        unsafe {
+            let mut cfg = TraceExporterConfig::default();
+            let error = ddog_trace_exporter_config_enable_telemetry(
+                Some(&mut cfg),
+                Some(&TelemetryClientConfig {
+                    interval: 1000,
+                    runtime_id: CharSlice::from("runtime"),
+                    debug_enabled: false,
+                    session_id: CharSlice::from("session-abc"),
+                    root_session_id: CharSlice::from("root-xyz"),
+                    parent_session_id: CharSlice::from("parent-123"),
+                }),
+            );
+            assert!(error.is_none());
+            let telemetry_cfg = cfg.telemetry_cfg.as_ref().unwrap();
+            assert_eq!(telemetry_cfg.session_id.as_deref(), Some("session-abc"));
+            assert_eq!(telemetry_cfg.root_session_id.as_deref(), Some("root-xyz"));
+            assert_eq!(
+                telemetry_cfg.parent_session_id.as_deref(),
+                Some("parent-123")
+            );
         }
     }
 
@@ -1183,6 +1261,7 @@ mod tests {
                     heartbeat: 10000,
                     runtime_id: Some("foo".to_string()),
                     debug_enabled: true,
+                    ..Default::default()
                 }),
                 ..Default::default()
             };

--- a/libdd-data-pipeline/src/telemetry/mod.rs
+++ b/libdd-data-pipeline/src/telemetry/mod.rs
@@ -98,6 +98,29 @@ impl TelemetryClientBuilder {
         self
     }
 
+    /// Sets the stable session identifier for the telemetry client. Sent as
+    /// the `DD-Session-ID` HTTP header on telemetry requests.
+    pub fn set_session_id(mut self, id: &str) -> Self {
+        self.config.session_id = Some(id.to_string());
+        self
+    }
+
+    /// Sets the root session identifier for the telemetry client. Sent as
+    /// the `DD-Root-Session-ID` HTTP header on telemetry requests when
+    /// distinct from the session id.
+    pub fn set_root_session_id(mut self, id: &str) -> Self {
+        self.config.root_session_id = Some(id.to_string());
+        self
+    }
+
+    /// Sets the parent session identifier for the telemetry client. Sent as
+    /// the `DD-Parent-Session-ID` HTTP header on telemetry requests when
+    /// distinct from the session id.
+    pub fn set_parent_session_id(mut self, id: &str) -> Self {
+        self.config.parent_session_id = Some(id.to_string());
+        self
+    }
+
     /// Builds the telemetry client.
     pub fn build(self) -> (TelemetryClient, TelemetryWorker) {
         #[allow(clippy::unwrap_used)]
@@ -361,6 +384,34 @@ mod tests {
             builder.config.telemetry_heartbeat_interval,
             Duration::from_millis(30)
         );
+    }
+
+    #[test]
+    fn builder_session_ids_test() {
+        let builder = TelemetryClientBuilder::default()
+            .set_session_id("session-abc")
+            .set_root_session_id("root-xyz")
+            .set_parent_session_id("parent-123");
+
+        assert_eq!(builder.config.session_id.as_deref(), Some("session-abc"));
+        assert_eq!(builder.config.root_session_id.as_deref(), Some("root-xyz"));
+        assert_eq!(
+            builder.config.parent_session_id.as_deref(),
+            Some("parent-123")
+        );
+    }
+
+    #[test]
+    fn builder_session_ids_unset_by_default_test() {
+        let builder = TelemetryClientBuilder::default()
+            .set_service_name("test_service")
+            .set_language("test_language")
+            .set_language_version("1.0")
+            .set_tracer_version("1.0");
+
+        assert!(builder.config.session_id.is_none());
+        assert!(builder.config.root_session_id.is_none());
+        assert!(builder.config.parent_session_id.is_none());
     }
 
     #[cfg_attr(miri, ignore)]

--- a/libdd-data-pipeline/src/trace_exporter/builder.rs
+++ b/libdd-data-pipeline/src/trace_exporter/builder.rs
@@ -331,6 +331,15 @@ impl TraceExporterBuilder {
                     if let Some(id) = telemetry_config.runtime_id {
                         builder = builder.set_runtime_id(&id);
                     }
+                    if let Some(id) = telemetry_config.session_id {
+                        builder = builder.set_session_id(&id);
+                    }
+                    if let Some(id) = telemetry_config.root_session_id {
+                        builder = builder.set_root_session_id(&id);
+                    }
+                    if let Some(id) = telemetry_config.parent_session_id {
+                        builder = builder.set_parent_session_id(&id);
+                    }
                     Ok(builder.build())
                 });
                 match telemetry {
@@ -547,6 +556,7 @@ mod tests {
                 heartbeat: 1000,
                 runtime_id: None,
                 debug_enabled: false,
+                ..Default::default()
             });
         let exporter = builder.build::<NativeCapabilities>().unwrap();
 

--- a/libdd-data-pipeline/src/trace_exporter/mod.rs
+++ b/libdd-data-pipeline/src/trace_exporter/mod.rs
@@ -840,6 +840,17 @@ pub struct TelemetryConfig {
     pub heartbeat: u64,
     pub runtime_id: Option<String>,
     pub debug_enabled: bool,
+    /// Stable session identifier for the instrumented process. Sent as the
+    /// `DD-Session-ID` HTTP header on telemetry requests.
+    pub session_id: Option<String>,
+    /// Identifier of the root process in a hierarchy of instrumented
+    /// processes. Sent as the `DD-Root-Session-ID` HTTP header on telemetry
+    /// requests when distinct from `session_id`.
+    pub root_session_id: Option<String>,
+    /// Identifier of the immediate parent process. Sent as the
+    /// `DD-Parent-Session-ID` HTTP header on telemetry requests when
+    /// distinct from `session_id`.
+    pub parent_session_id: Option<String>,
 }
 
 #[allow(missing_docs)]


### PR DESCRIPTION
## What does this PR do?

Extends `libdd-data-pipeline` and `libdd-data-pipeline-ffi` so SDKs that drive telemetry through the trace exporter (dd-trace-dotnet, dd-trace-py, …) can attach the stable session correlation headers introduced for `libdd-telemetry` in #1817.

Concretely:

- **`libdd_data_pipeline::trace_exporter::TelemetryConfig`** gains three optional fields: `session_id`, `root_session_id`, `parent_session_id`.
- **`libdd_data_pipeline::telemetry::TelemetryClientBuilder`** gains `set_session_id` / `set_root_session_id` / `set_parent_session_id` setters mirroring the existing `set_runtime_id` pattern. Values are written onto the embedded `libdd_telemetry::config::Config` so the worker emits the corresponding `DD-Session-ID` / `DD-Root-Session-ID` / `DD-Parent-Session-ID` HTTP headers added in #1817.
- **`TraceExporterBuilder::build`** forwards the new `TelemetryConfig` fields to the pipeline builder when telemetry is enabled.
- **`libdd_data_pipeline_ffi::trace_exporter::TelemetryClientConfig`** (the FFI struct passed to `ddog_trace_exporter_config_enable_telemetry`) gains three `CharSlice` fields. Empty slices are treated as unset so callers that don't need these IDs can leave them zero-initialized.

Payload JSON is unchanged — the correlation IDs are HTTP headers only, matching the semantics already established by #1817.

## Motivation

#1817 wired session correlation into `libdd-telemetry` and exposed it through `libdd-telemetry-ffi`. SDKs that consume telemetry directly (sidecar path) can already set these IDs. SDKs that consume telemetry indirectly via the trace exporter (`ddog_trace_exporter_config_enable_telemetry`) cannot — the two FFI surfaces are separate, and `libdd-data-pipeline`'s internal `TelemetryClientBuilder` never exposed the setters.

This is the blocker for dd-trace-dotnet's `DD_TRACE_DATA_PIPELINE_ENABLED=true` code path to emit the headers that its managed transport already emits from [dd-trace-dotnet#8352](https://github.com/DataDog/dd-trace-dotnet/pull/8352). A companion dd-trace-dotnet PR will consume this once it ships.

## How to test

```bash
cargo test -p libdd-data-pipeline --lib
cargo test -p libdd-data-pipeline-ffi --lib
cargo clippy -p libdd-data-pipeline -p libdd-data-pipeline-ffi --all-targets -- -D warnings
```

New tests:
- `libdd_data_pipeline::telemetry::tests::builder_session_ids_test` — setters write through to `config`.
- `libdd_data_pipeline::telemetry::tests::builder_session_ids_unset_by_default_test` — defaults remain `None`.
- `libdd_data_pipeline_ffi::trace_exporter::tests::config_telemetry_session_ids_test` — FFI round-trips `CharSlice` IDs into `TelemetryConfig`.
- Existing `config_telemetry_test` extended to assert that empty `CharSlice` fields stay `None`.

## Additional Notes

- **ABI**: adding fields to the `#[repr(C)]` `TelemetryClientConfig` struct is a size/layout change. Consumers (dd-trace-dotnet, dd-trace-py, etc.) will need to rebuild against the new header. No source-level break for callers that use field-named initializers once they add the new fields; empty-slice defaults keep them effectively opt-in.
- **`DD-Parent-Session-ID`**: plumbed through for parity with libdd-telemetry. Whether a given SDK emits it is up to the SDK.
- **Dependent PRs**: dd-trace-dotnet follow-up to populate these fields from `Tracer.RuntimeId` / `RuntimeId.GetRootSessionId()` on the `DataPipelineEnabled=true` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
