### PR TITLE
build(profiling): rustc-hash 2.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,7 +504,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "shlex",
  "syn 2.0.87",
 ]
@@ -3178,7 +3178,7 @@ dependencies = [
  "prost",
  "rand 0.8.5",
  "reqwest",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "rustls",
  "rustls-platform-verifier",
  "serde",
@@ -4744,12 +4744,6 @@ name = "rustc-demangle"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -343,7 +343,6 @@ rmp,https://github.com/3Hren/msgpack-rust,MIT,Evgeny Safronov <division494@gmail
 rmp-serde,https://github.com/3Hren/msgpack-rust,MIT,Evgeny Safronov <division494@gmail.com>
 rmpv,https://github.com/3Hren/msgpack-rust,MIT,Evgeny Safronov <division494@gmail.com>
 rustc-demangle,https://github.com/rust-lang/rustc-demangle,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
-rustc-hash,https://github.com/rust-lang-nursery/rustc-hash,Apache-2.0 OR MIT,The Rust Project Developers
 rustc-hash,https://github.com/rust-lang/rustc-hash,Apache-2.0 OR MIT,The Rust Project Developers
 rustix,https://github.com/bytecodealliance/rustix,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,"Dan Gohman <dev@sunfishcode.online>, Jakub Konka <kubkon@jakubkonka.com>"
 rustls,https://github.com/rustls/rustls,Apache-2.0 OR ISC OR MIT,The rustls Authors

--- a/libdd-profiling/Cargo.toml
+++ b/libdd-profiling/Cargo.toml
@@ -57,7 +57,7 @@ rand = "0.8"
 # backend. We install the ring provider explicitly via tls.rs / libdd-common instead.
 reqwest = { version = "0.13.2", features = ["multipart", "rustls-no-provider", "hickory-dns"], default-features = false}
 rustls-platform-verifier = "0.6"
-rustc-hash = { version = "1.1", default-features = false }
+rustc-hash = { version = "2.1", default-features = false }
 serde = {version = "1.0", features = ["derive"]}
 serde_json = {version = "1.0"}
 target-triple = "0.1.4"


### PR DESCRIPTION
# What does this PR do?

This updates from rustc-hash 1.1 to 2.1.2.

# Motivation

This is general maintenance but the hash quality is better in some cases, leading to improvements in bench `profile_add_sample2_frames_x1000`:

```
On main:
run 1: 253.57 µs
run 2: 266.87 µs
run 3: 262.89 µs

On this branch:
run 1: 239.81 µs
run 2: 233.25 µs
run 3: 243.97 µs
```

On real code (not adding the same specific thing over and over again), your results may be better or worse.

# Additional Notes

I have a commit in 2.1.2, though it's not particularly relevant: it removes an unreachable panic from the generated code.

# How to test the change?

Regular testing applies.