### PR TITLE
chore: release v32.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,7 +696,7 @@ checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "build_common"
-version = "32.0.0"
+version = "32.1.0"
 dependencies = [
  "cbindgen",
  "serde",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "builder"
-version = "32.0.0"
+version = "32.1.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1465,7 +1465,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-replayer"
-version = "32.0.0"
+version = "32.1.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1601,7 +1601,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-tracer-flare"
-version = "32.0.0"
+version = "32.1.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2903,7 +2903,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-common-ffi"
-version = "32.0.0"
+version = "32.1.0"
 dependencies = [
  "anyhow",
  "assert_no_alloc",
@@ -2956,7 +2956,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-crashtracker-ffi"
-version = "32.0.0"
+version = "32.1.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -3014,7 +3014,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-data-pipeline-ffi"
-version = "32.0.0"
+version = "32.1.0"
 dependencies = [
  "build_common",
  "httpmock",
@@ -3039,7 +3039,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-ddsketch-ffi"
-version = "32.0.0"
+version = "32.1.0"
 dependencies = [
  "build_common",
  "libdd-common-ffi",
@@ -3061,7 +3061,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-http-client"
-version = "32.0.0"
+version = "32.1.0"
 dependencies = [
  "bytes",
  "fastrand",
@@ -3132,7 +3132,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-log-ffi"
-version = "32.0.0"
+version = "32.1.0"
 dependencies = [
  "build_common",
  "libdd-common-ffi",
@@ -3244,7 +3244,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-shared-runtime-ffi"
-version = "32.0.0"
+version = "32.1.0"
 dependencies = [
  "build_common",
  "libdd-shared-runtime",
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-telemetry-ffi"
-version = "32.0.0"
+version = "32.1.0"
 dependencies = [
  "build_common",
  "function_name",
@@ -5502,7 +5502,7 @@ dependencies = [
 
 [[package]]
 name = "symbolizer-ffi"
-version = "32.0.0"
+version = "32.1.0"
 dependencies = [
  "blazesym-c",
  "build_common",
@@ -5944,7 +5944,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "32.0.0"
+version = "32.1.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.84.1"
 edition = "2021"
-version = "32.0.0"
+version = "32.1.0"
 license = "Apache-2.0"
 authors = ["Datadog Inc. <info@datadoghq.com>"]
 


### PR DESCRIPTION
Bump workspace version to `32.1.0` and regenerate lockfile.