### PR TITLE
feat: add PartialEq and Eq traits to TracerMetadata

### DIFF
--- a/libdd-library-config/src/tracer_metadata.rs
+++ b/libdd-library-config/src/tracer_metadata.rs
@@ -4,7 +4,7 @@ use libdd_trace_protobuf::opentelemetry::proto as otel_proto;
 use std::default::Default;
 
 /// This struct MUST be backward compatible.
-#[derive(serde::Serialize, Debug)]
+#[derive(serde::Serialize, Debug, PartialEq, Eq)]
 pub struct TracerMetadata {
     /// Version of the schema.
     pub schema_version: u8,

--- a/libdd-library-config/src/tracer_metadata.rs
+++ b/libdd-library-config/src/tracer_metadata.rs
@@ -248,6 +248,25 @@ mod tests {
     }
 
     #[test]
+    fn tracer_metadata_equality() {
+        let a = TracerMetadata {
+            tracer_language: "python".into(),
+            ..Default::default()
+        };
+        let b = TracerMetadata {
+            tracer_language: "python".into(),
+            ..Default::default()
+        };
+        let c = TracerMetadata {
+            tracer_language: "ruby".into(),
+            ..Default::default()
+        };
+
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
     fn threadlocal_attrs_absent_when_keys_empty() {
         let ctx = TracerMetadata::default().to_otel_process_ctx();
 


### PR DESCRIPTION
# What does this PR do?

Derives PartialEq and Eq on TracerMetadata, enabling equality comparisons between instances using `==` and `!=`.

# Motivation

Adding these standard library traits enables equality assertions without requiring callers to implement their own field by field comparison. Needed for https://github.com/DataDog/serverless-components/pull/51#discussion_r3029346636

# Additional Notes

# How to test the change?

Unit tests
