### PR TITLE
ci: add a test run with all features enabled

### DIFF
--- a/.github/workflows/test-ffi.yml
+++ b/.github/workflows/test-ffi.yml
@@ -103,6 +103,13 @@ jobs:
         # On Windows run happens in a PowerShell, so start bash explicitly
         run: bash -c 'echo "version=$(rustc --version)" >> $GITHUB_OUTPUT'
 
+      - name: Install Go (macOS)
+        if: runner.os == 'macOS'
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: 'stable'
+          cache: false
+
       - name: Cache [rust]
         uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # 2.8.1
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,6 +115,12 @@ jobs:
         uses: taiki-e/install-action@2c41309d51ede152b6f2ee6bf3b71e6dc9a8b7df # 2.49.27
         with:
           tool: nextest@0.9.96
+      - name: Install Go (macOS)
+        if: runner.os == 'macOS'
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: 'stable'
+          cache: false
       - name: Cache [rust]
         uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # 2.8.1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -164,10 +164,10 @@ jobs:
         shell: bash
         run: |
           if [[ -z "$PACKAGES" ]]; then
-            cargo nextest run --workspace --all-features --exclude builder --verbose -E '!test(tracing_integration_tests::)'
+            cargo nextest run --workspace --all-features --exclude builder --exclude test_spawn_from_lib --verbose -E '!test(tracing_integration_tests::)'
           else
             # shellcheck disable=SC2086
-            cargo nextest run $PACKAGES --all-features --verbose -E '!test(tracing_integration_tests::)'
+            cargo nextest run $PACKAGES --all-features --verbose -E '!test(tracing_integration_tests::) & !package(test_spawn_from_lib)'
           fi
         env:
           RUST_BACKTRACE: full

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,6 +154,17 @@ jobs:
           fi
         env:
           RUST_BACKTRACE: full
+      - name: "[${{ steps.rust-version.outputs.version}}] cargo nextest run --all-features"
+        shell: bash
+        run: |
+          if [[ -z "$PACKAGES" ]]; then
+            cargo nextest run --workspace --all-features --exclude builder --verbose -E '!test(tracing_integration_tests::)'
+          else
+            # shellcheck disable=SC2086
+            cargo nextest run $PACKAGES --all-features --verbose -E '!test(tracing_integration_tests::)'
+          fi
+        env:
+          RUST_BACKTRACE: full
       - name: "[${{ steps.rust-version.outputs.version}}] Tracing integration tests"
         if: runner.os == 'Linux'
         shell: bash


### PR DESCRIPTION
# What does this PR do?

Crates should be able to compile and run the tests with `--no-default-features` and `--all-features`

# Motivation

While trying to publish a new crate I found that libdd-common was not passing the release stage due to a failure when compiling with `--all-features`.
