### PR TITLE
fix(sidecar/telemetry): retry FFI telemetry batches when session conifg not yet available

### DIFF
--- a/datadog-sidecar/src/service/telemetry.rs
+++ b/datadog-sidecar/src/service/telemetry.rs
@@ -13,7 +13,7 @@ use crate::primary_sidecar_identifier;
 use base64::prelude::BASE64_URL_SAFE_NO_PAD;
 use base64::Engine;
 use datadog_ipc::platform::NamedShmHandle;
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::ffi::CString;
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
@@ -36,7 +36,274 @@ use libdd_telemetry::metrics::{ContextKey, MetricContext};
 use libdd_telemetry::worker::{LifecycleAction, TelemetryActions, TelemetryWorkerHandle};
 use manual_future::ManualFuture;
 use serde_with::{serde_as, VecSkipError};
-use tokio::time::sleep;
+use tokio::time::{sleep, sleep_until, Instant as TokioInstant};
+
+#[derive(Debug)]
+pub struct InternalTelemetryActions {
+    pub instance_id: InstanceId,
+    pub service_name: String,
+    pub env_name: String,
+    pub actions: Vec<InternalTelemetryAction>,
+}
+
+#[derive(Debug)]
+pub enum InternalTelemetryAction {
+    TelemetryAction(TelemetryActions),
+    RegisterTelemetryMetric(MetricContext),
+    AddMetricPoint((f64, String, Vec<Tag>)),
+}
+
+pub(crate) async fn telemetry_action_receiver_task(
+    sidecar: SidecarServer,
+    mut rx: mpsc::Receiver<InternalTelemetryActions>,
+) {
+    info!("Starting telemetry action receiver task...");
+    let mut pending: Vec<PerClientTelemetryBatch> = Vec::new();
+
+    while let Some(batch) = next_entry(&mut pending, &mut rx).await {
+        let Some(telemetry_client) = batch.get_client(&sidecar) else {
+            batch.defer_or_drop(&mut pending);
+            continue;
+        };
+
+        let Some(client) = telemetry_client
+            .lock_or_panic()
+            .as_ref()
+            .map(|t| t.worker.clone())
+        else {
+            warn!(
+                "Telemetry client stopped before delivery for {}/{}; dropping {} actions",
+                batch.service_name(),
+                batch.env_name(),
+                batch.action_count(),
+            );
+            continue;
+        };
+
+        batch.deliver(&telemetry_client, &client).await;
+    }
+
+    let total_pending: usize = pending.iter().map(|s| s.actions.len()).sum();
+    if total_pending > 0 {
+        warn!(
+            "Telemetry action receiver task shutting down with {total_pending} undelivered \
+             pending batches",
+        );
+    }
+    info!("Telemetry action receiver task shutting down.");
+}
+
+async fn next_entry(
+    pending: &mut Vec<PerClientTelemetryBatch>,
+    rx: &mut mpsc::Receiver<InternalTelemetryActions>,
+) -> Option<TelemetryBatch> {
+    loop {
+        if pending.is_empty() {
+            return rx.recv().await.map(TelemetryBatch::Fresh);
+        }
+
+        // we have batches to retry
+
+        #[allow(clippy::unwrap_used)]
+        let min_pos = pending
+            .iter()
+            .enumerate()
+            .min_by_key(|(_, s)| s.next_attempt_at)
+            .map(|(i, _)| i)
+            .unwrap();
+        let deadline = pending[min_pos].next_attempt_at;
+
+        tokio::select! {
+            biased;
+            _ = sleep_until(deadline) => {
+                return Some(TelemetryBatch::Deferred(pending.swap_remove(min_pos)));
+            }
+            result = rx.recv() => match result {
+                Some(batch) => {
+                    let key = (batch.service_name.as_str(), batch.env_name.as_str());
+                    if let Some(deferred) = pending.iter_mut().find(|s| s.key.0 == key.0 && s.key.1 == key.1) {
+                        deferred.actions.push_back(batch);
+                    } else {
+                        return Some(TelemetryBatch::Fresh(batch));
+                    }
+                }
+                None => return None,
+            },
+        }
+    }
+}
+
+async fn deliver_batch(
+    actions: Vec<InternalTelemetryAction>,
+    telemetry_client: &Arc<Mutex<Option<TelemetryCachedClient>>>,
+    client: &TelemetryWorkerHandle,
+) {
+    for it_action in actions {
+        match it_action {
+            InternalTelemetryAction::TelemetryAction(action) => {
+                let action_str = format!("{action:?}");
+                match client.send_msg(action).await {
+                    Ok(_) => debug!("Sent telemetry action to TelemetryWorker: {action_str}"),
+                    Err(e) => warn!(
+                        "Failed to send telemetry action {action_str} to TelemetryWorker: {e}"
+                    ),
+                }
+            }
+            InternalTelemetryAction::RegisterTelemetryMetric(metric) => {
+                debug!("Registered telemetry metric: {metric:?}");
+                if let Some(t) = telemetry_client.lock_or_panic().as_mut() {
+                    t.register_metric(metric);
+                }
+            }
+            InternalTelemetryAction::AddMetricPoint((value, name, tags)) => {
+                let metric_name = name.clone();
+                let point = telemetry_client
+                    .lock_or_panic()
+                    .as_ref()
+                    .and_then(|t| t.to_telemetry_point((name, value, tags)));
+                match point {
+                    Some(p) => {
+                        if let Err(e) = client.send_msg(p).await {
+                            warn!("Failed to send telemetry point to TelemetryWorker: {e}");
+                        }
+                    }
+                    None => warn!(
+                        "Attempted to send telemetry point for unregistered metric: {metric_name}"
+                    ),
+                }
+            }
+        }
+    }
+}
+
+enum TelemetryBatch {
+    Fresh(InternalTelemetryActions),
+    Deferred(PerClientTelemetryBatch),
+}
+
+impl TelemetryBatch {
+    fn service_name(&self) -> &str {
+        match self {
+            TelemetryBatch::Fresh(a) => &a.service_name,
+            TelemetryBatch::Deferred(d) => &d.key.0,
+        }
+    }
+
+    fn env_name(&self) -> &str {
+        match self {
+            TelemetryBatch::Fresh(a) => &a.env_name,
+            TelemetryBatch::Deferred(d) => &d.key.1,
+        }
+    }
+
+    fn action_count(&self) -> usize {
+        match self {
+            TelemetryBatch::Fresh(a) => a.actions.len(),
+            TelemetryBatch::Deferred(d) => d.actions.iter().map(|b| b.actions.len()).sum(),
+        }
+    }
+
+    fn get_client(
+        &self,
+        sidecar: &SidecarServer,
+    ) -> Option<Arc<Mutex<Option<TelemetryCachedClient>>>> {
+        match self {
+            TelemetryBatch::Fresh(a) => {
+                get_telemetry_client(sidecar, &a.instance_id, &a.service_name, &a.env_name)
+            }
+            TelemetryBatch::Deferred(d) => {
+                let (service_name, env_name) = &d.key;
+                let mut tried_sessions = HashSet::new();
+                for b in &d.actions {
+                    if tried_sessions.insert(b.instance_id.session_id.as_str()) {
+                        // repeated calls to get_existing_client could be avoided
+                        if let Some(client) =
+                            get_telemetry_client(sidecar, &b.instance_id, service_name, env_name)
+                        {
+                            return Some(client);
+                        }
+                    }
+                }
+                None
+            }
+        }
+    }
+
+    const RETRY_DELAY: Duration = Duration::from_millis(1500);
+    const MAX_ATTEMPTS: u8 = 3;
+
+    fn defer_or_drop(self, pending: &mut Vec<PerClientTelemetryBatch>) {
+        match self {
+            TelemetryBatch::Fresh(actions) => {
+                info!(
+                    "No telemetry session config for {}/{}, \
+                     retrying in {}ms ({} left)",
+                    actions.service_name,
+                    actions.env_name,
+                    Self::RETRY_DELAY.as_millis(),
+                    Self::MAX_ATTEMPTS - 1,
+                );
+                let next_at = TokioInstant::now() + Self::RETRY_DELAY;
+                pending.push(PerClientTelemetryBatch {
+                    key: (actions.service_name.clone(), actions.env_name.clone()),
+                    actions: VecDeque::from([actions]),
+                    attempts_left: Self::MAX_ATTEMPTS - 1,
+                    next_attempt_at: next_at,
+                });
+            }
+            TelemetryBatch::Deferred(deferred) => {
+                debug_assert!(!deferred.actions.is_empty());
+                let (service_name, env_name) = &deferred.key;
+                let remaining = deferred.attempts_left - 1;
+                if remaining > 0 {
+                    info!(
+                        "No telemetry session config for {service_name}/{env_name}, \
+                         retrying in {}ms ({remaining} left)",
+                        Self::RETRY_DELAY.as_millis(),
+                    );
+                    pending.push(PerClientTelemetryBatch {
+                        key: deferred.key,
+                        actions: deferred.actions,
+                        attempts_left: remaining,
+                        next_attempt_at: TokioInstant::now() + Self::RETRY_DELAY,
+                    });
+                } else {
+                    let count: usize = deferred.actions.iter().map(|b| b.actions.len()).sum();
+                    warn!(
+                        "Dropping {count} telemetry actions for {service_name}/{env_name}: \
+                         session_config never arrived after {} attempts",
+                        Self::MAX_ATTEMPTS,
+                    );
+                }
+            }
+        }
+    }
+
+    async fn deliver(
+        self,
+        telemetry_client: &Arc<Mutex<Option<TelemetryCachedClient>>>,
+        client: &TelemetryWorkerHandle,
+    ) {
+        match self {
+            TelemetryBatch::Fresh(actions) => {
+                deliver_batch(actions.actions, telemetry_client, client).await;
+            }
+            TelemetryBatch::Deferred(deferred) => {
+                debug_assert!(!deferred.actions.is_empty());
+                for batch in deferred.actions {
+                    deliver_batch(batch.actions, telemetry_client, client).await;
+                }
+            }
+        }
+    }
+}
+
+struct PerClientTelemetryBatch {
+    key: TelemetryCachedClientKey,
+    actions: VecDeque<InternalTelemetryActions>, // invariant: non-empty
+    attempts_left: u8,
+    next_attempt_at: TokioInstant,
+}
 
 type ComposerCache = HashMap<PathBuf, (SystemTime, Arc<Vec<data::Dependency>>)>;
 
@@ -317,6 +584,17 @@ impl Clone for TelemetryCachedClientSet {
 }
 
 impl TelemetryCachedClientSet {
+    fn get_existing_client(
+        &self,
+        service: &str,
+        env: &str,
+    ) -> Option<Arc<Mutex<Option<TelemetryCachedClient>>>> {
+        let key = (service.to_string(), env.to_string());
+
+        let map = self.inner.lock_or_panic();
+        map.get(&key).map(|e| e.client.clone())
+    }
+
     pub fn get_or_create<F>(
         &self,
         service: &str,
@@ -329,17 +607,8 @@ impl TelemetryCachedClientSet {
     where
         F: FnOnce() -> Config,
     {
-        let key = (service.to_string(), env.to_string());
-
-        let mut map = self.inner.lock_or_panic();
-
-        if let Some(existing) = map.get_mut(&key) {
-            if existing.client.lock_or_panic().is_some() {
-                existing.last_used = Instant::now();
-                info!("Reusing existing telemetry client for {key:?}");
-                return existing.client.clone();
-            }
-            // Dead (None) entry — fall through to replace it with a fresh client.
+        if let Some(existing) = self.get_existing_client(service, env) {
+            return existing;
         }
 
         let new_client = Arc::new(Mutex::new(Some(TelemetryCachedClient::new(
@@ -350,6 +619,9 @@ impl TelemetryCachedClientSet {
             get_config,
             process_tags,
         ))));
+
+        let mut map = self.inner.lock_or_panic();
+        let key = (service.to_string(), env.to_string());
         map.insert(
             key.clone(),
             TelemetryCachedEntry {
@@ -386,21 +658,6 @@ pub fn path_for_telemetry(service: &str, env: &str) -> CString {
     CString::new(path).unwrap()
 }
 
-#[derive(Debug)]
-pub enum InternalTelemetryAction {
-    TelemetryAction(TelemetryActions),
-    RegisterTelemetryMetric(MetricContext),
-    AddMetricPoint((f64, String, Vec<Tag>)),
-}
-
-#[derive(Debug)]
-pub struct InternalTelemetryActions {
-    pub instance_id: InstanceId,
-    pub service_name: String,
-    pub env_name: String,
-    pub actions: Vec<InternalTelemetryAction>,
-}
-
 pub fn get_telemetry_action_sender() -> Result<mpsc::Sender<InternalTelemetryActions>> {
     TELEMETRY_ACTION_SENDER
         .get()
@@ -417,77 +674,19 @@ pub(crate) fn init_telemetry_sender() -> Option<mpsc::Receiver<InternalTelemetry
     Some(rx)
 }
 
-pub(crate) async fn telemetry_action_receiver_task(
-    sidecar: SidecarServer,
-    mut rx: mpsc::Receiver<InternalTelemetryActions>,
-) {
-    info!("Starting telemetry action receiver task...");
-
-    while let Some(actions) = rx.recv().await {
-        let telemetry_client = get_telemetry_client(
-            &sidecar,
-            &actions.instance_id,
-            &actions.service_name,
-            &actions.env_name,
-        );
-        let Some(client) = telemetry_client
-            .lock_or_panic()
-            .as_ref()
-            .map(|t| t.worker.clone())
-        else {
-            continue;
-        };
-
-        for it_action in actions.actions {
-            match it_action {
-                InternalTelemetryAction::TelemetryAction(action) => {
-                    let action_str = format!("{action:?}");
-                    match client.send_msg(action).await {
-                        Ok(_) => {
-                            debug!("Sent telemetry action to TelemetryWorker: {action_str}");
-                        }
-                        Err(e) => {
-                            warn!("Failed to send telemetry action {action_str} to TelemetryWorker: {e}");
-                        }
-                    }
-                }
-                InternalTelemetryAction::RegisterTelemetryMetric(metric) => {
-                    debug!("Registered telemetry metric: {metric:?}");
-                    if let Some(t) = telemetry_client.lock_or_panic().as_mut() {
-                        t.register_metric(metric);
-                    }
-                }
-                InternalTelemetryAction::AddMetricPoint((value, name, tags)) => {
-                    let metric_name = name.clone();
-                    let actions_point_opt = {
-                        telemetry_client
-                            .lock_or_panic()
-                            .as_ref()
-                            .and_then(|t| t.to_telemetry_point((name, value, tags)))
-                    };
-                    if let Some(actions_point) = actions_point_opt {
-                        match client.send_msg(actions_point).await {
-                            Ok(_) => {}
-                            Err(e) => {
-                                warn!("Failed to send telemetry point to TelemetryWorker: {e}");
-                            }
-                        }
-                    } else {
-                        warn!("Attempted to send telemetry point for unregistered metric: {metric_name}");
-                    }
-                }
-            }
-        }
-    }
-    info!("Telemetry action receiver task shutting down.");
-}
-
 fn get_telemetry_client(
     sidecar: &SidecarServer,
     instance_id: &InstanceId,
     service_name: &str,
     env_name: &str,
-) -> Arc<Mutex<Option<TelemetryCachedClient>>> {
+) -> Option<Arc<Mutex<Option<TelemetryCachedClient>>>> {
+    if let Some(existing) = sidecar
+        .telemetry_clients
+        .get_existing_client(service_name, env_name)
+    {
+        return Some(existing);
+    }
+
     let session = sidecar.get_session(&instance_id.session_id);
     let trace_config = session.get_trace_config();
     let runtime_meta = RuntimeMetadata::new(
@@ -496,28 +695,20 @@ fn get_telemetry_client(
         trace_config.tracer_version.as_str(),
     );
 
-    let get_config = || {
-        sidecar
-            .get_session(&instance_id.session_id)
-            .session_config
-            .lock_or_panic()
-            .as_ref()
-            .cloned()
-            .unwrap_or_else(|| {
-                warn!("Failed to get telemetry session config for {instance_id:?}.");
-                Config::default()
-            })
+    let session_config = session.session_config.lock_or_panic().as_ref().cloned();
+    let Some(session_config) = session_config else {
+        // Session config not yet available (need to wait for set_session_config IPC)
+        return None;
     };
 
     let process_tags = session.process_tags.lock_or_panic().clone();
 
-    TelemetryCachedClientSet::get_or_create(
-        &sidecar.telemetry_clients,
+    Some(sidecar.telemetry_clients.get_or_create(
         service_name,
         env_name,
         instance_id,
         &runtime_meta,
-        get_config,
+        move || session_config,
         process_tags,
-    )
+    ))
 }

--- a/libdd-telemetry-ffi/src/lib.rs
+++ b/libdd-telemetry-ffi/src/lib.rs
@@ -23,6 +23,7 @@ macro_rules! c_setters {
         paste::paste! {
             $(
                 #[no_mangle]
+                #[allow(clippy::missing_safety_doc)]
                 pub unsafe extern "C" fn [<ddog_ $object_name _with_ $property_type_name_snakecase _ $path $(_ $path_rest)* >](
                     $object_name: &mut $object_ty,
                     param: $property_type,
@@ -39,6 +40,7 @@ macro_rules! c_setters {
             }
 
             #[no_mangle]
+            #[allow(clippy::missing_safety_doc)]
             #[doc=concat!(
                 "\n Sets a property from it's string value.\n\n",
                 " Available properties:\n\n",
@@ -61,6 +63,7 @@ macro_rules! c_setters {
             }
 
             #[no_mangle]
+            #[allow(clippy::missing_safety_doc)]
             #[doc=concat!(
                 "\n Sets a property from it's string value.\n\n",
                 " Available properties:\n\n",


### PR DESCRIPTION
# What does this PR do?

When the appsec helper posts telemetry via the in-process FFI path before the PHP IPC set_session_config message is processed, the telemetry client cache would be poisoned with a Config { endpoint: None } worker. All subsequent IPC enqueue_actions calls (including AddEndpoint) would reuse this bad client and never send HTTP requests to the agent, causing the Laravel8xTests "Endpoints are sent" test to time out.

Fix: when get_telemetry_client finds session_config is None, return None instead of calling get_or_create with Config::default(). The receiver task retries the batch up to 3 times with a 1.5 s delay before dropping. In the normal case set_session_config arrives within milliseconds so the first retry succeeds and no telemetry is lost.


# How to test the change?

Tested via `./gradlew test7.4-debug --tests "com.datadog.appsec.php.integration.Laravel8xTests.Endpoints are sent" -PuseHelperRust`. The error reproduced reliably on my machine after at most 3 or 4 retries.
