### PR TITLE
fix(libdd-common): crashes caused by `getenv` while retrieving AAS env vars

### DIFF
--- a/libdd-common/src/azure_app_services.rs
+++ b/libdd-common/src/azure_app_services.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use regex::Regex;
+#[cfg(target_os = "linux")]
+use std::collections::HashMap;
 use std::sync::LazyLock;
 
 const WEBSITE_OWNER_NAME: &str = "WEBSITE_OWNER_NAME";
@@ -25,7 +27,8 @@ enum AzureContext {
     AzureAppService,
 }
 
-/// Snapshot of the process environment as captured at exec time.
+/// Snapshot of the AAS-relevant subset of the process environment, captured at
+/// exec time.
 ///
 /// On Linux we parse `/proc/self/environ` (a kernel-managed snapshot of the
 /// initial `envp` block) instead of calling `getenv`. This avoids the
@@ -39,11 +42,36 @@ enum AzureContext {
 /// needs — every Azure App Services / Functions variable we inspect is set by
 /// the platform before the process starts.
 ///
+/// **Only the AAS variable names listed in [`AAS_VAR_NAMES`] are retained**;
+/// all other entries (which on real AAS deployments commonly include unrelated
+/// app secrets, API keys, connection strings, etc.) are dropped at parse time
+/// so we don't keep a long-lived in-memory copy of them.
+///
 /// On non-Linux platforms we fall back to `std::env::var`. AAS deployments are
 /// almost exclusively Linux containers, and Windows' `GetEnvironmentVariableW`
 /// (which `std::env::var` uses) is itself thread-safe.
 #[cfg(target_os = "linux")]
 static PROC_ENVIRON: LazyLock<HashMap<String, String>> = LazyLock::new(read_proc_self_environ);
+
+/// AAS-related variable names this module reads. Only entries with one of
+/// these names are kept in [`PROC_ENVIRON`]; everything else from
+/// `/proc/self/environ` is dropped at parse time.
+#[cfg(target_os = "linux")]
+const AAS_VAR_NAMES: &[&str] = &[
+    WEBSITE_OWNER_NAME,
+    WEBSITE_SITE_NAME,
+    WEBSITE_RESOURCE_GROUP,
+    SITE_EXTENSION_VERSION,
+    WEBSITE_OS,
+    INSTANCE_NAME,
+    INSTANCE_ID,
+    SERVICE_CONTEXT,
+    FUNCTIONS_WORKER_RUNTIME,
+    FUNCTIONS_WORKER_RUNTIME_VERSION,
+    FUNCTIONS_EXTENSION_VERSION,
+    DD_AZURE_RESOURCE_GROUP,
+    WEBSITE_SKU,
+];
 
 #[cfg(target_os = "linux")]
 fn read_proc_self_environ() -> HashMap<String, String> {
@@ -61,7 +89,10 @@ fn read_proc_self_environ() -> HashMap<String, String> {
             Err(_) => continue,
         };
         if let Some(eq) = s.find('=') {
-            map.insert(s[..eq].to_string(), s[eq + 1..].to_string());
+            let key = &s[..eq];
+            if AAS_VAR_NAMES.contains(&key) {
+                map.insert(key.to_string(), s[eq + 1..].to_string());
+            }
         }
     }
     map

--- a/libdd-common/src/azure_app_services.rs
+++ b/libdd-common/src/azure_app_services.rs
@@ -29,7 +29,7 @@ enum AzureContext {
 /// Snapshot of the process environment as captured at exec time.
 ///
 /// On Linux we parse `/proc/self/environ` (a kernel-managed snapshot of the
-/// initial `envp` block) instead of calling `getenv()`. This avoids the
+/// initial `envp` block) instead of calling `getenv`. This avoids the
 /// well-known race between libc's `getenv(3)` and `setenv(3)` from another
 /// thread, which has been observed to crash `ddog_prof_Exporter_new` when an
 /// embedder (e.g. dd-trace-py via `os.environ[...] = ...`) mutates the

--- a/libdd-common/src/azure_app_services.rs
+++ b/libdd-common/src/azure_app_services.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use regex::Regex;
-use std::env;
+use std::collections::HashMap;
 use std::sync::LazyLock;
 
 const WEBSITE_OWNER_NAME: &str = "WEBSITE_OWNER_NAME";
@@ -26,10 +26,62 @@ enum AzureContext {
     AzureAppService,
 }
 
+/// Snapshot of the process environment as captured at exec time.
+///
+/// On Linux we parse `/proc/self/environ` (a kernel-managed snapshot of the
+/// initial `envp` block) instead of calling `getenv()`. This avoids the
+/// well-known race between libc's `getenv(3)` and `setenv(3)` from another
+/// thread, which has been observed to crash `ddog_prof_Exporter_new` when an
+/// embedder (e.g. dd-trace-py via `os.environ[...] = ...`) mutates the
+/// environment concurrently with our AAS detection.
+///
+/// `/proc/self/environ` only contains variables present at `execve()` time;
+/// later `setenv` calls are not reflected. That is exactly what AAS detection
+/// needs — every Azure App Services / Functions variable we inspect is set by
+/// the platform before the process starts.
+///
+/// On non-Linux platforms we fall back to `std::env::var`. AAS deployments are
+/// almost exclusively Linux containers, and Windows' `GetEnvironmentVariableW`
+/// (which `std::env::var` uses) is itself thread-safe.
+#[cfg(target_os = "linux")]
+static PROC_ENVIRON: LazyLock<HashMap<String, String>> = LazyLock::new(read_proc_self_environ);
+
+#[cfg(target_os = "linux")]
+fn read_proc_self_environ() -> HashMap<String, String> {
+    let bytes = match std::fs::read("/proc/self/environ") {
+        Ok(b) => b,
+        Err(_) => return HashMap::new(),
+    };
+    let mut map = HashMap::new();
+    for entry in bytes.split(|&b| b == 0) {
+        if entry.is_empty() {
+            continue;
+        }
+        let s = match std::str::from_utf8(entry) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        if let Some(eq) = s.find('=') {
+            map.insert(s[..eq].to_string(), s[eq + 1..].to_string());
+        }
+    }
+    map
+}
+
+fn read_aas_var(name: &str) -> Option<String> {
+    #[cfg(target_os = "linux")]
+    {
+        PROC_ENVIRON.get(name).cloned()
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        std::env::var(name).ok()
+    }
+}
+
 macro_rules! get_trimmed_env_var {
     ($name:expr) => {
-        env::var($name)
-            .ok()
+        crate::azure_app_services::read_aas_var($name)
             .map(|v| v.trim().to_string())
             .filter(|s| !s.is_empty())
     };
@@ -912,11 +964,12 @@ mod tests {
     }
 
     #[test]
-    fn test_get_trimmed_env_var_empty_string() {
-        env::remove_var("TEST_VAR_NONE");
-        assert_eq!(get_trimmed_env_var!("TEST_VAR_NONE"), None);
-
-        env::set_var("TEST_VAR_EMPTY_STRING", "");
-        assert_eq!(get_trimmed_env_var!("TEST_VAR_EMPTY_STRING"), None);
+    fn test_get_trimmed_env_var_missing() {
+        // The proc-environ snapshot is frozen at exec time, so we can't inject
+        // an empty value here. Just verify the missing-var path returns None.
+        assert_eq!(
+            get_trimmed_env_var!("__LIBDD_AAS_DEFINITELY_NOT_SET__"),
+            None
+        );
     }
 }

--- a/libdd-common/src/azure_app_services.rs
+++ b/libdd-common/src/azure_app_services.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use regex::Regex;
-use std::collections::HashMap;
 use std::sync::LazyLock;
 
 const WEBSITE_OWNER_NAME: &str = "WEBSITE_OWNER_NAME";


### PR DESCRIPTION
# What does this PR do?

This PR reads `/proc/self/environ` to populate AAS metadata (from env var) instead of using `getenv`.

# Motivation

`getenv` is not thread-safe. A call can crash if another thread is calling `setenv`. This will invalidate the `environ` pointers and cause a crash.

```
0x79319d662c1d __GI_getenv (stdlib/stdlib/getenv.c:84)
0x7931996ccec6 std::sys::env::unix::getenv::{{closure}}
0x7931996ccdd5 std::env::_var_os
0x7931996d1acb std::env::_var
0x7931993daf7f <libdd_common::azure_app_services::RealEnv as libdd_common::azure_app_services::QueryEnv>::get_var
0x7931993da137 core::ops::function::FnOnce::call_once
0x7931994cbffb std::sync::poison::once::Once::call_once_force::{{closure}}
0x7931996d0557 std::sys::sync::once::futex::Once::call
0x7931994ca917 libdd_profiling::exporter::profile_exporter::ProfileExporter::new
0x79319933b201 ddog_prof_Exporter_new
0x79319b15695d Datadog::UploaderBuilder::build()
0x79319b157667 ddup_upload
0x793044b34f3a __pyx_pw_7ddtrace_8internal_7datadog_9profiling_4ddup_5_ddup_7upload(_object*, _object* const*, long, _object*)
_PyErr_Occurred (/usr/src/python/Include/internal/pycore_pyerrors.h:23)
_Py_CheckFunctionResult (/usr/src/python/Objects/call.c:29)
_PyObject_VectorcallTstate (/usr/src/python/Include/internal/pycore_call.h:93)
0x63ceb6009738 PyObject_Vectorcall.cold (/usr/src/python/Objects/call.c:325)
0x63ceb6030406 _PyEval_EvalFrameDefault.cold (/usr/src/python/Python/bytecodes.c:2719)
_PyObject_VectorcallTstate (/usr/src/python/Include/internal/pycore_call.h:93)
0x63ceb600a716 method_vectorcall.cold (/usr/src/python/Objects/classobject.c:69)
0x63ceb6009324 _PyObject_VectorcallTstate (/usr/src/python/Include/internal/pycore_call.h:93)
0x793198e47284 std::thread::_State_impl<std::thread::_Invoker<std::tuple<_PeriodicThread_do_start(periodic_thread*, bool)::{lambda()#1}> > >::_M_run()
0x793198e47f60 execute_native_thread_routine
0x79319d6b2ac3 start_thread (nptl/nptl/pthread_create.c:442)
0x79319d7448d0 __clone3
```

