### PR TITLE
feat: add Hash trait to TracerMetadata

### DIFF
--- a/libdd-library-config/src/tracer_metadata.rs
+++ b/libdd-library-config/src/tracer_metadata.rs
@@ -248,34 +248,6 @@ mod tests {
     }
 
     #[test]
-    fn tracer_metadata_hash() {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
-
-        fn hash(m: &TracerMetadata) -> u64 {
-            let mut h = DefaultHasher::new();
-            m.hash(&mut h);
-            h.finish()
-        }
-
-        let a = TracerMetadata {
-            tracer_language: "python".into(),
-            ..Default::default()
-        };
-        let b = TracerMetadata {
-            tracer_language: "python".into(),
-            ..Default::default()
-        };
-        let c = TracerMetadata {
-            tracer_language: "ruby".into(),
-            ..Default::default()
-        };
-
-        assert_eq!(hash(&a), hash(&b));
-        assert_ne!(hash(&a), hash(&c));
-    }
-
-    #[test]
     fn tracer_metadata_equality() {
         let a = TracerMetadata {
             tracer_language: "python".into(),

--- a/libdd-library-config/src/tracer_metadata.rs
+++ b/libdd-library-config/src/tracer_metadata.rs
@@ -4,7 +4,7 @@ use libdd_trace_protobuf::opentelemetry::proto as otel_proto;
 use std::default::Default;
 
 /// This struct MUST be backward compatible.
-#[derive(serde::Serialize, Debug, PartialEq, Eq)]
+#[derive(serde::Serialize, Debug, PartialEq, Eq, Hash)]
 pub struct TracerMetadata {
     /// Version of the schema.
     pub schema_version: u8,
@@ -245,6 +245,34 @@ mod tests {
             .find(|kv| kv.key == key)?
             .value
             .as_ref()
+    }
+
+    #[test]
+    fn tracer_metadata_hash() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        fn hash(m: &TracerMetadata) -> u64 {
+            let mut h = DefaultHasher::new();
+            m.hash(&mut h);
+            h.finish()
+        }
+
+        let a = TracerMetadata {
+            tracer_language: "python".into(),
+            ..Default::default()
+        };
+        let b = TracerMetadata {
+            tracer_language: "python".into(),
+            ..Default::default()
+        };
+        let c = TracerMetadata {
+            tracer_language: "ruby".into(),
+            ..Default::default()
+        };
+
+        assert_eq!(hash(&a), hash(&b));
+        assert_ne!(hash(&a), hash(&c));
     }
 
     #[test]


### PR DESCRIPTION
# What does this PR do?

Derives Hash on TracerMetadata, allowing instances to be used as keys in hash-based collections such as HashMap and HashSet.

# Motivation

Needed for https://github.com/DataDog/serverless-components/pull/51#discussion_r3029346636

# Additional Notes

Follows [feat: add PartialEq and Eq traits to TracerMetadata](https://github.com/DataDog/libdatadog/pull/1922).

# How to test the change?

Unit tests.
