### PR TITLE
ci: prevent runner from going out of space

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,8 +117,8 @@ jobs:
         uses: taiki-e/install-action@2c41309d51ede152b6f2ee6bf3b71e6dc9a8b7df # 2.49.27
         with:
           tool: nextest@0.9.96
-      - name: Install Go (macOS)
-        if: runner.os == 'macOS'
+      - name: Install Go (macOS and Linux)
+        if: runner.os == 'macOS' || runner.os == 'Linux'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: 'stable'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,12 +96,12 @@ jobs:
         if: runner.os == 'Linux' && matrix.platform == 'ubuntu-latest'
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # 1.3.1
         with:
-          tool-cache: false
+          tool-cache: true
           android: true
           dotnet: true
           haskell: true
           large-packages: true
-          docker-images: false
+          docker-images: true
           swap-storage: true
       - name: Checkout sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2


### PR DESCRIPTION
# What does this PR do?

Increase the space available on ubuntu runners so the test workflow does not fail on the main branch.
