### PR TITLE
feat(datadog-ffe): add semver conditions handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1363,6 +1363,7 @@ dependencies = [
  "md5",
  "pyo3",
  "regex",
+ "semver",
  "serde",
  "serde-bool",
  "serde_json",

--- a/datadog-ffe/Cargo.toml
+++ b/datadog-ffe/Cargo.toml
@@ -19,6 +19,7 @@ derive_more = { version = "2.0.0", default-features = false, features = ["from",
 log = { version = "0.4.21", default-features = false, features = ["kv", "kv_serde"] }
 md5 = { version = "0.7.0", default-features = false }
 regex = "1.10.4"
+semver = "1.0"
 serde-bool = { version = "0.1.3", default-features = false }
 serde_with = { version = "3.11.0", default-features = false, features = ["base64", "hex", "macros"] }
 thiserror = { version = "2.0.3", default-features = false }

--- a/datadog-ffe/src/rules_based/eval/eval_rules.rs
+++ b/datadog-ffe/src/rules_based/eval/eval_rules.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::rules_based::{
-    ufc::{ComparisonOperator, Condition, ConditionCheck, RuleWire},
+    ufc::{ComparisonOperator, Condition, ConditionCheck, RuleWire, SemverComparisonOperator},
     Attribute, EvaluationContext,
 };
 
@@ -61,6 +61,22 @@ impl ConditionCheck {
                 let is_null = !is_present;
                 is_null == *expected_null
             }
+            ConditionCheck::SemverComparison {
+                operator,
+                comparand,
+            } => {
+                let attr_str = attribute?.as_str()?;
+                let attr_version = semver::Version::parse(attr_str.as_ref()).ok()?;
+                let ordering = attr_version.cmp(comparand);
+                match operator {
+                    SemverComparisonOperator::Eq => ordering.is_eq(),
+                    SemverComparisonOperator::Neq => !ordering.is_eq(),
+                    SemverComparisonOperator::Lt => ordering.is_lt(),
+                    SemverComparisonOperator::Lte => ordering.is_le(),
+                    SemverComparisonOperator::Gt => ordering.is_gt(),
+                    SemverComparisonOperator::Gte => ordering.is_ge(),
+                }
+            }
         };
 
         Some(result)
@@ -72,7 +88,7 @@ mod tests {
     use std::{collections::HashMap, sync::Arc};
 
     use crate::rules_based::{
-        ufc::{ComparisonOperator, Condition, ConditionCheck, RuleWire},
+        ufc::{ComparisonOperator, Condition, ConditionCheck, RuleWire, SemverComparisonOperator},
         EvaluationContext,
     };
 
@@ -286,5 +302,98 @@ mod tests {
             Some("key".into()),
             Arc::new(HashMap::from([("name".into(), "alice".into())]))
         )));
+    }
+
+    fn semver(s: &str) -> semver::Version {
+        semver::Version::parse(s).unwrap()
+    }
+
+    #[test]
+    fn semver_eq() {
+        let check = ConditionCheck::SemverComparison {
+            operator: SemverComparisonOperator::Eq,
+            comparand: semver("1.2.3"),
+        };
+        assert!(check.eval(Some(&"1.2.3".into())));
+        assert!(!check.eval(Some(&"1.2.4".into())));
+        assert!(!check.eval(Some(&"1.2.2".into())));
+        assert!(!check.eval(None));
+    }
+
+    #[test]
+    fn semver_neq() {
+        let check = ConditionCheck::SemverComparison {
+            operator: SemverComparisonOperator::Neq,
+            comparand: semver("1.2.3"),
+        };
+        assert!(!check.eval(Some(&"1.2.3".into())));
+        assert!(check.eval(Some(&"1.2.4".into())));
+        assert!(!check.eval(None));
+    }
+
+    #[test]
+    fn semver_lt() {
+        let check = ConditionCheck::SemverComparison {
+            operator: SemverComparisonOperator::Lt,
+            comparand: semver("2.0.0"),
+        };
+        assert!(check.eval(Some(&"1.9.9".into())));
+        assert!(!check.eval(Some(&"2.0.0".into())));
+        assert!(!check.eval(Some(&"2.0.1".into())));
+    }
+
+    #[test]
+    fn semver_lte() {
+        let check = ConditionCheck::SemverComparison {
+            operator: SemverComparisonOperator::Lte,
+            comparand: semver("2.0.0"),
+        };
+        assert!(check.eval(Some(&"1.9.9".into())));
+        assert!(check.eval(Some(&"2.0.0".into())));
+        assert!(!check.eval(Some(&"2.0.1".into())));
+    }
+
+    #[test]
+    fn semver_gt() {
+        let check = ConditionCheck::SemverComparison {
+            operator: SemverComparisonOperator::Gt,
+            comparand: semver("1.0.0"),
+        };
+        assert!(check.eval(Some(&"1.0.1".into())));
+        assert!(!check.eval(Some(&"1.0.0".into())));
+        assert!(!check.eval(Some(&"0.9.9".into())));
+    }
+
+    #[test]
+    fn semver_gte() {
+        let check = ConditionCheck::SemverComparison {
+            operator: SemverComparisonOperator::Gte,
+            comparand: semver("1.0.0"),
+        };
+        assert!(check.eval(Some(&"1.0.1".into())));
+        assert!(check.eval(Some(&"1.0.0".into())));
+        assert!(!check.eval(Some(&"0.9.9".into())));
+    }
+
+    #[test]
+    fn semver_prerelease_ordering() {
+        let check = ConditionCheck::SemverComparison {
+            operator: SemverComparisonOperator::Lt,
+            comparand: semver("1.0.0"),
+        };
+        assert!(check.eval(Some(&"1.0.0-alpha".into())));
+        assert!(check.eval(Some(&"1.0.0-beta.1".into())));
+        assert!(!check.eval(Some(&"1.0.0".into())));
+    }
+
+    #[test]
+    fn semver_invalid_attribute_returns_false() {
+        let check = ConditionCheck::SemverComparison {
+            operator: SemverComparisonOperator::Gte,
+            comparand: semver("1.0.0"),
+        };
+        assert!(!check.eval(Some(&"not-a-version".into())));
+        assert!(!check.eval(Some(&"1.2".into())));
+        assert!(!check.eval(None));
     }
 }

--- a/datadog-ffe/src/rules_based/ufc/models.rs
+++ b/datadog-ffe/src/rules_based/ufc/models.rs
@@ -178,6 +178,10 @@ pub(crate) enum ConditionCheck {
     Null {
         expected_null: bool,
     },
+    SemverComparison {
+        operator: SemverComparisonOperator,
+        comparand: semver::Version,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -188,6 +192,16 @@ pub(crate) enum ComparisonOperator {
     Lt,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum SemverComparisonOperator {
+    Eq,
+    Neq,
+    Lt,
+    Lte,
+    Gt,
+    Gte,
+}
+
 impl From<ComparisonOperator> for ConditionOperator {
     fn from(value: ComparisonOperator) -> ConditionOperator {
         match value {
@@ -195,6 +209,19 @@ impl From<ComparisonOperator> for ConditionOperator {
             ComparisonOperator::Gt => ConditionOperator::Gt,
             ComparisonOperator::Lte => ConditionOperator::Lte,
             ComparisonOperator::Lt => ConditionOperator::Lt,
+        }
+    }
+}
+
+impl From<SemverComparisonOperator> for ConditionOperator {
+    fn from(value: SemverComparisonOperator) -> ConditionOperator {
+        match value {
+            SemverComparisonOperator::Eq => ConditionOperator::SemverEq,
+            SemverComparisonOperator::Neq => ConditionOperator::SemverNeq,
+            SemverComparisonOperator::Lt => ConditionOperator::SemverLt,
+            SemverComparisonOperator::Lte => ConditionOperator::SemverLte,
+            SemverComparisonOperator::Gt => ConditionOperator::SemverGt,
+            SemverComparisonOperator::Gte => ConditionOperator::SemverGte,
         }
     }
 }
@@ -241,6 +268,15 @@ impl From<Condition> for ConditionWire {
             ConditionCheck::Null { expected_null } => {
                 (ConditionOperator::IsNull, expected_null.into())
             }
+            ConditionCheck::SemverComparison {
+                operator,
+                comparand,
+            } => (
+                operator.into(),
+                ConditionValue::Single(SingleConditionValue::String(Str::from(
+                    comparand.to_string().as_str(),
+                ))),
+            ),
         };
         ConditionWire {
             attribute: condition.attribute,
@@ -343,6 +379,43 @@ impl TryFrom<ConditionWire> for Condition {
                 };
                 ConditionCheck::Null { expected_null }
             }
+            ConditionOperator::SemverEq
+            | ConditionOperator::SemverNeq
+            | ConditionOperator::SemverLt
+            | ConditionOperator::SemverLte
+            | ConditionOperator::SemverGt
+            | ConditionOperator::SemverGte => {
+                let operator = match condition.operator {
+                    ConditionOperator::SemverEq => SemverComparisonOperator::Eq,
+                    ConditionOperator::SemverNeq => SemverComparisonOperator::Neq,
+                    ConditionOperator::SemverLt => SemverComparisonOperator::Lt,
+                    ConditionOperator::SemverLte => SemverComparisonOperator::Lte,
+                    ConditionOperator::SemverGt => SemverComparisonOperator::Gt,
+                    ConditionOperator::SemverGte => SemverComparisonOperator::Gte,
+                    _ => unreachable!(),
+                };
+                let semver_string = match condition.value.singleton() {
+                    Some(SingleConditionValue::String(s)) => s,
+                    _ => {
+                        log::warn!(
+                            "failed to parse condition: {:?} condition with non-string condition value",
+                            condition.operator
+                        );
+                        return Err(EvaluationError::ConfigurationParseError);
+                    }
+                };
+                let comparand = semver::Version::parse(&semver_string).map_err(|err| {
+                    log::warn!(
+                        "failed to parse condition: invalid semver {:?}: {err:?}",
+                        semver_string
+                    );
+                    EvaluationError::ConfigurationParseError
+                })?;
+                ConditionCheck::SemverComparison {
+                    operator,
+                    comparand,
+                }
+            }
         };
         Ok(Condition { attribute, check })
     }
@@ -376,6 +449,18 @@ pub(crate) enum ConditionOperator {
     /// Condition value must be a boolean. If it's `true`, this is a null check. If it's `false`,
     /// this is a not null check.
     IsNull,
+    /// Semantic version equal. Condition value must be a semver string.
+    SemverEq,
+    /// Semantic version not equal. Condition value must be a semver string.
+    SemverNeq,
+    /// Semantic version less than. Condition value must be a semver string.
+    SemverLt,
+    /// Semantic version less than or equal. Condition value must be a semver string.
+    SemverLte,
+    /// Semantic version greater than. Condition value must be a semver string.
+    SemverGt,
+    /// Semantic version greater than or equal. Condition value must be a semver string.
+    SemverGte,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
# What does this PR do?

Add support for semver condition operators.

# Motivation

First step in reconciling our evaluation library across libdatadog and dd-source one.

# Additional Notes

This is more or less a copy of existing changes.

# How to test the change?

Describe here in detail how the change can be validated.
