### PR TITLE
chore(crashtracking): clean up stale in-line comment

### DIFF
--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -614,11 +614,6 @@ fn test_crash_tracking_errors_intake_uds_socket() {
     );
 }
 
-/// For some reason, the next two tests fail on MacOS, because the callstack cannot be collected.
-/// We get this error:
-/// thread 'test_crash_tracking_bin_segfault' (88268) panicked at
-/// bin_tests/tests/crashtracker_bin_test.rs:250:5: got Ok("Unable to process line:
-/// DD_CRASHTRACK_END_STACKTRACE. Error: Can't set non-existant stack complete\n")
 #[test]
 #[cfg_attr(miri, ignore)]
 fn test_crash_tracking_bin_panic() {


### PR DESCRIPTION
# What does this PR do?

This comment is no longer relevant, as we now collect stacks for MacOS with [chore(crashtracking): emit a best effort stacktrace for Mac](https://github.com/DataDog/libdatadog/pull/1645)


# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
