### PR TITLE
fix(ipc): Fallback to ftruncate if fallocate gets EPERM

### DIFF
--- a/datadog-ipc/src/platform/mem_handle.rs
+++ b/datadog-ipc/src/platform/mem_handle.rs
@@ -96,12 +96,16 @@ where
         // Use fallocate on Linux to eagerly commit the new pages: ENOSPC at resize time is
         // recoverable; a later SIGBUS mid-execution is not.
         #[cfg(target_os = "linux")]
-        nix::fcntl::fallocate(
+        match nix::fcntl::fallocate(
             fd.as_raw_fd(),
             nix::fcntl::FallocateFlags::empty(),
             0,
             new_size,
-        )?;
+        ) {
+            Err(nix::Error::EPERM | nix::Error::ENOSYS) => nix::unistd::ftruncate(fd, new_size)?,
+            Err(e) => return Err(e.into()),
+            Ok(_) => {}
+        }
         #[cfg(not(target_os = "linux"))]
         nix::unistd::ftruncate(&fd, new_size)?;
         Ok(())

--- a/datadog-ipc/src/platform/mem_handle.rs
+++ b/datadog-ipc/src/platform/mem_handle.rs
@@ -93,7 +93,7 @@ where
         }
         let new_size = self.get_shm().size as libc::off_t;
         let fd = self.get_shm().handle.as_owned_fd()?;
-        // Use fallocate on Linux to eagerly commit the new pages: ENOSPC at resize time is
+        // Try to se fallocate on Linux to eagerly commit the new pages: ENOSPC at resize time is
         // recoverable; a later SIGBUS mid-execution is not.
         #[cfg(target_os = "linux")]
         match nix::fcntl::fallocate(
@@ -102,7 +102,9 @@ where
             0,
             new_size,
         ) {
-            Err(nix::Error::EPERM | nix::Error::ENOSYS) => nix::unistd::ftruncate(fd, new_size)?,
+            Err(nix::Error::EPERM | nix::Error::ENOSYS | nix::Error::ENOTSUP) => {
+                nix::unistd::ftruncate(fd, new_size)?
+            }
             Err(e) => return Err(e.into()),
             Ok(_) => {}
         }

--- a/datadog-ipc/src/platform/unix/mem_handle.rs
+++ b/datadog-ipc/src/platform/unix/mem_handle.rs
@@ -168,7 +168,11 @@ impl NamedShmHandle {
         // Use fallocate on Linux to eagerly commit pages: if /dev/shm is full we get ENOSPC
         // here (recoverable) rather than SIGBUS mid-execution when a worker writes a slot.
         #[cfg(target_os = "linux")]
-        fallocate(fd.as_raw_fd(), FallocateFlags::empty(), 0, size as off_t)?;
+        match fallocate(fd.as_raw_fd(), FallocateFlags::empty(), 0, size as off_t) {
+            Err(nix::Error::EPERM | nix::Error::ENOSYS) => ftruncate(&fd, size as off_t)?,
+            Err(e) => return Err(e.into()),
+            Ok(_) => {}
+        }
         #[cfg(not(target_os = "linux"))]
         ftruncate(&fd, size as off_t)?;
         if let Some(uid) = shm_owner_uid() {

--- a/datadog-ipc/src/platform/unix/mem_handle.rs
+++ b/datadog-ipc/src/platform/unix/mem_handle.rs
@@ -165,11 +165,13 @@ impl NamedShmHandle {
 
     pub fn create_mode(path: CString, size: usize, mode: Mode) -> io::Result<NamedShmHandle> {
         let fd = shm_open(path.as_bytes(), OFlag::O_CREAT | OFlag::O_RDWR, mode)?;
-        // Use fallocate on Linux to eagerly commit pages: if /dev/shm is full we get ENOSPC
+        // Try to use fallocate on Linux to eagerly commit pages: if /dev/shm is full we get ENOSPC
         // here (recoverable) rather than SIGBUS mid-execution when a worker writes a slot.
         #[cfg(target_os = "linux")]
         match fallocate(fd.as_raw_fd(), FallocateFlags::empty(), 0, size as off_t) {
-            Err(nix::Error::EPERM | nix::Error::ENOSYS) => ftruncate(&fd, size as off_t)?,
+            Err(nix::Error::EPERM | nix::Error::ENOSYS | nix::Error::ENOTSUP) => {
+                ftruncate(&fd, size as off_t)?
+            }
             Err(e) => return Err(e.into()),
             Ok(_) => {}
         }


### PR DESCRIPTION
I have no idea how fallocate is ever returning EPERM here, but apparently it is for some users. So, ... falling back it is.