### PR TITLE
feat(ffe): add __dd_allocation_key metadata to ResolutionDetails

### DIFF
--- a/datadog-ffe-ffi/src/assignment.rs
+++ b/datadog-ffe-ffi/src/assignment.rs
@@ -49,7 +49,17 @@ impl ResolutionDetails {
             })
             .collect();
 
-        let flag_metadata = Vec::new();
+        let mut flag_metadata = Vec::new();
+        if let Ok(value) = (*inner).as_ref() {
+            flag_metadata.push(KeyValue {
+                key: BorrowedStr::borrow_static("__dd_allocation_key"),
+                // SAFETY: The returned BorrowedStr does not outlive the source string v. The
+                // source string v lives in the pinned Assignment inside `inner`, which is owned
+                // by ResolutionDetails and will not move (guaranteed by Pin) or be modified (we
+                // only hold shared references).
+                value: unsafe { BorrowedStr::borrow_from_str(&value.allocation_key) },
+            });
+        }
 
         ResolutionDetails {
             inner,
@@ -268,6 +278,13 @@ impl BorrowedStr {
             ptr: s.as_ptr(),
             len: s.len(),
         }
+    }
+
+    /// Borrow string from `s`.
+    #[inline]
+    fn borrow_static(s: &'static str) -> BorrowedStr {
+        // SAFETY: static string outlives any scope, so borrowing from it is safe.
+        unsafe { BorrowedStr::borrow_from_str(s) }
     }
 
     #[inline]


### PR DESCRIPTION
# What does this PR do?

Add `__dd_allocation_key` metadata to `ResolutionDetails`.

# Motivation

Follow-up from https://github.com/DataDog/dd-trace-rb/pull/5599#discussion_r3169168526

# Additional Notes

# How to test the change?

