### PR TITLE
feat(ffe)!: remove extra_logging

### DIFF
--- a/datadog-ffe-ffi/src/assignment.rs
+++ b/datadog-ffe-ffi/src/assignment.rs
@@ -19,7 +19,6 @@ pub struct ResolutionDetails {
     inner: Pin<Box<Result<Assignment, EvaluationError>>>,
     // memoizing some fields, so we can hand off references to them:
     error_message: Option<String>,
-    extra_logging: Vec<KeyValue<BorrowedStr, BorrowedStr>>,
     flag_metadata: Vec<KeyValue<BorrowedStr, BorrowedStr>>,
 }
 impl ResolutionDetails {
@@ -28,26 +27,6 @@ impl ResolutionDetails {
         let inner = Box::pin(value);
 
         let error_message = (*inner).as_ref().err().map(|err| err.to_string());
-
-        let extra_logging = (*inner)
-            .as_ref()
-            .iter()
-            .flat_map(|it| it.extra_logging.iter())
-            .map(|(k, v)| {
-                KeyValue {
-                    // SAFETY: The returned BorrowedStr does not outlive the source string k. The
-                    // source string k lives in the pinned Assignment inside `inner`, which is owned
-                    // by ResolutionDetails and will not move (guaranteed by Pin) or be modified (we
-                    // only hold shared references).
-                    key: unsafe { BorrowedStr::borrow_from_str(k.as_str()) },
-                    // SAFETY: The returned BorrowedStr does not outlive the source string v. The
-                    // source string v lives in the pinned Assignment inside `inner`, which is owned
-                    // by ResolutionDetails and will not move (guaranteed by Pin) or be modified (we
-                    // only hold shared references).
-                    value: unsafe { BorrowedStr::borrow_from_str(v.as_str()) },
-                }
-            })
-            .collect();
 
         let mut flag_metadata = Vec::new();
         if let Ok(value) = (*inner).as_ref() {
@@ -64,7 +43,6 @@ impl ResolutionDetails {
         ResolutionDetails {
             inner,
             error_message,
-            extra_logging,
             flag_metadata,
         }
     }
@@ -477,18 +455,6 @@ pub unsafe extern "C" fn ddog_ffe_assignnment_get_flag_metadata(
     let a = unsafe { assignment.as_ref() };
     // SAFETY: the caller must ensure that returned value is not used after `assignment` is freed.
     unsafe { ArrayMap::borrow_from_slice(&a.flag_metadata) }
-}
-
-/// # Safety
-/// `assignment` must be a valid handle.
-#[no_mangle]
-pub unsafe extern "C" fn ddog_ffe_assignnment_get_extra_logging(
-    assignment: Handle<ResolutionDetails>,
-) -> ArrayMap<BorrowedStr, BorrowedStr> {
-    // SAFETY: the caller must ensure that assignment is valid
-    let a = unsafe { assignment.as_ref() };
-    // SAFETY: the caller must ensure that returned value is not used after `assignment` is freed.
-    unsafe { ArrayMap::borrow_from_slice(&a.extra_logging) }
 }
 
 /// Frees an Assignment handle.

--- a/datadog-ffe/src/rules_based/eval/eval_assignment.rs
+++ b/datadog-ffe/src/rules_based/eval/eval_assignment.rs
@@ -104,7 +104,6 @@ impl Flag {
             value: split.value.clone(),
             variation_key: split.variation_key.clone(),
             allocation_key: allocation.key.clone(),
-            extra_logging: split.extra_logging.clone(),
             reason,
             do_log: allocation.do_log,
         })

--- a/datadog-ffe/src/rules_based/ufc/assignment.rs
+++ b/datadog-ffe/src/rules_based/ufc/assignment.rs
@@ -1,7 +1,6 @@
 // Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
@@ -34,8 +33,6 @@ pub struct Assignment {
 
     /// Whether this assignment is part of an experiment and should be logged.
     pub do_log: bool,
-    /// Extra logging information for this assignment.
-    pub extra_logging: Arc<HashMap<String, String>>,
 }
 
 /// Enum representing values assigned to a subject as a result of feature flag evaluation.

--- a/datadog-ffe/src/rules_based/ufc/compiled_flag_config.rs
+++ b/datadog-ffe/src/rules_based/ufc/compiled_flag_config.rs
@@ -1,7 +1,7 @@
 // Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 use serde::Deserialize;
 
@@ -52,7 +52,6 @@ pub(crate) struct Allocation {
 pub(crate) struct Split {
     pub shards: Vec<Shard>,
     pub variation_key: Str,
-    pub extra_logging: Arc<HashMap<String, String>>,
     pub value: AssignmentValue,
 }
 
@@ -160,8 +159,6 @@ fn compile_split(
         .filter_map(compile_shard)
         .collect();
 
-    let extra_logging = split.extra_logging.unwrap_or_default();
-
     let result = variation_values
         .get(&split.variation_key)
         .cloned()
@@ -170,7 +167,6 @@ fn compile_split(
     Ok(Split {
         shards,
         variation_key: split.variation_key,
-        extra_logging,
         value: result,
     })
 }

--- a/datadog-ffe/src/rules_based/ufc/models.rs
+++ b/datadog-ffe/src/rules_based/ufc/models.rs
@@ -528,8 +528,6 @@ impl From<Vec<String>> for ConditionValue {
 pub(crate) struct SplitWire {
     pub shards: Vec<ShardWire>,
     pub variation_key: Str,
-    #[serde(default)]
-    pub extra_logging: Option<Arc<HashMap<String, String>>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
# What does this PR do?

Remove `extra_logging` handling.

# Motivation

It was a leftover from migration and was never used. It is also never emitted by the backend.

# Additional Notes

Stacked on top of #1940 to avoid merge conflicts.

# How to test the change?

