### PR TITLE
chore(crashtracking): bump libdatadog-libunwind to v1.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3093,9 +3093,9 @@ dependencies = [
 
 [[package]]
 name = "libdd-libunwind-sys"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eecc52581f5ccbcced4e2264fb7dd95112dba55f47d217c859420dd64e62c43a"
+checksum = "227f0e30af5fbb91d1b3768db7997fdd1ded87c44b371663783c4ff3eb686908"
 dependencies = [
  "cc",
  "libc",

--- a/libdd-crashtracker/Cargo.toml
+++ b/libdd-crashtracker/Cargo.toml
@@ -42,7 +42,7 @@ cxx = ["dep:cxx", "dep:cxx-build"]
 blazesym = "=0.2.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-libdd-libunwind-sys = { version = "1.0.0" }
+libdd-libunwind-sys = { version = "1.0.2" }
 
 [dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
# What does this PR do?

A new version is out with fixes: https://crates.io/crates/libdd-libunwind-sys/1.0.2

 Let's use the new version

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
