### PR TITLE
fix(crypto): gate libdd-common TLS features in remaining internal crates + add CI guard

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,6 +66,7 @@ README.md                            @DataDog/libdatadog
 repository.datadog.yml               @DataDog/apm-common-components-core
 rustfmt.toml                         @DataDog/libdatadog-core
 scripts/check_cargo_metadata.sh      @DataDog/libdatadog-core
+scripts/check_crypto_providers.sh    @DataDog/libdatadog-core
 scripts/commits-since-release.sh     @DataDog/libdatadog-core
 scripts/create-release.sh            @DataDog/apm-common-components-core
 scripts/crates-to-package.sh         @DataDog/libdatadog-core

--- a/.github/workflows/check-crypto-providers.yml
+++ b/.github/workflows/check-crypto-providers.yml
@@ -11,7 +11,7 @@ env:
   CARGO_INCREMENTAL: 0
 jobs:
   check-crypto-providers:
-    name: "ring + aws-lc-rs are not both pulled into any libdd-* crate"
+    name: "ring + aws-lc-rs are not both pulled into any workspace crate"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources

--- a/.github/workflows/check-crypto-providers.yml
+++ b/.github/workflows/check-crypto-providers.yml
@@ -1,0 +1,27 @@
+name: 'Check crypto providers'
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - mq-working-branch-*
+env:
+  rust_version: "1.84.1"
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+jobs:
+  check-crypto-providers:
+    name: "ring + aws-lc-rs are not both pulled into any libdd-* crate"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+      - name: Install ${{ env.rust_version }} toolchain
+        run: rustup set profile minimal && rustup install ${{ env.rust_version }} && rustup default ${{ env.rust_version }}
+      - name: Cache [rust]
+        uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # 2.8.1
+        with:
+          cache-targets: true # cache build artifacts
+          cache-bin: true # cache the ~/.cargo/bin directory
+      - name: Run crypto provider check
+        run: ./scripts/check_crypto_providers.sh

--- a/libdd-data-pipeline/Cargo.toml
+++ b/libdd-data-pipeline/Cargo.toml
@@ -46,7 +46,7 @@ libdd-tinybytes = { version = "1.1.0", path = "../libdd-tinybytes", features = [
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1.23", features = ["time", "test-util"], default-features = false }
-libdd-capabilities-impl = { version = "1.0.0", path = "../libdd-capabilities-impl" }
+libdd-capabilities-impl = { version = "1.0.0", path = "../libdd-capabilities-impl", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
@@ -84,9 +84,18 @@ default = ["https", "telemetry"]
 telemetry = ["libdd-telemetry"]
 https = [
     "libdd-common/https",
+    "libdd-capabilities-impl/https",
     "libdd-telemetry?/https",
     "libdd-trace-stats/https",
     "libdd-trace-utils/https",
     "libdd-dogstatsd-client/https",
+]
+fips = [
+    "libdd-common/fips",
+    "libdd-capabilities-impl/fips",
+    "libdd-telemetry?/fips",
+    "libdd-trace-stats/fips",
+    "libdd-trace-utils/fips",
+    "libdd-dogstatsd-client/fips",
 ]
 test-utils = []

--- a/libdd-dogstatsd-client/Cargo.toml
+++ b/libdd-dogstatsd-client/Cargo.toml
@@ -22,6 +22,7 @@ http = "1.1"
 [features]
 default = ["https"]
 https = ["libdd-common/https"]
+fips = ["libdd-common/fips"]
 
 
 [dev-dependencies]

--- a/libdd-telemetry/Cargo.toml
+++ b/libdd-telemetry/Cargo.toml
@@ -15,6 +15,7 @@ bench = false
 default = ["tracing"]
 tracing = ["tracing/std"]
 https = ["libdd-common/https"]
+fips = ["libdd-common/fips"]
 
 [dependencies]
 anyhow = { version = "1.0" }

--- a/libdd-trace-stats/Cargo.toml
+++ b/libdd-trace-stats/Cargo.toml
@@ -27,7 +27,7 @@ tracing = { version = "0.1", default-features = false }
 async-trait = "0.1.85"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-libdd-capabilities-impl = { version = "1.0.0", path = "../libdd-capabilities-impl" }
+libdd-capabilities-impl = { version = "1.0.0", path = "../libdd-capabilities-impl", default-features = false }
 
 [lib]
 bench = false
@@ -46,4 +46,5 @@ tokio = { version = "1.23", features = ["rt-multi-thread", "macros", "test-util"
 
 [features]
 default = ["https"]
-https = ["libdd-common/https"]
+https = ["libdd-common/https", "libdd-capabilities-impl/https"]
+fips = ["libdd-common/fips", "libdd-capabilities-impl/fips"]

--- a/scripts/check_crypto_providers.sh
+++ b/scripts/check_crypto_providers.sh
@@ -40,16 +40,32 @@ crate_has_feature() {
 # 0 if `package` is in the runtime dep graph of `manifest`. Resolved against
 # the crate's manifest in isolation, with dev-deps excluded.
 #
-# `cargo tree -i` exits 0 with a "nothing to print" warning when the package
-# exists in the workspace but is NOT pulled by the target crate, and exits
-# non-zero only when the package id is unknown entirely. Match the package
-# heading line directly instead of relying on the exit code alone.
+# `cargo tree -i` has three observed outcomes:
+#   - exit 0, output starts with "<pkg> v..."         → pulled
+#   - exit 0, output contains "nothing to print"      → not pulled (in workspace
+#                                                       but not in this graph)
+#   - exit non-zero, "did not match any packages"     → not pulled (not in
+#                                                       workspace at all)
+# Anything else (transient registry / git failures, manifest errors, etc.)
+# is surfaced as a hard error so the guard cannot silently pass when
+# dependency resolution itself broke.
 pulls() {
     local manifest="$1" pkg="$2"
     shift 2
-    local output
-    output=$(cargo tree --manifest-path "$manifest" --edges no-dev "$@" -i "$pkg" 2>&1) || return 1
-    [[ "$output" =~ ^"$pkg"" v" ]]
+    local output rc
+    output=$(cargo tree --manifest-path "$manifest" --edges no-dev "$@" -i "$pkg" 2>&1) && rc=0 || rc=$?
+
+    if [[ "$output" =~ ^"$pkg"" v" ]]; then
+        return 0
+    fi
+    if [[ "$output" == *"nothing to print"* ]] || \
+       [[ "$output" == *"did not match any packages"* ]]; then
+        return 1
+    fi
+
+    echo "ERROR: cargo tree failed for $(basename "$(dirname "$manifest")") -i $pkg (exit $rc):" >&2
+    echo "$output" | sed 's/^/  /' >&2
+    exit 2
 }
 
 tree_for() {

--- a/scripts/check_crypto_providers.sh
+++ b/scripts/check_crypto_providers.sh
@@ -55,7 +55,9 @@ pulls() {
     local output rc
     output=$(cargo tree --manifest-path "$manifest" --edges no-dev "$@" -i "$pkg" 2>&1) && rc=0 || rc=$?
 
-    if [[ "$output" =~ ^"$pkg"" v" ]]; then
+    # The tree heading line is "<pkg> v<version>" — match it line-anchored so
+    # `Downloading crates...` progress noise printed first does not throw us off.
+    if grep -qE "^${pkg} v[0-9]" <<<"$output"; then
         return 0
     fi
     if [[ "$output" == *"nothing to print"* ]] || \

--- a/scripts/check_crypto_providers.sh
+++ b/scripts/check_crypto_providers.sh
@@ -2,17 +2,19 @@
 # Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
 # SPDX-License-Identifier: Apache-2.0
 #
-# Asserts that no libdd-* crate ends up with both `ring` and `aws-lc-rs` in
+# Asserts that no workspace crate ends up with both `ring` and `aws-lc-rs` in
 # its runtime dependency graph at the same time.
 #
 # Mixing both backends bloats release binaries (e.g. datadog-lambda-extension
 # pulls a few hundred KiB of unused crypto) and breaks downstream FIPS
 # compliance checks. See #1816 and #1872 for the original gating work.
 #
-# For every libdd-* crate the check runs:
+# Iterates every workspace member (libdd-* and the datadog-* / sidecar /
+# remote-config / live-debugger / etc. crates that depend transitively on
+# libdd-common) and runs:
 #   * default feature set (whatever `cargo` picks)
-#   * `--no-default-features --features fips` if the crate has a `fips` feature
-#   * `--no-default-features --features https` if the crate has an `https` feature
+#   * `--no-default-features --features fips` if the crate exposes `fips`
+#   * `--no-default-features --features https` if the crate exposes `https`
 #
 # Each crate is resolved against its own Cargo.toml so workspace-level feature
 # unification from other members does not skew the result, and dev-deps are
@@ -96,7 +98,13 @@ check() {
 errors=0
 checked=0
 
-for manifest in libdd-*/Cargo.toml; do
+# Enumerate all workspace members (libdd-* and the datadog-* / sidecar /
+# live-debugger / remote-config / ffi crates) via `cargo metadata` so we
+# don't have to hardcode prefixes or maintain an allow-list.
+manifests=$(cargo metadata --no-deps --format-version 1 \
+    | python3 -c 'import json,sys; m=json.load(sys.stdin); print("\n".join(p["manifest_path"] for p in m["packages"]))')
+
+for manifest in $manifests; do
     crate="$(basename "$(dirname "$manifest")")"
     checked=$((checked + 1))
 

--- a/scripts/check_crypto_providers.sh
+++ b/scripts/check_crypto_providers.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+#
+# Asserts that no libdd-* crate ends up with both `ring` and `aws-lc-rs` in
+# its runtime dependency graph at the same time.
+#
+# Mixing both backends bloats release binaries (e.g. datadog-lambda-extension
+# pulls a few hundred KiB of unused crypto) and breaks downstream FIPS
+# compliance checks. See #1816 and #1872 for the original gating work.
+#
+# For every libdd-* crate the check runs:
+#   * default feature set (whatever `cargo` picks)
+#   * `--no-default-features --features fips` if the crate has a `fips` feature
+#   * `--no-default-features --features https` if the crate has an `https` feature
+#
+# Each crate is resolved against its own Cargo.toml so workspace-level feature
+# unification from other members does not skew the result, and dev-deps are
+# excluded so test-only graphs do not produce false positives.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+cd "$ROOT_DIR"
+
+# crate_has_feature <Cargo.toml> <feature_name>
+# 0 if the [features] table declares the named feature, 1 otherwise.
+crate_has_feature() {
+    awk -v feat="$2" '
+        /^\[features\]/ { in_features = 1; next }
+        /^\[/           { in_features = 0 }
+        in_features && $1 == feat && $2 == "=" { found = 1; exit }
+        END { exit !found }
+    ' "$1"
+}
+
+# pulls <manifest> <package> [extra-cargo-flags...]
+# 0 if `package` is in the runtime dep graph of `manifest`. Resolved against
+# the crate's manifest in isolation, with dev-deps excluded.
+#
+# `cargo tree -i` exits 0 with a "nothing to print" warning when the package
+# exists in the workspace but is NOT pulled by the target crate, and exits
+# non-zero only when the package id is unknown entirely. Match the package
+# heading line directly instead of relying on the exit code alone.
+pulls() {
+    local manifest="$1" pkg="$2"
+    shift 2
+    local output
+    output=$(cargo tree --manifest-path "$manifest" --edges no-dev "$@" -i "$pkg" 2>&1) || return 1
+    [[ "$output" =~ ^"$pkg"" v" ]]
+}
+
+tree_for() {
+    local manifest="$1" pkg="$2"
+    shift 2
+    cargo tree --manifest-path "$manifest" --edges no-dev "$@" -i "$pkg" 2>&1 | sed 's/^/    /'
+}
+
+# check <manifest> <label> [cargo flags...]
+# Fails if the dep graph contains both ring and aws-lc-rs.
+check() {
+    local manifest="$1" label="$2"
+    shift 2
+    local crate
+    crate="$(basename "$(dirname "$manifest")")"
+
+    if pulls "$manifest" "ring" "$@" && pulls "$manifest" "aws-lc-rs" "$@"; then
+        echo "FAIL: $crate ($label) pulls both ring and aws-lc-rs"
+        tree_for "$manifest" "ring" "$@"
+        tree_for "$manifest" "aws-lc-rs" "$@"
+        return 1
+    fi
+    return 0
+}
+
+errors=0
+checked=0
+
+for manifest in libdd-*/Cargo.toml; do
+    crate="$(basename "$(dirname "$manifest")")"
+    checked=$((checked + 1))
+
+    check "$manifest" "default" || errors=$((errors + 1))
+
+    if crate_has_feature "$manifest" "https"; then
+        check "$manifest" "--features https" --no-default-features --features https \
+            || errors=$((errors + 1))
+    fi
+
+    if crate_has_feature "$manifest" "fips"; then
+        check "$manifest" "--features fips" --no-default-features --features fips \
+            || errors=$((errors + 1))
+    fi
+done
+
+if [ "$checked" -eq 0 ]; then
+    echo "no libdd-* crates found" >&2
+    exit 2
+fi
+
+if [ "$errors" -gt 0 ]; then
+    echo
+    echo "crypto provider check failed: $errors violation(s) across $checked crate(s)"
+    exit 1
+fi
+
+echo "crypto provider check passed for $checked crate(s)"

--- a/scripts/check_crypto_providers.sh
+++ b/scripts/check_crypto_providers.sh
@@ -27,15 +27,10 @@ ROOT_DIR="$(dirname "$SCRIPT_DIR")"
 
 cd "$ROOT_DIR"
 
-# crate_has_feature <Cargo.toml> <feature_name>
-# 0 if the [features] table declares the named feature, 1 otherwise.
+# crate_has_feature <pkg_json> <feature_name>
+# 0 if the cargo-metadata package blob declares the named feature, 1 otherwise.
 crate_has_feature() {
-    awk -v feat="$2" '
-        /^\[features\]/ { in_features = 1; next }
-        /^\[/           { in_features = 0 }
-        in_features && $1 == feat && $2 == "=" { found = 1; exit }
-        END { exit !found }
-    ' "$1"
+    printf '%s' "$1" | jq -e --arg feat "$2" '.features | has($feat)' > /dev/null 2>&1
 }
 
 # pulls <manifest> <package> [extra-cargo-flags...]
@@ -101,28 +96,30 @@ checked=0
 # Enumerate all workspace members (libdd-* and the datadog-* / sidecar /
 # live-debugger / remote-config / ffi crates) via `cargo metadata` so we
 # don't have to hardcode prefixes or maintain an allow-list.
-manifests=$(cargo metadata --no-deps --format-version 1 \
-    | python3 -c 'import json,sys; m=json.load(sys.stdin); print("\n".join(p["manifest_path"] for p in m["packages"]))')
+METADATA=$(cargo metadata --no-deps --format-version 1)
 
-for manifest in $manifests; do
-    crate="$(basename "$(dirname "$manifest")")"
+mapfile -t PACKAGES < <(printf '%s' "$METADATA" | jq -c \
+    '.packages[] | {manifest: .manifest_path, features: .features}')
+
+for pkg in "${PACKAGES[@]}"; do
+    manifest=$(printf '%s' "$pkg" | jq -r '.manifest')
     checked=$((checked + 1))
 
     check "$manifest" "default" || errors=$((errors + 1))
 
-    if crate_has_feature "$manifest" "https"; then
+    if crate_has_feature "$pkg" "https"; then
         check "$manifest" "--features https" --no-default-features --features https \
             || errors=$((errors + 1))
     fi
 
-    if crate_has_feature "$manifest" "fips"; then
+    if crate_has_feature "$pkg" "fips"; then
         check "$manifest" "--features fips" --no-default-features --features fips \
             || errors=$((errors + 1))
     fi
 done
 
 if [ "$checked" -eq 0 ]; then
-    echo "no libdd-* crates found" >&2
+    echo "no workspace crates found" >&2
     exit 2
 fi
 


### PR DESCRIPTION
## What does this PR do?

Follows up #1872 by applying the same `default-features = false` + explicit `https`/`fips` feature forwarding pattern to the four internal crates that #1872 missed, and adds a CI guard so this class of regression cannot reland silently.

### Cargo.toml changes

| Crate | Before | After |
|---|---|---|
| `libdd-trace-stats` | `libdd-capabilities-impl` ungated; no `fips` feature | `default-features = false` + `https`/`fips` features forwarding to `libdd-common` and `libdd-capabilities-impl` |
| `libdd-data-pipeline` | target-cfg `libdd-capabilities-impl` ungated; no `fips` feature | `default-features = false` + new `fips` feature mirroring the existing `https` forwarding (`libdd-common`, `libdd-capabilities-impl`, `libdd-telemetry?`, `libdd-trace-stats`, `libdd-trace-utils`, `libdd-dogstatsd-client`) |
| `libdd-dogstatsd-client` | no `fips` feature | adds `fips = ["libdd-common/fips"]` |
| `libdd-telemetry` | no `fips` feature | adds `fips = ["libdd-common/fips"]` |

### CI guard

Adds `scripts/check_crypto_providers.sh` plus `.github/workflows/check-crypto-providers.yml`. The script asserts that no `libdd-*` crate ends up with both `ring` and `aws-lc-rs` in its runtime dependency graph, in *any* of these build modes:

- default features (whatever `cargo` picks)
- `--no-default-features --features https` (when the crate exposes an `https` feature)
- `--no-default-features --features fips` (when the crate exposes a `fips` feature)

It iterates **all** `libdd-*` crates so a regression introduced via a transitive edge — even on a crate that doesn't itself expose `https`/`fips` — gets flagged. Resolution is per-crate (via `--manifest-path`) so workspace-level feature unification from other members can't mask a violation, and dev-deps are excluded so test-only graphs don't produce false positives. Locally on this branch: `crypto provider check passed for 32 crate(s)`.

## Motivation

Without these gates, downstream consumers that build with `--no-default-features --features fips` still get `ring` in the dep graph through:

```
ring → rustls → hyper-rustls → libdd-common (https feature)
                                ↑
                                activated transitively because:
                                libdd-trace-stats → libdd-capabilities-impl (default-features = true → https)
                                libdd-data-pipeline → libdd-capabilities-impl (default-features = true → https)
```

This is the same shape #1872 fixed for `libdd-trace-obfuscation`, `libdd-capabilities-impl`, and `libdd-trace-utils`; these four crates were left out. It also affects non-FIPS builds: any consumer that pulls `rustls/aws-lc-rs` directly (e.g. `datadog-lambda-extension`) ends up with **both** `ring` and `aws-lc-rs` linked into the binary, bloating release artifacts and contradicting the gating intent of #1816.

## How to test the change?

Default builds are unchanged (the `default = ["https"]` feature on each crate preserves the existing `ring` behavior).

Verify ring is absent from FIPS feature builds of the affected crates:

```
cargo tree --manifest-path libdd-trace-stats/Cargo.toml --no-default-features --features fips --edges no-dev -i ring
# Expected: warning: nothing to print.

cargo tree --manifest-path libdd-data-pipeline/Cargo.toml --no-default-features --features fips --edges no-dev -i ring
# Expected: warning: nothing to print.
```

Run the full guard locally:

```
./scripts/check_crypto_providers.sh
# Expected: crypto provider check passed for 32 crate(s)
```

Sanity-check the guard catches regressions — temporarily drop `default-features = false` from `libdd-trace-stats`'s `libdd-capabilities-impl` edge and re-run the script. It correctly fails with `libdd-trace-stats (--features fips) pulls both ring and aws-lc-rs` and `libdd-data-pipeline (--features fips) pulls both ring and aws-lc-rs`.