### PR TITLE
fix(profiling-ffi): Use `try_intern` instead of `intern` to avoid panicking in a `try_xxx` function

### DIFF
--- a/libdd-profiling/src/collections/string_table/error.rs
+++ b/libdd-profiling/src/collections/string_table/error.rs
@@ -19,6 +19,16 @@ impl core::fmt::Display for Error {
 
 impl core::error::Error for Error {}
 
+impl From<Error> for std::io::Error {
+    fn from(err: Error) -> Self {
+        let kind = match err {
+            Error::OutOfMemory => std::io::ErrorKind::OutOfMemory,
+            Error::StorageFull => std::io::ErrorKind::Other,
+        };
+        Self::new(kind, err.to_string())
+    }
+}
+
 impl From<libdd_alloc::AllocError> for Error {
     fn from(_: libdd_alloc::AllocError) -> Error {
         Error::OutOfMemory

--- a/libdd-profiling/src/internal/profile/mod.rs
+++ b/libdd-profiling/src/internal/profile/mod.rs
@@ -941,12 +941,12 @@ impl Profile {
             upscaling_rules: Default::default(),
         };
 
-        let _id = profile.intern("");
+        let _id = profile.try_intern("")?;
         debug_assert!(_id == StringId::ZERO);
 
-        profile.endpoints.local_root_span_id_label = profile.intern("local root span id");
-        profile.endpoints.endpoint_label = profile.intern("trace endpoint");
-        profile.timestamp_key = profile.intern("end_timestamp_ns");
+        profile.endpoints.local_root_span_id_label = profile.try_intern("local root span id")?;
+        profile.endpoints.endpoint_label = profile.try_intern("trace endpoint")?;
+        profile.timestamp_key = profile.try_intern("end_timestamp_ns")?;
 
         profile.observations = Observations::try_new(profile.sample_types.len())?;
         Ok(profile)


### PR DESCRIPTION
# What does this PR do?

This PR replaces `.intern(..)` usage with `.try_intern` to prevent panicking if an error occurred.
example:
```
0x7FFE8DEC0645 RtlUnwindEx
0x7FFE739C5CAA __FrameHandler3::UnwindNestedFrames(unsigned long long*, EHExceptionRecord*, _CONTEXT*, unsigned long long*, void*, _s_FuncInfo const*, int, int, _s_HandlerType const*, _xDISPATCHER_CONTEXT*, unsigned char) (D:\a\_work\1\s\src\vctools\crt\vcruntime\src\eh\risctrnsctrl.cpp:759)
0x7FFE739C6C31 CatchIt<__FrameHandler3>(EHExceptionRecord*, unsigned long long*, _CONTEXT*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*, _s_HandlerType const*, _s_CatchableType const*, _s_TryBlockMapEntry const*, int, unsigned long long*, unsigned char, unsigned char) (D:\a\_work\1\s\src\vctools\crt\vcruntime\src\eh\frame.cpp:1328)
0x7FFE739C6F73 FindHandler<__FrameHandler3>(EHExceptionRecord*, unsigned long long*, _CONTEXT*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*, unsigned char, int, unsigned long long*) (D:\a\_work\1\s\src\vctools\crt\vcruntime\src\eh\frame.cpp:604)
0x7FFE739C767D __InternalCxxFrameHandler<__FrameHandler3>(EHExceptionRecord*, unsigned long long*, _CONTEXT*, _xDISPATCHER_CONTEXT*, _s_FuncInfo const*, int, unsigned long long*, unsigned char) (D:\a\_work\1\s\src\vctools\crt\vcruntime\src\eh\frame.cpp:357)
0x7FFE739C5E19 __CxxFrameHandler3(EHExceptionRecord*, unsigned long long, _CONTEXT*, _xDISPATCHER_CONTEXT*) (D:\a\_work\1\s\src\vctools\crt\vcruntime\src\eh\risctrnsctrl.cpp:283)
0x7FFE8DF3296F RtlpExecuteHandlerForException
0x7FFE8DEE2554 RtlDispatchException
0x7FFE8DEE22A7 RtlRaiseException
0x7FFE8B965369 RaiseException
0x7FFE739C61D8 _CxxThrowException(void*, _s__ThrowInfo const*) (D:\a\_work\1\s\src\vctools\crt\vcruntime\src\eh\throw.cpp:75)
panic_unwind::imp::panic() (\rustc\e71f9a9a98b0faf423844bf0ba7438f29dc27d58\library\panic_unwind\src\seh.rs:352)
0x7FFE737BA3DF panic_unwind::__rust_start_panic() (\rustc\e71f9a9a98b0faf423844bf0ba7438f29dc27d58\library\panic_unwind\src\lib.rs:97)
0x7FFE738DD33F std::panicking::rust_panic() (\rustc\e71f9a9a98b0faf423844bf0ba7438f29dc27d58\library\std\src\panicking.rs:862)
std::panicking::default_hook() (\rustc\e71f9a9a98b0faf423844bf0ba7438f29dc27d58\library\std\src\panicking.rs:250)
0x7FFE738ED2BD std::panicking::rust_panic_with_hook() (\rustc\e71f9a9a98b0faf423844bf0ba7438f29dc27d58\library\std\src\panicking.rs:801)
0x7FFE738ED09A std::panicking::begin_panic_handler::closure$0() (\rustc\e71f9a9a98b0faf423844bf0ba7438f29dc27d58\library\std\src\panicking.rs:674)
0x7FFE738ECFEF std::sys::backtrace::__rust_end_short_backtrace<std::panicking::begin_panic_handler::closure_env$0,never$>() (\rustc\e71f9a9a98b0faf423844bf0ba7438f29dc27d58\library\std\src\sys\backtrace.rs:170)
0x7FFE738ECFDE std::panicking::begin_panic_handler() (\rustc\e71f9a9a98b0faf423844bf0ba7438f29dc27d58\library\std\src\panicking.rs:665)
0x7FFE739D9581 core::panicking::panic_fmt() (\rustc\e71f9a9a98b0faf423844bf0ba7438f29dc27d58\library\core\src\panicking.rs:76)
0x7FFE739D98F0 core::result::unwrap_failed() (\rustc\e71f9a9a98b0faf423844bf0ba7438f29dc27d58\library\core\src\result.rs:1699)
core::result::Result::expect() (\rustc\e71f9a9a98b0faf423844bf0ba7438f29dc27d58\library\core\src\result.rs:1061)
0x7FFE7371439B libdd_profiling::collections::string_table::StringTable::intern() (C:\mnt\libdatadog\libdd-profiling\src\collections\string_table\mod.rs:133)
0x7FFE73747489 libdd_profiling::internal::profile::Profile::try_new_internal() (C:\mnt\libdatadog\libdd-profiling\src\internal\profile\mod.rs:960)
anyhow::context::impl$0::context() (C:\Users\ContainerAdministrator\.cargo\registry\src\index.crates.io-6f17d22bba15001f\anyhow-1.0.100\src\context.rs:52)
0x7FFE735849D2 datadog_profiling_ffi::profiles::datatypes::profile_new() (C:\mnt\libdatadog\libdd-profiling-ffi\src\profiles\datatypes.rs:522)
0x7FFE73583A62 datadog_profiling_ffi::profiles::datatypes::ddog_prof_Profile_new() (C:\mnt\libdatadog\libdd-profiling-ffi\src\profiles\datatypes.rs:441)
0x7FFE73C9980D libdatadog::CreateProfile(std::vector<SampleValueType,std::allocator<SampleValueType> > const&, std::basic_string<char,std::char_traits<char>,std::allocator<char> > const&, std::basic_string<char,std::char_traits<char>,std::allocator<char> > const&) (c:\mnt\profiler\src\ProfilerEngine\Datadog.Profiler.Native\Profile.cpp:212)
std::exchange(libdatadog::ProfileImpl*&, void*&&) (c:\devtools\vstudio\VC\Tools\MSVC\14.44.35207\include\utility:773)
std::unique_ptr<libdatadog::ProfileImpl,std::default_delete<libdatadog::ProfileImpl> >::release() (c:\devtools\vstudio\VC\Tools\MSVC\14.44.35207\include\memory:3465)
std::unique_ptr<libdatadog::ProfileImpl,std::default_delete<libdatadog::ProfileImpl> >::operator=(std::unique_ptr<libdatadog::ProfileImpl,std::default_delete<libdatadog::ProfileImpl> >&&) (c:\devtools\vstudio\VC\Tools\MSVC\14.44.35207\include\memory:3414)
libdatadog::Profile::{ctor}(IConfiguration*, std::vector<SampleValueType,std::allocator<SampleValueType> > const&, std::basic_string<char,std::char_traits<char>,std::allocator<char> > const&, std::basic_string<char,std::char_traits<char>,std::allocator<char> > const&, std::basic_string<char,std::char_traits<char>,std::allocator<char> >) (c:\mnt\profiler\src\ProfilerEngine\Datadog.Profiler.Native\Profile.cpp:25)
std::make_unique(IConfiguration*&, std::vector<SampleValueType,std::allocator<SampleValueType> >&, std::basic_string<char,std::char_traits<char>,std::allocator<char> > const&, std::basic_string<char,std::char_traits<char>,std::allocator<char> > const&, std::basic_string<char,std::char_traits<char>,std::allocator<char> >&&) (c:\devtools\vstudio\VC\Tools\MSVC\14.44.35207\include\memory:3630)
0x7FFE73C60B24 ProfileExporter::CreateProfile(std::basic_string<char,std::char_traits<char>,std::allocator<char> >) (c:\mnt\profiler\src\ProfilerEngine\Datadog.Profiler.Native\ProfileExporter.cpp:165)
std::exchange(libdatadog::Profile*&, void*&&) (c:\devtools\vstudio\VC\Tools\MSVC\14.44.35207\include\utility:773)
std::unique_ptr<libdatadog::Profile,std::default_delete<libdatadog::Profile> >::release() (c:\devtools\vstudio\VC\Tools\MSVC\14.44.35207\include\memory:3465)
std::unique_ptr<libdatadog::Profile,std::default_delete<libdatadog::Profile> >::operator=(std::unique_ptr<libdatadog::Profile,std::default_delete<libdatadog::Profile> >&&) (c:\devtools\vstudio\VC\Tools\MSVC\14.44.35207\include\memory:3414)
0x7FFE73C61C27 ProfileExporter::Add(std::shared_ptr<Sample> const&) (c:\mnt\profiler\src\ProfilerEngine\Datadog.Profiler.Native\ProfileExporter.cpp:402)
0x7FFE73C67F6B SamplesCollector::CollectSamples(std::forward_list<std::pair<ISamplesProvider *,unsigned __int64>,std::allocator<std::pair<ISamplesProvider *,unsigned __int64> > >&) (c:\mnt\profiler\src\ProfilerEngine\Datadog.Profiler.Native\SamplesCollector.cpp:154)
0x7FFE73C67B50 SamplesCollector::SamplesWork() (c:\mnt\profiler\src\ProfilerEngine\Datadog.Profiler.Native\SamplesCollector.cpp:85)
0x7FFE73C683DC std::thread::_Invoke<std::tuple<`SamplesCollector::StartImpl'::`2'::<lambda_1> >,0>(void*) (c:\devtools\vstudio\VC\Tools\MSVC\14.44.35207\include\thread:61)
0x7FFE73CB3DB0 thread_start<unsigned int (__cdecl*)(void *),1>(void* const) (minkernel\crts\ucrt\src\appcrt\startup\thread.cpp:97)
0x7FFE8DD97374 BaseThreadInitThunk
0x7FFE8DEDCC91 RtlUserThreadStart
```

# Motivation

This is to prevent crashes and let the client to log the error instead of crashing customers application(s)

