### PR TITLE
Harden Windows crashtracking trampoline handling

### DIFF
--- a/datadog-sidecar/src/windows.rs
+++ b/datadog-sidecar/src/windows.rs
@@ -12,6 +12,7 @@ use libdd_crashtracker_ffi::{ddog_crasht_init_windows, Metadata};
 use manual_future::ManualFuture;
 use spawn_worker::{write_crashtracking_trampoline, SpawnWorker, Stdio, TrampolineData};
 use std::ffi::CStr;
+use std::fs::File;
 use std::io::{self, Error};
 use std::os::windows::io::{FromRawHandle, IntoRawHandle, OwnedHandle};
 use std::ptr::null_mut;
@@ -124,7 +125,8 @@ pub fn ddog_setup_crashtracking(endpoint: Option<&Endpoint>, metadata: Metadata)
         "datadog-crashtracking-{}",
         primary_sidecar_identifier()
     )) {
-        Ok((path, _)) => {
+        Ok((path, file)) => {
+            *CRASHTRACKING_TRAMPOLINE.lock_or_panic() = Some(file);
             if let Ok(path_str) = path.into_os_string().into_string() {
                 return ddog_crasht_init_windows(
                     CharSlice::from(path_str.as_str()),
@@ -142,6 +144,8 @@ pub fn ddog_setup_crashtracking(endpoint: Option<&Endpoint>, metadata: Metadata)
 
     false
 }
+
+static CRASHTRACKING_TRAMPOLINE: LazyLock<Mutex<Option<File>>> = LazyLock::new(|| Mutex::new(None));
 
 static SIDECAR_IDENTIFIER: LazyLock<String> = LazyLock::new(fetch_sidecar_identifier);
 

--- a/spawn_worker/src/win32.rs
+++ b/spawn_worker/src/win32.rs
@@ -86,13 +86,19 @@ fn write_trampoline(process_name: &Option<String>) -> io::Result<(PathBuf, File)
 }
 
 pub fn write_crashtracking_trampoline(process_name: &String) -> io::Result<(PathBuf, File)> {
-    let mut path = env::temp_dir().join(process_name);
-    path.set_extension("dll");
-
-    // Attempt to move it just in case it already exists
-    let mut old_path = path.clone();
-    old_path.set_extension("old");
-    let _ = fs::rename(&path, old_path);
+    let path = loop {
+        let mut path = env::temp_dir().join(format!(
+            "{}-{}",
+            process_name,
+            std::iter::repeat_with(fastrand::alphanumeric)
+                .take(8)
+                .collect::<String>()
+        ));
+        path.set_extension("dll");
+        if !path.exists() {
+            break path;
+        }
+    };
 
     let mut file = OpenOptions::new()
         .create_new(true)
@@ -109,6 +115,7 @@ pub fn write_crashtracking_trampoline(process_name: &String) -> io::Result<(Path
     let file = OpenOptions::new()
         .read(true)
         .share_mode(FILE_SHARE_READ | FILE_SHARE_DELETE)
+        .custom_flags(FILE_FLAG_DELETE_ON_CLOSE)
         .open(path.clone())?;
 
     Ok((path, file))


### PR DESCRIPTION
### Motivation

- The Windows crashtracking path wrote a DLL to a predictable `%TEMP%` path derived from the process SID, closed the writer handle, and registered that path with WER, creating a DLL planting/TOCTOU risk.

### Description

- Generate crashtracking trampoline filenames with an added random suffix instead of using the SID-only deterministic name to make on-disk paths unpredictable.
- Reopen the trampoline with `FILE_FLAG_DELETE_ON_CLOSE` so the helper DLL is removed when the owning handle is dropped instead of leaving a persistent target.
- Retain the crashtracking trampoline `File` handle in the sidecar process for the process lifetime via a static `LazyLock<Mutex<Option<File>>>` to preserve delete-on-close semantics while WER may load the module.
- Changes made in `spawn_worker/src/win32.rs` and `datadog-sidecar/src/windows.rs` to implement the above.

### Testing

- Ran `cargo check -p spawn_worker -p datadog-sidecar` which completed successfully.
- Ran `cargo fmt --all` which completed successfully (rustfmt emitted warnings about some nightly options from repository config but formatting run succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fe24838f64832294d9ebfcad037173)