### PR TITLE
crashtracker: verify unix socket peer uid before parsing reports

### DIFF
--- a/libdd-crashtracker/src/receiver/entry_points.rs
+++ b/libdd-crashtracker/src/receiver/entry_points.rs
@@ -7,6 +7,8 @@ use crate::CrashtrackerConfiguration;
 #[cfg(target_os = "linux")]
 use crate::StacktraceCollection;
 use anyhow::Context;
+#[cfg(target_os = "linux")]
+use std::os::fd::AsRawFd;
 use std::time::Duration;
 use tokio::{
     io::{AsyncBufReadExt, BufReader},
@@ -30,8 +32,36 @@ pub async fn async_receiver_entry_point_unix_listener(
     listener: &UnixListener,
 ) -> anyhow::Result<()> {
     let (unix_stream, _) = listener.accept().await?;
+    #[cfg(target_os = "linux")]
+    ensure_same_user(&unix_stream)?;
     let stream = BufReader::new(unix_stream);
     receiver_entry_point(receiver_timeout(), stream).await
+}
+
+#[cfg(target_os = "linux")]
+fn ensure_same_user(unix_stream: &tokio::net::UnixStream) -> anyhow::Result<()> {
+    let mut ucred = libc::ucred {
+        pid: 0,
+        uid: 0,
+        gid: 0,
+    };
+    let mut ucred_len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+    let getsockopt_res = unsafe {
+        libc::getsockopt(
+            unix_stream.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_PEERCRED,
+            &mut ucred as *mut libc::ucred as *mut libc::c_void,
+            &mut ucred_len,
+        )
+    };
+
+    anyhow::ensure!(getsockopt_res == 0, "Failed to get unix peer credentials");
+    anyhow::ensure!(
+        ucred.uid == unsafe { libc::geteuid() },
+        "Refusing crash report from another user"
+    );
+    Ok(())
 }
 
 pub async fn async_receiver_entry_point_unix_socket(


### PR DESCRIPTION
### Motivation
- The UNIX-socket receiver previously accepted the first connection without authentication and trusted client-supplied crash configuration, allowing a local attacker to inject forged reports that read receiver-readable files and exfiltrate them.
- A minimal, targeted hardening is needed to prevent cross-user local spoofing without changing the reporting protocol.

### Description
- Added a Linux-only helper `ensure_same_user` that uses `getsockopt(..., SO_PEERCRED, ...)` to obtain the peer `ucred` and compares the peer UID to the receiver effective UID via `libc::geteuid()`.
- The check is invoked for accepted connections in `async_receiver_entry_point_unix_listener` before any parsing of the incoming crashreport stream.
- Imported `AsRawFd` for access to the accepted socket file descriptor and kept the change confined to `libdd-crashtracker/src/receiver/entry_points.rs` to minimize surface area.
- The change rejects connections from other users with a clear error, preserving the existing protocol and single-accept behavior for same-user clients.

### Testing
- Ran `cargo fmt --all` and formatting completed successfully.
- Ran `cargo test -p libdd-crashtracker --no-run` which compiled the crate tests successfully (tests were prepared but not executed) and completed without build errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fe431b2d2c832285b44ab93428817b)