### PR TITLE
refactor(ffe): validate at parse time that total_shards is non-zero

### DIFF
--- a/datadog-ffe/src/rules_based/sharder.rs
+++ b/datadog-ffe/src/rules_based/sharder.rs
@@ -2,17 +2,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Sharder implementation.
+use std::num::NonZeroU32;
+
 use md5;
 
 /// A sharder that has part of its hash pre-computed with the given salt.
 #[derive(Clone)]
 pub struct PreSaltedSharder {
     ctx: md5::Context,
-    total_shards: u32,
+    total_shards: NonZeroU32,
 }
 
 impl PreSaltedSharder {
-    pub fn new(salt: &[impl AsRef<[u8]>], total_shards: u32) -> PreSaltedSharder {
+    pub fn new(salt: &[impl AsRef<[u8]>], total_shards: NonZeroU32) -> PreSaltedSharder {
         let mut ctx = md5::Context::new();
         for s in salt {
             ctx.consume(s);

--- a/datadog-ffe/src/rules_based/ufc/compiled_flag_config.rs
+++ b/datadog-ffe/src/rules_based/ufc/compiled_flag_config.rs
@@ -176,7 +176,7 @@ fn compile_split(
 fn compile_shard(shard: ShardWire) -> Option<Shard> {
     if shard.ranges.contains(&ShardRange {
         start: 0,
-        end: shard.total_shards,
+        end: shard.total_shards.get(),
     }) {
         // The shard is "insignificant" because it always matches, so we don't need to waste time
         // checking it.

--- a/datadog-ffe/src/rules_based/ufc/models.rs
+++ b/datadog-ffe/src/rules_based/ufc/models.rs
@@ -1,7 +1,7 @@
 // Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, num::NonZeroU32, sync::Arc};
 
 use libdd_common::regex_engine::Regex;
 use serde::{Deserialize, Serialize};
@@ -537,7 +537,7 @@ pub(crate) struct SplitWire {
 #[allow(missing_docs)]
 pub(crate) struct ShardWire {
     pub salt: String,
-    pub total_shards: u32,
+    pub total_shards: NonZeroU32,
     pub ranges: Box<[ShardRange]>,
 }
 


### PR DESCRIPTION
# What does this PR do?

This fixes a spurious finding that shard calculation may panic on division by zero.

# Motivation

Spurious security scan finding.

