### PR TITLE
ci: harden rustfmt auto workflow against PR token abuse

### DIFF
--- a/.github/workflows/rustfmt-auto.yml
+++ b/.github/workflows/rustfmt-auto.yml
@@ -1,13 +1,14 @@
 name: Rustfmt Auto
 on:
   pull_request:
-    types: [opened, synchronize, reopened, labeled]
+    types: [opened, reopened, labeled]
 
 jobs:
   rustfmt:
     runs-on: ubuntu-latest
     if: >-
       contains(github.event.pull_request.labels.*.name, 'commit-rustfmt-changes') &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       !startsWith(github.head_ref, 'mq-working-branch')
     permissions:
       id-token: write
@@ -16,7 +17,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
         with:
-          ref: ${{ github.head_ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
       - name: Get GitHub App token
         uses: DataDog/dd-octo-sts-action@acaa02eee7e3bb0839e4272dacb37b8f3b58ba80 # v1.0.3
         id: octo-sts

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,8 @@ cargo +nightly fmt --all
 ```
 
 If you'd like CI to automatically format your code and commit the changes to your PR, add the `commit-rustfmt-changes`
-label to your pull request. This will trigger an automatic formatting commit if any changes are needed.
+label to your pull request. This will trigger a one-time formatting commit if any changes are needed. If you push
+additional commits after labeling, remove and re-add the label to re-run formatting.
 
 ## Commit Message Guidelines
 


### PR DESCRIPTION
### Motivation
- Close a repository-integrity vulnerability where a `pull_request`-triggered workflow could mint a write GitHub App token for PR-controlled runs and be retriggered on pushes after a label was applied.
- Prevent forked-PR heads and post-label `synchronize` events from gaining access to repository `contents: write` credentials via the `rustfmt-auto` job.

### Description
- Removed the `synchronize` event from `on: pull_request` so labeled PRs are not automatically re-run on subsequent pushes.
- Added a same-repository guard to the job `if` condition: `github.event.pull_request.head.repo.full_name == github.repository` to block fork PR heads from exercising the write-token flow.
- Made the checkout explicit by setting `repository: ${{ github.event.pull_request.head.repo.full_name }}` and `ref: ${{ github.event.pull_request.head.ref }}` to avoid ambiguous branch-only checkouts.

### Testing
- Inspected the updated workflow with `sed -n '1,220p' .github/workflows/rustfmt-auto.yml` and confirmed the trigger and guard changes, which succeeded.
- Verified the diff with `git diff -- .github/workflows/rustfmt-auto.yml` to ensure only the intended workflow hardening edits were made, which succeeded.
- Committed the change with `git add` and `git commit` to record the fix, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fded74568c8322a6cf3c1d295c26b0)