### PR TITLE
fix(ci): restore protected-branch constraints for STS policies

### DIFF
--- a/.github/chainguard/self.read.members.sts.yaml
+++ b/.github/chainguard/self.read.members.sts.yaml
@@ -3,8 +3,8 @@ issuer: https://token.actions.githubusercontent.com
 subject_pattern: "repo:DataDog/libdatadog.*"
 
 claim_pattern:
-  ref: "refs/heads/(main|release|igor/.*|julio/.*)"
-  # ref_protected: "true"
+  ref: "refs/heads/(main|release)"
+  ref_protected: "true"
 
 permissions:
   members: read

--- a/.github/chainguard/self.write.pr.sts.yaml
+++ b/.github/chainguard/self.write.pr.sts.yaml
@@ -3,8 +3,8 @@ issuer: https://token.actions.githubusercontent.com
 subject_pattern: "repo:DataDog/libdatadog.*"
 
 claim_pattern:
-  ref: "refs/heads/(main|release|igor/.*|julio/.*)"
-  # ref_protected: "true"
+  ref: "refs/heads/(main|release)"
+  ref_protected: "true"
   job_workflow_ref: DataDog/libdatadog/\.github/workflows/release-proposal-dispatch\.yml@.+
 
 permissions:


### PR DESCRIPTION
### Motivation
- A previous change broadened Chainguard STS `claim_pattern.ref` to allow unprotected personal branches and commented out `ref_protected`, enabling untrusted branch runs to mint privileged tokens for repository write and org-membership reads, so the trust boundary must be restored.

### Description
- Restrict `claim_pattern.ref` back to `refs/heads/(main|release)` in `.github/chainguard/self.write.pr.sts.yaml` and `.github/chainguard/self.read.members.sts.yaml`.
- Re-enable `claim_pattern.ref_protected: "true"` in both STS policy files so only protected refs can obtain these tokens.
- No other functional changes were made and the workflows that consume these policies remain unchanged.

### Testing
- Printed the updated files using `sed -n '1,200p'` to confirm the `ref` and `ref_protected` values were restored and the file contents are correct, and the command succeeded.
- Listed files with line numbers using `nl -ba` to verify the exact lines of the `claim_pattern` and `ref_protected` entries, and the command succeeded.
- Verified the repository diff shows only the two STS policy files were modified and that the policies now require protected `main`/`release` refs, and this check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fdf2189e688322a26a2f5f4e70ab01)