### PR TITLE
ci: verify nextest download integrity in CentOS7 image

### DIFF
--- a/tools/docker/Dockerfile.centos
+++ b/tools/docker/Dockerfile.centos
@@ -18,4 +18,10 @@ RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo \
 ENV PATH="/opt/rh/devtoolset-11/root/usr/bin:$PATH"
 
 # use the musl binary for nextest since glibc isn't new enough on CentOS7 for nextest
-RUN curl -LsSf https://get.nexte.st/0.9.96/linux-musl | tar zxf - -C /usr/local/bin
+RUN set -eux; \
+    NEXTEST_URL="https://get.nexte.st/0.9.96/linux-musl"; \
+    NEXTEST_SHA256="4f98a0f8c0b0f1a335f17d6385b799ec23f953a54358d49358c2a39bd6fd7fa9"; \
+    curl -LsSf "$NEXTEST_URL" -o /tmp/cargo-nextest-linux-musl.tar.gz; \
+    echo "$NEXTEST_SHA256  /tmp/cargo-nextest-linux-musl.tar.gz" | sha256sum -c -; \
+    tar zxf /tmp/cargo-nextest-linux-musl.tar.gz -C /usr/local/bin; \
+    rm -f /tmp/cargo-nextest-linux-musl.tar.gz


### PR DESCRIPTION
### Motivation
- Mitigate a CI supply-chain risk introduced by an unauthenticated `nextest` binary download in `tools/docker/Dockerfile.centos` that could allow workspace poisoning and later secret exfiltration.

### Description
- Replace the previous `curl | tar` install with downloading the pinned musl tarball to a temporary file in `tools/docker/Dockerfile.centos`.
- Add a hardcoded SHA-256 (`4f98a0f8c0b0f1a335f17d6385b799ec23f953a54358d49358c2a39bd6fd7fa9`) and verify it with `sha256sum -c` before extraction.
- Extract the tarball to `/usr/local/bin` only after successful verification and remove the downloaded archive to avoid leaving the artifact in the image layer.

### Testing
- Applied the patch to `tools/docker/Dockerfile.centos` and confirmed the file now contains the download+checksum+extract sequence (static verification).
- No CI or unit tests were executed as part of this change; image build-time verification via `sha256sum -c` will fail the Docker build if the digest does not match.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a01d6bed9588322a94b4d450894a8c5)