### PR TITLE
chore(deps): bump proptest and use upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,24 +510,24 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.6.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bitmaps"
@@ -4300,16 +4300,16 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.5.0"
-source = "git+https://github.com/bantonsson/proptest.git?branch=ban%2Favoid-libm-in-std#9f623fbab7a1a4da487551128c2bffeee2ed6b87"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
  "bitflags",
- "lazy_static",
  "num-traits",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
+ "rand 0.9.0",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -4575,11 +4575,11 @@ dependencies = [
 
 [[package]]
 name = "rand_xorshift"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.9.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,8 +109,3 @@ opt-level = 3
 incremental = false
 codegen-units = 1
 
-[patch.crates-io]
-# proptest pulls in a dependency on libm, which changes the runtime of some math functions
-# so benchmarks are not measuring the same thing as the release build. This patch removes
-# the default dependency on libm. A PR will be opened to proptest to make this optional.
-proptest = { git = 'https://github.com/bantonsson/proptest.git', branch = "ban/avoid-libm-in-std" }

--- a/libdd-profiling/Cargo.toml
+++ b/libdd-profiling/Cargo.toml
@@ -74,7 +74,7 @@ bolero = "0.13"
 criterion = "0.5.1"
 libdd-common = { path = "../libdd-common", features = ["test-utils"] }
 libdd-profiling = { path = ".", features = ["test-utils"] }
-proptest = "1"
+proptest = "1.11.0"
 strum = { version = "0.26", features = ["derive"] }
 tempfile = "3"
 

--- a/libdd-tinybytes/Cargo.toml
+++ b/libdd-tinybytes/Cargo.toml
@@ -14,7 +14,7 @@ bench = false
 [dev-dependencies]
 once_cell = "1.8"
 pretty_assertions = "1.3"
-proptest = {version = "1.5", features = ["std"], default-features = false}
+proptest = {version = "1.11.0", features = ["std"], default-features = false}
 test-case = "2.2"
 serde_json = "1.0.127"
 libdd-tinybytes = { path = ".", features = ["bytes_string", "serialization"] }


### PR DESCRIPTION
# Motivation

Bjorn's changes have been upstreamed and released https://github.com/proptest-rs/proptest/pull/524

