### PR TITLE
perf(sampling): optimize matching and limit cache memory [APMSP-2948]

### DIFF
--- a/benchmark/run_benchmarks_ci.sh
+++ b/benchmark/run_benchmarks_ci.sh
@@ -22,7 +22,7 @@ pushd "${PROJECT_DIR}" > /dev/null
 
 # Run benchmarks
 message "Running benchmarks"
-cargo bench --workspace --features libdd-crashtracker/benchmarking,libdd-sampling/v04_span -- --warm-up-time 1 --measurement-time 5 --sample-size=200
+cargo bench --workspace --features libdd-crashtracker/benchmarking,libdd-sampling/v04_span,libdd-sampling/bench-internals -- --warm-up-time 1 --measurement-time 5 --sample-size=200
 message "Finished running benchmarks"
 
 # Copy the benchmark results to the output directory

--- a/libdd-sampling/Cargo.toml
+++ b/libdd-sampling/Cargo.toml
@@ -22,6 +22,12 @@ harness = false
 path = "benches/sampling_bench.rs"
 required-features = ["v04_span"]
 
+[[bench]]
+name = "glob_matcher_bench"
+harness = false
+path = "benches/glob_matcher_bench.rs"
+required-features = ["bench-internals"]
+
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -31,6 +37,9 @@ libdd-trace-utils = { path = "../libdd-trace-utils", version = "3.0.1", optional
 
 [features]
 v04_span = ["dep:libdd-trace-utils"]
+# Exposes internal modules (e.g. `glob_matcher`) for benchmarks. Not intended for downstream
+# consumers — enable only when running benches in this crate.
+bench-internals = []
 
 [dev-dependencies]
 criterion = "0.5"

--- a/libdd-sampling/benches/glob_matcher_bench.rs
+++ b/libdd-sampling/benches/glob_matcher_bench.rs
@@ -1,0 +1,130 @@
+// Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+//! Microbenchmarks for `GlobMatcher` covering the `*` short-circuit, ASCII fast path (with and
+//! without wildcards, including backtracking), and Unicode fallback path.
+
+use std::alloc::System;
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use libdd_common::bench_utils::{
+    memory_allocated_measurement, AllocatedBytesMeasurement, ReportingAllocator,
+};
+use libdd_sampling::glob_matcher::GlobMatcher;
+
+#[global_allocator]
+static GLOBAL: ReportingAllocator<System> = ReportingAllocator::new(System);
+
+struct BenchCase {
+    name: &'static str,
+    pattern: &'static str,
+    subject: &'static str,
+}
+
+fn cases() -> Vec<BenchCase> {
+    vec![
+        BenchCase {
+            name: "star_short_circuit",
+            pattern: "*",
+            subject: "anything-goes-here",
+        },
+        BenchCase {
+            name: "ascii_exact_match",
+            pattern: "my-service",
+            subject: "my-service",
+        },
+        BenchCase {
+            name: "ascii_exact_miss",
+            pattern: "my-service",
+            subject: "other-service",
+        },
+        BenchCase {
+            name: "ascii_case_insensitive_match",
+            pattern: "my-service",
+            subject: "MY-SERVICE",
+        },
+        BenchCase {
+            name: "ascii_wildcard_star_match",
+            pattern: "svc-*",
+            subject: "svc-web",
+        },
+        BenchCase {
+            name: "ascii_wildcard_question_match",
+            pattern: "svc-???",
+            subject: "svc-web",
+        },
+        BenchCase {
+            name: "ascii_wildcard_backtrack_match",
+            pattern: "*-controller",
+            subject: "users-controller",
+        },
+        // Worst-case shape for the two-pointer backtracking algorithm.
+        BenchCase {
+            name: "ascii_wildcard_heavy_backtrack",
+            pattern: "a*a*a*a*b",
+            subject: "aaaaaaaaaaaaaaaaaaaab",
+        },
+        BenchCase {
+            name: "unicode_pattern_wildcard_match",
+            pattern: "caf\u{00e9}-*",
+            subject: "CAF\u{00c9}-PAYMENT",
+        },
+        BenchCase {
+            name: "unicode_pattern_ascii_subject",
+            pattern: "caf\u{00e9}-*",
+            subject: "CAFE-PAYMENT",
+        },
+        BenchCase {
+            name: "ascii_pattern_unicode_subject",
+            pattern: "caf*",
+            subject: "caf\u{00e9}-controller",
+        },
+        BenchCase {
+            name: "unicode_exact_match",
+            pattern: "caf\u{00e9}",
+            subject: "CAF\u{00c9}",
+        },
+    ]
+}
+
+fn bench_wall_time(c: &mut Criterion) {
+    for case in cases() {
+        let matcher = GlobMatcher::new(case.pattern);
+        c.bench_function(&format!("glob_matcher/{}/wall_time", case.name), |b| {
+            b.iter_batched(
+                || (),
+                |_| {
+                    black_box(matcher.matches(black_box(case.subject)));
+                },
+                BatchSize::SmallInput,
+            )
+        });
+    }
+}
+
+fn bench_allocs(c: &mut Criterion<AllocatedBytesMeasurement<System>>) {
+    for case in cases() {
+        let matcher = GlobMatcher::new(case.pattern);
+        c.bench_function(
+            &format!("glob_matcher/{}/allocated_bytes", case.name),
+            |b| {
+                b.iter_batched(
+                    || (),
+                    |_| {
+                        black_box(matcher.matches(black_box(case.subject)));
+                    },
+                    BatchSize::SmallInput,
+                )
+            },
+        );
+    }
+}
+
+criterion_group!(benches, bench_wall_time);
+criterion_group!(
+    name = alloc_benches;
+    config = memory_allocated_measurement(&GLOBAL);
+    targets = bench_allocs
+);
+criterion_main!(alloc_benches, benches);

--- a/libdd-sampling/benches/sampling_bench.rs
+++ b/libdd-sampling/benches/sampling_bench.rs
@@ -435,4 +435,4 @@ criterion_group!(
     config = memory_allocated_measurement(&GLOBAL);
     targets = criterion_benchmark_allocs
 );
-criterion_main!(benches, alloc_benches);
+criterion_main!(alloc_benches, benches);

--- a/libdd-sampling/src/bounded_byte_cache.rs
+++ b/libdd-sampling/src/bounded_byte_cache.rs
@@ -16,8 +16,12 @@ use std::num::NonZeroUsize;
 /// Default maximum entry count.
 pub const DEFAULT_MAX_ENTRIES: usize = 256;
 
-/// Default maximum tracked byte size (256 KiB).
-pub const DEFAULT_MAX_BYTES: usize = 256 * 1024;
+/// Default maximum tracked byte size (64 KiB).
+///
+/// Under normal use (short keys such as service or resource names), the entry count cap binds
+/// first. This byte budget acts as a safety valve against memory exhaustion from unexpectedly
+/// large keys due to misconfiguration or adversarial input.
+pub const DEFAULT_MAX_BYTES: usize = 256 * 256;
 
 /// LRU cache bounded by both entry count and total tracked byte size.
 ///
@@ -57,7 +61,6 @@ where
 
     /// Insert `key -> value`. Entries larger than `max_bytes` are dropped silently. Otherwise
     /// LRU entries are evicted until the new entry fits.
-    #[inline]
     pub fn put(&mut self, key: K, value: V) {
         let entry_bytes = Self::entry_size(&key);
 
@@ -91,6 +94,7 @@ where
     }
 
     #[cfg(test)]
+    #[inline]
     pub fn current_bytes(&self) -> usize {
         self.current_bytes
     }

--- a/libdd-sampling/src/bounded_byte_cache.rs
+++ b/libdd-sampling/src/bounded_byte_cache.rs
@@ -1,0 +1,215 @@
+// Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+//! LRU cache wrapper with dual limits: maximum entry count AND maximum tracked byte size.
+//!
+//! `lru::LruCache` only supports an entry-count capacity, which is unsafe for caches keyed on
+//! arbitrary user strings: a few very large keys can balloon memory. `BoundedByteCache` adds
+//! a byte budget on top, evicting least-recently-used entries until both limits are satisfied.
+
+use lru::LruCache;
+use std::borrow::Borrow;
+use std::hash::Hash;
+use std::mem::size_of;
+use std::num::NonZeroUsize;
+
+/// Default maximum entry count.
+pub const DEFAULT_MAX_ENTRIES: usize = 256;
+
+/// Default maximum tracked byte size (256 KiB).
+pub const DEFAULT_MAX_BYTES: usize = 256 * 1024;
+
+/// LRU cache bounded by both entry count and total tracked byte size.
+///
+/// Byte accounting covers `key.as_ref().len() + size_of::<V>()`. Heap-allocated value contents
+/// are not tracked; this wrapper assumes small inline values (e.g. `bool`).
+pub struct BoundedByteCache<K, V>
+where
+    K: Hash + Eq + AsRef<[u8]>,
+{
+    inner: LruCache<K, V>,
+    current_bytes: usize,
+    max_bytes: usize,
+}
+
+impl<K, V> BoundedByteCache<K, V>
+where
+    K: Hash + Eq + AsRef<[u8]>,
+{
+    /// `max_entries` of zero is treated as 1 (a cache with no slots is nonsensical).
+    pub fn new(max_entries: usize, max_bytes: usize) -> Self {
+        let entry_cap = NonZeroUsize::new(max_entries).unwrap_or(NonZeroUsize::MIN);
+        Self {
+            inner: LruCache::new(entry_cap),
+            current_bytes: 0,
+            max_bytes,
+        }
+    }
+
+    #[inline]
+    pub fn get<Q>(&mut self, key: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq + ?Sized,
+    {
+        self.inner.get(key)
+    }
+
+    /// Insert `key -> value`. Entries larger than `max_bytes` are dropped silently. Otherwise
+    /// LRU entries are evicted until the new entry fits.
+    #[inline]
+    pub fn put(&mut self, key: K, value: V) {
+        let entry_bytes = Self::entry_size(&key);
+
+        if entry_bytes > self.max_bytes {
+            return;
+        }
+
+        // Replacing an existing key: deduct its bytes first.
+        if self.inner.pop(&key).is_some() {
+            self.current_bytes = self.current_bytes.saturating_sub(entry_bytes);
+        }
+
+        while self.current_bytes + entry_bytes > self.max_bytes {
+            match self.inner.pop_lru() {
+                Some((evicted_key, _)) => {
+                    self.current_bytes = self
+                        .current_bytes
+                        .saturating_sub(Self::entry_size(&evicted_key));
+                }
+                None => break,
+            }
+        }
+
+        // `push` may evict an LRU entry to honor the entry-count cap; deduct its bytes.
+        if let Some((replaced_key, _)) = self.inner.push(key, value) {
+            self.current_bytes = self
+                .current_bytes
+                .saturating_sub(Self::entry_size(&replaced_key));
+        }
+        self.current_bytes += entry_bytes;
+    }
+
+    #[cfg(test)]
+    pub fn current_bytes(&self) -> usize {
+        self.current_bytes
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    fn entry_size(key: &K) -> usize {
+        Self::PER_ENTRY_OVERHEAD + key.as_ref().len() + size_of::<V>()
+    }
+
+    /// Approximate per-entry fixed heap overhead, in bytes. Covers:
+    /// - `Vec<u8>` header on the key (24 B on 64-bit targets)
+    /// - `lru` doubly-linked-list node (prev/next pointers, ~24 B)
+    /// - `HashMap` bucket amortized (~16 B)
+    ///
+    /// Rounded up so `max_bytes` is a pessimistic upper bound on actual heap usage. Recheck
+    /// if the `lru` crate is upgraded across a major version — the linked-list node layout
+    /// is the volatile piece.
+    const PER_ENTRY_OVERHEAD: usize = 64;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_put_and_get() {
+        let mut cache: BoundedByteCache<Vec<u8>, bool> = BoundedByteCache::new(256, 1024);
+        cache.put(b"hello".to_vec(), true);
+        assert_eq!(cache.get(b"hello".as_ref()), Some(&true));
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn test_evicts_lru_when_over_byte_budget() {
+        // Each entry costs PER_ENTRY_OVERHEAD (64) + 4 (key) + 1 (bool) = 69 bytes. Budget
+        // of 150 fits two entries (138 B) but not three.
+        let budget = 150;
+        let mut cache: BoundedByteCache<Vec<u8>, bool> = BoundedByteCache::new(256, budget);
+        cache.put(b"aaaa".to_vec(), true);
+        cache.put(b"bbbb".to_vec(), false);
+        assert_eq!(cache.len(), 2);
+        cache.put(b"cccc".to_vec(), true);
+        assert_eq!(cache.len(), 2);
+        assert_eq!(cache.get(b"aaaa".as_ref()), None);
+        assert_eq!(cache.get(b"bbbb".as_ref()), Some(&false));
+        assert_eq!(cache.get(b"cccc".as_ref()), Some(&true));
+        assert!(cache.current_bytes() <= budget);
+    }
+
+    #[test]
+    fn test_evicts_lru_when_over_entry_count() {
+        // Generous byte budget; entry-count cap of 2 drives eviction.
+        let mut cache: BoundedByteCache<Vec<u8>, bool> = BoundedByteCache::new(2, 1024);
+        cache.put(b"a".to_vec(), true);
+        cache.put(b"b".to_vec(), false);
+        cache.put(b"c".to_vec(), true);
+        assert_eq!(cache.len(), 2);
+        assert_eq!(cache.get(b"a".as_ref()), None);
+        assert_eq!(cache.get(b"b".as_ref()), Some(&false));
+        assert_eq!(cache.get(b"c".as_ref()), Some(&true));
+    }
+
+    #[test]
+    fn test_oversize_entry_is_rejected() {
+        // Any entry costs at least PER_ENTRY_OVERHEAD bytes, so a 32-byte budget rejects
+        // every insertion.
+        let mut cache: BoundedByteCache<Vec<u8>, bool> = BoundedByteCache::new(256, 32);
+        cache.put(b"small".to_vec(), true);
+        assert_eq!(cache.len(), 0);
+        assert_eq!(cache.current_bytes(), 0);
+    }
+
+    #[test]
+    fn test_replacing_key_does_not_double_count() {
+        let mut cache: BoundedByteCache<Vec<u8>, bool> = BoundedByteCache::new(256, 1024);
+        cache.put(b"k".to_vec(), true);
+        let bytes_after_first = cache.current_bytes();
+        cache.put(b"k".to_vec(), false);
+        assert_eq!(cache.current_bytes(), bytes_after_first);
+        assert_eq!(cache.get(b"k".as_ref()), Some(&false));
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn test_get_bumps_recency() {
+        // Budget for exactly two 4-byte-keyed entries (69 B each = 138 B total).
+        let mut cache: BoundedByteCache<Vec<u8>, bool> = BoundedByteCache::new(256, 150);
+        cache.put(b"aaaa".to_vec(), true);
+        cache.put(b"bbbb".to_vec(), true);
+        let _ = cache.get(b"aaaa".as_ref());
+        cache.put(b"cccc".to_vec(), true);
+        assert_eq!(cache.get(b"aaaa".as_ref()), Some(&true));
+        assert_eq!(cache.get(b"bbbb".as_ref()), None);
+    }
+
+    #[test]
+    fn test_many_inserts_stay_within_both_limits() {
+        let max_entries = 8;
+        // 8 entries * (PER_ENTRY_OVERHEAD 64 + 8-byte key + 1) = 584 bytes; round up.
+        let max_bytes = 600;
+        let mut cache: BoundedByteCache<Vec<u8>, bool> =
+            BoundedByteCache::new(max_entries, max_bytes);
+        for i in 0u16..1000 {
+            cache.put(format!("key-{:04}", i).into_bytes(), i % 2 == 0);
+            assert!(cache.current_bytes() <= max_bytes);
+            assert!(cache.len() <= max_entries);
+        }
+    }
+
+    #[test]
+    fn test_zero_entries_clamps_to_one() {
+        let mut cache: BoundedByteCache<Vec<u8>, bool> = BoundedByteCache::new(0, 1024);
+        cache.put(b"a".to_vec(), true);
+        cache.put(b"b".to_vec(), false);
+        assert_eq!(cache.len(), 1);
+        assert_eq!(cache.get(b"a".as_ref()), None);
+        assert_eq!(cache.get(b"b".as_ref()), Some(&false));
+    }
+}

--- a/libdd-sampling/src/glob_matcher.rs
+++ b/libdd-sampling/src/glob_matcher.rs
@@ -1,10 +1,9 @@
 // Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::bounded_byte_cache::{BoundedByteCache, DEFAULT_MAX_BYTES, DEFAULT_MAX_ENTRIES};
 use libdd_common::MutexExt;
-use lru::LruCache;
 use std::fmt;
-use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
 
 /// A backtracking implementation of the glob matching algorithm.
@@ -13,14 +12,39 @@ use std::sync::{Arc, Mutex};
 /// and `?` as a single character wildcard (not including empty string). The match is case
 /// insensitive.
 ///
-/// This implementation includes an LRU cache for faster repeated matching. The cache is
-/// shared across clones via `Arc`, so cloning a `GlobMatcher` does not discard cached
-/// results or allocate a new cache.
+/// # Performance
+///
+/// The matcher distinguishes two paths:
+///
+/// - **ASCII fast path** (`pattern` and `subject` both ASCII): matches in place on the byte slices
+///   using `eq_ignore_ascii_case` semantics. No-wildcard patterns skip the cache (a hash lookup on
+///   ~10 bytes costs more than the comparison itself). Wildcard patterns consult the shared LRU
+///   cache keyed on the raw subject bytes, because backtracking on adversarial inputs can be O(P·S)
+///   and repeated calls with the same subject are the common case.
+/// - **Unicode fallback** (either side contains non-ASCII): lowercases the subject with
+///   `str::to_lowercase` (one right-sized allocation, SIMD ASCII prefix) and consults the same
+///   shared LRU cache keyed on the lowercased bytes.
+///
+/// # Complexity
+///
+/// The matching algorithm is the classic two-pointer backtracking glob, with a worst case of
+/// `O(P * S)` where `P` is the pattern length and `S` is the subject length. This worst case
+/// only occurs for adversarially crafted patterns with many `*` separated by literals that
+/// almost match (e.g. `a*a*a*a*b` against `aaaaaaaa...`); in practice, the runtime is close to
+/// `O(P + S)` for the kinds of patterns and subjects produced by sampling rules.
 pub struct GlobMatcher {
-    /// Lowercased pattern for case-insensitive matching
+    /// Lowercased pattern for case-insensitive matching.
     pattern_lower: String,
-    /// Shared LRU cache of previously matched strings to their results.
-    cache: Arc<Mutex<LruCache<String, bool>>>,
+    /// Whether the pattern is pure ASCII. Computed once at construction.
+    pattern_is_ascii: bool,
+    /// Whether the pattern contains any `*` or `?` wildcard. Computed once at construction.
+    pattern_has_wildcards: bool,
+    /// Whether the pattern is exactly `*` (matches anything).
+    pattern_is_star: bool,
+    /// Shared LRU cache of matched subjects, keyed on raw bytes (ASCII path) or lowercased
+    /// UTF-8 (Unicode path). Only consulted for wildcard patterns. Bounded by byte size to
+    /// cap memory under arbitrary key sizes.
+    cache: Arc<Mutex<BoundedByteCache<Vec<u8>, bool>>>,
 }
 
 impl fmt::Debug for GlobMatcher {
@@ -33,13 +57,22 @@ impl fmt::Debug for GlobMatcher {
 }
 
 impl GlobMatcher {
-    /// Creates a new GlobMatcher with the given pattern
+    /// Creates a new GlobMatcher with the given pattern.
     pub fn new(pattern: &str) -> Self {
-        // Use a cache of size 256
-        let cache_size = unsafe { NonZeroUsize::new_unchecked(256) };
+        let pattern_lower = pattern.to_lowercase();
+        let pattern_is_ascii = pattern_lower.is_ascii();
+        let pattern_has_wildcards = pattern_lower.contains('*') || pattern_lower.contains('?');
+        // Any non-empty run of only `*` matches everything (e.g. `*`, `**`, `***`).
+        let pattern_is_star = !pattern_lower.is_empty() && pattern_lower.bytes().all(|b| b == b'*');
         GlobMatcher {
-            pattern_lower: pattern.to_lowercase(),
-            cache: Arc::new(Mutex::new(LruCache::new(cache_size))),
+            pattern_lower,
+            pattern_is_ascii,
+            pattern_has_wildcards,
+            pattern_is_star,
+            cache: Arc::new(Mutex::new(BoundedByteCache::new(
+                DEFAULT_MAX_ENTRIES,
+                DEFAULT_MAX_BYTES,
+            ))),
         }
     }
 
@@ -48,102 +81,158 @@ impl GlobMatcher {
         &self.pattern_lower
     }
 
-    /// Checks if the given subject matches the glob pattern
+    /// Checks if the given subject matches the glob pattern.
     /// The match is case insensitive.
     pub fn matches(&self, subject: &str) -> bool {
-        let subject_lower = subject.to_lowercase();
-
-        // short circuit for common cases
-        // "*" matches everything
-        if self.pattern_lower == "*" {
+        // "*" matches everything (covers the most common rule pattern).
+        if self.pattern_is_star {
             return true;
         }
-        // exact match
+
+        // ASCII fast path: no allocation, no lock.
+        if self.pattern_is_ascii && subject.is_ascii() {
+            return self.matches_ascii(subject.as_bytes());
+        }
+
+        // Unicode fallback: allocate a lowercased subject and consult the cache.
+        self.matches_unicode(subject)
+    }
+
+    /// ASCII fast path. Operates directly on the subject bytes using ASCII case folding.
+    ///
+    /// Pre-conditions: `self.pattern_lower` is ASCII (verified at construction) and `subject` is
+    /// ASCII (verified by the caller).
+    fn matches_ascii(&self, subject: &[u8]) -> bool {
+        let pattern = self.pattern_lower.as_bytes();
+
+        // Exact match (no wildcards): a plain case-insensitive byte compare beats a hash
+        // lookup, so skip the cache entirely.
+        if !self.pattern_has_wildcards {
+            return pattern.eq_ignore_ascii_case(subject);
+        }
+
+        // Wildcard ASCII: cache results keyed on the raw subject bytes. Repeated calls with
+        // the same input (the common case in sampling rules) become an O(1) lookup, avoiding
+        // potentially O(P·S) backtracking. Different case spellings get separate entries,
+        // which is acceptable: real callers don't mix cases for the same logical value, and
+        // lowercasing for canonicalization would allocate on every call.
+        //
+        // The lock is released around `glob_match_bytes` so a slow (worst-case backtracking)
+        // match on one thread doesn't block cache hits on other threads sharing this matcher.
+        // A concurrent inserter racing us on the same key is harmless: `put` overwrites with
+        // the same boolean result.
+        if let Some(&result) = self.cache.lock_or_panic().get(subject) {
+            return result;
+        }
+        let result = glob_match_bytes::<true>(pattern, subject);
+        self.cache.lock_or_panic().put(subject.to_vec(), result);
+        result
+    }
+
+    /// Unicode fallback. Lowercases the subject with `str::to_lowercase` (one right-sized
+    /// allocation, SIMD-vectorized for the ASCII prefix) and runs the matcher on the resulting
+    /// bytes. Results for wildcard patterns are cached in the shared LRU.
+    fn matches_unicode(&self, subject: &str) -> bool {
+        let subject_lower = subject.to_lowercase();
+
+        // Exact match.
         if self.pattern_lower == subject_lower {
             return true;
         }
-        // if not exact, and no wildcards, return false
-        if !self.pattern_lower.contains('*') && !self.pattern_lower.contains('?') {
+        // Pattern has no wildcards and isn't an exact match: definite miss.
+        if !self.pattern_has_wildcards {
             return false;
         }
 
-        // Try to get from cache first
-        {
-            let mut cache = self.cache.lock_or_panic();
-            if let Some(&result) = cache.get(&subject_lower) {
-                return result;
-            }
+        let subject_lower_bytes = subject_lower.into_bytes();
+
+        // Release the lock around the match so a slow backtracking computation doesn't block
+        // cache hits on other threads. Concurrent inserts on the same key are harmless.
+        if let Some(&result) = self.cache.lock_or_panic().get(&subject_lower_bytes) {
+            return result;
         }
-
-        // Backtracking algorithm
-        let pattern = self.pattern_lower.as_bytes();
-        let subject = subject_lower.as_bytes();
-
-        let mut px = 0; // Pattern index
-        let mut sx = 0; // Subject index
-        let mut next_px = 0; // Next backtracking pattern index
-        let mut next_sx = 0; // Next backtracking subject index
-
-        while px < pattern.len() || sx < subject.len() {
-            if px < pattern.len() {
-                let char = pattern[px];
-
-                if char == b'?' {
-                    // Single character wildcard
-                    if sx < subject.len() {
-                        px += 1;
-                        sx += 1;
-                        continue;
-                    }
-                } else if char == b'*' {
-                    // Zero-or-more characters wildcard
-                    next_px = px;
-                    next_sx = sx + 1;
-                    px += 1;
-                    continue;
-                } else if sx < subject.len() && subject[sx] == char {
-                    // Normal character match
-                    px += 1;
-                    sx += 1;
-                    continue;
-                }
-            }
-
-            // If we can backtrack (we've seen a * and have more characters in subject)
-            if 0 < next_sx && next_sx <= subject.len() {
-                px = next_px;
-                sx = next_sx;
-                continue;
-            }
-
-            // If we're here, we've exhausted all options and no match was found
-            // Store in cache and return
-            {
-                let mut cache = self.cache.lock_or_panic();
-                cache.put(subject_lower, false);
-            }
-            return false;
-        }
-
-        // If we reached here, we've consumed both strings entirely - it's a match
-        // Store in cache and return
-        {
-            let mut cache = self.cache.lock_or_panic();
-            cache.put(subject_lower, true);
-        }
-        true
+        // Unicode path: subject already lowercased — skip per-byte ASCII case-fold.
+        let result = glob_match_bytes::<false>(self.pattern_lower.as_bytes(), &subject_lower_bytes);
+        self.cache.lock_or_panic().put(subject_lower_bytes, result);
+        result
     }
 }
 
 impl Clone for GlobMatcher {
     fn clone(&self) -> Self {
-        // Share the cache across clones so that previously cached results are reused
-        // and we don't allocate a fresh empty `LruCache` on every clone.
+        // Share the cache across clones so previously cached results are reused and we don't
+        // allocate a fresh empty `LruCache` on every clone.
         GlobMatcher {
             pattern_lower: self.pattern_lower.clone(),
+            pattern_is_ascii: self.pattern_is_ascii,
+            pattern_has_wildcards: self.pattern_has_wildcards,
+            pattern_is_star: self.pattern_is_star,
             cache: Arc::clone(&self.cache),
         }
     }
+}
+
+/// Backtracking glob match on byte slices. `pattern` is always pre-lowercased.
+///
+/// `ASCII_FOLD` selects how literal bytes are compared:
+/// - `true`: caller passes raw mixed-case subject bytes (ASCII path); fold per byte via
+///   `eq_ignore_ascii_case`.
+/// - `false`: caller has already lowercased the subject (Unicode fallback); plain byte equality is
+///   sufficient and avoids redundant ASCII folding inside the hot loop.
+///
+/// The const-generic is monomorphized at compile time, so the branch is eliminated.
+fn glob_match_bytes<const ASCII_FOLD: bool>(pattern: &[u8], subject: &[u8]) -> bool {
+    let mut px = 0; // Pattern index.
+    let mut sx = 0; // Subject index.
+    let mut next_px = 0; // Next backtracking pattern index.
+    let mut next_sx = 0; // Next backtracking subject index.
+
+    while px < pattern.len() || sx < subject.len() {
+        if px < pattern.len() {
+            let p = pattern[px];
+
+            if p == b'?' {
+                // Single character wildcard.
+                if sx < subject.len() {
+                    px += 1;
+                    sx += 1;
+                    continue;
+                }
+            } else if p == b'*' {
+                // Zero-or-more characters wildcard.
+                next_px = px;
+                next_sx = sx + 1;
+                px += 1;
+                continue;
+            } else if sx < subject.len() && {
+                // Pattern is always pre-lowercased, so only the subject side needs folding.
+                // `eq_ignore_ascii_case` folds *both* operands, doubling the work in the hot
+                // loop — measurably worse on backtracking-heavy inputs.
+                let s = subject[sx];
+                let folded = if ASCII_FOLD {
+                    s.to_ascii_lowercase()
+                } else {
+                    s
+                };
+                folded == p
+            } {
+                px += 1;
+                sx += 1;
+                continue;
+            }
+        }
+
+        // Backtrack to the last `*` if we have any subject left to consume.
+        if 0 < next_sx && next_sx <= subject.len() {
+            px = next_px;
+            sx = next_sx;
+            continue;
+        }
+
+        return false;
+    }
+
+    true
 }
 
 #[cfg(test)]
@@ -212,23 +301,119 @@ mod tests {
     }
 
     #[test]
-    fn test_glob_caching() {
-        let matcher = GlobMatcher::new("c*t?r*");
+    fn test_all_star_patterns_short_circuit() {
+        // Any pattern that is only `*` characters takes the `pattern_is_star` short-circuit.
+        for pattern in ["*", "**", "***", "****"] {
+            let matcher = GlobMatcher::new(pattern);
+            assert!(
+                matcher.pattern_is_star,
+                "pattern {:?} should set pattern_is_star",
+                pattern
+            );
+            assert!(matcher.matches(""));
+            assert!(matcher.matches("anything"));
+            assert!(matcher.matches("caf\u{00e9}"));
+        }
 
-        // First match should populate cache
-        assert!(matcher.matches("contoroller"));
+        // Patterns containing non-`*` characters do not short-circuit.
+        for pattern in ["", "a*", "*a*", "?"] {
+            let matcher = GlobMatcher::new(pattern);
+            assert!(
+                !matcher.pattern_is_star,
+                "pattern {:?} should not set pattern_is_star",
+                pattern
+            );
+        }
+    }
 
-        // Check the cache
+    #[test]
+    fn test_unicode_exact_match_no_wildcard() {
+        // No-wildcard unicode pattern: exercises the `pattern_lower == subject_lower` early
+        // return in the unicode fallback path.
+        let matcher = GlobMatcher::new("caf\u{00e9}");
+        assert!(!matcher.pattern_has_wildcards);
+        assert!(matcher.matches("caf\u{00e9}")); // exact lowercase
+        assert!(matcher.matches("CAF\u{00c9}")); // uppercase folds to same
+        assert!(!matcher.matches("cafe")); // ASCII miss
+        assert!(!matcher.matches("caf\u{00e9}s")); // longer miss
+    }
+
+    #[test]
+    fn test_unicode_subject_against_ascii_pattern() {
+        // Pattern is ASCII but subject is not -> takes the unicode fallback path.
+        let matcher = GlobMatcher::new("caf*");
+        assert!(matcher.matches("caf\u{00e9}")); // "café"
+        assert!(!matcher.matches("\u{00e9}cole")); // "école"
+    }
+
+    #[test]
+    fn test_unicode_pattern() {
+        // Non-ASCII pattern -> always unicode path.
+        let matcher = GlobMatcher::new("caf\u{00e9}*");
+        assert!(matcher.matches("caf\u{00e9}-shop"));
+        assert!(matcher.matches("CAF\u{00c9}-SHOP")); // Uppercase Unicode
+        assert!(!matcher.matches("cafe-shop"));
+    }
+
+    #[test]
+    fn test_unicode_repeated_calls() {
+        // Smoke test: repeated unicode calls should all succeed (hits + misses interleaved).
+        let matcher = GlobMatcher::new("caf\u{00e9}*");
+        for _ in 0..10 {
+            assert!(matcher.matches("caf\u{00e9}-controller"));
+            assert!(!matcher.matches("x\u{00e9}"));
+        }
+    }
+
+    #[test]
+    fn test_clone_independent() {
+        let matcher = GlobMatcher::new("caf*");
+        let clone = matcher.clone();
+        assert!(matcher.matches("caf\u{00e9}"));
+        assert!(clone.matches("caf\u{00e9}"));
+    }
+
+    #[test]
+    fn test_ascii_no_wildcard_skips_cache() {
+        let matcher = GlobMatcher::new("svc-web");
+        assert!(matcher.matches("svc-web"));
+        assert!(!matcher.matches("svc-db"));
         let cache = matcher.cache.lock_or_panic();
-        assert!(cache.contains(&"contoroller".to_string()));
-        drop(cache);
+        assert_eq!(
+            cache.len(),
+            0,
+            "non-wildcard ASCII path should not touch cache"
+        );
+    }
 
-        // Add another entry to cache
-        assert!(!matcher.matches("car"));
-
-        // Verify both are in cache
+    #[test]
+    fn test_ascii_wildcard_populates_cache() {
+        let matcher = GlobMatcher::new("svc-*");
+        assert!(matcher.matches("svc-web"));
+        assert!(matcher.matches("svc-db"));
         let cache = matcher.cache.lock_or_panic();
-        assert!(cache.contains(&"contoroller".to_string()));
-        assert!(cache.contains(&"car".to_string()));
+        assert_eq!(
+            cache.len(),
+            2,
+            "ASCII wildcard path should cache each unique subject"
+        );
+    }
+
+    #[test]
+    fn test_unicode_path_populates_cache() {
+        let matcher = GlobMatcher::new("caf*");
+        assert!(matcher.matches("caf\u{00e9}"));
+        let cache = matcher.cache.lock_or_panic();
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn test_clone_shares_cache() {
+        let matcher = GlobMatcher::new("caf*");
+        let clone = matcher.clone();
+        assert!(matcher.matches("caf\u{00e9}"));
+        // Clone sees the same cache entry (Arc-shared).
+        let cache = clone.cache.lock_or_panic();
+        assert_eq!(cache.len(), 1);
     }
 }

--- a/libdd-sampling/src/glob_matcher.rs
+++ b/libdd-sampling/src/glob_matcher.rs
@@ -43,7 +43,7 @@ pub struct GlobMatcher {
     pattern_is_star: bool,
     /// Shared LRU cache of matched subjects, keyed on raw bytes (ASCII path) or lowercased
     /// UTF-8 (Unicode path). Only consulted for wildcard patterns. Bounded by byte size to
-    /// cap memory under arbitrary key sizes.
+    /// cap memory under arbitrarily large attribute values.
     cache: Arc<Mutex<BoundedByteCache<Vec<u8>, bool>>>,
 }
 
@@ -60,15 +60,12 @@ impl GlobMatcher {
     /// Creates a new GlobMatcher with the given pattern.
     pub fn new(pattern: &str) -> Self {
         let pattern_lower = pattern.to_lowercase();
-        let pattern_is_ascii = pattern_lower.is_ascii();
-        let pattern_has_wildcards = pattern_lower.contains('*') || pattern_lower.contains('?');
-        // Any non-empty run of only `*` matches everything (e.g. `*`, `**`, `***`).
-        let pattern_is_star = !pattern_lower.is_empty() && pattern_lower.bytes().all(|b| b == b'*');
         GlobMatcher {
+            pattern_is_ascii: pattern_lower.is_ascii(),
+            pattern_has_wildcards: pattern_lower.contains('*') || pattern_lower.contains('?'),
+            // Any non-empty run of only `*` matches everything (e.g. `*`, `**`, `***`).
+            pattern_is_star: !pattern_lower.is_empty() && pattern_lower.bytes().all(|b| b == b'*'),
             pattern_lower,
-            pattern_is_ascii,
-            pattern_has_wildcards,
-            pattern_is_star,
             cache: Arc::new(Mutex::new(BoundedByteCache::new(
                 DEFAULT_MAX_ENTRIES,
                 DEFAULT_MAX_BYTES,

--- a/libdd-sampling/src/lib.rs
+++ b/libdd-sampling/src/lib.rs
@@ -25,6 +25,7 @@
 )]
 
 pub(crate) mod agent_service_sampler;
+pub(crate) mod bounded_byte_cache;
 pub(crate) mod constants;
 pub(crate) mod datadog_sampler;
 pub mod dd_constants;

--- a/libdd-sampling/src/lib.rs
+++ b/libdd-sampling/src/lib.rs
@@ -29,7 +29,11 @@ pub(crate) mod constants;
 pub(crate) mod datadog_sampler;
 pub mod dd_constants;
 pub mod dd_sampling;
+#[cfg(not(feature = "bench-internals"))]
 pub(crate) mod glob_matcher;
+#[cfg(feature = "bench-internals")]
+#[doc(hidden)]
+pub mod glob_matcher;
 pub(crate) mod rate_limiter;
 pub(crate) mod rate_sampler;
 pub(crate) mod rules_sampler;


### PR DESCRIPTION
# What does this PR do?

Optimizes the glob matching and limits the memory taken up by the LRU match cache.

# Motivation

A follow up PR for bigger performance questions that came up in #1927 as well as bounding the cache memory for the LRU cache that came up in a security review.

# How to test the change?

Unit tests and benchmarks are in the PR.
