### PR TITLE
ci: prevent miri fail by allowing nextest to pass on no-tests condition

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,7 +43,7 @@ jobs:
           cache-bin: true # cache the ~/.cargo/bin directory
       - name: Generate code coverage (including doc tests)
         run: |
-          cargo llvm-cov --all-features --workspace --no-report nextest
+          cargo llvm-cov --all-features --workspace --no-report nextest --no-tests=pass
           cargo llvm-cov --all-features --workspace --no-report --doc
           cargo llvm-cov report --doctests --lcov --output-path lcov.info
       - name: Upload coverage to Codecov

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -73,6 +73,6 @@ jobs:
         with:
           cache-targets: true # cache build artifacts
           cache-bin: true # cache the ~/.cargo/bin directory
-      - run: MIRIFLAGS="-Zmiri-disable-isolation" cargo miri nextest run ${{ needs.setup.outputs.crates }} --partition count:${{ matrix.partition }}/5
+      - run: MIRIFLAGS="-Zmiri-disable-isolation" cargo miri nextest run ${{ needs.setup.outputs.crates }} --partition count:${{ matrix.partition }}/5 --no-tests=pass
       # We need to disable isolation because
       # "unsupported operation: `clock_gettime` with `REALTIME` clocks not available when isolation is enabled"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,13 +149,13 @@ jobs:
             # shellcheck disable=SC2086
             cargo test --workspace $CRASHTRACKER_FEATURE --exclude builder --doc --verbose
             # shellcheck disable=SC2086
-            cargo nextest run --workspace $CRASHTRACKER_FEATURE --exclude builder --profile ci --verbose -E '!test(tracing_integration_tests::)'
+            cargo nextest run --workspace $CRASHTRACKER_FEATURE --exclude builder --profile ci --verbose --no-tests=pass -E '!test(tracing_integration_tests::)'
             cargo nextest run -p libdd-http-client --no-default-features --features hyper-backend,https --profile ci --verbose
           else
             # shellcheck disable=SC2086
             cargo test $PACKAGES $CRASHTRACKER_FEATURE --doc --verbose
             # shellcheck disable=SC2086
-            cargo nextest run $PACKAGES $CRASHTRACKER_FEATURE --profile ci --verbose -E '!test(tracing_integration_tests::)'
+            cargo nextest run $PACKAGES $CRASHTRACKER_FEATURE --profile ci --verbose --no-tests=pass -E '!test(tracing_integration_tests::)'
             if echo "$PACKAGES" | grep -q "libdd-http-client"; then
               cargo nextest run -p libdd-http-client --no-default-features --features hyper-backend,https --profile ci --verbose
             fi
@@ -166,10 +166,10 @@ jobs:
         shell: bash
         run: |
           if [[ -z "$PACKAGES" ]]; then
-            cargo nextest run --workspace --all-features --exclude builder --exclude test_spawn_from_lib --verbose -E '!test(tracing_integration_tests::)'
+            cargo nextest run --workspace --all-features --exclude builder --exclude test_spawn_from_lib --verbose --no-tests=pass -E '!test(tracing_integration_tests::)'
           else
             # shellcheck disable=SC2086
-            cargo nextest run $PACKAGES --all-features --verbose -E '!test(tracing_integration_tests::) & !package(test_spawn_from_lib)'
+            cargo nextest run $PACKAGES --all-features --verbose --no-tests=pass -E '!test(tracing_integration_tests::) & !package(test_spawn_from_lib)'
           fi
         env:
           RUST_BACKTRACE: full
@@ -182,7 +182,7 @@ jobs:
             for crate in $TRACING_CRATES; do
               PACKAGES="$PACKAGES -p $crate"
             done
-            cargo nextest run $PACKAGES --profile ci --test-threads=1 --verbose -E 'test(tracing_integration_tests::)'
+            cargo nextest run $PACKAGES --profile ci --test-threads=1 --verbose --no-tests=pass -E 'test(tracing_integration_tests::)'
           else
             TRACING_PACKAGES=""
             for crate in $TRACING_CRATES; do
@@ -194,7 +194,7 @@ jobs:
               echo "No tracing integration test crates found in PACKAGES, skipping."
             else
               # shellcheck disable=SC2086
-              cargo nextest run $TRACING_PACKAGES --profile ci --test-threads=1 --verbose -E 'test(tracing_integration_tests::)'
+              cargo nextest run $TRACING_PACKAGES --profile ci --test-threads=1 --verbose --no-tests=pass -E 'test(tracing_integration_tests::)'
             fi
           fi
         env:
@@ -304,10 +304,10 @@ jobs:
         run: |
           if [[ -z "$PACKAGES" ]]; then
             # shellcheck disable=SC2086
-            NEXTEST_CMD="cargo nextest run --workspace $CRASHTRACKER_FEATURE --exclude builder --profile ci -E '!test(tracing_integration_tests::)'"
+            NEXTEST_CMD="cargo nextest run --workspace $CRASHTRACKER_FEATURE --exclude builder --profile ci --no-tests=pass -E '!test(tracing_integration_tests::)'"
           else
             # shellcheck disable=SC2086
-            NEXTEST_CMD="cargo nextest run $PACKAGES $CRASHTRACKER_FEATURE --profile ci -E '!test(tracing_integration_tests::)'"
+            NEXTEST_CMD="cargo nextest run $PACKAGES $CRASHTRACKER_FEATURE --profile ci --no-tests=pass -E '!test(tracing_integration_tests::)'"
           fi
           docker run --rm \
             --user "$(id -u):$(id -g)" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,15 +48,14 @@ jobs:
           CRASHTRACKER_FEATURE=""
           RUN_TEST_SPAWN="false"
         else
-          UNIT_CRATES=$(echo "$AFFECTED_CRATES" | jq '[.[] | select(. != "builder")]')
-          COUNT=$(echo "$UNIT_CRATES" | jq 'length')
-          PACKAGES=$(echo "$UNIT_CRATES" | jq -r 'map("-p " + .) | join(" ")')
-          if echo "$UNIT_CRATES" | jq -e 'any(. == "libdd-crashtracker")' > /dev/null; then
+          COUNT=$(echo "$AFFECTED_CRATES" | jq 'length')
+          PACKAGES=$(echo "$AFFECTED_CRATES" | jq -r 'map("-p " + .) | join(" ")')
+          if echo "$AFFECTED_CRATES" | jq -e 'any(. == "libdd-crashtracker")' > /dev/null; then
             CRASHTRACKER_FEATURE="--features libdd-crashtracker/generate-unit-test-files"
           else
             CRASHTRACKER_FEATURE=""
           fi
-          if echo "$UNIT_CRATES" | jq -e 'any(. == "test_spawn_from_lib")' > /dev/null; then
+          if echo "$AFFECTED_CRATES" | jq -e 'any(. == "test_spawn_from_lib")' > /dev/null; then
             RUN_TEST_SPAWN="true"
           else
             RUN_TEST_SPAWN="false"
@@ -149,7 +148,7 @@ jobs:
             # shellcheck disable=SC2086
             cargo test --workspace $CRASHTRACKER_FEATURE --exclude builder --doc --verbose
             # shellcheck disable=SC2086
-            cargo nextest run --workspace $CRASHTRACKER_FEATURE --exclude builder --profile ci --verbose --no-tests=pass -E '!test(tracing_integration_tests::)'
+            cargo nextest run --workspace $CRASHTRACKER_FEATURE --profile ci --verbose --no-tests=pass -E '!test(tracing_integration_tests::)'
             cargo nextest run -p libdd-http-client --no-default-features --features hyper-backend,https --profile ci --verbose
           else
             # shellcheck disable=SC2086
@@ -166,7 +165,7 @@ jobs:
         shell: bash
         run: |
           if [[ -z "$PACKAGES" ]]; then
-            cargo nextest run --workspace --all-features --exclude builder --exclude test_spawn_from_lib --verbose --no-tests=pass -E '!test(tracing_integration_tests::)'
+            cargo nextest run --workspace --all-features --exclude test_spawn_from_lib --verbose --no-tests=pass -E '!test(tracing_integration_tests::)'
           else
             # shellcheck disable=SC2086
             cargo nextest run $PACKAGES --all-features --verbose --no-tests=pass -E '!test(tracing_integration_tests::) & !package(test_spawn_from_lib)'
@@ -304,7 +303,7 @@ jobs:
         run: |
           if [[ -z "$PACKAGES" ]]; then
             # shellcheck disable=SC2086
-            NEXTEST_CMD="cargo nextest run --workspace $CRASHTRACKER_FEATURE --exclude builder --profile ci --no-tests=pass -E '!test(tracing_integration_tests::)'"
+            NEXTEST_CMD="cargo nextest run --workspace $CRASHTRACKER_FEATURE --profile ci --no-tests=pass -E '!test(tracing_integration_tests::)'"
           else
             # shellcheck disable=SC2086
             NEXTEST_CMD="cargo nextest run $PACKAGES $CRASHTRACKER_FEATURE --profile ci --no-tests=pass -E '!test(tracing_integration_tests::)'"


### PR DESCRIPTION
# What does this PR do?

  **CI: nextest hardening** — `.github/workflows/{miri,test,coverage}.yml`
  - Added `--no-tests=pass` to every dynamic-scope nextest invocation
    (9 total). Prevents exit-code-4 "no tests to run" failures when the
    affected-crates list contains a test-less crate.
  - Dropped three now-redundant `--exclude builder` and one jq filter
    `select(. != "builder")` that all served the same purpose as the
    new flag.
 
# Motivation
Tests can fail if no tests are run by nextest. This will allow future utility crates to be compiled without failing.