### PR TITLE
fix(profiling): drop malformed info / internal_metadata JSON instead of failing the upload

### DIFF
--- a/libdd-profiling-ffi/src/exporter.rs
+++ b/libdd-profiling-ffi/src/exporter.rs
@@ -201,23 +201,31 @@ unsafe fn into_vec_files<'a>(slice: Slice<'a, File>) -> Vec<exporter::File<'a>> 
         .collect()
 }
 
-unsafe fn parse_json(
+/// Best-effort parse of an optional caller-supplied JSON blob. On invalid
+/// UTF-8 or a `serde_json` parse error, log a warning and return `None`
+/// instead of propagating the error. The `info` and `internal_metadata`
+/// channels are supplementary signals attached to the profile upload event;
+/// a malformed payload there should not cause us to drop the pprof itself,
+/// which is the primary artifact.
+unsafe fn parse_json_lossy(
     string_id: &str,
     json_string: Option<&CharSlice>,
-) -> anyhow::Result<Option<serde_json::Value>> {
-    match json_string {
-        None => Ok(None),
-        Some(json_string) => {
-            let json = json_string.try_to_utf8()?;
-            match serde_json::from_str(json) {
-                Ok(parsed) => Ok(Some(parsed)),
-                Err(error) => Err(anyhow::anyhow!(
-                    "Failed to parse contents of {} json string (`{}`): {}.",
-                    string_id,
-                    json,
-                    error
-                )),
-            }
+) -> Option<serde_json::Value> {
+    let cs = json_string?;
+    let json = match cs.try_to_utf8() {
+        Ok(s) => s,
+        Err(err) => {
+            eprintln!("warning: profile {string_id} JSON is not valid UTF-8, dropping it: {err}");
+            return None;
+        }
+    };
+    match serde_json::from_str(json) {
+        Ok(parsed) => Some(parsed),
+        Err(err) => {
+            eprintln!(
+                "warning: failed to parse profile {string_id} JSON (`{json}`), dropping it: {err}"
+            );
+            None
         }
     }
 }
@@ -289,8 +297,9 @@ pub unsafe extern "C" fn ddog_prof_Exporter_send_blocking(
         let process_tags_str = optional_process_tags
             .map(|cs| cs.try_to_utf8())
             .transpose()?;
-        let internal_metadata = parse_json("internal_metadata", optional_internal_metadata_json)?;
-        let info = parse_json("info", optional_info_json)?;
+        let internal_metadata =
+            parse_json_lossy("internal_metadata", optional_internal_metadata_json);
+        let info = parse_json_lossy("info", optional_info_json);
 
         let cancel = cancel.to_inner_mut().ok();
         let status = exporter.send_blocking(
@@ -443,8 +452,9 @@ pub unsafe extern "C" fn ddog_prof_ExporterManager_queue(
         let process_tags_str = optional_process_tags
             .map(|cs| cs.try_to_utf8())
             .transpose()?;
-        let internal_metadata = parse_json("internal_metadata", optional_internal_metadata_json)?;
-        let info = parse_json("info", optional_info_json)?;
+        let internal_metadata =
+            parse_json_lossy("internal_metadata", optional_internal_metadata_json);
+        let info = parse_json_lossy("info", optional_info_json);
 
         manager.queue(
             profile,
@@ -765,5 +775,28 @@ mod tests {
                 panic!("Expected error since no server is running");
             }
         }
+    }
+
+    #[test]
+    fn test_parse_json_lossy_none() {
+        let parsed = unsafe { parse_json_lossy("info", None) };
+        assert!(parsed.is_none());
+    }
+
+    #[test]
+    fn test_parse_json_lossy_valid() {
+        let s = CharSlice::from(r#"{"runtime": {"engine": "test"}}"#);
+        let parsed = unsafe { parse_json_lossy("info", Some(&s)) }.expect("valid JSON");
+        assert_eq!(parsed["runtime"]["engine"], "test");
+    }
+
+    #[test]
+    fn test_parse_json_lossy_drops_invalid() {
+        // Malformed JSON: trailing comma + missing closing brace. Must not
+        // propagate an error; we should silently drop the payload so the
+        // pprof itself can still upload.
+        let s = CharSlice::from(r#"{"runtime": {"engine": "test",}"#);
+        let parsed = unsafe { parse_json_lossy("info", Some(&s)) };
+        assert!(parsed.is_none());
     }
 }

--- a/libdd-profiling-ffi/src/exporter.rs
+++ b/libdd-profiling-ffi/src/exporter.rs
@@ -222,9 +222,7 @@ unsafe fn parse_json_lossy(
     match serde_json::from_str(json) {
         Ok(parsed) => Some(parsed),
         Err(err) => {
-            eprintln!(
-                "warning: failed to parse profile {string_id} JSON (`{json}`), dropping it: {err}"
-            );
+            eprintln!("warning: failed to parse profile {string_id} JSON, dropping it: {err}");
             None
         }
     }
@@ -796,6 +794,15 @@ mod tests {
         // propagate an error; we should silently drop the payload so the
         // pprof itself can still upload.
         let s = CharSlice::from(r#"{"runtime": {"engine": "test",}"#);
+        let parsed = unsafe { parse_json_lossy("info", Some(&s)) };
+        assert!(parsed.is_none());
+    }
+
+    #[test]
+    fn test_parse_json_lossy_drops_invalid_utf8() {
+        // 0xFF is never valid in UTF-8. Must be dropped, not propagated.
+        let raw: &[u8] = &[b'{', 0xFF, b'}'];
+        let s = CharSlice::from_bytes(raw);
         let parsed = unsafe { parse_json_lossy("info", Some(&s)) };
         assert!(parsed.is_none());
     }


### PR DESCRIPTION
# What does this PR do?

Replaces the strict `parse_json` helper used by `ddog_prof_Exporter_send_blocking` and the async `send` entry point with `parse_json_lossy`, which logs a warning to stderr and returns `None` instead of propagating an error when either `optional_internal_metadata_json` or `optional_info_json` fails to parse.

```rust
unsafe fn parse_json_lossy(
    string_id: &str,
    json_string: Option<&CharSlice>,
) -> Option<serde_json::Value> {
    let cs = json_string?;
    let json = match cs.try_to_utf8() {
        Ok(s) => s,
        Err(err) => {
            eprintln!("warning: profile {string_id} JSON is not valid UTF-8, dropping it: {err}");
            return None;
        }
    };
    match serde_json::from_str(json) {
        Ok(parsed) => Some(parsed),
        Err(err) => {
            eprintln!("warning: failed to parse profile {string_id} JSON (`{json}`), dropping it: {err}");
            None
        }
    }
}
```

The 4 internal call sites in `libdd-profiling-ffi/src/exporter.rs` (lines 302-303 in `send_blocking`, 456-457 in `send`) drop the `?` and let the lossy helper handle errors locally.

# Motivation

Before this change, the FFI entry points used `parse_json(...)?` for both supplementary JSON channels. A parse failure aborted the whole upload and the caller observed a `Result::Err`, meaning the **entire pprof profile was dropped** because of a bad metadata blob.

This is asymmetric with what callers already do on their own side. dd-trace-py wraps `json.dumps(info_payload)` in a `try/except` ([profiler.py:209-217](https://github.com/DataDog/dd-trace-py/blob/main/ddtrace/profiling/profiler.py)) and continues on failure. dd-trace-go and dd-trace-php take similar best-effort approaches when building the upload event. The native FFI layer was the one place where a malformed supplementary blob could escalate to a dropped profile.

Realistic ways the parse can fail even when the caller's own serializer succeeded:
- Python's `json.dumps` emits the literal `Infinity` / `NaN` by default (non-standard JSON). `serde_json::from_str` rejects them.
- Integers that exceed `f64` range silently round in serde_json; integers above that fail outright.
- Future custom encoders or escaping bugs.

The pprof is the primary artifact. `info` and `internal_metadata` are supplementary signals attached to the multipart event. A bad supplementary blob should not be allowed to take down the primary artifact.

# Additional Notes

- `parse_json_lossy` replaces the old `parse_json` outright. The old function was private to the module (`unsafe fn`, no `pub`) and was not referenced from any other crate (verified with a repo-wide grep; the other `parse_json` matches under `datadog-remote-config/` are unrelated functions in different modules).
- Logging is via `eprintln!` to match the existing style in `libdd-profiling/src/exporter/exporter_manager.rs:476/509/579`. Happy to switch to `tracing::warn!` if that's the desired direction for this crate.
- This is the upstream fix for [DataDog/dd-trace-py#18057](https://github.com/DataDog/dd-trace-py/pull/18057) (PROF-14617), which added a per-profile `info.profiler.settings` snapshot of `ProfilingConfig` to each upload. The downstream side already wraps its `json.dumps` in a try/except, so this PR closes the only remaining gap.

# How to test the change?

```
cargo test -p libdd-profiling-ffi --lib
```

Three new tests cover the contract:

- `exporter::tests::test_parse_json_lossy_none` - `None` input passes through unchanged.
- `exporter::tests::test_parse_json_lossy_valid` - valid JSON round-trips into `serde_json::Value`.
- `exporter::tests::test_parse_json_lossy_drops_invalid` - malformed JSON (trailing comma, missing brace) returns `None` rather than panicking or propagating an error.

All 57 tests in the crate pass, including the existing `test_send_blocking_with_metadata` which exercises the FFI end-to-end with valid metadata + info JSON.