### PR TITLE
perf(profiling): observation map doesn't need HashDos protection

### DIFF
--- a/libdd-profiling/src/internal/observation/observations.rs
+++ b/libdd-profiling/src/internal/observation/observations.rs
@@ -10,6 +10,8 @@ use crate::internal::Timestamp;
 use std::collections::HashMap;
 use std::io;
 
+type Hasher = core::hash::BuildHasherDefault<rustc_hash::FxHasher>;
+
 struct NonEmptyObservations {
     // Samples with no timestamps are aggregated in-place as each observation is added
     aggregated_data: AggregatedObservations,
@@ -131,7 +133,7 @@ impl Observations {
 #[derive(Default)]
 struct AggregatedObservations {
     obs_len: ObservationLength,
-    data: HashMap<Sample, TrimmedObservation>,
+    data: HashMap<Sample, TrimmedObservation, Hasher>,
 }
 
 impl AggregatedObservations {


### PR DESCRIPTION
# What does this PR do?

This changes `AggregatedObservations`'s `HashMap` to use `FxHasher` for its hasher instead of the default.

# Motivation

HashDos protection comes built-in with the default hasher type, and it's unnecessary here. It's more performant in general to use `FxHasher`.

# Additional Notes

My motivation here isn't actually performance, although it's true; I want a deterministic hasher between runs so iteration order is preserved. I am trying to make another version of the `ddog_prof_Profile_serialize` function. I want bit-for-bit fuzz accuracy for property testing it, but with a HashDos protected HashMap, the order of iteration will change from map to map.

But even if this other work doesn't land, it's true we're paying for HashDos protection that we don't need, which is why I opened this as its own PR.

# How to test the change?

Test as regularly done--this shouldn't change anything.
