### PR TITLE
chore: bump libdd-capabilities-impl to 1.1.0 and libdd-data-pipeline to 3.1.0

### DIFF
--- a/libdd-capabilities-impl/Cargo.toml
+++ b/libdd-capabilities-impl/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "libdd-capabilities-impl"
-version = "1.0.0"
+version = "1.1.0"
 description = "Native implementations of libdd-capabilities traits"
 homepage = "https://github.com/DataDog/libdatadog/tree/main/libdd-capabilities-impl"
 repository = "https://github.com/DataDog/libdatadog/tree/main/libdd-capabilities-impl"

--- a/libdd-data-pipeline/Cargo.toml
+++ b/libdd-data-pipeline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libdd-data-pipeline"
-version= "3.0.1"
+version= "3.1.0"
 description = "Trace exporter package allowing sending data from datadog SDKs to the Trace Agent."
 homepage = "https://github.com/DataDog/libdatadog/tree/main/libdd-data-pipeline"
 repository = "https://github.com/DataDog/libdatadog/tree/main/libdd-data-pipeline"
@@ -48,7 +48,7 @@ libdd-tinybytes = { version = "1.1.0", path = "../libdd-tinybytes", features = [
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1.23", features = ["time", "test-util"], default-features = false }
-libdd-capabilities-impl = { version = "1.0.0", path = "../libdd-capabilities-impl", default-features = false }
+libdd-capabilities-impl = { version = "1.1.0", path = "../libdd-capabilities-impl", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
@@ -63,7 +63,7 @@ harness = false
 path = "benches/trace_buffer.rs"
 
 [dev-dependencies]
-libdd-capabilities-impl = { version = "1.0.0", path = "../libdd-capabilities-impl" }
+libdd-capabilities-impl = { version = "1.1.0", path = "../libdd-capabilities-impl" }
 libdd-log = { path = "../libdd-log" }
 libdd-shared-runtime = { version = "0.1.0", path = "../libdd-shared-runtime" }
 regex = "1.5"


### PR DESCRIPTION
## What does this PR do?

Bumps two crates that added public APIs in [#1822](https://github.com/DataDog/libdatadog/pull/1822) without incrementing their version numbers. Without a version bump these APIs cannot be published to crates.io (you cannot republish the same version), blocking downstream consumers from using them without a `[patch.crates-io]` workaround.

| Crate | Old | New | New APIs |
|---|---|---|---|
| `libdd-capabilities-impl` | `1.0.0` | `1.1.0` | `NativeCapabilities` |
| `libdd-data-pipeline` | `3.0.1` | `3.1.0` | `telemetry` feature, `TelemetryInstrumentationSessions`, `TraceExporter<C>` |

`libdd-telemetry` is already at `5.0.0` on main (unpublished), so no bump is needed there.

## Motivation

`dd-trace-rs` [#216](https://github.com/DataDog/dd-trace-rs/pull/216) implements instrumentation session ID propagation using these APIs. Until this PR lands and these crates are published, `dd-trace-rs` must carry a `[patch.crates-io]` block in every workspace that consumes it — including `DataDog/system-tests` for parametric tests.

## After merge

Once this PR is merged, publish `libdd-capabilities-impl 1.1.0` and `libdd-data-pipeline 3.1.0` to crates.io (along with the already-bumped `libdd-telemetry 5.0.0`). Then `dd-trace-rs` PR #216 can be updated to reference the published versions and drop `[patch.crates-io]` entirely.