### PR TITLE
fix(libdd-telemetry): restore previous Cargo.toml version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3266,7 +3266,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-telemetry"
-version = "5.0.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/libdd-crashtracker/Cargo.toml
+++ b/libdd-crashtracker/Cargo.toml
@@ -50,7 +50,7 @@ chrono = {version = "0.4", default-features = false, features = ["std", "clock",
 cxx = { version = "1.0", optional = true }
 errno = "0.3"
 libdd-common = { version = "4.0.0", path = "../libdd-common" }
-libdd-telemetry = { version = "5.0.0", path = "../libdd-telemetry" }
+libdd-telemetry = { version = "4.0.0", path = "../libdd-telemetry" }
 http = "1.1"
 libc = "0.2"
 nix = { version = "0.29", features = ["poll", "signal", "socket"] }

--- a/libdd-data-pipeline/Cargo.toml
+++ b/libdd-data-pipeline/Cargo.toml
@@ -34,7 +34,7 @@ tokio-util = "0.7.11"
 libdd-capabilities = { path = "../libdd-capabilities", version = "1.0.0" }
 libdd-common = { version = "4.0.0", path = "../libdd-common", default-features = false }
 libdd-shared-runtime = { version = "0.1.0", path = "../libdd-shared-runtime", default-features = false }
-libdd-telemetry = { version = "5.0.0", path = "../libdd-telemetry", default-features = false, optional = true}
+libdd-telemetry = { version = "4.0.0", path = "../libdd-telemetry", default-features = false, optional = true}
 libdd-trace-protobuf = { version = "3.0.1", path = "../libdd-trace-protobuf" }
 libdd-trace-stats = { version = "2.0.0", path = "../libdd-trace-stats", default-features = false }
 libdd-trace-utils = { version = "3.0.1", path = "../libdd-trace-utils", default-features = false }

--- a/libdd-telemetry/Cargo.toml
+++ b/libdd-telemetry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libdd-telemetry"
-version= "5.0.0"
+version= "4.0.0"
 description = "Telemetry client allowing to send data as described in https://docs.datadoghq.com/tracing/configure_data_security/?tab=net#telemetry-collection"
 homepage = "https://github.com/DataDog/libdatadog/tree/main/libdd-telemetry"
 repository = "https://github.com/DataDog/libdatadog/tree/main/libdd-telemetry"


### PR DESCRIPTION
# What does this PR do?

Restore `libdd-telemetry` version bumped manually

# Motivation

Version bumps should only be performed through the release workflow.

Note: A check should have failed when the version was changed manually but it didn't (under review [here](https://github.com/DataDog/libdatadog/pull/1994))

