### PR TITLE
fix(ci): pr-metadata-docs-and-deps

### DIFF
--- a/.github/workflows/pr-metadata-docs-and-deps.yml
+++ b/.github/workflows/pr-metadata-docs-and-deps.yml
@@ -47,16 +47,20 @@ jobs:
         # Get the list of changed crates
         CRATES='${{ needs.changed-crates.outputs.crates }}'
         
+        WORKSPACE_ROOT=$(cargo metadata --format-version=1 --no-deps | jq -r '.workspace_root')
+
         FAILED=0
         while read -r crate; do
           NAME=$(echo "$crate" | jq -r '.name')
           CURRENT_VERSION=$(echo "$crate" | jq -r '.version')
-          MANIFEST=$(echo "$crate" | jq -r '.manifest')
+          MANIFEST_REL=$(echo "$crate" | jq -r --arg root "$WORKSPACE_ROOT" '
+            .manifest | sub($root + "/"; "")
+          ')
           
           echo "Checking $NAME version is not changed in the PR..."
           
           # Get base version from Cargo.toml at base ref
-          BASE_VERSION=$(git show "$BASE_REF:$MANIFEST" 2>/dev/null | grep -E '^\s*version\s*=' | head -1 | sed -E 's/.*=\s*"([^"]+)".*/\1/' || echo "")
+          BASE_VERSION=$(git show "origin/$BASE_REF:$MANIFEST_REL" 2>/dev/null | grep -E '^\s*version\s*=' | head -1 | sed -E 's/.*=\s*"([^"]+)".*/\1/' || echo "")
           
           if [[ -z "$BASE_VERSION" ]]; then
             echo "  ✓ $NAME is a new crate (no base version found)"


### PR DESCRIPTION
# What does this PR do?

Use manifest's relative path to check the original version of the crate
