### PR TITLE
ci: include libdd-sampling & the latest tracer version in proposal test

### DIFF
--- a/.github/workflows/release-proposal-dispatch.yml
+++ b/.github/workflows/release-proposal-dispatch.yml
@@ -519,29 +519,35 @@ jobs:
           # iterate over the major bumps and check the major bumps and update the version
           jq -c '.[]' /tmp/api-changes-with-major-bumps-pre-commit.json | while read -r bump; do
             NAME=$(echo "$bump" | jq -r '.name')
+            LEVEL=$(echo "$bump" | jq -r '.level')
             PREV_TAG=$(echo "$bump" | jq -r '.prev_tag')
             TAG=$(echo "$bump" | jq -r '.tag')
             VERSION=$(echo "$bump" | jq -r '.version')
-            MAJOR_BUMPS=$(echo "$bump" | jq -r '.major_bumps')
+            MAJOR_BUMPS=$(echo "$bump" | jq -c '.major_bumps')
 
             if [ "$MAJOR_BUMPS" != "[]" ]; then
-              echo "Updating version for $NAME with major bumps: $MAJOR_BUMPS"
-              cargo release version -p "$NAME" --prev-tag-name "$PREV_TAG" --allow-branch "$BRANCH_NAME" -x major --no-confirm
-              
-              git commit -am "chore(release): update version for $NAME with major bumps"
+              # Already bumped at major in the API semver step; do not bump major again for libdd-* propagation.
+              if [ "$LEVEL" = "major" ]; then
+                echo "Skipping $NAME: already bumped at major level in the previous step (major_bumps: $MAJOR_BUMPS)"
+              else
+                echo "Updating version for $NAME with major bumps: $MAJOR_BUMPS"
+                cargo release version -p "$NAME" --prev-tag-name "$PREV_TAG" --allow-branch "$BRANCH_NAME" -x major --no-confirm
+                
+                git commit -am "chore(release): update version for $NAME with major bumps"
 
-              NEXT_VERSION=$(cargo metadata --format-version=1 --no-deps | jq -r --arg name "$NAME" '.packages[] | select(.name == $name) | .version')
-              NEXT_TAG="$NAME-v$NEXT_VERSION"
+                NEXT_VERSION=$(cargo metadata --format-version=1 --no-deps | jq -r --arg name "$NAME" '.packages[] | select(.name == $name) | .version')
+                NEXT_TAG="$NAME-v$NEXT_VERSION"
 
-              echo "Updating tag $TAG to $NEXT_TAG and version $VERSION to $NEXT_VERSION for $NAME"
+                echo "Updating tag $TAG to $NEXT_TAG and version $VERSION to $NEXT_VERSION for $NAME"
 
-              jq --arg name "$NAME" \
-                --arg nl "major" \
-                --arg version "$NEXT_VERSION" \
-                --arg tag "$NEXT_TAG" \
-                'map(if .name == $name then . + {level: $nl, version: $version, tag: $tag} else . end)' \
-                /tmp/api-changes-with-major-bumps.json > /tmp/api-changes-with-major-bumps.tmp \
-                && mv /tmp/api-changes-with-major-bumps.tmp /tmp/api-changes-with-major-bumps.json
+                jq --arg name "$NAME" \
+                  --arg nl "major" \
+                  --arg version "$NEXT_VERSION" \
+                  --arg tag "$NEXT_TAG" \
+                  'map(if .name == $name then . + {level: $nl, version: $version, tag: $tag} else . end)' \
+                  /tmp/api-changes-with-major-bumps.json > /tmp/api-changes-with-major-bumps.tmp \
+                  && mv /tmp/api-changes-with-major-bumps.tmp /tmp/api-changes-with-major-bumps.json
+              fi
             fi
           done
 

--- a/.github/workflows/release-proposal-dispatch.yml
+++ b/.github/workflows/release-proposal-dispatch.yml
@@ -21,6 +21,7 @@ on:
           - libdd-otel-thread-ctx
           - libdd-profiling
           - libdd-profiling-protobuf
+          - libdd-sampling
           - libdd-shared-runtime
           - libdd-telemetry
           - libdd-tinybytes

--- a/.github/workflows/release-proposal-test.yml
+++ b/.github/workflows/release-proposal-test.yml
@@ -85,7 +85,7 @@ jobs:
     if: needs.package-and-upload-crates.outputs.upload_artifact == 'true'
     strategy:
       matrix:
-        version: ["datadog-opentelemetry-v0.3.2", "datadog-opentelemetry-v0.3.1"]
+        version: ["datadog-opentelemetry-v0.3.3", "datadog-opentelemetry-v0.3.2", "datadog-opentelemetry-v0.3.1"]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
         with:


### PR DESCRIPTION
# What does this PR do?

- Fix a case where a major was bumped twice: first in `'Release version bumps'` step and last in `'Update version for crates with libdd-* direct dependency major bumps since last release'` step
- Include `libdd-sampling` crate
- Include `datadog-opentelemetry-v0.3.3` in the release proposal test.

Note: The test could be improved by getting  automatically the `datadog-opentelemetry-v` tags from `dd-trace-rs` and using them in the matrix

