### PR TITLE
fix(ci): handle other kinds of minor semver changes

### DIFF
--- a/scripts/semver-level.sh
+++ b/scripts/semver-level.sh
@@ -90,6 +90,13 @@ compute_semver_results() {
             LEVEL="minor"
             REASON="New crate (not present in baseline)"
             log_verbose "New crate '$crate' not found in baseline, treating as minor change" >&2
+        elif echo "$SEMVER_OUTPUT" | grep -qE "Summary semver requires new minor version"; then
+            LEVEL="minor"
+            REASON="cargo-semver-checks detected minor breaking changes"
+            # Extract the relevant violation details (skip the header/summary lines)
+            DETAILS=$(echo "$SEMVER_OUTPUT" | grep -A 1000 "^--- failure" | head -100 || echo "$SEMVER_OUTPUT" | tail -50)
+            log_verbose "Detected semver violations (minor change)" >&2
+            log_verbose "$SEMVER_OUTPUT" >&2
         else
             echo "Error running cargo-semver-checks: $SEMVER_OUTPUT" >&2
             exit $SEMVER_EXIT_CODE


### PR DESCRIPTION
# What does this PR do?

When cargo-semver fails in CI for a minor change, the pattern in logs was not checked and it errored: [example failure](https://github.com/DataDog/libdatadog/actions/runs/25924100283/job/76200605744?pr=1947).

# Motivation

Fixes the semver-check CI failure on https://github.com/DataDog/libdatadog/pull/1947

# Additional Notes

# How to test the change?
The script now outputs
```
crate=libdd-trace-obfuscation
semver_level=minor
```
in local on the [problematic PR](https://github.com/DataDog/libdatadog/pull/1947) instead of failing and incorrectly returning empty fields:
```
crate=
semver_level=
```