### PR TITLE
chore(ci): use the large runners for ubuntu as we keep running out of disk space

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,9 @@ jobs:
     name: "cargo test #${{ matrix.platform }} ${{ matrix.rust_version }}"
     needs: setup
     if: needs.setup.outputs.packages-count != '0'
-    runs-on: ${{ matrix.platform }}
+    # Ubuntu jobs run on the larger APM runner pool — the default GitHub-hosted
+    # ubuntu-latest disk fills up partway through the workspace build.
+    runs-on: ${{ (matrix.platform == 'ubuntu-latest' && fromJSON('{"labels":"ubuntu-latest-16-cores","group":"APM Larger Runners"}')) || matrix.platform }}
     permissions:
       checks: write
       contents: read


### PR DESCRIPTION
# What does this PR do?

Since https://github.com/DataDog/libdatadog/pull/1928 we've been intermittently running out of disk space on our GH runners for tests. This PR bumps the size of our ubuntu runners, which includes more disk space and should solve this issue.  

# Motivation

@morrisonlevi was seeing consistent failures on the MQ when running the full test suite on this PR: https://github.com/DataDog/libdatadog/pull/1988

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
