### PR TITLE
fix(data-pipeline): allow old PascalCase fields in obfuscation config scheme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1712,6 +1712,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "duplicate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e92f10a49176cbffacaedabfaa11d51db1ea0f80a83c26e1873b43cd1742c24"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2980,6 +2991,7 @@ dependencies = [
  "bytes",
  "clap",
  "criterion",
+ "duplicate 2.0.1",
  "either",
  "getrandom 0.2.15",
  "http",
@@ -3338,7 +3350,7 @@ dependencies = [
  "anyhow",
  "arbitrary",
  "criterion",
- "duplicate",
+ "duplicate 0.4.1",
  "libdd-trace-protobuf",
  "rand 0.8.5",
 ]
@@ -3349,7 +3361,7 @@ version = "2.0.0"
 dependencies = [
  "anyhow",
  "criterion",
- "duplicate",
+ "duplicate 0.4.1",
  "fluent-uri",
  "libdd-common",
  "libdd-trace-protobuf",
@@ -4320,6 +4332,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "version_check",
 ]
 
 [[package]]

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -305,6 +305,7 @@ proc-macro-crate,https://github.com/bkchr/proc-macro-crate,MIT OR Apache-2.0,Bas
 proc-macro-error,https://gitlab.com/CreepySkeleton/proc-macro-error,MIT OR Apache-2.0,CreepySkeleton <creepy-skeleton@yandex.ru>
 proc-macro-error-attr,https://gitlab.com/CreepySkeleton/proc-macro-error,MIT OR Apache-2.0,CreepySkeleton <creepy-skeleton@yandex.ru>
 proc-macro2,https://github.com/dtolnay/proc-macro2,MIT OR Apache-2.0,"David Tolnay <dtolnay@gmail.com>, Alex Crichton <alex@alexcrichton.com>"
+proc-macro2-diagnostics,https://github.com/SergioBenitez/proc-macro2-diagnostics,MIT OR Apache-2.0,Sergio Benitez <sb@sergio.bz>
 prost,https://github.com/tokio-rs/prost,Apache-2.0,"Dan Burkert <dan@danburkert.com>, Lucio Franco <luciofranco14@gmail.com>, Casper Meijn <casper@meijn.net>, Tokio Contributors <team@tokio.rs>"
 prost-derive,https://github.com/tokio-rs/prost,Apache-2.0,"Dan Burkert <dan@danburkert.com>, Lucio Franco <luciofranco14@gmail.com>, Casper Meijn <casper@meijn.net>, Tokio Contributors <team@tokio.rs>"
 prost-types,https://github.com/tokio-rs/prost,Apache-2.0,"Dan Burkert <dan@danburkert.com>, Lucio Franco <luciofranco14@gmail.com>, Casper Meijn <casper@meijn.net>, Tokio Contributors <team@tokio.rs>"

--- a/libdd-data-pipeline/Cargo.toml
+++ b/libdd-data-pipeline/Cargo.toml
@@ -80,6 +80,7 @@ tokio = { version = "1.23", features = [
     "time",
     "test-util",
 ], default-features = false }
+duplicate = "2.0.1"
 
 [features]
 default = ["https", "telemetry"]

--- a/libdd-data-pipeline/src/agent_info/fetcher.rs
+++ b/libdd-data-pipeline/src/agent_info/fetcher.rs
@@ -408,23 +408,43 @@ mod single_threaded_tests {
                         },
                         "remove_stack_traces": false,
                         "redis": {
-                                "enabled": true,
-                                "remove_all_args": false
+                                "Enabled": true,
+                                "RemoveAllArgs": false
                         },
                         "memcached": {
-                                "enabled": true,
-                                "keep_command": false
+                                "Enabled": true,
+                                "KeepCommand": false
                         }
                 }
         },
-        "peer_tags": ["db.hostname","http.host","aws.s3.bucket"]
+        "peer_tags": ["db.hostname","http.host","aws.s3.bucket"],
+        "obfuscation_version": 1,
+        "filter_tags": {
+            "reject": [
+              "appsec.events.system_tests_appsec_event.value:tf-reject-exact"
+            ],
+            "require": [
+              "appsec.events.system_tests_appsec_event.value:tf-require-exact"
+            ]
+        },
+        "filter_tags_regex": {
+            "reject": [
+              "appsec.events.system_tests_appsec_event.value:tf-reject-regex-.*"
+            ],
+            "require": [
+              "appsec.events.system_tests_appsec_event.value:tf-require-regex-.*"
+            ]
+        },
+        "ignore_resources": [
+            ".*(stats-unique|StatsUniqueHandler).*"
+        ]
     }"#;
 
     fn calculate_hash(json: &str) -> String {
         format!("{:x}", Sha256::digest(json.as_bytes()))
     }
 
-    const TEST_INFO_HASH: &str = "cce54bf6e7d1bf38088a3ec809bfeec160bc52d37f70bd6b581ce3c2f7be5a65";
+    const TEST_INFO_HASH: &str = "d0f6dde2c1ef3b7b776a58162d42574346e23f4677c3fafb440f5c7ca83a8a28";
 
     #[cfg_attr(miri, ignore)]
     #[tokio::test]

--- a/libdd-data-pipeline/src/agent_info/schema.rs
+++ b/libdd-data-pipeline/src/agent_info/schema.rs
@@ -99,14 +99,21 @@ pub struct HttpObfuscationConfig {
 
 #[allow(missing_docs)]
 #[derive(Clone, Serialize, Deserialize, Default, Debug, PartialEq)]
+#[serde(rename_all = "PascalCase")]
 pub struct RedisObfuscationConfig {
+    // Agent sent pascal case fields here in versions <7.79.0
+    #[serde(alias = "Enabled")]
     pub enabled: bool,
+    #[serde(alias = "RemoveAllArgs")]
     pub remove_all_args: bool,
 }
 
 #[allow(missing_docs)]
 #[derive(Clone, Serialize, Deserialize, Default, Debug, PartialEq)]
 pub struct MemcachedObfuscationConfig {
+    // Agent sent pascal case fields here in versions <7.79.0
+    #[serde(alias = "Enabled")]
     pub enabled: bool,
+    #[serde(alias = "KeepCommand")]
     pub keep_command: bool,
 }

--- a/libdd-data-pipeline/src/agent_info/schema.rs
+++ b/libdd-data-pipeline/src/agent_info/schema.rs
@@ -116,3 +116,84 @@ pub struct MemcachedObfuscationConfig {
     #[serde(alias = "KeepCommand")]
     pub keep_command: bool,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::AgentInfoStruct;
+    #[duplicate::duplicate_item(
+        test_name input;
+        [parse_empty] ["{}"];
+        [parse_old_obfuscation_config] [r#"{
+            "config": {
+                "obfuscation": {
+                    "elastic_search": true,
+                    "mongo": true,
+                    "sql_exec_plan": false,
+                    "sql_exec_plan_normalize": false,
+                    "http": {
+                        "remove_query_string": false,
+                        "remove_path_digits": false
+                    },
+                    "remove_stack_traces": false,
+                    "redis": {
+                        "Enabled": true,
+                        "RemoveAllArgs": false
+                    },
+                    "memcached": {
+                        "Enabled": true,
+                        "KeepCommand": false
+                    }
+                }
+            }
+        }"#];
+        [parse_new_obfuscation_config] [r#"{
+            "config": {
+                "obfuscation": {
+                    "elastic_search": true,
+                    "mongo": true,
+                    "sql_exec_plan": false,
+                    "sql_exec_plan_normalize": false,
+                    "http": {
+                        "remove_query_string": false,
+                        "remove_path_digits": false
+                    },
+                    "remove_stack_traces": false,
+                    "redis": {
+                        "enabled": true,
+                        "remove_all_args": false
+                    },
+                    "memcached": {
+                        "enabled": true,
+                        "keep_command": false
+                    }
+                }
+            }
+        }"#];
+        [parse_filter_tags] [r#"{
+            "filter_tags": {
+                "reject": [
+                  "appsec.events.system_tests_appsec_event.value:tf-reject-exact"
+                ],
+                "require": [
+                  "appsec.events.system_tests_appsec_event.value:tf-require-exact"
+                ]
+            },
+            "filter_tags_regex": {
+                "reject": [
+                  "appsec.events.system_tests_appsec_event.value:tf-reject-regex-.*"
+                ],
+                "require": [
+                  "appsec.events.system_tests_appsec_event.value:tf-require-regex-.*"
+                ]
+            },
+            "ignore_resources": [
+                ".*(stats-unique|StatsUniqueHandler).*"
+            ]
+        }"#]
+    )]
+    #[test]
+    fn test_name() {
+        let _info: AgentInfoStruct = serde_json::from_str(input)
+            .expect("AgentInfoStruct should be parsed succefully from input");
+    }
+}

--- a/libdd-data-pipeline/src/agent_info/schema.rs
+++ b/libdd-data-pipeline/src/agent_info/schema.rs
@@ -99,7 +99,6 @@ pub struct HttpObfuscationConfig {
 
 #[allow(missing_docs)]
 #[derive(Clone, Serialize, Deserialize, Default, Debug, PartialEq)]
-#[serde(rename_all = "PascalCase")]
 pub struct RedisObfuscationConfig {
     // Agent sent pascal case fields here in versions <7.79.0
     #[serde(alias = "Enabled")]

--- a/libdd-data-pipeline/src/agent_info/schema.rs
+++ b/libdd-data-pipeline/src/agent_info/schema.rs
@@ -194,6 +194,6 @@ mod tests {
     #[test]
     fn test_name() {
         let _info: AgentInfoStruct = serde_json::from_str(input)
-            .expect("AgentInfoStruct should be parsed succefully from input");
+            .expect("AgentInfoStruct should be parsed successfully from input");
     }
 }


### PR DESCRIPTION
These fields were renamed in version 7.79.0 of the agent for consistency.

# What does this PR do?

Allow both PascalCase and the newer snake_case format for these fields.

# Motivation

The trace exporter was crashing in a confusing way in new system tests I wrote for another feature: https://github.com/DataDog/system-tests/pull/6952. I had an older agent.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
