### PR TITLE
refactor(profiling): more try_reserve fixes

### DIFF
--- a/libdd-profiling-ffi/src/exporter.rs
+++ b/libdd-profiling-ffi/src/exporter.rs
@@ -44,6 +44,15 @@ pub extern "C" fn ddog_prof_Exporter_Slice_File_empty() -> Slice<'static, File<'
 /// cbindgen:field-names=[code]
 pub struct HttpStatus(u16);
 
+fn try_clone_optional_tags(tags: Option<&libdd_common_ffi::Vec<Tag>>) -> anyhow::Result<Vec<Tag>> {
+    let mut cloned = Vec::new();
+    if let Some(tags) = tags {
+        cloned.try_reserve_exact(tags.len())?;
+        cloned.extend(tags.iter().cloned());
+    }
+    Ok(cloned)
+}
+
 /// Creates an endpoint that uses the agent.
 /// # Arguments
 /// * `base_url` - Contains a URL with scheme, host, and port e.g. "https://agent:8126/".
@@ -162,9 +171,7 @@ pub unsafe extern "C" fn ddog_prof_Exporter_new(
         let library_version = profiling_library_version.try_to_utf8()?;
         let family = family.try_to_utf8()?;
         let converted_endpoint = unsafe { try_to_endpoint(endpoint)? };
-        let tags = tags
-            .map(|tags| tags.iter().cloned().collect())
-            .unwrap_or_default();
+        let tags = try_clone_optional_tags(tags)?;
         anyhow::Ok(
             ProfileExporter::new(
                 library_name,
@@ -189,16 +196,18 @@ pub unsafe extern "C" fn ddog_prof_Exporter_drop(mut exporter: *mut Handle<Profi
     drop(exporter.take())
 }
 
-unsafe fn into_vec_files<'a>(slice: Slice<'a, File>) -> Vec<exporter::File<'a>> {
-    slice
-        .into_slice()
-        .iter()
-        .map(|file| {
-            let name = file.name.try_to_utf8().unwrap_or("{invalid utf-8}");
-            let bytes = file.file.as_slice();
-            exporter::File { name, bytes }
-        })
-        .collect()
+unsafe fn try_into_vec_files<'a>(
+    slice: Slice<'a, File>,
+) -> anyhow::Result<Vec<exporter::File<'a>>> {
+    let files = slice.try_as_slice()?;
+    let mut converted = Vec::new();
+    converted.try_reserve_exact(files.len())?;
+    for file in files {
+        let name = file.name.try_to_utf8().unwrap_or("{invalid utf-8}");
+        let bytes = file.file.try_as_slice()?;
+        converted.push(exporter::File { name, bytes });
+    }
+    Ok(converted)
 }
 
 unsafe fn parse_json(
@@ -282,10 +291,8 @@ pub unsafe extern "C" fn ddog_prof_Exporter_send_blocking(
     wrap_with_ffi_result!({
         let exporter = exporter.to_inner_mut()?;
         let profile = *profile.take()?;
-        let files_to_compress_and_export = into_vec_files(files_to_compress_and_export);
-        let tags: Vec<Tag> = optional_additional_tags
-            .map(|tags| tags.iter().cloned().collect())
-            .unwrap_or_default();
+        let files_to_compress_and_export = try_into_vec_files(files_to_compress_and_export)?;
+        let tags = try_clone_optional_tags(optional_additional_tags)?;
         let process_tags_str = optional_process_tags
             .map(|cs| cs.try_to_utf8())
             .transpose()?;
@@ -436,10 +443,8 @@ pub unsafe extern "C" fn ddog_prof_ExporterManager_queue(
     wrap_with_void_ffi_result!({
         let manager = manager.to_inner_mut()?;
         let profile = *profile.take()?;
-        let files_to_compress_and_export = into_vec_files(files_to_compress_and_export);
-        let tags: Vec<Tag> = optional_additional_tags
-            .map(|tags| tags.iter().cloned().collect())
-            .unwrap_or_default();
+        let files_to_compress_and_export = try_into_vec_files(files_to_compress_and_export)?;
+        let tags = try_clone_optional_tags(optional_additional_tags)?;
         let process_tags_str = optional_process_tags
             .map(|cs| cs.try_to_utf8())
             .transpose()?;

--- a/libdd-profiling-ffi/src/profiles/interning_api.rs
+++ b/libdd-profiling-ffi/src/profiles/interning_api.rs
@@ -383,7 +383,8 @@ pub unsafe extern "C" fn ddog_prof_Profile_intern_strings(
 ) -> VoidResult {
     wrap_with_void_ffi_result!({
         anyhow::ensure!(strings.len() == out.len());
-        let mut v = Vec::with_capacity(strings.len());
+        let mut v = Vec::new();
+        v.try_reserve_exact(strings.len())?;
         for s in strings.iter() {
             v.push(s.try_to_utf8()?);
         }

--- a/libdd-profiling/src/internal/profile/interning_api/mod.rs
+++ b/libdd-profiling/src/internal/profile/interning_api/mod.rs
@@ -55,11 +55,12 @@ impl Profile {
         &mut self,
         labels: &[GenerationalId<LabelId>],
     ) -> anyhow::Result<GenerationalId<LabelSetId>> {
-        let labels = labels
-            .iter()
-            .map(|l| l.get(self.generation))
-            .collect::<anyhow::Result<Box<_>>>()?;
-        let labels = LabelSet::new(labels);
+        let mut vec = Vec::new();
+        vec.try_reserve_exact(labels.len())?;
+        for l in labels.iter() {
+            vec.push(l.get(self.generation)?);
+        }
+        let labels = LabelSet::new(vec.into_boxed_slice());
         let id = self.label_sets.dedup(labels);
         Ok(GenerationalId::new(id, self.generation))
     }
@@ -145,10 +146,14 @@ impl Profile {
         &mut self,
         locations: &[GenerationalId<LocationId>],
     ) -> anyhow::Result<GenerationalId<StackTraceId>> {
-        let locations = locations
-            .iter()
-            .map(|l| l.get(self.generation))
-            .collect::<anyhow::Result<Vec<_>>>()?;
+        let locations = {
+            let mut vec = Vec::new();
+            vec.try_reserve_exact(locations.len())?;
+            for l in locations.iter() {
+                vec.push(l.get(self.generation)?);
+            }
+            vec
+        };
         let stacktrace = StackTrace { locations };
         let id = self.stack_traces.dedup(stacktrace);
         Ok(GenerationalId::new(id, self.generation))

--- a/libdd-profiling/src/internal/profile/mod.rs
+++ b/libdd-profiling/src/internal/profile/mod.rs
@@ -269,10 +269,10 @@ impl Profile {
 
         self.validate_string_id_sample_labels(&sample)?;
 
-        let labels = sample
-            .labels
-            .iter()
-            .map(|label| -> anyhow::Result<LabelId> {
+        let labels = {
+            let mut vec = Vec::new();
+            vec.try_reserve_exact(sample.labels.len())?;
+            for label in sample.labels.iter() {
                 let key = self.resolve(label.key)?;
                 let internal_label = if label.str != ManagedStringId::empty() {
                     let str = self.resolve(label.str)?;
@@ -283,9 +283,10 @@ impl Profile {
                     Label::num(key, num, num_unit)
                 };
 
-                self.labels.try_dedup(internal_label)
-            })
-            .collect::<Result<Box<[_]>, _>>()?;
+                vec.push(self.labels.try_dedup(internal_label)?);
+            }
+            vec.into_boxed_slice()
+        };
 
         let mut locations = Vec::new();
         locations.try_reserve_exact(sample.locations.len())?;
@@ -546,12 +547,10 @@ impl Profile {
         for (sample, timestamp, mut values) in iter {
             let off = sample.labels.to_offset();
             let labels = extended_label_sets.get_mut(off).ok_or_else(oob_label_set)?;
-            let location_ids: Vec<_> = self
-                .get_stacktrace(sample.stacktrace)?
-                .locations
-                .iter()
-                .map(Id::to_raw_id)
-                .collect();
+            let locations = &self.get_stacktrace(sample.stacktrace)?.locations;
+            let mut location_ids = Vec::new();
+            location_ids.try_reserve_exact(locations.len())?;
+            location_ids.extend(locations.iter().map(LocationId::to_raw_id));
             self.check_location_ids_are_valid(&location_ids, self.locations.len())?;
             self.upscaling_rules.upscale_values(&mut values, labels);
 


### PR DESCRIPTION
# What does this PR do?

This migrates more `Vec` code to use `try_reserve*`.

Makes two helpers, `try_clone_optional_tags`, and `try_into_vec_files` (which replaced `into_vec_files` and fixes some other panics in this helper too)..

# Motivation

Trying to reduce the places we panic without breaking APIs.

# Additional Notes

This is based on #2002, so that should merge first.

There are still `Vec::with_capacity` calls in the code, but I think all of the remainder require either API breaks or parallel helpers, which I may investigate in future PRs.

# How to test the change?

Should test all the same!
