### PR TITLE
chore: release v34.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,7 +695,7 @@ checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "build_common"
-version = "33.0.0"
+version = "34.0.0"
 dependencies = [
  "cbindgen",
  "serde",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "builder"
-version = "33.0.0"
+version = "34.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1382,7 +1382,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-ffe-test-suite"
-version = "33.0.0"
+version = "34.0.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-replayer"
-version = "33.0.0"
+version = "34.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2911,7 +2911,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-common-ffi"
-version = "33.0.0"
+version = "34.0.0"
 dependencies = [
  "anyhow",
  "assert_no_alloc",
@@ -2964,7 +2964,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-crashtracker-ffi"
-version = "33.0.0"
+version = "34.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -3025,7 +3025,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-data-pipeline-ffi"
-version = "33.0.0"
+version = "34.0.0"
 dependencies = [
  "build_common",
  "httpmock",
@@ -3050,7 +3050,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-ddsketch-ffi"
-version = "33.0.0"
+version = "34.0.0"
 dependencies = [
  "build_common",
  "libdd-common-ffi",
@@ -3072,7 +3072,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-http-client"
-version = "33.0.0"
+version = "34.0.0"
 dependencies = [
  "bytes",
  "fastrand",
@@ -3143,7 +3143,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-log-ffi"
-version = "33.0.0"
+version = "34.0.0"
 dependencies = [
  "build_common",
  "libdd-common-ffi",
@@ -3279,7 +3279,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-shared-runtime-ffi"
-version = "33.0.0"
+version = "34.0.0"
 dependencies = [
  "build_common",
  "libdd-shared-runtime",
@@ -3316,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-telemetry-ffi"
-version = "33.0.0"
+version = "34.0.0"
 dependencies = [
  "build_common",
  "function_name",
@@ -5579,7 +5579,7 @@ dependencies = [
 
 [[package]]
 name = "symbolizer-ffi"
-version = "33.0.0"
+version = "34.0.0"
 dependencies = [
  "blazesym-c",
  "build_common",
@@ -6021,7 +6021,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "33.0.0"
+version = "34.0.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.84.1"
 edition = "2021"
-version = "33.0.0"
+version = "34.0.0"
 license = "Apache-2.0"
 authors = ["Datadog Inc. <info@datadoghq.com>"]
 


### PR DESCRIPTION
Bump workspace version to `34.0.0` and regenerate lockfile.