### PR TITLE
chore(dependencies): only depend on the `windows` crate when targeting windows

### DIFF
--- a/datadog-sidecar/Cargo.toml
+++ b/datadog-sidecar/Cargo.toml
@@ -77,7 +77,7 @@ libc = { version = "0.2" }
 # watchdog and self telemetry
 memory-stats = { version = "1.2.0", features = ["always_use_statm"] }
 
-[dependencies.windows]
+[target.'cfg(windows)'.dependencies.windows]
 features = [
     "Win32_Foundation",
     "Wdk_Storage_FileSystem",

--- a/spawn_worker/Cargo.toml
+++ b/spawn_worker/Cargo.toml
@@ -16,7 +16,7 @@ libc = "0.2"
 [build-dependencies]
 cc_utils = { path = "../tools/cc_utils" }
 
-[dependencies.windows]
+[target.'cfg(windows)'.dependencies.windows]
 features = [
   "Win32_Foundation",
   "Win32_Security",


### PR DESCRIPTION
# What does this PR do?

`spawn_worker` and `datadog-sidecar` both declare `windows` as an
unconditional dependency:

    [dependencies.windows]
    ...

Cargo builds dependencies for every target, so the `windows` crate is
compiled on non-Windows platforms even though it is only ever used from
modules gated behind `#[cfg(target_os = "windows")]`
(`spawn_worker::win32` and `datadog_sidecar::windows`).

The `windows` crate carries architecture-specific definitions and does
not compile on every Rust target. On a target it does not support
(e.g. FreeBSD/powerpc64) the build fails with errors such as:

    error[E0425]: cannot find type `CONTEXT` in this scope
    error[E0425]: cannot find type `SLIST_HEADER` in this scope

This goes unnoticed on x86_64/aarch64 because the crate happens to
compile there.

Move the dependency under `[target.'cfg(windows)'.dependencies]` so
cargo only builds it on Windows, matching how it is actually used. The
workspace's other `windows`-crate users (`libdd-crashtracker`,
`libdd-crashtracker-ffi`, `libdd-telemetry`) already gate it this way.


# Motivation

Building on FreeBSD/powerpc64le.

# How to test the change?

Build outside of x86_64/aarch64.
