### PR TITLE
ci: remove dd-octo-sts email

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -13,7 +13,6 @@ rules:
   - require: all-files-are-owned
   - require: commit-signatures
     excluded_emails:
-      - '200755185+dd-octo-sts[bot]@users.noreply.github.com' # version-bump bots
       - '41898282+github-actions[bot]@users.noreply.github.com' # version-bump bots
 ---
 schema-version: v2


### PR DESCRIPTION
# What does this PR do?

Remove `hardcoded 200755185+dd-octo-sts[bot]@users.noreply.github.com` email from mergegate config
