### PR TITLE
feat(sampling): accept Remote Config list-shape tags natively

### DIFF
--- a/libdd-sampling/src/sampling_rule_config.rs
+++ b/libdd-sampling/src/sampling_rule_config.rs
@@ -25,8 +25,13 @@ pub struct SamplingRuleConfig {
     #[serde(default)]
     pub resource: Option<String>,
 
-    /// Tags that must match (key-value pairs)
-    #[serde(default)]
+    /// Tags that must match (key-value pairs).
+    ///
+    /// Accepts either the map shape `{"env": "prod"}` or the Remote Config
+    /// wire shape `[{"key": "env", "value_glob": "prod"}]`. Internally both
+    /// normalize to the map shape; the list-shape entries are required to
+    /// have both `key` and `value_glob` (missing either rejects the rule).
+    #[serde(default, deserialize_with = "deserialize_tags")]
     pub tags: HashMap<String, String>,
 
     /// Where this rule comes from (customer, dynamic, default).
@@ -59,6 +64,61 @@ impl Display for SamplingRuleConfig {
 
 fn default_provenance() -> String {
     "default".to_string()
+}
+
+/// Deserializes the `tags` field, accepting either:
+///   - map shape:  `{"env": "prod", "region": "us-east-1"}`
+///   - list shape: `[{"key": "env", "value_glob": "prod"}, ...]`
+///
+/// A list entry missing `key` or `value_glob` produces a deserialization
+/// error; we never silently drop entries because that could broaden a
+/// tag-constrained sampling rule.
+fn deserialize_tags<'de, D>(deserializer: D) -> Result<HashMap<String, String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::{MapAccess, SeqAccess, Visitor};
+    use std::fmt;
+
+    #[derive(serde::Deserialize)]
+    struct ListEntry {
+        key: String,
+        value_glob: String,
+    }
+
+    struct TagsVisitor;
+
+    impl<'de> Visitor<'de> for TagsVisitor {
+        type Value = HashMap<String, String>;
+
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.write_str("a map of string to string or a list of {key, value_glob} objects")
+        }
+
+        fn visit_map<M>(self, mut access: M) -> Result<Self::Value, M::Error>
+        where
+            M: MapAccess<'de>,
+        {
+            let mut map = HashMap::with_capacity(access.size_hint().unwrap_or(0));
+            while let Some((k, v)) = access.next_entry::<String, String>()? {
+                map.insert(k, v);
+            }
+            Ok(map)
+        }
+
+        fn visit_seq<S>(self, mut access: S) -> Result<Self::Value, S::Error>
+        where
+            S: SeqAccess<'de>,
+        {
+            let mut map = HashMap::with_capacity(access.size_hint().unwrap_or(0));
+            while let Some(entry) = access.next_element::<ListEntry>()? {
+                map.insert(entry.key, entry.value_glob);
+            }
+            Ok(map)
+        }
+    }
+
+    deserializer.deserialize_any(TagsVisitor)
 }
 
 #[derive(Debug, Default, Clone, PartialEq)]
@@ -179,6 +239,65 @@ mod tests {
         let json = serde_json::to_string(&original).unwrap();
         let restored: SamplingRuleConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(original, restored);
+    }
+
+    #[test]
+    fn test_sampling_rule_config_tags_accepts_map_shape() {
+        // Already supported — guard against regression.
+        let json = r#"{
+            "sample_rate": 0.5,
+            "service": "svc",
+            "tags": {"env": "prod", "region": "us-east-1"}
+        }"#;
+        let cfg: SamplingRuleConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.tags.get("env").map(String::as_str), Some("prod"));
+        assert_eq!(
+            cfg.tags.get("region").map(String::as_str),
+            Some("us-east-1")
+        );
+    }
+
+    #[test]
+    fn test_sampling_rule_config_tags_accepts_rc_list_shape() {
+        // Remote Config wire shape: list of {key, value_glob} entries.
+        let json = r#"{
+            "sample_rate": 0.5,
+            "service": "svc",
+            "tags": [
+                {"key": "env", "value_glob": "prod"},
+                {"key": "region", "value_glob": "us-east-1"}
+            ]
+        }"#;
+        let cfg: SamplingRuleConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.tags.get("env").map(String::as_str), Some("prod"));
+        assert_eq!(
+            cfg.tags.get("region").map(String::as_str),
+            Some("us-east-1")
+        );
+    }
+
+    #[test]
+    fn test_sampling_rule_config_tags_list_with_malformed_entry_rejects() {
+        // A list entry missing `value_glob` must reject the whole rule rather
+        // than silently dropping the entry — silently dropping a constraint could
+        // broaden a tag-constrained rule and produce a security-relevant change
+        // in sampling decisions.
+        let json = r#"{
+            "sample_rate": 0.5,
+            "tags": [
+                {"key": "env", "value_glob": "prod"},
+                {"key": "region"}
+            ]
+        }"#;
+        let result: Result<SamplingRuleConfig, _> = serde_json::from_str(json);
+        assert!(result.is_err(), "expected deserialization to fail");
+    }
+
+    #[test]
+    fn test_sampling_rule_config_tags_absent_defaults_to_empty() {
+        let json = r#"{"sample_rate": 0.5}"#;
+        let cfg: SamplingRuleConfig = serde_json::from_str(json).unwrap();
+        assert!(cfg.tags.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
# What does this PR do?

Makes `libdd_sampling::SamplingRuleConfig::tags` accept two wire shapes:

- Map shape: `{"env": "prod"}` (current).
- Remote Config list shape: `[{"key": "env", "value_glob": "prod"}]` (new).

Internally both normalize to `HashMap<String, String>`. List entries missing `key` or `value_glob` produce a deserialization error. We don't silently drop bad entries because doing so could broaden a tag-constrained sampling rule.

# Motivation

Remote Config delivers `tracing_sampling_rules` entries with tags in the list shape. The previous `#[serde(default)]` on `tags` only accepted the map shape, so every tracer adopting `libdd-sampling` has to normalize at the tracer ↔ libdatadog boundary. dd-trace-rs ships a `normalize_rc_tags` helper for this. With this change, that workaround is no longer needed in any tracer.

# Additional Notes

- No public API changes. The `tags` field type stays `HashMap<String, String>`; only the deserializer is broader.
- The helper uses `serde::Deserializer::deserialize_any`, which is safe for self-describing formats (JSON). Non-self-describing formats (bincode/postcard) would fail at deserialization time with a clear serde error.
- A follow-up PR in DataDog/dd-trace-rs (tracked alongside #227) removes the `normalize_rc_tags` workaround once this lands in a libdatadog release.

# How to test the change?

Four unit tests in `libdd-sampling/src/sampling_rule_config.rs`:

- `test_sampling_rule_config_tags_accepts_map_shape` (regression).
- `test_sampling_rule_config_tags_accepts_rc_list_shape`.
- `test_sampling_rule_config_tags_list_with_malformed_entry_rejects`.
- `test_sampling_rule_config_tags_absent_defaults_to_empty`.

Run: `cargo test -p libdd-sampling sampling_rule_config_tags`.

Integration verified locally against DataDog/dd-trace-rs#227: pointing dd-trace-rs at this branch and removing its `normalize_rc_tags` workaround keeps all 352 dd-trace-rs tests green, including the handler-level tag tests that now traverse the upstream deserializer end-to-end.