### PR TITLE
refactor(crashtracker): update imports to linux only

### DIFF
--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -25,9 +25,6 @@ use libdd_crashtracker::{
 };
 use serde_json::Value;
 
-#[cfg(target_os = "linux")]
-use libdd_crashtracker::default_max_threads;
-
 /// Macro to generate simple crash tracking tests using the new infrastructure.
 /// This replaces 16+ nearly identical test functions with a single declaration.
 macro_rules! crash_tracking_tests {
@@ -315,7 +312,7 @@ fn test_crash_tracking_multi_thread_collection() {
 #[cfg(target_os = "linux")]
 #[cfg_attr(miri, ignore)]
 fn test_crash_tracking_thread_limit() {
-    const THREAD_COUNT: usize = default_max_threads();
+    const THREAD_COUNT: usize = libdd_crashtracker::default_max_threads();
 
     let config = CrashTestConfig::new(
         BuildProfile::Release,

--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -21,10 +21,13 @@ use bin_tests::{
     ArtifactsBuild, BuildProfile,
 };
 use libdd_crashtracker::{
-    default_max_threads, CrashtrackerConfiguration, Metadata, SiCodes, SigInfo, SignalNames,
+    CrashtrackerConfiguration, Metadata, SiCodes, SigInfo, SignalNames,
     StacktraceCollection,
 };
 use serde_json::Value;
+
+#[cfg(target_os = "linux")]
+use libdd_crashtracker::default_max_threads;
 
 /// Macro to generate simple crash tracking tests using the new infrastructure.
 /// This replaces 16+ nearly identical test functions with a single declaration.

--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -21,8 +21,7 @@ use bin_tests::{
     ArtifactsBuild, BuildProfile,
 };
 use libdd_crashtracker::{
-    CrashtrackerConfiguration, Metadata, SiCodes, SigInfo, SignalNames,
-    StacktraceCollection,
+    CrashtrackerConfiguration, Metadata, SiCodes, SigInfo, SignalNames, StacktraceCollection,
 };
 use serde_json::Value;
 

--- a/libdd-crashtracker/src/receiver/receive_report.rs
+++ b/libdd-crashtracker/src/receiver/receive_report.rs
@@ -4,7 +4,7 @@
 use crate::{
     crash_info::{
         CrashInfo, CrashInfoBuilder, ErrorKind, SigInfo, Span, StackFrame, TelemetryCrashUploader,
-        Threads, Ucontext,
+        Ucontext,
     },
     runtime_callback::RuntimeStack,
     shared::constants::*,
@@ -17,6 +17,9 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::io::AsyncBufReadExt;
+
+#[cfg(target_os = "linux")]
+use crate::crash_info::Threads;
 
 #[derive(Debug)]
 enum ReceiverIssue {

--- a/libdd-crashtracker/src/receiver/receive_report.rs
+++ b/libdd-crashtracker/src/receiver/receive_report.rs
@@ -18,9 +18,6 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::io::AsyncBufReadExt;
 
-#[cfg(target_os = "linux")]
-use crate::crash_info::Threads;
-
 #[derive(Debug)]
 enum ReceiverIssue {
     Timeout,
@@ -563,7 +560,7 @@ fn collect_and_add_thread_contexts(
     crashing_tid: Option<u32>,
     budget: Duration,
 ) -> anyhow::Result<()> {
-    use crate::crash_info::ThreadData;
+    use crate::crash_info::{ThreadData, Threads};
     use crate::receiver::ptrace_collector::stream_thread_contexts;
 
     let crashing_tid = crashing_tid.unwrap_or(0) as i32;


### PR DESCRIPTION
# What does this PR do?

Put some import under linux os only.

# Motivation

These imports were falsely reported as unused on my IDE.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
