### PR TITLE
feat: update test agent version

### DIFF
--- a/libdd-trace-utils/src/test_utils/datadog_test_agent.rs
+++ b/libdd-trace-utils/src/test_utils/datadog_test_agent.rs
@@ -14,7 +14,7 @@ use std::str::FromStr;
 use std::time::Duration;
 
 const TEST_AGENT_IMAGE_NAME: &str = "ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent";
-const TEST_AGENT_IMAGE_TAG: &str = "v1.39.0";
+const TEST_AGENT_IMAGE_TAG: &str = "v1.55.0";
 const TEST_AGENT_READY_MSG: &str =
     "INFO:ddapm_test_agent.agent:Trace request stall seconds setting set to 0.0.";
 

--- a/libdd-trace-utils/src/test_utils/datadog_test_agent.rs
+++ b/libdd-trace-utils/src/test_utils/datadog_test_agent.rs
@@ -14,7 +14,7 @@ use std::str::FromStr;
 use std::time::Duration;
 
 const TEST_AGENT_IMAGE_NAME: &str = "ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent";
-const TEST_AGENT_IMAGE_TAG: &str = "v1.55.0";
+const TEST_AGENT_IMAGE_TAG: &str = "v1.56.0";
 const TEST_AGENT_READY_MSG: &str =
     "INFO:ddapm_test_agent.agent:Trace request stall seconds setting set to 0.0.";
 


### PR DESCRIPTION
# What does this PR do?

Update dd-apm-test-agent version to 1.56.0 to test V1.
