### PR TITLE
fix(ci): pin RUSTUP_TOOLCHAIN

### DIFF
--- a/.github/workflows/release-proposal-dispatch.yml
+++ b/.github/workflows/release-proposal-dispatch.yml
@@ -137,7 +137,7 @@ jobs:
         run: ln -sf ~/.rustup/toolchains/${{ steps.nightly-version.outputs.version }}-x86_64-unknown-linux-gnu ~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: 1.92.0
+          toolchain: ${{ env.RUSTUP_TOOLCHAIN }}
       - uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7 # 2.3.1
         with:
           tool: cargo-public-api@0.50.2

--- a/.github/workflows/release-proposal-dispatch.yml
+++ b/.github/workflows/release-proposal-dispatch.yml
@@ -116,6 +116,8 @@ jobs:
       contents: write
     needs: check-membership
     runs-on: ubuntu-latest
+    env:
+      RUSTUP_TOOLCHAIN: 1.92.0
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
         with:


### PR DESCRIPTION
# What does this PR do?

Pin rustup toolchain version

# Motivation

```
error: failed to compile `cargo-public-api v0.50.2`, intermediate artifacts can be found at `/tmp/cargo-installU0E62f`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

Caused by:
  rustc 1.87.0 is not supported by the following package:
    home@0.5.12 requires rustc 1.88
```