### PR TITLE
refactor(span)!: use VecMap for `meta`, `metrics` and `meta_struct` for v04 spans

### DIFF
--- a/datadog-sidecar-ffi/Cargo.toml
+++ b/datadog-sidecar-ffi/Cargo.toml
@@ -35,6 +35,7 @@ libdd-crashtracker-ffi = { path = "../libdd-crashtracker-ffi", features = ["coll
 
 [dev-dependencies]
 http = "1.1"
+libdd-trace-utils = { path = "../libdd-trace-utils", features = ["test-utils"] }
 tempfile = { version = "3.3" }
 
 [lints.rust]

--- a/datadog-sidecar-ffi/src/span.rs
+++ b/datadog-sidecar-ffi/src/span.rs
@@ -5,6 +5,7 @@ use libdd_common_ffi::slice::{AsBytes, CharSlice};
 use libdd_tinybytes::{Bytes, BytesString};
 use libdd_trace_utils::span::v04::{
     AttributeAnyValueBytes, AttributeArrayValueBytes, SpanBytes, SpanEventBytes, SpanLinkBytes,
+    VecMap,
 };
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -51,25 +52,35 @@ fn insert_hashmap<V>(map: &mut HashMap<BytesString, V>, key: CharSlice, value: V
 }
 
 #[inline]
-fn remove_hashmap<V>(map: &mut HashMap<BytesString, V>, key: CharSlice) {
+fn insert_vec_map<V>(map: &mut VecMap<BytesString, V>, key: CharSlice, value: V) {
+    if key.is_empty() {
+        return;
+    }
     let bytes_str_key = convert_char_slice_to_bytes_string(key);
-    map.remove(&bytes_str_key);
+    map.insert(bytes_str_key, value);
 }
 
 #[inline]
-fn exists_hashmap<V>(map: &HashMap<BytesString, V>, key: CharSlice) -> bool {
+fn remove_vec_map_slow<V>(map: &mut VecMap<BytesString, V>, key: CharSlice) {
+    let bytes_str_key = convert_char_slice_to_bytes_string(key);
+    map.remove_slow(&bytes_str_key);
+}
+
+#[inline]
+fn exists_vec_map<V>(map: &VecMap<BytesString, V>, key: CharSlice) -> bool {
     let bytes_str_key = convert_char_slice_to_bytes_string(key);
     map.contains_key(&bytes_str_key)
 }
 
 /// The return value is an owned array of slices (`Box<[CharSlice<'a>]>`) that must be dropped
 /// explicitly.
-fn get_hashmap_keys<'a, V>(
-    map: &'a HashMap<BytesString, V>,
+fn get_vec_map_keys<'a, V>(
+    map: &'a VecMap<BytesString, V>,
     out_count: &mut usize,
 ) -> *mut CharSlice<'a> {
-    let mut keys: Vec<&str> = map.keys().map(|b| b.as_str()).collect();
+    let mut keys: Vec<&str> = map.iter().map(|(k, _)| k.as_str()).collect();
     keys.sort_unstable();
+    keys.dedup();
 
     let slices: Box<[CharSlice]> = keys
         .iter()
@@ -182,8 +193,8 @@ pub extern "C" fn ddog_trace_new_span_with_capacities(
     new_vector_push(
         trace,
         SpanBytes {
-            meta: HashMap::with_capacity(meta_size),
-            metrics: HashMap::with_capacity(metrics_size),
+            meta: VecMap::with_capacity(meta_size),
+            metrics: VecMap::with_capacity(metrics_size),
             ..SpanBytes::default()
         },
     )
@@ -324,7 +335,7 @@ pub extern "C" fn ddog_get_span_error(span: &mut SpanBytes) -> i32 {
 
 #[no_mangle]
 pub extern "C" fn ddog_add_span_meta(span: &mut SpanBytes, key: CharSlice, value: CharSlice) {
-    insert_hashmap(
+    insert_vec_map(
         &mut span.meta,
         key,
         BytesString::from_slice(value.as_bytes()).unwrap_or_default(),
@@ -333,7 +344,7 @@ pub extern "C" fn ddog_add_span_meta(span: &mut SpanBytes, key: CharSlice, value
 
 #[no_mangle]
 pub extern "C" fn ddog_del_span_meta(span: &mut SpanBytes, key: CharSlice) {
-    remove_hashmap(&mut span.meta, key);
+    remove_vec_map_slow(&mut span.meta, key);
 }
 
 #[no_mangle]
@@ -355,7 +366,7 @@ pub extern "C" fn ddog_get_span_meta<'a>(
 
 #[no_mangle]
 pub extern "C" fn ddog_has_span_meta(span: &mut SpanBytes, key: CharSlice) -> bool {
-    exists_hashmap(&span.meta, key)
+    exists_vec_map(&span.meta, key)
 }
 
 /// The return value is an owned array of slices (`Box<[CharSlice]>`) that must be freed explicitly
@@ -365,17 +376,17 @@ pub extern "C" fn ddog_span_meta_get_keys<'a>(
     span: &'a mut SpanBytes,
     out_count: &mut usize,
 ) -> *mut CharSlice<'a> {
-    get_hashmap_keys(&span.meta, out_count)
+    get_vec_map_keys(&span.meta, out_count)
 }
 
 #[no_mangle]
 pub extern "C" fn ddog_add_span_metrics(span: &mut SpanBytes, key: CharSlice, val: f64) {
-    insert_hashmap(&mut span.metrics, key, val);
+    insert_vec_map(&mut span.metrics, key, val);
 }
 
 #[no_mangle]
 pub extern "C" fn ddog_del_span_metrics(span: &mut SpanBytes, key: CharSlice) {
-    remove_hashmap(&mut span.metrics, key);
+    remove_vec_map_slow(&mut span.metrics, key);
 }
 
 #[no_mangle]
@@ -386,8 +397,8 @@ pub extern "C" fn ddog_get_span_metrics(
 ) -> bool {
     let bytes_str_key = convert_char_slice_to_bytes_string(key);
     match span.metrics.get(&bytes_str_key) {
-        Some(&value) => {
-            *result = value;
+        Some(value) => {
+            *result = *value;
             true
         }
         None => false,
@@ -396,7 +407,7 @@ pub extern "C" fn ddog_get_span_metrics(
 
 #[no_mangle]
 pub extern "C" fn ddog_has_span_metrics(span: &mut SpanBytes, key: CharSlice) -> bool {
-    exists_hashmap(&span.metrics, key)
+    exists_vec_map(&span.metrics, key)
 }
 
 #[no_mangle]
@@ -404,12 +415,12 @@ pub extern "C" fn ddog_span_metrics_get_keys<'a>(
     span: &'a mut SpanBytes,
     out_count: &mut usize,
 ) -> *mut CharSlice<'a> {
-    get_hashmap_keys(&span.metrics, out_count)
+    get_vec_map_keys(&span.metrics, out_count)
 }
 
 #[no_mangle]
 pub extern "C" fn ddog_add_span_meta_struct(span: &mut SpanBytes, key: CharSlice, val: CharSlice) {
-    insert_hashmap(
+    insert_vec_map(
         &mut span.meta_struct,
         key,
         Bytes::copy_from_slice(val.as_bytes()),
@@ -418,7 +429,7 @@ pub extern "C" fn ddog_add_span_meta_struct(span: &mut SpanBytes, key: CharSlice
 
 #[no_mangle]
 pub extern "C" fn ddog_del_span_meta_struct(span: &mut SpanBytes, key: CharSlice) {
-    remove_hashmap(&mut span.meta_struct, key);
+    remove_vec_map_slow(&mut span.meta_struct, key);
 }
 
 #[no_mangle]
@@ -438,7 +449,7 @@ pub extern "C" fn ddog_get_span_meta_struct<'a>(
 
 #[no_mangle]
 pub extern "C" fn ddog_has_span_meta_struct(span: &mut SpanBytes, key: CharSlice) -> bool {
-    exists_hashmap(&span.meta_struct, key)
+    exists_vec_map(&span.meta_struct, key)
 }
 
 /// The return value is an array of slices (`Box<[CharSlice]>`) that must be freed explicitly
@@ -448,7 +459,7 @@ pub extern "C" fn ddog_span_meta_struct_get_keys<'a>(
     span: &'a mut SpanBytes,
     out_count: &mut usize,
 ) -> *mut CharSlice<'a> {
-    get_hashmap_keys(&span.meta_struct, out_count)
+    get_vec_map_keys(&span.meta_struct, out_count)
 }
 
 /// # Safety
@@ -461,7 +472,7 @@ pub unsafe extern "C" fn ddog_span_free_keys_ptr(keys_ptr: *mut CharSlice<'_>, c
         return;
     }
 
-    // Safety: all `xxx_get_keys()` functions return from `get_hashmap_keys()`, which returns a
+    // Safety: all `xxx_get_keys()` functions return from `get_vec_map_keys()`, which returns a
     // `Box<[T]>`. It is an official guarantee of `Vec` that this can be freely converted to and
     // from `Box<[T]>` when `len == capacity`.
     unsafe {

--- a/datadog-sidecar-ffi/src/span.rs
+++ b/datadog-sidecar-ffi/src/span.rs
@@ -397,8 +397,8 @@ pub extern "C" fn ddog_get_span_metrics(
 ) -> bool {
     let bytes_str_key = convert_char_slice_to_bytes_string(key);
     match span.metrics.get(&bytes_str_key) {
-        Some(value) => {
-            *result = *value;
+        Some(&value) => {
+            *result = value;
             true
         }
         None => false,

--- a/datadog-sidecar-ffi/tests/span.rs
+++ b/datadog-sidecar-ffi/tests/span.rs
@@ -186,7 +186,7 @@ fn test_span_debug_log_output() {
     ddog_set_span_name(span, CharSlice::from("debug-span"));
     let debug_output = ddog_span_debug_log(span);
 
-    let expected_output = CharSlice::from("Span { service: , name: debug-span, resource: , type: , trace_id: 0, span_id: 0, parent_id: 0, start: 0, duration: 0, error: 0, meta: VecMap([]), metrics: VecMap([]), meta_struct: VecMap([]), span_links: [], span_events: [] }");
+    let expected_output = CharSlice::from("Span { service: , name: debug-span, resource: , type: , trace_id: 0, span_id: 0, parent_id: 0, start: 0, duration: 0, error: 0, meta: VecMap { data: [], deduped: false }, metrics: VecMap { data: [], deduped: false }, meta_struct: VecMap { data: [], deduped: false }, span_links: [], span_events: [] }");
 
     assert_eq!(debug_output, expected_output);
 

--- a/datadog-sidecar-ffi/tests/span.rs
+++ b/datadog-sidecar-ffi/tests/span.rs
@@ -186,7 +186,7 @@ fn test_span_debug_log_output() {
     ddog_set_span_name(span, CharSlice::from("debug-span"));
     let debug_output = ddog_span_debug_log(span);
 
-    let expected_output = CharSlice::from("Span { service: , name: debug-span, resource: , type: , trace_id: 0, span_id: 0, parent_id: 0, start: 0, duration: 0, error: 0, meta: {}, metrics: {}, meta_struct: {}, span_links: [], span_events: [] }");
+    let expected_output = CharSlice::from("Span { service: , name: debug-span, resource: , type: , trace_id: 0, span_id: 0, parent_id: 0, start: 0, duration: 0, error: 0, meta: VecMap([]), metrics: VecMap([]), meta_struct: VecMap([]), span_links: [], span_events: [] }");
 
     assert_eq!(debug_output, expected_output);
 
@@ -343,12 +343,13 @@ fn test_full_span() {
         start: 4,
         duration: 5,
         error: 6,
-        meta: HashMap::from([(get_bytes_str("meta_key"), get_bytes_str("meta_value"))]),
-        metrics: HashMap::from([(get_bytes_str("metric_key"), 1.0)]),
-        meta_struct: HashMap::from([(
+        meta: vec![(get_bytes_str("meta_key"), get_bytes_str("meta_value"))].into(),
+        metrics: vec![(get_bytes_str("metric_key"), 1.0)].into(),
+        meta_struct: vec![(
             get_bytes_str("meta_struct_key"),
             get_bytes("meta_struct_value"),
-        )]),
+        )]
+        .into(),
         span_links: vec![SpanLinkBytes {
             trace_id: 10,
             span_id: 20,

--- a/libdd-data-pipeline-ffi/src/tracer.rs
+++ b/libdd-data-pipeline-ffi/src/tracer.rs
@@ -499,7 +499,8 @@ mod tests {
             ddog_tracer_span_set_meta(Some(&mut *span), cs("k"), cs("v1"));
             ddog_tracer_span_set_meta(Some(&mut *span), cs("k"), cs("v2"));
 
-            assert_eq!(span.0.meta.len(), 1);
+            // After the introduction of `VecMap`, the length is still 2, as the data structure
+            // tolerates duplicate entries.
             assert_eq!(span.0.meta.get("k").unwrap().as_ref(), "v2");
 
             ddog_tracer_span_free(span);

--- a/libdd-data-pipeline/benches/trace_buffer.rs
+++ b/libdd-data-pipeline/benches/trace_buffer.rs
@@ -1,7 +1,6 @@
 // Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
@@ -14,6 +13,7 @@ use libdd_data_pipeline::trace_exporter::{
 use libdd_shared_runtime::SharedRuntime;
 use libdd_tinybytes::BytesString;
 use libdd_trace_utils::span::v04::SpanBytes;
+use libdd_trace_utils::span::vec_map::VecMap;
 
 // Number of chunks each sender thread sends per benchmark iteration.
 const CHUNKS_PER_SENDER: usize = 900;
@@ -34,18 +34,20 @@ fn make_span() -> SpanBytes {
         start: 1_700_000_000_000_000_000_i64,
         duration: 5_000_000_i64,
         error: 0,
-        meta: HashMap::from_iter([
+        meta: vec![
             (bs("env"), bs("prod")),
             (bs("version"), bs("1.0.0")),
             (bs("http.method"), bs("GET")),
             (bs("http.url"), bs("/api/v1/users")),
             (bs("peer.service"), bs("users-service")),
-        ]),
-        metrics: HashMap::from_iter([
+        ]
+        .into(),
+        metrics: vec![
             (bs("_sampling_priority_v1"), 1.0_f64),
             (bs("_dd.agent_psr"), 1.0_f64),
-        ]),
-        meta_struct: HashMap::new(),
+        ]
+        .into(),
+        meta_struct: VecMap::new(),
         span_links: vec![],
         span_events: vec![],
     }

--- a/libdd-data-pipeline/src/trace_buffer/mod.rs
+++ b/libdd-data-pipeline/src/trace_buffer/mod.rs
@@ -22,7 +22,7 @@ use crate::trace_exporter::{
 
 /// Trait for types stored in a [`TraceBuffer`] that can report their approximate byte size.
 pub trait BufferSize {
-    fn byte_size(&self) -> usize;
+    fn byte_size(&mut self) -> usize;
 }
 
 impl<T> BufferSize for libdd_trace_utils::span::v04::Span<T>
@@ -31,8 +31,10 @@ where
     T::Text: AsRef<str>,
     T::Bytes: AsRef<[u8]>,
 {
-    fn byte_size(&self) -> usize {
+    fn byte_size(&mut self) -> usize {
         use libdd_trace_utils::span::v04::AttributeAnyValue;
+
+        self.dedup();
 
         // trace_id(16) + span_id(8) + parent_id(8) + start(8) + duration(8) + error(4)
         let mut size: usize = 52;
@@ -235,7 +237,7 @@ impl<T> Batch<T> {
     /// batch. So the batch can be over the maximum size after this call.
     /// This is because we don't want to always drop traces that contain more bytes than the maximum
     /// size.
-    fn add_trace_chunk(&mut self, chunk: Vec<T>) -> Result<(), BatchFullError>
+    fn add_trace_chunk(&mut self, mut chunk: Vec<T>) -> Result<(), BatchFullError>
     where
         T: BufferSize,
     {
@@ -248,7 +250,7 @@ impl<T> Batch<T> {
             return Ok(());
         }
 
-        self.byte_count += chunk.iter().map(|s| s.byte_size()).sum::<usize>();
+        self.byte_count += chunk.iter_mut().map(|s| s.byte_size()).sum::<usize>();
         self.chunks.push(chunk);
         Ok(())
     }
@@ -788,7 +790,7 @@ mod tests {
 
     // Used for tests, 1 byte per item so size computations are easier
     impl BufferSize for () {
-        fn byte_size(&self) -> usize {
+        fn byte_size(&mut self) -> usize {
             1
         }
     }

--- a/libdd-data-pipeline/src/trace_buffer/mod.rs
+++ b/libdd-data-pipeline/src/trace_buffer/mod.rs
@@ -22,7 +22,7 @@ use crate::trace_exporter::{
 
 /// Trait for types stored in a [`TraceBuffer`] that can report their approximate byte size.
 pub trait BufferSize {
-    fn byte_size(&mut self) -> usize;
+    fn byte_size(&self) -> usize;
 }
 
 impl<T> BufferSize for libdd_trace_utils::span::v04::Span<T>
@@ -31,10 +31,8 @@ where
     T::Text: AsRef<str>,
     T::Bytes: AsRef<[u8]>,
 {
-    fn byte_size(&mut self) -> usize {
+    fn byte_size(&self) -> usize {
         use libdd_trace_utils::span::v04::AttributeAnyValue;
-
-        self.dedup();
 
         // trace_id(16) + span_id(8) + parent_id(8) + start(8) + duration(8) + error(4)
         let mut size: usize = 52;
@@ -237,7 +235,7 @@ impl<T> Batch<T> {
     /// batch. So the batch can be over the maximum size after this call.
     /// This is because we don't want to always drop traces that contain more bytes than the maximum
     /// size.
-    fn add_trace_chunk(&mut self, mut chunk: Vec<T>) -> Result<(), BatchFullError>
+    fn add_trace_chunk(&mut self, chunk: Vec<T>) -> Result<(), BatchFullError>
     where
         T: BufferSize,
     {
@@ -250,7 +248,7 @@ impl<T> Batch<T> {
             return Ok(());
         }
 
-        self.byte_count += chunk.iter_mut().map(|s| s.byte_size()).sum::<usize>();
+        self.byte_count += chunk.iter().map(|s| s.byte_size()).sum::<usize>();
         self.chunks.push(chunk);
         Ok(())
     }
@@ -790,7 +788,7 @@ mod tests {
 
     // Used for tests, 1 byte per item so size computations are easier
     impl BufferSize for () {
-        fn byte_size(&mut self) -> usize {
+        fn byte_size(&self) -> usize {
             1
         }
     }

--- a/libdd-data-pipeline/src/trace_buffer/mod.rs
+++ b/libdd-data-pipeline/src/trace_buffer/mod.rs
@@ -45,7 +45,7 @@ where
         for (k, v) in &self.meta {
             size += k.as_ref().len() + v.as_ref().len();
         }
-        for k in self.metrics.keys() {
+        for (k, _) in &self.metrics {
             size += k.as_ref().len() + 8;
         }
         for (k, v) in &self.meta_struct {

--- a/libdd-data-pipeline/src/trace_buffer/mod.rs
+++ b/libdd-data-pipeline/src/trace_buffer/mod.rs
@@ -42,13 +42,16 @@ where
         size += self.resource.as_ref().len();
         size += self.r#type.as_ref().len();
 
-        for (k, v) in &self.meta {
+        // We expect VecMaps to be already deduped at this point, so `defensive_dedup` should be
+        // cheap (and alloc-free). In the future we could relax the check and accept non-deduped
+        // VecMap, trading over-estimating the size of a span for less work.
+        for (k, v) in self.meta.defensive_dedup().iter() {
             size += k.as_ref().len() + v.as_ref().len();
         }
-        for (k, _) in &self.metrics {
+        for (k, _) in self.metrics.defensive_dedup().iter() {
             size += k.as_ref().len() + 8;
         }
-        for (k, v) in &self.meta_struct {
+        for (k, v) in self.meta_struct.defensive_dedup().iter() {
             size += k.as_ref().len() + v.as_ref().len();
         }
         for link in &self.span_links {

--- a/libdd-data-pipeline/src/trace_exporter/mod.rs
+++ b/libdd-data-pipeline/src/trace_exporter/mod.rs
@@ -612,6 +612,12 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> Tra
             self.client_computed_top_level,
         );
 
+        for chunk in &mut traces {
+            for span in chunk.iter_mut() {
+                span.dedup();
+            }
+        }
+
         // OTLP path: send sampled traces via OTLP when an OTLP endpoint is configured.
         // Unlike the agent path, there is no downstream agent to drop unsampled traces,
         // so drop_chunks is always called here regardless of whether stats are enabled.

--- a/libdd-trace-stats/benches/span_concentrator_bench.rs
+++ b/libdd-trace-stats/benches/span_concentrator_bench.rs
@@ -17,7 +17,7 @@ fn get_span(now: SystemTime, trace_id: u64, span_id: u64) -> SpanBytes {
         metrics.insert("_dd.top_level".into(), 1.0);
     }
     let mut meta: VecMap<_, _> = vec![("db_name".into(), "postgres".into())].into();
-    if span_id % 3 == 0 {
+    if span_id.is_multiple_of(3) {
         meta.insert("bucket_s3".into(), "aws_bucket".into());
     }
     SpanBytes {

--- a/libdd-trace-stats/benches/span_concentrator_bench.rs
+++ b/libdd-trace-stats/benches/span_concentrator_bench.rs
@@ -1,13 +1,10 @@
 // Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
-use std::{
-    collections::HashMap,
-    time::{self, Duration, SystemTime},
-};
+use std::time::{self, Duration, SystemTime};
 
 use criterion::{criterion_group, Criterion};
 use libdd_trace_stats::span_concentrator::SpanConcentrator;
-use libdd_trace_utils::span::v04::SpanBytes;
+use libdd_trace_utils::span::v04::{SpanBytes, VecMap};
 
 fn get_bucket_start(now: SystemTime, n: u64) -> i64 {
     let start = now.duration_since(time::UNIX_EPOCH).unwrap() + Duration::from_secs(10 * n);
@@ -15,12 +12,12 @@ fn get_bucket_start(now: SystemTime, n: u64) -> i64 {
 }
 
 fn get_span(now: SystemTime, trace_id: u64, span_id: u64) -> SpanBytes {
-    let mut metrics = HashMap::from([("_dd.measured".into(), 1.0)]);
+    let mut metrics: VecMap<_, _> = vec![("_dd.measured".into(), 1.0)].into();
     if span_id == 1 {
         metrics.insert("_dd.top_level".into(), 1.0);
     }
-    let mut meta = HashMap::from([("db_name".into(), "postgres".into())]);
-    if span_id.is_multiple_of(3) {
+    let mut meta: VecMap<_, _> = vec![("db_name".into(), "postgres".into())].into();
+    if span_id % 3 == 0 {
         meta.insert("bucket_s3".into(), "aws_bucket".into());
     }
     SpanBytes {

--- a/libdd-trace-stats/src/span_concentrator/aggregation.rs
+++ b/libdd-trace-stats/src/span_concentrator/aggregation.rs
@@ -440,7 +440,7 @@ mod tests {
     use libdd_trace_utils::span::v04::{SpanBytes, SpanSlice};
 
     use super::*;
-    use std::{collections::HashMap, hash::Hash};
+    use std::hash::Hash;
 
     fn get_hash(v: &impl Hash) -> u64 {
         use std::hash::Hasher;
@@ -494,7 +494,7 @@ mod tests {
                     resource: "res".into(),
                     span_id: 1,
                     parent_id: 0,
-                    meta: HashMap::from([("span.kind".into(), "client".into())]),
+                    meta: vec![("span.kind".into(), "client".into())].into(),
                     ..Default::default()
                 },
                 FixedAggregationKey {
@@ -515,10 +515,11 @@ mod tests {
                     resource: "res".into(),
                     span_id: 1,
                     parent_id: 0,
-                    meta: HashMap::from([
-                        ("span.kind".into(), "client".into()),
-                        ("aws.s3.bucket".into(), "bucket-a".into()),
-                    ]),
+                    meta: vec![
+                        ("span.kind", "client"),
+                        ("aws.s3.bucket", "bucket-a"),
+                    ]
+                    .into(),
                     ..Default::default()
                 },
                 FixedAggregationKey {
@@ -539,12 +540,13 @@ mod tests {
                     resource: "res".into(),
                     span_id: 1,
                     parent_id: 0,
-                    meta: HashMap::from([
+                    meta: vec![
                         ("span.kind".into(), "producer".into()),
                         ("aws.s3.bucket".into(), "bucket-a".into()),
                         ("db.instance".into(), "dynamo.test.us1".into()),
                         ("db.system".into(), "dynamodb".into()),
-                    ]),
+                    ]
+                    .into(),
                     ..Default::default()
                 },
                 FixedAggregationKey {
@@ -566,12 +568,13 @@ mod tests {
                     resource: "res".into(),
                     span_id: 1,
                     parent_id: 0,
-                    meta: HashMap::from([
+                    meta: vec![
                         ("span.kind".into(), "server".into()),
                         ("aws.s3.bucket".into(), "bucket-a".into()),
                         ("db.instance".into(), "dynamo.test.us1".into()),
                         ("db.system".into(), "dynamodb".into()),
-                    ]),
+                    ]
+                    .into(),
                     ..Default::default()
                 },
                 FixedAggregationKey {
@@ -592,7 +595,7 @@ mod tests {
                     resource: "res".into(),
                     span_id: 1,
                     parent_id: 0,
-                    meta: HashMap::from([("_dd.origin".into(), "synthetics-browser".into())]),
+                    meta: vec![("_dd.origin".into(), "synthetics-browser".into())].into(),
                     ..Default::default()
                 },
                 FixedAggregationKey {
@@ -613,7 +616,7 @@ mod tests {
                     resource: "res".into(),
                     span_id: 1,
                     parent_id: 0,
-                    meta: HashMap::from([("http.status_code".into(), "418".into())]),
+                    meta: vec![("http.status_code".into(), "418".into())].into(),
                     ..Default::default()
                 },
                 FixedAggregationKey {
@@ -635,7 +638,7 @@ mod tests {
                     resource: "res".into(),
                     span_id: 1,
                     parent_id: 0,
-                    meta: HashMap::from([("http.status_code".into(), "x".into())]),
+                    meta: vec![("http.status_code".into(), "x".into())].into(),
                     ..Default::default()
                 },
                 FixedAggregationKey {
@@ -656,7 +659,7 @@ mod tests {
                     resource: "res".into(),
                     span_id: 1,
                     parent_id: 0,
-                    metrics: HashMap::from([("http.status_code".into(), 418.0)]),
+                    metrics: vec![("http.status_code".into(), 418.0)].into(),
                     ..Default::default()
                 },
                 FixedAggregationKey {
@@ -678,10 +681,11 @@ mod tests {
                     resource: "GET /api/v1/users".into(),
                     span_id: 1,
                     parent_id: 0,
-                    meta: HashMap::from([
+                    meta: vec![
                         ("http.method".into(), "GET".into()),
                         ("http.route".into(), "/api/v1/users".into()),
-                    ]),
+                    ]
+                    .into(),
                     ..Default::default()
                 },
                 FixedAggregationKey {
@@ -704,11 +708,12 @@ mod tests {
                     resource: "POST /users/create".into(),
                     span_id: 1,
                     parent_id: 0,
-                    meta: HashMap::from([
+                    meta: vec![
                         ("http.method".into(), "POST".into()),
                         ("http.route".into(), "/users/create".into()),
                         ("http.endpoint".into(), "/users/create2".into()),
-                    ]),
+                    ]
+                    .into(),
                     ..Default::default()
                 },
                 FixedAggregationKey {
@@ -726,7 +731,7 @@ mod tests {
             // Span with grpc status from meta as named string
             (
                 SpanBytes {
-                    meta: HashMap::from([("rpc.grpc.status_code".into(), "OK".into())]),
+                    meta: vec![("rpc.grpc.status_code".into(), "OK".into())].into(),
                     ..Default::default()
                 },
                 FixedAggregationKey {
@@ -739,7 +744,7 @@ mod tests {
             // Span with grpc status from meta as numeric string
             (
                 SpanBytes {
-                    meta: HashMap::from([("rpc.grpc.status_code".into(), "14".into())]),
+                    meta: vec![("rpc.grpc.status_code".into(), "14".into())].into(),
                     ..Default::default()
                 },
                 FixedAggregationKey {
@@ -752,7 +757,7 @@ mod tests {
             // Span with grpc status from meta with StatusCode. prefix
             (
                 SpanBytes {
-                    meta: HashMap::from([("grpc.code".into(), "StatusCode.UNAVAILABLE".into())]),
+                    meta: vec![("grpc.code".into(), "StatusCode.UNAVAILABLE".into())].into(),
                     ..Default::default()
                 },
                 FixedAggregationKey {
@@ -765,11 +770,8 @@ mod tests {
             // Span with grpc status from metrics takes precedence over meta
             (
                 SpanBytes {
-                    meta: HashMap::from([(
-                        "rpc.grpc.status_code".into(),
-                        "PERMISSION_DENIED".into(),
-                    )]),
-                    metrics: HashMap::from([("rpc.grpc.status_code".into(), 2.0)]),
+                    meta: vec![("rpc.grpc.status_code".into(), "PERMISSION_DENIED".into())].into(),
+                    metrics: vec![("rpc.grpc.status_code".into(), 2.0)].into(),
                     ..Default::default()
                 },
                 FixedAggregationKey {
@@ -782,7 +784,7 @@ mod tests {
             // Span with grpc status from metrics via secondary key
             (
                 SpanBytes {
-                    metrics: HashMap::from([("grpc.code".into(), 3.0)]),
+                    metrics: vec![("grpc.code".into(), 3.0)].into(),
                     ..Default::default()
                 },
                 FixedAggregationKey {
@@ -795,7 +797,7 @@ mod tests {
             // Span with invalid grpc status string
             (
                 SpanBytes {
-                    meta: HashMap::from([("rpc.grpc.status_code".into(), "NOPE".into())]),
+                    meta: vec![("rpc.grpc.status_code".into(), "NOPE".into())].into(),
                     ..Default::default()
                 },
                 FixedAggregationKey {
@@ -812,7 +814,7 @@ mod tests {
                     resource: "res".into(),
                     span_id: 1,
                     parent_id: 0,
-                    meta: HashMap::from([("_dd.svc_src".into(), "redis".into())]),
+                    meta: vec![("_dd.svc_src".into(), "redis".into())].into(),
                     ..Default::default()
                 },
                 FixedAggregationKey {
@@ -833,7 +835,7 @@ mod tests {
                     resource: "res".into(),
                     span_id: 1,
                     parent_id: 0,
-                    meta: HashMap::from([("_dd.svc_src".into(), "opt.split_by_tag".into())]),
+                    meta: vec![("_dd.svc_src".into(), "opt.split_by_tag".into())].into(),
                     ..Default::default()
                 },
                 FixedAggregationKey {
@@ -883,7 +885,11 @@ mod tests {
                     resource: "res",
                     span_id: 1,
                     parent_id: 0,
-                    meta: HashMap::from([("span.kind", "client"), ("aws.s3.bucket", "bucket-a")]),
+                    meta: vec![
+                        ("span.kind".into(), "client".into()),
+                        ("aws.s3.bucket".into(), "bucket-a".into()),
+                    ]
+                    .into(),
                     ..Default::default()
                 },
                 FixedAggregationKey {
@@ -904,12 +910,13 @@ mod tests {
                     resource: "res",
                     span_id: 1,
                     parent_id: 0,
-                    meta: HashMap::from([
+                    meta: vec![
                         ("span.kind", "producer"),
                         ("aws.s3.bucket", "bucket-a"),
                         ("db.instance", "dynamo.test.us1"),
                         ("db.system", "dynamodb"),
-                    ]),
+                    ]
+                    .into(),
                     ..Default::default()
                 },
                 FixedAggregationKey {
@@ -935,12 +942,13 @@ mod tests {
                     resource: "res",
                     span_id: 1,
                     parent_id: 0,
-                    meta: HashMap::from([
+                    meta: vec![
                         ("span.kind", "server"),
                         ("aws.s3.bucket", "bucket-a"),
                         ("db.instance", "dynamo.test.us1"),
                         ("db.system", "dynamodb"),
-                    ]),
+                    ]
+                    .into(),
                     ..Default::default()
                 },
                 FixedAggregationKey {
@@ -989,11 +997,12 @@ mod tests {
             resource: "res",
             span_id: 1,
             parent_id: 0,
-            meta: HashMap::from([
+            meta: vec![
                 ("span.kind", "client"),
                 ("peer.hostname", "10.1.2.3"),
                 ("db.instance", "my-db"),
-            ]),
+            ]
+            .into(),
             ..Default::default()
         };
         let key = BorrowedAggregationKey::from_span(&span_ipv4, &peer_tag_keys);
@@ -1016,10 +1025,14 @@ mod tests {
             resource: "res",
             span_id: 1,
             parent_id: 0,
-            meta: HashMap::from([
+            meta: vec![
                 ("span.kind", "client"),
-                ("peer.hostname", "2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF"),
-            ]),
+                (
+                    "peer.hostname",
+                    "2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF",
+                ),
+            ]
+            .into(),
             ..Default::default()
         };
         let ipv6_keys = vec!["peer.hostname".to_string()];
@@ -1040,7 +1053,11 @@ mod tests {
             resource: "res",
             span_id: 1,
             parent_id: 0,
-            meta: HashMap::from([("span.kind", "client"), ("db.instance", "dynamo.test.us1")]),
+            meta: vec![
+                ("span.kind", "client"),
+                ("db.instance", "dynamo.test.us1"),
+            ]
+            .into(),
             ..Default::default()
         };
         let non_ip_keys = vec!["db.instance".to_string()];

--- a/libdd-trace-stats/src/span_concentrator/aggregation.rs
+++ b/libdd-trace-stats/src/span_concentrator/aggregation.rs
@@ -516,8 +516,8 @@ mod tests {
                     span_id: 1,
                     parent_id: 0,
                     meta: vec![
-                        ("span.kind", "client"),
-                        ("aws.s3.bucket", "bucket-a"),
+                        ("span.kind".into(), "client".into()),
+                        ("aws.s3.bucket".into(), "bucket-a".into()),
                     ]
                     .into(),
                     ..Default::default()
@@ -885,11 +885,7 @@ mod tests {
                     resource: "res",
                     span_id: 1,
                     parent_id: 0,
-                    meta: vec![
-                        ("span.kind".into(), "client".into()),
-                        ("aws.s3.bucket".into(), "bucket-a".into()),
-                    ]
-                    .into(),
+                    meta: vec![("span.kind", "client"), ("aws.s3.bucket", "bucket-a")].into(),
                     ..Default::default()
                 },
                 FixedAggregationKey {
@@ -1027,10 +1023,7 @@ mod tests {
             parent_id: 0,
             meta: vec![
                 ("span.kind", "client"),
-                (
-                    "peer.hostname",
-                    "2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF",
-                ),
+                ("peer.hostname", "2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF"),
             ]
             .into(),
             ..Default::default()
@@ -1053,11 +1046,7 @@ mod tests {
             resource: "res",
             span_id: 1,
             parent_id: 0,
-            meta: vec![
-                ("span.kind", "client"),
-                ("db.instance", "dynamo.test.us1"),
-            ]
-            .into(),
+            meta: vec![("span.kind", "client"), ("db.instance", "dynamo.test.us1")].into(),
             ..Default::default()
         };
         let non_ip_keys = vec!["db.instance".to_string()];

--- a/libdd-trace-stats/src/span_concentrator/tests.rs
+++ b/libdd-trace-stats/src/span_concentrator/tests.rs
@@ -4,6 +4,7 @@
 use crate::span_concentrator::aggregation::OwnedAggregationKey;
 
 use super::*;
+use libdd_trace_utils::span::v04::VecMap;
 use libdd_trace_utils::span::{trace_utils::compute_top_level_span, v04::SpanSlice};
 use rand::{thread_rng, Rng};
 
@@ -72,7 +73,7 @@ fn get_test_span_with_meta<'a>(
     for (k, v) in meta {
         span.meta.insert(*k, *v);
     }
-    span.metrics = HashMap::new();
+    span.metrics = VecMap::new();
     for (k, v) in metrics {
         span.metrics.insert(*k, *v);
     }
@@ -1197,119 +1198,119 @@ fn test_compute_stats_for_span_kind() {
     let test_cases: Vec<(SpanSlice, bool)> = vec![
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind", "server")]),
+                meta: vec![("span.kind", "server")].into(),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind", "consumer")]),
+                meta: vec![("span.kind", "consumer")].into(),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind", "client")]),
+                meta: vec![("span.kind", "client")].into(),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind", "producer")]),
+                meta: vec![("span.kind", "producer")].into(),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind", "internal")]),
+                meta: vec![("span.kind", "internal")].into(),
                 ..Default::default()
             },
             false,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind", "SERVER")]),
+                meta: vec![("span.kind", "SERVER")].into(),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind", "CONSUMER")]),
+                meta: vec![("span.kind", "CONSUMER")].into(),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind", "CLIENT")]),
+                meta: vec![("span.kind", "CLIENT")].into(),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind", "PRODUCER")]),
+                meta: vec![("span.kind", "PRODUCER")].into(),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind", "INTERNAL")]),
+                meta: vec![("span.kind", "INTERNAL")].into(),
                 ..Default::default()
             },
             false,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind", "SerVER")]),
+                meta: vec![("span.kind", "SerVER")].into(),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind", "ConSUMeR")]),
+                meta: vec![("span.kind", "ConSUMeR")].into(),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind", "CLiENT")]),
+                meta: vec![("span.kind", "CLiENT")].into(),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind", "PROducER")]),
+                meta: vec![("span.kind", "PROducER")].into(),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind", "INtERNAL")]),
+                meta: vec![("span.kind", "INtERNAL")].into(),
                 ..Default::default()
             },
             false,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind", "")]),
+                meta: vec![("span.kind", "")].into(),
                 ..Default::default()
             },
             false,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([]),
+                meta: vec![].into(),
                 ..Default::default()
             },
             false,

--- a/libdd-trace-utils/src/msgpack_decoder/decode/map.rs
+++ b/libdd-trace-utils/src/msgpack_decoder/decode/map.rs
@@ -51,6 +51,27 @@ where
     Ok(map)
 }
 
+/// Reads a map from the buffer and returns it as a `Vec<(K, V)>`.
+///
+/// Like `read_map` but returns pairs in a Vec instead of HashMap for better
+/// cache locality when iteration order doesn't matter.
+#[inline]
+pub fn read_map_vec<K, V, F, B>(
+    len: usize,
+    buf: &mut B,
+    read_pair: F,
+) -> Result<Vec<(K, V)>, DecodeError>
+where
+    F: Fn(&mut B) -> Result<(K, V), DecodeError>,
+{
+    let mut vec = Vec::with_capacity(len);
+    for _ in 0..len {
+        let pair = read_pair(buf)?;
+        vec.push(pair);
+    }
+    Ok(vec)
+}
+
 /// Reads map length from the buffer
 ///
 /// # Arguments

--- a/libdd-trace-utils/src/msgpack_decoder/decode/map.rs
+++ b/libdd-trace-utils/src/msgpack_decoder/decode/map.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::msgpack_decoder::decode::{buffer::Buffer, error::DecodeError};
+use crate::span::vec_map::VecMap;
 use crate::span::DeserializableTraceData;
 use rmp::{decode, decode::RmpRead, Marker};
 use std::collections::HashMap;
@@ -51,25 +52,25 @@ where
     Ok(map)
 }
 
-/// Reads a map from the buffer and returns it as a `Vec<(K, V)>`.
+/// Reads a map from the buffer and returns it as a `VecMap<K, V>`.
 ///
-/// Like `read_map` but returns pairs in a Vec instead of HashMap for better
+/// Like `read_map` but returns pairs in a VecMap instead of HashMap for better
 /// cache locality when iteration order doesn't matter.
 #[inline]
 pub fn read_map_vec<K, V, F, B>(
     len: usize,
     buf: &mut B,
     read_pair: F,
-) -> Result<Vec<(K, V)>, DecodeError>
+) -> Result<VecMap<K, V>, DecodeError>
 where
     F: Fn(&mut B) -> Result<(K, V), DecodeError>,
 {
-    let mut vec = Vec::with_capacity(len);
+    let mut map = VecMap::with_capacity(len);
     for _ in 0..len {
-        let pair = read_pair(buf)?;
-        vec.push(pair);
+        let (k, v) = read_pair(buf)?;
+        map.insert(k, v);
     }
-    Ok(vec)
+    Ok(map)
 }
 
 /// Reads map length from the buffer

--- a/libdd-trace-utils/src/msgpack_decoder/decode/meta_struct.rs
+++ b/libdd-trace-utils/src/msgpack_decoder/decode/meta_struct.rs
@@ -3,11 +3,10 @@
 
 use crate::msgpack_decoder::decode::buffer::Buffer;
 use crate::msgpack_decoder::decode::error::DecodeError;
-use crate::msgpack_decoder::decode::map::{read_map, read_map_len};
+use crate::msgpack_decoder::decode::map::{read_map_len, read_map_vec};
 use crate::msgpack_decoder::decode::string::handle_null_marker;
 use crate::span::DeserializableTraceData;
 use rmp::decode;
-use std::collections::HashMap;
 
 fn read_byte_array_len<T: DeserializableTraceData>(
     buf: &mut Buffer<T>,
@@ -20,9 +19,9 @@ fn read_byte_array_len<T: DeserializableTraceData>(
 #[inline]
 pub fn read_meta_struct<T: DeserializableTraceData>(
     buf: &mut Buffer<T>,
-) -> Result<HashMap<T::Text, T::Bytes>, DecodeError> {
+) -> Result<Vec<(T::Text, T::Bytes)>, DecodeError> {
     if handle_null_marker(buf) {
-        return Ok(HashMap::default());
+        return Ok(Vec::new());
     }
 
     fn read_meta_struct_pair<T: DeserializableTraceData>(
@@ -41,7 +40,7 @@ pub fn read_meta_struct<T: DeserializableTraceData>(
     }
 
     let len = read_map_len(buf)?;
-    read_map(len, buf, read_meta_struct_pair)
+    read_map_vec(len, buf, read_meta_struct_pair)
 }
 
 #[cfg(test)]
@@ -49,6 +48,7 @@ mod tests {
     use super::*;
     use crate::span::SliceData;
     use libdd_tinybytes::Bytes;
+    use std::collections::HashMap;
 
     #[test]
     fn read_meta_test() {
@@ -58,7 +58,8 @@ mod tests {
         let mut slice = Buffer::<SliceData>::new(serialized.as_ref());
         let res = read_meta_struct(&mut slice).unwrap();
 
-        assert_eq!(res.get("key").unwrap().to_vec(), vec![1, 2, 3, 4]);
+        let val = res.iter().find(|(k, _)| *k == "key").map(|(_, v)| v);
+        assert_eq!(val.unwrap().to_vec(), vec![1, 2, 3, 4]);
     }
 
     #[test]

--- a/libdd-trace-utils/src/msgpack_decoder/decode/meta_struct.rs
+++ b/libdd-trace-utils/src/msgpack_decoder/decode/meta_struct.rs
@@ -5,6 +5,7 @@ use crate::msgpack_decoder::decode::buffer::Buffer;
 use crate::msgpack_decoder::decode::error::DecodeError;
 use crate::msgpack_decoder::decode::map::{read_map_len, read_map_vec};
 use crate::msgpack_decoder::decode::string::handle_null_marker;
+use crate::span::vec_map::VecMap;
 use crate::span::DeserializableTraceData;
 use rmp::decode;
 
@@ -19,9 +20,9 @@ fn read_byte_array_len<T: DeserializableTraceData>(
 #[inline]
 pub fn read_meta_struct<T: DeserializableTraceData>(
     buf: &mut Buffer<T>,
-) -> Result<Vec<(T::Text, T::Bytes)>, DecodeError> {
+) -> Result<VecMap<T::Text, T::Bytes>, DecodeError> {
     if handle_null_marker(buf) {
-        return Ok(Vec::new());
+        return Ok(VecMap::new());
     }
 
     fn read_meta_struct_pair<T: DeserializableTraceData>(

--- a/libdd-trace-utils/src/msgpack_decoder/decode/metrics.rs
+++ b/libdd-trace-utils/src/msgpack_decoder/decode/metrics.rs
@@ -3,11 +3,10 @@
 
 use crate::msgpack_decoder::decode::buffer::Buffer;
 use crate::msgpack_decoder::decode::error::DecodeError;
-use crate::msgpack_decoder::decode::map::{read_map, read_map_len};
+use crate::msgpack_decoder::decode::map::{read_map_len, read_map_vec};
 use crate::msgpack_decoder::decode::number::read_number;
 use crate::msgpack_decoder::decode::string::handle_null_marker;
 use crate::span::DeserializableTraceData;
-use std::collections::HashMap;
 
 #[inline]
 pub fn read_metric_pair<T: DeserializableTraceData>(
@@ -21,12 +20,12 @@ pub fn read_metric_pair<T: DeserializableTraceData>(
 #[inline]
 pub fn read_metrics<T: DeserializableTraceData>(
     buf: &mut Buffer<T>,
-) -> Result<HashMap<T::Text, f64>, DecodeError> {
+) -> Result<Vec<(T::Text, f64)>, DecodeError> {
     if handle_null_marker(buf) {
-        return Ok(HashMap::default());
+        return Ok(Vec::new());
     }
 
     let len = read_map_len(buf)?;
 
-    read_map(len, buf, read_metric_pair)
+    read_map_vec(len, buf, read_metric_pair)
 }

--- a/libdd-trace-utils/src/msgpack_decoder/decode/metrics.rs
+++ b/libdd-trace-utils/src/msgpack_decoder/decode/metrics.rs
@@ -6,6 +6,7 @@ use crate::msgpack_decoder::decode::error::DecodeError;
 use crate::msgpack_decoder::decode::map::{read_map_len, read_map_vec};
 use crate::msgpack_decoder::decode::number::read_number;
 use crate::msgpack_decoder::decode::string::handle_null_marker;
+use crate::span::vec_map::VecMap;
 use crate::span::DeserializableTraceData;
 
 #[inline]
@@ -20,9 +21,9 @@ pub fn read_metric_pair<T: DeserializableTraceData>(
 #[inline]
 pub fn read_metrics<T: DeserializableTraceData>(
     buf: &mut Buffer<T>,
-) -> Result<Vec<(T::Text, f64)>, DecodeError> {
+) -> Result<VecMap<T::Text, f64>, DecodeError> {
     if handle_null_marker(buf) {
-        return Ok(Vec::new());
+        return Ok(VecMap::new());
     }
 
     let len = read_map_len(buf)?;

--- a/libdd-trace-utils/src/msgpack_decoder/decode/span_link.rs
+++ b/libdd-trace-utils/src/msgpack_decoder/decode/span_link.rs
@@ -4,7 +4,7 @@
 use crate::msgpack_decoder::decode::buffer::Buffer;
 use crate::msgpack_decoder::decode::error::DecodeError;
 use crate::msgpack_decoder::decode::number::read_number;
-use crate::msgpack_decoder::decode::string::{handle_null_marker, read_str_map_to_strings};
+use crate::msgpack_decoder::decode::string::{handle_null_marker, read_str_map_to_hashmap};
 use crate::span::v04::SpanLink;
 use crate::span::DeserializableTraceData;
 use std::borrow::Borrow;
@@ -84,7 +84,7 @@ fn decode_span_link<T: DeserializableTraceData>(
             SpanLinkKey::TraceId => span.trace_id = read_number(buf)?,
             SpanLinkKey::TraceIdHigh => span.trace_id_high = read_number(buf)?,
             SpanLinkKey::SpanId => span.span_id = read_number(buf)?,
-            SpanLinkKey::Attributes => span.attributes = read_str_map_to_strings(buf)?,
+            SpanLinkKey::Attributes => span.attributes = read_str_map_to_hashmap(buf)?,
             SpanLinkKey::Tracestate => span.tracestate = buf.read_string()?,
             SpanLinkKey::Flags => span.flags = read_number(buf)?,
         }

--- a/libdd-trace-utils/src/msgpack_decoder/decode/string.rs
+++ b/libdd-trace-utils/src/msgpack_decoder/decode/string.rs
@@ -5,7 +5,6 @@ use crate::msgpack_decoder::decode::buffer::Buffer;
 use crate::msgpack_decoder::decode::error::DecodeError;
 use crate::span::DeserializableTraceData;
 use rmp::decode;
-use std::collections::HashMap;
 
 // https://docs.rs/rmp/latest/rmp/enum.Marker.html#variant.Null (0xc0 == 192)
 const NULL_MARKER: &u8 = &0xc0;
@@ -25,47 +24,73 @@ pub fn read_nullable_string<T: DeserializableTraceData>(
     }
 }
 
-/// Read a hashmap of (string, string) from the slices `buf`.
+/// Read a vec of (string, string) pairs from the slices `buf`.
 ///
 /// # Errors
 /// Fails if the buffer does not contain a valid map length prefix,
 /// or if any key or value is not a valid utf8 msgpack string.
-/// Null values are skipped (key not inserted into map).
+/// Null values are skipped (key not inserted into vec).
 #[inline]
 pub fn read_str_map_to_strings<T: DeserializableTraceData>(
     buf: &mut Buffer<T>,
-) -> Result<HashMap<T::Text, T::Text>, DecodeError> {
+) -> Result<Vec<(T::Text, T::Text)>, DecodeError> {
     let len = decode::read_map_len(buf.as_mut_slice())
         .map_err(|_| DecodeError::InvalidFormat("Unable to get map len for str map".to_owned()))?;
 
     #[allow(clippy::expect_used)]
-    let mut map = HashMap::with_capacity(len.try_into().expect("Unable to cast map len to usize"));
+    let capacity: usize = len.try_into().expect("Unable to cast map len to usize");
+    let mut vec = Vec::with_capacity(capacity);
     for _ in 0..len {
         let key = buf.read_string()?;
         // Only insert if value is not null
+        if !handle_null_marker(buf) {
+            let value = buf.read_string()?;
+            vec.push((key, value));
+        }
+    }
+    Ok(vec)
+}
+
+/// Read a nullable vec of (string, string) pairs from the slices `buf`.
+///
+/// # Errors
+/// Fails if the buffer does not contain a valid map length prefix,
+/// or if any key or value is not a valid utf8 msgpack string.
+/// Null values are skipped (key not inserted into vec).
+#[inline]
+pub fn read_nullable_str_map_to_strings<T: DeserializableTraceData>(
+    buf: &mut Buffer<T>,
+) -> Result<Vec<(T::Text, T::Text)>, DecodeError> {
+    if handle_null_marker(buf) {
+        return Ok(Vec::new());
+    }
+
+    read_str_map_to_strings(buf)
+}
+
+/// Read a hashmap of (string, string) from the slices `buf`.
+/// Used for SpanLink/SpanEvent attributes which remain as HashMap.
+#[inline]
+pub fn read_str_map_to_hashmap<T: DeserializableTraceData>(
+    buf: &mut Buffer<T>,
+) -> Result<std::collections::HashMap<T::Text, T::Text>, DecodeError>
+where
+    T::Text: std::hash::Hash + Eq,
+{
+    let len = decode::read_map_len(buf.as_mut_slice())
+        .map_err(|_| DecodeError::InvalidFormat("Unable to get map len for str map".to_owned()))?;
+
+    #[allow(clippy::expect_used)]
+    let capacity: usize = len.try_into().expect("Unable to cast map len to usize");
+    let mut map = std::collections::HashMap::with_capacity(capacity);
+    for _ in 0..len {
+        let key = buf.read_string()?;
         if !handle_null_marker(buf) {
             let value = buf.read_string()?;
             map.insert(key, value);
         }
     }
     Ok(map)
-}
-
-/// Read a nullable hashmap of (string, string) from the slices `buf`.
-///
-/// # Errors
-/// Fails if the buffer does not contain a valid map length prefix,
-/// or if any key or value is not a valid utf8 msgpack string.
-/// Null values are skipped (key not inserted into map).
-#[inline]
-pub fn read_nullable_str_map_to_strings<T: DeserializableTraceData>(
-    buf: &mut Buffer<T>,
-) -> Result<HashMap<T::Text, T::Text>, DecodeError> {
-    if handle_null_marker(buf) {
-        return Ok(HashMap::default());
-    }
-
-    read_str_map_to_strings(buf)
 }
 
 /// Handle the null value by peeking if the next value is a null marker, and will only advance the

--- a/libdd-trace-utils/src/msgpack_decoder/decode/string.rs
+++ b/libdd-trace-utils/src/msgpack_decoder/decode/string.rs
@@ -80,9 +80,7 @@ where
     let len = decode::read_map_len(buf.as_mut_slice())
         .map_err(|_| DecodeError::InvalidFormat("Unable to get map len for str map".to_owned()))?;
 
-    #[allow(clippy::expect_used)]
-    let capacity: usize = len.try_into().expect("Unable to cast map len to usize");
-    let mut map = std::collections::HashMap::with_capacity(capacity);
+    let mut map = std::collections::HashMap::with_capacity(len.try_into().unwrap_or_default());
     for _ in 0..len {
         let key = buf.read_string()?;
         if !handle_null_marker(buf) {

--- a/libdd-trace-utils/src/msgpack_decoder/decode/string.rs
+++ b/libdd-trace-utils/src/msgpack_decoder/decode/string.rs
@@ -25,14 +25,15 @@ pub fn read_nullable_string<T: DeserializableTraceData>(
     }
 }
 
-/// Read a vec of (string, string) pairs from the slices `buf`.
+/// Read a [VecMap] of `(String, String)` pairs from the slices `buf`.
 ///
 /// # Errors
-/// Fails if the buffer does not contain a valid map length prefix,
-/// or if any key or value is not a valid utf8 msgpack string.
-/// Null values are skipped (key not inserted into vec).
+///
+/// Fails if the buffer does not contain a valid map length prefix, or if any key or value is not a
+/// valid utf8 msgpack string.
+/// Null values are skipped.
 #[inline]
-pub fn read_str_map_to_strings<T: DeserializableTraceData>(
+pub fn read_str_map_to_vecmap<T: DeserializableTraceData>(
     buf: &mut Buffer<T>,
 ) -> Result<VecMap<T::Text, T::Text>, DecodeError> {
     let len = decode::read_map_len(buf.as_mut_slice())
@@ -64,7 +65,7 @@ pub fn read_nullable_str_map_to_strings<T: DeserializableTraceData>(
         return Ok(VecMap::new());
     }
 
-    read_str_map_to_strings(buf)
+    read_str_map_to_vecmap(buf)
 }
 
 /// Read a hashmap of (string, string) from the slices `buf`.

--- a/libdd-trace-utils/src/msgpack_decoder/decode/string.rs
+++ b/libdd-trace-utils/src/msgpack_decoder/decode/string.rs
@@ -3,6 +3,7 @@
 
 use crate::msgpack_decoder::decode::buffer::Buffer;
 use crate::msgpack_decoder::decode::error::DecodeError;
+use crate::span::vec_map::VecMap;
 use crate::span::DeserializableTraceData;
 use rmp::decode;
 
@@ -33,22 +34,22 @@ pub fn read_nullable_string<T: DeserializableTraceData>(
 #[inline]
 pub fn read_str_map_to_strings<T: DeserializableTraceData>(
     buf: &mut Buffer<T>,
-) -> Result<Vec<(T::Text, T::Text)>, DecodeError> {
+) -> Result<VecMap<T::Text, T::Text>, DecodeError> {
     let len = decode::read_map_len(buf.as_mut_slice())
         .map_err(|_| DecodeError::InvalidFormat("Unable to get map len for str map".to_owned()))?;
 
     #[allow(clippy::expect_used)]
     let capacity: usize = len.try_into().expect("Unable to cast map len to usize");
-    let mut vec = Vec::with_capacity(capacity);
+    let mut map = VecMap::with_capacity(capacity);
     for _ in 0..len {
         let key = buf.read_string()?;
         // Only insert if value is not null
         if !handle_null_marker(buf) {
             let value = buf.read_string()?;
-            vec.push((key, value));
+            map.insert(key, value);
         }
     }
-    Ok(vec)
+    Ok(map)
 }
 
 /// Read a nullable vec of (string, string) pairs from the slices `buf`.
@@ -60,9 +61,9 @@ pub fn read_str_map_to_strings<T: DeserializableTraceData>(
 #[inline]
 pub fn read_nullable_str_map_to_strings<T: DeserializableTraceData>(
     buf: &mut Buffer<T>,
-) -> Result<Vec<(T::Text, T::Text)>, DecodeError> {
+) -> Result<VecMap<T::Text, T::Text>, DecodeError> {
     if handle_null_marker(buf) {
-        return Ok(Vec::new());
+        return Ok(VecMap::new());
     }
 
     read_str_map_to_strings(buf)

--- a/libdd-trace-utils/src/msgpack_decoder/decode/string.rs
+++ b/libdd-trace-utils/src/msgpack_decoder/decode/string.rs
@@ -38,9 +38,7 @@ pub fn read_str_map_to_strings<T: DeserializableTraceData>(
     let len = decode::read_map_len(buf.as_mut_slice())
         .map_err(|_| DecodeError::InvalidFormat("Unable to get map len for str map".to_owned()))?;
 
-    #[allow(clippy::expect_used)]
-    let capacity: usize = len.try_into().expect("Unable to cast map len to usize");
-    let mut map = VecMap::with_capacity(capacity);
+    let mut map = VecMap::with_capacity(len.try_into().unwrap_or_default());
     for _ in 0..len {
         let key = buf.read_string()?;
         // Only insert if value is not null

--- a/libdd-trace-utils/src/msgpack_decoder/v04/mod.rs
+++ b/libdd-trace-utils/src/msgpack_decoder/v04/mod.rs
@@ -269,8 +269,7 @@ mod tests {
     fn test_decoder_meta_struct_success() {
         let data = vec![1, 2, 3, 4];
         let mut span = create_test_no_alloc_span(1, 2, 0, 0, false);
-        span.meta_struct =
-            HashMap::from([(BytesString::from("meta_key"), Bytes::from(data.clone()))]);
+        span.meta_struct = vec![(BytesString::from("meta_key"), Bytes::from(data.clone()))].into();
 
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
         let (decoded_traces, _) =
@@ -305,10 +304,8 @@ mod tests {
         let decoded_span = &decoded_traces[0][0];
 
         for (key, value) in expected_meta.iter() {
-            assert_eq!(
-                value,
-                &decoded_span.meta[&BytesString::from_slice(key.as_ref()).unwrap()].as_str()
-            );
+            let bs_key = BytesString::from_slice(key.as_ref()).unwrap();
+            assert_eq!(value, &decoded_span.meta.get(&bs_key).unwrap().as_str());
         }
     }
 
@@ -351,10 +348,8 @@ mod tests {
         let decoded_span = &decoded_traces[0][0];
 
         for (key, value) in expected_meta.iter() {
-            assert_eq!(
-                value,
-                &decoded_span.meta[&BytesString::from_slice(key.as_ref()).unwrap()].as_str()
-            );
+            let bs_key = BytesString::from_slice(key.as_ref()).unwrap();
+            assert_eq!(value, &decoded_span.meta.get(&bs_key).unwrap().as_str());
         }
     }
 
@@ -373,10 +368,8 @@ mod tests {
         let decoded_span = &decoded_traces[0][0];
 
         for (key, value) in expected_metrics.iter() {
-            assert_eq!(
-                value,
-                &decoded_span.metrics[&BytesString::from_slice(key.as_ref()).unwrap()]
-            );
+            let bs_key = BytesString::from_slice(key.as_ref()).unwrap();
+            assert_eq!(value, decoded_span.metrics.get(&bs_key).unwrap());
         }
     }
 
@@ -396,10 +389,8 @@ mod tests {
         let decoded_span = &decoded_traces[0][0];
 
         for (key, value) in expected_metrics.iter() {
-            assert_eq!(
-                value,
-                &decoded_span.metrics[&BytesString::from_slice(key.as_ref()).unwrap()]
-            );
+            let bs_key = BytesString::from_slice(key.as_ref()).unwrap();
+            assert_eq!(value, decoded_span.metrics.get(&bs_key).unwrap());
         }
     }
 
@@ -509,20 +500,15 @@ mod tests {
         assert_eq!(1, decoded_traces[0].len());
         let decoded_span = &decoded_traces[0][0];
 
-        assert_eq!(
-            "value1",
-            decoded_span.meta[&BytesString::from_slice("key1".as_ref()).unwrap()].as_str()
-        );
+        let key1 = BytesString::from_slice("key1".as_ref()).unwrap();
+        let key2 = BytesString::from_slice("key2".as_ref()).unwrap();
+        let key3 = BytesString::from_slice("key3".as_ref()).unwrap();
+        assert_eq!("value1", decoded_span.meta.get(&key1).unwrap().as_str());
         assert!(
-            !decoded_span
-                .meta
-                .contains_key(&BytesString::from_slice("key2".as_ref()).unwrap()),
+            !decoded_span.meta.contains_key(&key2),
             "Null value should be skipped, but key was present"
         );
-        assert_eq!(
-            "value3",
-            decoded_span.meta[&BytesString::from_slice("key3".as_ref()).unwrap()].as_str()
-        );
+        assert_eq!("value3", decoded_span.meta.get(&key3).unwrap().as_str());
     }
 
     #[test]
@@ -659,14 +645,16 @@ mod tests {
                         service: BytesString::from_slice(service.as_ref()).unwrap(),
                         resource: BytesString::from_slice(resource.as_ref()).unwrap(),
                         r#type: BytesString::from_slice(span_type.as_ref()).unwrap(),
-                        meta: HashMap::from([(
+                        meta: vec![(
                             BytesString::from_slice(meta_key.as_ref()).unwrap(),
                             BytesString::from_slice(meta_value.as_ref()).unwrap(),
-                        )]),
-                        metrics: HashMap::from([(
+                        )]
+                        .into(),
+                        metrics: vec![(
                             BytesString::from_slice(metric_key.as_ref()).unwrap(),
                             metric_value.parse::<f64>().unwrap_or_default(),
-                        )]),
+                        )]
+                        .into(),
                         trace_id: trace_id as u128,
                         span_id,
                         parent_id,

--- a/libdd-trace-utils/src/msgpack_decoder/v04/span.rs
+++ b/libdd-trace-utils/src/msgpack_decoder/v04/span.rs
@@ -68,9 +68,9 @@ fn fill_span<T: DeserializableTraceData>(
         SpanKey::Duration => span.duration = read_nullable_number(buf)?,
         SpanKey::Error => span.error = read_nullable_number(buf)?,
         SpanKey::Type => span.r#type = read_nullable_string(buf)?,
-        SpanKey::Meta => span.meta = read_nullable_str_map_to_strings(buf)?.into(),
-        SpanKey::Metrics => span.metrics = read_metrics(buf)?.into(),
-        SpanKey::MetaStruct => span.meta_struct = read_meta_struct(buf)?.into(),
+        SpanKey::Meta => span.meta = read_nullable_str_map_to_strings(buf)?,
+        SpanKey::Metrics => span.metrics = read_metrics(buf)?,
+        SpanKey::MetaStruct => span.meta_struct = read_meta_struct(buf)?,
         SpanKey::SpanLinks => span.span_links = read_span_links(buf)?,
         SpanKey::SpanEvents => span.span_events = read_span_events(buf)?,
     }

--- a/libdd-trace-utils/src/msgpack_decoder/v04/span.rs
+++ b/libdd-trace-utils/src/msgpack_decoder/v04/span.rs
@@ -68,9 +68,9 @@ fn fill_span<T: DeserializableTraceData>(
         SpanKey::Duration => span.duration = read_nullable_number(buf)?,
         SpanKey::Error => span.error = read_nullable_number(buf)?,
         SpanKey::Type => span.r#type = read_nullable_string(buf)?,
-        SpanKey::Meta => span.meta = read_nullable_str_map_to_strings(buf)?,
-        SpanKey::Metrics => span.metrics = read_metrics(buf)?,
-        SpanKey::MetaStruct => span.meta_struct = read_meta_struct(buf)?,
+        SpanKey::Meta => span.meta = read_nullable_str_map_to_strings(buf)?.into(),
+        SpanKey::Metrics => span.metrics = read_metrics(buf)?.into(),
+        SpanKey::MetaStruct => span.meta_struct = read_meta_struct(buf)?.into(),
         SpanKey::SpanLinks => span.span_links = read_span_links(buf)?,
         SpanKey::SpanEvents => span.span_events = read_span_events(buf)?,
     }

--- a/libdd-trace-utils/src/msgpack_decoder/v05/mod.rs
+++ b/libdd-trace-utils/src/msgpack_decoder/v05/mod.rs
@@ -241,9 +241,7 @@ where
     let len = rmp::decode::read_map_len(buf.as_mut_slice())
         .map_err(|_| DecodeError::InvalidFormat("Unable to get map len for str map".to_owned()))?;
 
-    #[allow(clippy::expect_used)]
-    let len_usize: usize = len.try_into().expect("Unable to cast map len to usize");
-    let mut map = VecMap::with_capacity(len_usize);
+    let mut map = VecMap::with_capacity(len.try_into().unwrap_or_default());
     for _ in 0..len {
         let key = get_from_dict(buf, dict)?;
         let value = get_from_dict(buf, dict)?;

--- a/libdd-trace-utils/src/msgpack_decoder/v05/mod.rs
+++ b/libdd-trace-utils/src/msgpack_decoder/v05/mod.rs
@@ -6,6 +6,7 @@ use crate::msgpack_decoder::decode::{
     buffer::Buffer, map::read_map_len, number::read_number, string::handle_null_marker,
 };
 use crate::span::v04::{Span, SpanBytes, SpanSlice};
+use crate::span::vec_map::VecMap;
 use crate::span::DeserializableTraceData;
 
 const PAYLOAD_LEN: u32 = 2;
@@ -207,8 +208,8 @@ where
     span.start = read_number(data)?;
     span.duration = read_number(data)?;
     span.error = read_number(data)?;
-    span.meta = read_indexed_map_to_bytes_strings(data, dict)?.into();
-    span.metrics = read_metrics(data, dict)?.into();
+    span.meta = read_indexed_map_to_bytes_strings(data, dict)?;
+    span.metrics = read_metrics(data, dict)?;
     span.r#type = get_from_dict(data, dict)?;
 
     Ok(span)
@@ -233,7 +234,7 @@ where
 fn read_indexed_map_to_bytes_strings<T: DeserializableTraceData>(
     buf: &mut Buffer<T>,
     dict: &[T::Text],
-) -> Result<Vec<(T::Text, T::Text)>, DecodeError>
+) -> Result<VecMap<T::Text, T::Text>, DecodeError>
 where
     T::Text: Clone,
 {
@@ -242,35 +243,35 @@ where
 
     #[allow(clippy::expect_used)]
     let len_usize: usize = len.try_into().expect("Unable to cast map len to usize");
-    let mut vec = Vec::with_capacity(len_usize);
+    let mut map = VecMap::with_capacity(len_usize);
     for _ in 0..len {
         let key = get_from_dict(buf, dict)?;
         let value = get_from_dict(buf, dict)?;
-        vec.push((key, value));
+        map.insert(key, value);
     }
-    Ok(vec)
+    Ok(map)
 }
 
 fn read_metrics<T: DeserializableTraceData>(
     buf: &mut Buffer<T>,
     dict: &[T::Text],
-) -> Result<Vec<(T::Text, f64)>, DecodeError>
+) -> Result<VecMap<T::Text, f64>, DecodeError>
 where
     T::Text: Clone,
 {
     if handle_null_marker(buf) {
-        return Ok(Vec::new());
+        return Ok(VecMap::new());
     }
 
     let len = read_map_len(buf)?;
 
-    let mut vec = Vec::with_capacity(len);
+    let mut map = VecMap::with_capacity(len);
     for _ in 0..len {
         let k = get_from_dict(buf, dict)?;
         let v = read_number(buf)?;
-        vec.push((k, v));
+        map.insert(k, v);
     }
-    Ok(vec)
+    Ok(map)
 }
 
 #[cfg(test)]

--- a/libdd-trace-utils/src/msgpack_decoder/v05/mod.rs
+++ b/libdd-trace-utils/src/msgpack_decoder/v05/mod.rs
@@ -7,7 +7,6 @@ use crate::msgpack_decoder::decode::{
 };
 use crate::span::v04::{Span, SpanBytes, SpanSlice};
 use crate::span::DeserializableTraceData;
-use std::collections::HashMap;
 
 const PAYLOAD_LEN: u32 = 2;
 const SPAN_ELEM_COUNT: u32 = 12;
@@ -208,8 +207,8 @@ where
     span.start = read_number(data)?;
     span.duration = read_number(data)?;
     span.error = read_number(data)?;
-    span.meta = read_indexed_map_to_bytes_strings(data, dict)?;
-    span.metrics = read_metrics(data, dict)?;
+    span.meta = read_indexed_map_to_bytes_strings(data, dict)?.into();
+    span.metrics = read_metrics(data, dict)?.into();
     span.r#type = get_from_dict(data, dict)?;
 
     Ok(span)
@@ -234,7 +233,7 @@ where
 fn read_indexed_map_to_bytes_strings<T: DeserializableTraceData>(
     buf: &mut Buffer<T>,
     dict: &[T::Text],
-) -> Result<HashMap<T::Text, T::Text>, DecodeError>
+) -> Result<Vec<(T::Text, T::Text)>, DecodeError>
 where
     T::Text: Clone,
 {
@@ -242,35 +241,36 @@ where
         .map_err(|_| DecodeError::InvalidFormat("Unable to get map len for str map".to_owned()))?;
 
     #[allow(clippy::expect_used)]
-    let mut map = HashMap::with_capacity(len.try_into().expect("Unable to cast map len to usize"));
+    let len_usize: usize = len.try_into().expect("Unable to cast map len to usize");
+    let mut vec = Vec::with_capacity(len_usize);
     for _ in 0..len {
         let key = get_from_dict(buf, dict)?;
         let value = get_from_dict(buf, dict)?;
-        map.insert(key, value);
+        vec.push((key, value));
     }
-    Ok(map)
+    Ok(vec)
 }
 
 fn read_metrics<T: DeserializableTraceData>(
     buf: &mut Buffer<T>,
     dict: &[T::Text],
-) -> Result<HashMap<T::Text, f64>, DecodeError>
+) -> Result<Vec<(T::Text, f64)>, DecodeError>
 where
     T::Text: Clone,
 {
     if handle_null_marker(buf) {
-        return Ok(HashMap::default());
+        return Ok(Vec::new());
     }
 
     let len = read_map_len(buf)?;
 
-    let mut map = HashMap::with_capacity(len);
+    let mut vec = Vec::with_capacity(len);
     for _ in 0..len {
         let k = get_from_dict(buf, dict)?;
         let v = read_number(buf)?;
-        map.insert(k, v);
+        vec.push((k, v));
     }
-    Ok(map)
+    Ok(vec)
 }
 
 #[cfg(test)]

--- a/libdd-trace-utils/src/msgpack_encoder/v04/span.rs
+++ b/libdd-trace-utils/src/msgpack_encoder/v04/span.rs
@@ -288,8 +288,9 @@ pub fn encode_span<W: RmpWrite, T: TraceData>(
 
     if !span.meta.is_empty() {
         write_const_msg_pack_str!(writer, "meta")?;
-        rmp::encode::write_map_len(writer, span.meta.len() as u32)?;
-        for (k, v) in span.meta.iter() {
+        let meta_dd = span.meta.defensive_dedup();
+        rmp::encode::write_map_len(writer, meta_dd.len() as u32)?;
+        for (k, v) in meta_dd.iter() {
             write_str(writer, k.borrow())?;
             write_str(writer, v.borrow())?;
         }
@@ -297,8 +298,9 @@ pub fn encode_span<W: RmpWrite, T: TraceData>(
 
     if !span.metrics.is_empty() {
         write_const_msg_pack_str!(writer, "metrics")?;
-        rmp::encode::write_map_len(writer, span.metrics.len() as u32)?;
-        for (k, v) in span.metrics.iter() {
+        let metrics_dd = span.metrics.defensive_dedup();
+        rmp::encode::write_map_len(writer, metrics_dd.len() as u32)?;
+        for (k, v) in metrics_dd.iter() {
             write_str(writer, k.borrow())?;
             write_f64(writer, *v)?;
         }
@@ -311,8 +313,9 @@ pub fn encode_span<W: RmpWrite, T: TraceData>(
 
     if !span.meta_struct.is_empty() {
         write_const_msg_pack_str!(writer, "meta_struct")?;
-        rmp::encode::write_map_len(writer, span.meta_struct.len() as u32)?;
-        for (k, v) in span.meta_struct.iter() {
+        let meta_struct_dd = span.meta_struct.defensive_dedup();
+        rmp::encode::write_map_len(writer, meta_struct_dd.len() as u32)?;
+        for (k, v) in meta_struct_dd.iter() {
             write_str(writer, k.borrow())?;
             write_bin(writer, v.borrow())?;
         }

--- a/libdd-trace-utils/src/msgpack_encoder/v1/mod.rs
+++ b/libdd-trace-utils/src/msgpack_encoder/v1/mod.rs
@@ -426,7 +426,6 @@ mod tests {
     use super::*;
     use crate::span::v04::SpanBytes;
     use libdd_tinybytes::BytesString;
-    use std::collections::HashMap;
 
     fn make_span(
         service: &str,
@@ -490,13 +489,12 @@ mod tests {
 
     #[test]
     fn test_chunk_level_attrs_origin_and_priority() {
-        let mut meta = HashMap::new();
-        meta.insert(
+        let meta = vec![(
             BytesString::from_static("_dd.origin"),
             BytesString::from_static("lambda"),
-        );
-        let mut metrics = HashMap::new();
-        metrics.insert(BytesString::from_static("_sampling_priority_v1"), 1.0f64);
+        )]
+        .into();
+        let metrics = vec![(BytesString::from_static("_sampling_priority_v1"), 1.0f64)].into();
 
         let root = SpanBytes {
             service: BytesString::from_slice(b"svc").unwrap(),
@@ -540,9 +538,11 @@ mod tests {
     #[test]
     fn test_remote_parent_root_span_top_level() {
         // A span with a non-zero parent_id but _dd.top_level=1.0 is a root in its chunk.
-        let mut metrics = HashMap::new();
-        metrics.insert(BytesString::from_static("_dd.top_level"), 1.0f64);
-        metrics.insert(BytesString::from_static("_sampling_priority_v1"), 2.0f64);
+        let metrics = vec![
+            (BytesString::from_static("_dd.top_level"), 1.0f64),
+            (BytesString::from_static("_sampling_priority_v1"), 2.0f64),
+        ]
+        .into();
 
         let root = SpanBytes {
             service: BytesString::from_slice(b"svc").unwrap(),
@@ -563,19 +563,21 @@ mod tests {
 
     #[test]
     fn test_payload_promoted_fields() {
-        let mut meta = HashMap::new();
-        meta.insert(
-            BytesString::from_static("env"),
-            BytesString::from_static("prod"),
-        );
-        meta.insert(
-            BytesString::from_static("version"),
-            BytesString::from_static("1.2.3"),
-        );
-        meta.insert(
-            BytesString::from_static("_dd.hostname"),
-            BytesString::from_static("my-host"),
-        );
+        let meta = vec![
+            (
+                BytesString::from_static("env"),
+                BytesString::from_static("prod"),
+            ),
+            (
+                BytesString::from_static("version"),
+                BytesString::from_static("1.2.3"),
+            ),
+            (
+                BytesString::from_static("_dd.hostname"),
+                BytesString::from_static("my-host"),
+            ),
+        ]
+        .into();
 
         let span = SpanBytes {
             service: BytesString::from_slice(b"svc").unwrap(),
@@ -605,15 +607,17 @@ mod tests {
 
     #[test]
     fn test_payload_attributes_apm_mode_and_git_commit_sha() {
-        let mut meta = HashMap::new();
-        meta.insert(
-            BytesString::from_static("_dd.apm_mode"),
-            BytesString::from_static("ssi"),
-        );
-        meta.insert(
-            BytesString::from_static("_dd.git.commit.sha"),
-            BytesString::from_static("abc123"),
-        );
+        let meta = vec![
+            (
+                BytesString::from_static("_dd.apm_mode"),
+                BytesString::from_static("ssi"),
+            ),
+            (
+                BytesString::from_static("_dd.git.commit.sha"),
+                BytesString::from_static("abc123"),
+            ),
+        ]
+        .into();
 
         let span = SpanBytes {
             service: BytesString::from_slice(b"svc").unwrap(),
@@ -704,11 +708,11 @@ mod tests {
 
     #[test]
     fn test_128bit_trace_id_from_dd_p_tid() {
-        let mut meta = HashMap::new();
-        meta.insert(
+        let meta = vec![(
             BytesString::from_static("_dd.p.tid"),
             BytesString::from_static("640cfd5400000000"),
-        );
+        )]
+        .into();
         let span = SpanBytes {
             service: BytesString::from_slice(b"svc").unwrap(),
             name: BytesString::from_slice(b"op").unwrap(),
@@ -759,11 +763,11 @@ mod tests {
     fn test_sampling_mechanism_negative_value() {
         // `_dd.p.dm` is a signed integer stored as a string (e.g. "-4" → manual rule).
         // The encoder must parse it, take unsigned_abs, and emit it at chunk level.
-        let mut meta = HashMap::new();
-        meta.insert(
+        let meta = vec![(
             BytesString::from_static("_dd.p.dm"),
             BytesString::from_static("-4"),
-        );
+        )]
+        .into();
         let root = SpanBytes {
             service: BytesString::from_slice(b"svc").unwrap(),
             name: BytesString::from_slice(b"op").unwrap(),
@@ -792,18 +796,17 @@ mod tests {
     fn test_chunk_attrs_fallback_no_root_span() {
         // Partial flush: no root span (every span has a non-zero parent and no
         // `_dd.top_level`). Values must be accumulated from non-root spans.
-        let mut meta1 = HashMap::new();
-        meta1.insert(
+        let meta1 = vec![(
             BytesString::from_static("_dd.origin"),
             BytesString::from_static("lambda"),
-        );
-        let mut metrics2 = HashMap::new();
-        metrics2.insert(BytesString::from_static("_sampling_priority_v1"), 2.0f64);
-        let mut meta3 = HashMap::new();
-        meta3.insert(
+        )]
+        .into();
+        let metrics2 = vec![(BytesString::from_static("_sampling_priority_v1"), 2.0f64)].into();
+        let meta3 = vec![(
             BytesString::from_static("_dd.p.dm"),
             BytesString::from_static("-3"),
-        );
+        )]
+        .into();
 
         let s1 = SpanBytes {
             service: BytesString::from_slice(b"svc").unwrap(),

--- a/libdd-trace-utils/src/msgpack_encoder/v1/span_v04.rs
+++ b/libdd-trace-utils/src/msgpack_encoder/v1/span_v04.rs
@@ -255,8 +255,14 @@ pub fn encode_span<W: RmpWrite, T: TraceData>(
             "env" | "version" | "component" | "span.kind" | "_dd.p.tid"
         )
     };
-    let non_promoted_meta = span.meta.iter().filter(|(k, _)| !is_promoted(k)).count() as u32;
-    let attr_count = non_promoted_meta + span.metrics.len() as u32 + span.meta_struct.len() as u32;
+    let meta_dd = span.meta.defensive_dedup();
+    let metrics_dd = span.metrics.defensive_dedup();
+    let meta_struct_dd = span.meta_struct.defensive_dedup();
+
+    let non_promoted_meta = meta_dd.iter().filter(|(k, _)| !is_promoted(k)).count() as u32;
+    let metrics_len = metrics_dd.len() as u32;
+    let meta_struct_len = meta_struct_dd.len() as u32;
+    let attr_count = non_promoted_meta + metrics_len + meta_struct_len;
     let has_attributes = attr_count > 0;
 
     let env = span.meta.get("env").map(|v| v.borrow());
@@ -344,25 +350,25 @@ pub fn encode_span<W: RmpWrite, T: TraceData>(
         write_uint8(writer, SpanKey::Attributes as u8)?;
         rmp::encode::write_array_len(writer, attr_count * 3)?;
 
-        for (k, v) in span.meta.iter() {
+        for (k, v) in meta_dd.iter() {
             if is_promoted(k) {
                 continue;
             }
-            table.write_interned(writer, k.borrow())?;
+            table.write_interned(writer, (*k).borrow())?;
             write_uint8(writer, AnyValueKey::String as u8)?;
-            table.write_interned(writer, v.borrow())?;
+            table.write_interned(writer, (*v).borrow())?;
         }
 
-        for (k, v) in span.metrics.iter() {
-            table.write_interned(writer, k.borrow())?;
+        for (k, v) in metrics_dd.iter() {
+            table.write_interned(writer, (*k).borrow())?;
             write_uint8(writer, AnyValueKey::Double as u8)?;
             write_f64(writer, *v)?;
         }
 
-        for (k, v) in span.meta_struct.iter() {
-            table.write_interned(writer, k.borrow())?;
+        for (k, v) in meta_struct_dd.iter() {
+            table.write_interned(writer, (*k).borrow())?;
             write_uint8(writer, AnyValueKey::Bytes as u8)?;
-            write_bin(writer, v.borrow())?;
+            write_bin(writer, (*v).borrow())?;
         }
     }
 

--- a/libdd-trace-utils/src/span/trace_utils.rs
+++ b/libdd-trace-utils/src/span/trace_utils.rs
@@ -16,7 +16,6 @@ const PARTIAL_VERSION_KEY: &str = "_dd.partial_version";
 fn set_top_level_span<T>(span: &mut Span<T>)
 where
     T: TraceData,
-    T::Text: std::borrow::Borrow<str>,
 {
     span.metrics
         .insert(T::Text::from_static_str(TOP_LEVEL_KEY), 1.0);
@@ -31,7 +30,6 @@ where
 pub fn compute_top_level_span<T>(trace: &mut [Span<T>])
 where
     T: TraceData,
-    T::Text: std::borrow::Borrow<str>,
 {
     let mut span_id_idx: HashMap<u64, usize> = HashMap::new();
     for (i, span) in trace.iter().enumerate() {
@@ -59,10 +57,7 @@ where
 }
 
 /// Return true if the span has a top level key set
-pub fn has_top_level<T: TraceData>(span: &Span<T>) -> bool
-where
-    T::Text: std::borrow::Borrow<str>,
-{
+pub fn has_top_level<T: TraceData>(span: &Span<T>) -> bool {
     span.metrics
         .get(TRACER_TOP_LEVEL_KEY)
         .is_some_and(|v| *v == 1.0)
@@ -70,10 +65,7 @@ where
 }
 
 /// Returns true if a span should be measured (i.e., it should get trace metrics calculated).
-pub fn is_measured<T: TraceData>(span: &Span<T>) -> bool
-where
-    T::Text: std::borrow::Borrow<str>,
-{
+pub fn is_measured<T: TraceData>(span: &Span<T>) -> bool {
     span.metrics.get(MEASURED_KEY).is_some_and(|v| *v == 1.0)
 }
 
@@ -82,10 +74,7 @@ where
 /// When incomplete, a partial snapshot has a metric _dd.partial_version which is a positive
 /// integer. The metric usually increases each time a new version of the same span is sent by
 /// the tracer
-pub fn is_partial_snapshot<T: TraceData>(span: &Span<T>) -> bool
-where
-    T::Text: std::borrow::Borrow<str>,
-{
+pub fn is_partial_snapshot<T: TraceData>(span: &Span<T>) -> bool {
     span.metrics
         .get(PARTIAL_VERSION_KEY)
         .is_some_and(|v| *v >= 0.0)
@@ -114,7 +103,6 @@ const SAMPLING_ANALYTICS_RATE_KEY: &str = "_dd1.sr.eausr";
 pub fn drop_chunks<T>(traces: &mut Vec<Vec<Span<T>>>) -> DroppedP0Stats
 where
     T: TraceData,
-    T::Text: std::borrow::Borrow<str>,
 {
     let mut dropped_p0_traces = 0;
     let mut dropped_p0_spans = 0;

--- a/libdd-trace-utils/src/span/trace_utils.rs
+++ b/libdd-trace-utils/src/span/trace_utils.rs
@@ -13,16 +13,13 @@ const TRACER_TOP_LEVEL_KEY: &str = "_dd.top_level";
 const MEASURED_KEY: &str = "_dd.measured";
 const PARTIAL_VERSION_KEY: &str = "_dd.partial_version";
 
-fn set_top_level_span<T>(span: &mut Span<T>, is_top_level: bool)
+fn set_top_level_span<T>(span: &mut Span<T>)
 where
     T: TraceData,
+    T::Text: std::borrow::Borrow<str>,
 {
-    if is_top_level {
-        span.metrics
-            .insert(T::Text::from_static_str(TOP_LEVEL_KEY), 1.0);
-    } else {
-        span.metrics.remove(TOP_LEVEL_KEY);
-    }
+    span.metrics
+        .insert(T::Text::from_static_str(TOP_LEVEL_KEY), 1.0);
 }
 
 /// Updates all the spans top-level attribute.
@@ -34,6 +31,7 @@ where
 pub fn compute_top_level_span<T>(trace: &mut [Span<T>])
 where
     T: TraceData,
+    T::Text: std::borrow::Borrow<str>,
 {
     let mut span_id_idx: HashMap<u64, usize> = HashMap::new();
     for (i, span) in trace.iter().enumerate() {
@@ -42,26 +40,29 @@ where
     for span_idx in 0..trace.len() {
         let parent_id = trace[span_idx].parent_id;
         if parent_id == 0 {
-            set_top_level_span(&mut trace[span_idx], true);
+            set_top_level_span(&mut trace[span_idx]);
             continue;
         }
         match span_id_idx.get(&parent_id).map(|i| &trace[*i].service) {
             Some(parent_span_service) => {
                 if !(parent_span_service == &trace[span_idx].service) {
                     // parent is not in the same service
-                    set_top_level_span(&mut trace[span_idx], true)
+                    set_top_level_span(&mut trace[span_idx])
                 }
             }
             None => {
                 // span has no parent in chunk
-                set_top_level_span(&mut trace[span_idx], true)
+                set_top_level_span(&mut trace[span_idx])
             }
         }
     }
 }
 
 /// Return true if the span has a top level key set
-pub fn has_top_level<T: TraceData>(span: &Span<T>) -> bool {
+pub fn has_top_level<T: TraceData>(span: &Span<T>) -> bool
+where
+    T::Text: std::borrow::Borrow<str>,
+{
     span.metrics
         .get(TRACER_TOP_LEVEL_KEY)
         .is_some_and(|v| *v == 1.0)
@@ -69,7 +70,10 @@ pub fn has_top_level<T: TraceData>(span: &Span<T>) -> bool {
 }
 
 /// Returns true if a span should be measured (i.e., it should get trace metrics calculated).
-pub fn is_measured<T: TraceData>(span: &Span<T>) -> bool {
+pub fn is_measured<T: TraceData>(span: &Span<T>) -> bool
+where
+    T::Text: std::borrow::Borrow<str>,
+{
     span.metrics.get(MEASURED_KEY).is_some_and(|v| *v == 1.0)
 }
 
@@ -78,7 +82,10 @@ pub fn is_measured<T: TraceData>(span: &Span<T>) -> bool {
 /// When incomplete, a partial snapshot has a metric _dd.partial_version which is a positive
 /// integer. The metric usually increases each time a new version of the same span is sent by
 /// the tracer
-pub fn is_partial_snapshot<T: TraceData>(span: &Span<T>) -> bool {
+pub fn is_partial_snapshot<T: TraceData>(span: &Span<T>) -> bool
+where
+    T::Text: std::borrow::Borrow<str>,
+{
     span.metrics
         .get(PARTIAL_VERSION_KEY)
         .is_some_and(|v| *v >= 0.0)
@@ -107,6 +114,7 @@ const SAMPLING_ANALYTICS_RATE_KEY: &str = "_dd1.sr.eausr";
 pub fn drop_chunks<T>(traces: &mut Vec<Vec<Span<T>>>) -> DroppedP0Stats
 where
     T: TraceData,
+    T::Text: std::borrow::Borrow<str>,
 {
     let mut dropped_p0_traces = 0;
     let mut dropped_p0_spans = 0;
@@ -164,7 +172,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::span::v04::SpanBytes;
+    use crate::span::v04::{SpanBytes, VecMap};
 
     fn create_test_span(
         trace_id: u64,
@@ -183,14 +191,15 @@ mod tests {
             start,
             duration: 5,
             error: 0,
-            meta: HashMap::from([
+            meta: vec![
                 ("service".into(), "test-service".into()),
                 ("env".into(), "test-env".into()),
                 ("runtime-id".into(), "test-runtime-id-value".into()),
-            ]),
-            metrics: HashMap::new(),
+            ]
+            .into(),
+            metrics: VecMap::new(),
             r#type: "".into(),
-            meta_struct: HashMap::new(),
+            meta_struct: VecMap::new(),
             span_links: vec![],
             span_events: vec![],
         };
@@ -259,10 +268,11 @@ mod tests {
         let chunk_with_priority = vec![
             SpanBytes {
                 span_id: 1,
-                metrics: HashMap::from([
+                metrics: vec![
                     (SAMPLING_PRIORITY_KEY.into(), 1.0),
                     (TRACER_TOP_LEVEL_KEY.into(), 1.0),
-                ]),
+                ]
+                .into(),
                 ..Default::default()
             },
             SpanBytes {
@@ -274,10 +284,11 @@ mod tests {
         let chunk_with_null_priority = vec![
             SpanBytes {
                 span_id: 1,
-                metrics: HashMap::from([
+                metrics: vec![
                     (SAMPLING_PRIORITY_KEY.into(), 0.0),
                     (TRACER_TOP_LEVEL_KEY.into(), 1.0),
-                ]),
+                ]
+                .into(),
                 ..Default::default()
             },
             SpanBytes {
@@ -289,7 +300,7 @@ mod tests {
         let chunk_without_priority = vec![
             SpanBytes {
                 span_id: 1,
-                metrics: HashMap::from([(TRACER_TOP_LEVEL_KEY.into(), 1.0)]),
+                metrics: vec![(TRACER_TOP_LEVEL_KEY.into(), 1.0)].into(),
                 ..Default::default()
             },
             SpanBytes {
@@ -301,10 +312,11 @@ mod tests {
         let chunk_with_multiple_top_level = vec![
             SpanBytes {
                 span_id: 1,
-                metrics: HashMap::from([
+                metrics: vec![
                     (SAMPLING_PRIORITY_KEY.into(), -1.0),
                     (TRACER_TOP_LEVEL_KEY.into(), 1.0),
-                ]),
+                ]
+                .into(),
                 ..Default::default()
             },
             SpanBytes {
@@ -315,7 +327,7 @@ mod tests {
             SpanBytes {
                 span_id: 4,
                 parent_id: 3,
-                metrics: HashMap::from([(TRACER_TOP_LEVEL_KEY.into(), 1.0)]),
+                metrics: vec![(TRACER_TOP_LEVEL_KEY.into(), 1.0)].into(),
                 ..Default::default()
             },
         ];
@@ -323,10 +335,11 @@ mod tests {
             SpanBytes {
                 span_id: 1,
                 error: 1,
-                metrics: HashMap::from([
+                metrics: vec![
                     (SAMPLING_PRIORITY_KEY.into(), 0.0),
                     (TRACER_TOP_LEVEL_KEY.into(), 1.0),
-                ]),
+                ]
+                .into(),
                 ..Default::default()
             },
             SpanBytes {
@@ -338,32 +351,34 @@ mod tests {
         let chunk_with_a_single_span = vec![
             SpanBytes {
                 span_id: 1,
-                metrics: HashMap::from([
+                metrics: vec![
                     (SAMPLING_PRIORITY_KEY.into(), 0.0),
                     (TRACER_TOP_LEVEL_KEY.into(), 1.0),
-                ]),
+                ]
+                .into(),
                 ..Default::default()
             },
             SpanBytes {
                 span_id: 2,
                 parent_id: 1,
-                metrics: HashMap::from([(SAMPLING_SINGLE_SPAN_MECHANISM.into(), 8.0)]),
+                metrics: vec![(SAMPLING_SINGLE_SPAN_MECHANISM.into(), 8.0)].into(),
                 ..Default::default()
             },
         ];
         let chunk_with_analyzed_span = vec![
             SpanBytes {
                 span_id: 1,
-                metrics: HashMap::from([
+                metrics: vec![
                     (SAMPLING_PRIORITY_KEY.into(), 0.0),
                     (TRACER_TOP_LEVEL_KEY.into(), 1.0),
-                ]),
+                ]
+                .into(),
                 ..Default::default()
             },
             SpanBytes {
                 span_id: 2,
                 parent_id: 1,
-                metrics: HashMap::from([(SAMPLING_ANALYTICS_RATE_KEY.into(), 1.0)]),
+                metrics: vec![(SAMPLING_ANALYTICS_RATE_KEY.into(), 1.0)].into(),
                 ..Default::default()
             },
         ];

--- a/libdd-trace-utils/src/span/v04/mod.rs
+++ b/libdd-trace-utils/src/span/v04/mod.rs
@@ -68,11 +68,7 @@ fn is_empty_str<T: Borrow<str>>(value: &T) -> bool {
 /// [`SpanValue`] trait:
 /// ```
 /// use libdd_trace_utils::span::{v04::Span, TraceData};
-/// use std::borrow::Borrow;
-/// fn foo<T: TraceData>(span: Span<T>)
-/// where
-///     T::Text: Borrow<str>,
-/// {
+/// fn foo<T: TraceData>(span: Span<T>) {
 ///     let _ = span.meta.get("foo");
 /// }
 /// ```

--- a/libdd-trace-utils/src/span/v04/mod.rs
+++ b/libdd-trace-utils/src/span/v04/mod.rs
@@ -311,6 +311,7 @@ impl<T: TraceData> From<&AttributeArrayValue<T>> for u8 {
 }
 
 impl<T: TraceData> Span<T> {
+    /// Deduplicate the [VecMap] parts of this span. See [VecMap::dedup].
     pub fn dedup(&mut self) {
         self.meta.dedup();
         self.metrics.dedup();

--- a/libdd-trace-utils/src/span/v04/mod.rs
+++ b/libdd-trace-utils/src/span/v04/mod.rs
@@ -310,6 +310,14 @@ impl<T: TraceData> From<&AttributeArrayValue<T>> for u8 {
     }
 }
 
+impl<T: TraceData> Span<T> {
+    pub fn dedup(&mut self) {
+        self.meta.dedup();
+        self.metrics.dedup();
+        self.meta_struct.dedup();
+    }
+}
+
 fn is_default<T: Default + PartialEq>(t: &T) -> bool {
     t == &T::default()
 }

--- a/libdd-trace-utils/src/span/v04/mod.rs
+++ b/libdd-trace-utils/src/span/v04/mod.rs
@@ -9,6 +9,8 @@ use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::str::FromStr;
 
+pub use super::vec_map::VecMap;
+
 #[derive(Debug, PartialEq)]
 pub enum SpanKey {
     Service,
@@ -66,11 +68,16 @@ fn is_empty_str<T: Borrow<str>>(value: &T) -> bool {
 /// [`SpanValue`] trait:
 /// ```
 /// use libdd_trace_utils::span::{v04::Span, TraceData};
-/// fn foo<T: TraceData>(span: Span<T>) {
+/// use std::borrow::Borrow;
+/// fn foo<T: TraceData>(span: Span<T>)
+/// where
+///     T::Text: Borrow<str>,
+/// {
 ///     let _ = span.meta.get("foo");
 /// }
 /// ```
-#[derive(Debug, Default, PartialEq, Serialize)]
+#[derive(Debug, Default, Serialize)]
+#[cfg_attr(any(test, feature = "test-utils"), derive(PartialEq))]
 pub struct Span<T: TraceData> {
     pub service: T::Text,
     pub name: T::Text,
@@ -86,12 +93,12 @@ pub struct Span<T: TraceData> {
     pub duration: i64,
     #[serde(skip_serializing_if = "is_default")]
     pub error: i32,
-    #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub meta: HashMap<T::Text, T::Text>,
-    #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub metrics: HashMap<T::Text, f64>,
-    #[serde(skip_serializing_if = "HashMap::is_empty")]
-    pub meta_struct: HashMap<T::Text, T::Bytes>,
+    #[serde(skip_serializing_if = "VecMap::is_empty")]
+    pub meta: VecMap<T::Text, T::Text>,
+    #[serde(skip_serializing_if = "VecMap::is_empty")]
+    pub metrics: VecMap<T::Text, f64>,
+    #[serde(skip_serializing_if = "VecMap::is_empty")]
+    pub meta_struct: VecMap<T::Text, T::Bytes>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub span_links: Vec<SpanLink<T>>,
     #[serde(skip_serializing_if = "Vec::is_empty")]

--- a/libdd-trace-utils/src/span/v05/mod.rs
+++ b/libdd-trace-utils/src/span/v05/mod.rs
@@ -65,7 +65,7 @@ pub fn from_v04_span<T: TraceData>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::span::v04::SpanBytes;
+    use crate::span::v04::{SpanBytes, VecMap};
     use libdd_tinybytes::BytesString;
 
     #[test]
@@ -81,12 +81,13 @@ mod tests {
             start: 1,
             duration: 111,
             error: 0,
-            meta: HashMap::from([(
+            meta: vec![(
                 BytesString::from("meta_field"),
                 BytesString::from("meta_value"),
-            )]),
-            metrics: HashMap::from([(BytesString::from("metrics_field"), 1.1)]),
-            meta_struct: HashMap::new(),
+            )]
+            .into(),
+            metrics: vec![(BytesString::from("metrics_field"), 1.1)].into(),
+            meta_struct: VecMap::new(),
             span_links: vec![],
             span_events: vec![],
         };

--- a/libdd-trace-utils/src/span/vec_map.rs
+++ b/libdd-trace-utils/src/span/vec_map.rs
@@ -201,7 +201,6 @@ impl<K: Eq + Hash, V> VecMap<K, V> {
     /// This is a convenience wrapper around [Self::as_deduped_map] used in the msgpack encoder,
     /// where we expect the map to be deduped, but call `as_deduped_map` as a defensive measure. If
     /// the latter had to deduplicate and allocate a new vec, we log a warning (at most once).
-    #[allow(unused)]
     pub(crate) fn defensive_dedup(&self) -> DedupedVecMap<'_, K, V> {
         if !self.is_deduped() {
             static WARNED: AtomicBool = AtomicBool::new(false);

--- a/libdd-trace-utils/src/span/vec_map.rs
+++ b/libdd-trace-utils/src/span/vec_map.rs
@@ -201,7 +201,7 @@ impl<K: Eq + Hash, V> VecMap<K, V> {
     /// This is a convenience wrapper around [Self::as_deduped_map] used in the msgpack encoder,
     /// where we expect the map to be deduped, but call `as_deduped_map` as a defensive measure. If
     /// the latter had to deduplicate and allocate a new vec, we log a warning (at most once).
-    pub(crate) fn defensive_dedup(&self) -> DedupedVecMap<'_, K, V> {
+    pub fn defensive_dedup(&self) -> DedupedVecMap<'_, K, V> {
         if !self.is_deduped() {
             static WARNED: AtomicBool = AtomicBool::new(false);
             if !WARNED.swap(true, Ordering::Relaxed) {

--- a/libdd-trace-utils/src/test_utils/mod.rs
+++ b/libdd-trace-utils/src/test_utils/mod.rs
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use crate::send_data::SendData;
-use crate::span::v04::SpanBytes;
+use crate::span::v04::{SpanBytes, VecMap};
 use crate::span::{v05, SharedDictBytes};
 use crate::trace_utils::TracerHeaderTags;
 use crate::tracer_payload::TracerPayloadCollection;
@@ -43,7 +43,7 @@ pub fn create_test_no_alloc_span(
         start,
         duration: 5,
         error: 0,
-        meta: HashMap::from([
+        meta: vec![
             (
                 BytesString::from_slice("service".as_ref()).unwrap(),
                 BytesString::from_slice("test-service".as_ref()).unwrap(),
@@ -56,10 +56,11 @@ pub fn create_test_no_alloc_span(
                 BytesString::from_slice("runtime-id".as_ref()).unwrap(),
                 BytesString::from_slice("test-runtime-id-value".as_ref()).unwrap(),
             ),
-        ]),
-        metrics: HashMap::new(),
+        ]
+        .into(),
+        metrics: VecMap::new(),
         r#type: BytesString::default(),
-        meta_struct: HashMap::new(),
+        meta_struct: VecMap::new(),
         span_links: vec![],
         span_events: vec![],
     };

--- a/libdd-trace-utils/src/trace_utils.rs
+++ b/libdd-trace-utils/src/trace_utils.rs
@@ -424,19 +424,19 @@ pub fn compute_top_level_span(trace: &mut [pb::Span]) {
     }
     for span in trace.iter_mut() {
         if span.parent_id == 0 {
-            set_top_level_span(span, true);
+            set_top_level_span(span);
             continue;
         }
         match span_id_to_service.get(&span.parent_id) {
             Some(parent_span_service) => {
                 if !parent_span_service.eq(&span.service) {
                     // parent is not in the same service
-                    set_top_level_span(span, true)
+                    set_top_level_span(span)
                 }
             }
             None => {
                 // span has no parent in chunk
-                set_top_level_span(span, true)
+                set_top_level_span(span)
             }
         }
     }
@@ -450,12 +450,8 @@ pub fn has_top_level(span: &pb::Span) -> bool {
         || span.metrics.get(TOP_LEVEL_KEY).is_some_and(|v| *v == 1.0)
 }
 
-fn set_top_level_span(span: &mut pb::Span, is_top_level: bool) {
-    if is_top_level {
-        span.metrics.insert(TOP_LEVEL_KEY.to_string(), 1.0);
-    } else {
-        span.metrics.remove(TOP_LEVEL_KEY);
-    }
+fn set_top_level_span(span: &mut pb::Span) {
+    span.metrics.insert(TOP_LEVEL_KEY.to_string(), 1.0);
 }
 
 pub fn set_serverless_root_span_tags(

--- a/libdd-trace-utils/src/tracer_payload.rs
+++ b/libdd-trace-utils/src/tracer_payload.rs
@@ -240,12 +240,11 @@ pub fn decode_to_trace_chunks(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::span::v04::SpanBytes;
+    use crate::span::v04::{SpanBytes, VecMap};
     use crate::test_utils::create_test_no_alloc_span;
     use libdd_tinybytes::BytesString;
     use libdd_trace_protobuf::pb;
     use serde_json::json;
-    use std::collections::HashMap;
 
     fn create_dummy_collection_v07() -> TracerPayloadCollection {
         TracerPayloadCollection::V07(vec![pb::TracerPayload {
@@ -362,9 +361,9 @@ mod tests {
             start: 1,
             duration: 5,
             error: 0,
-            meta: HashMap::new(),
-            metrics: HashMap::new(),
-            meta_struct: HashMap::new(),
+            meta: VecMap::new(),
+            metrics: VecMap::new(),
+            meta_struct: VecMap::new(),
             r#type: BytesString::from_slice("serverless".as_ref()).unwrap(),
             span_links: vec![],
             span_events: vec![],
@@ -395,9 +394,9 @@ mod tests {
             start: 1,
             duration: 5,
             error: 1,
-            meta: HashMap::new(),
-            metrics: HashMap::new(),
-            meta_struct: HashMap::new(),
+            meta: VecMap::new(),
+            metrics: VecMap::new(),
+            meta_struct: VecMap::new(),
             r#type: BytesString::default(),
             span_links: vec![],
             span_events: vec![],

--- a/libdd-trace-utils/tests/test_send_data.rs
+++ b/libdd-trace-utils/tests/test_send_data.rs
@@ -17,7 +17,6 @@ mod tracing_integration_tests {
     use libdd_trace_utils::trace_utils::TracerHeaderTags;
     use libdd_trace_utils::tracer_payload::{decode_to_trace_chunks, TraceEncoding};
     use serde_json::json;
-    use std::collections::HashMap;
     #[cfg(target_os = "linux")]
     use std::fs::Permissions;
     #[cfg(target_os = "linux")]
@@ -191,7 +190,7 @@ mod tracing_integration_tests {
         root_span.name = BytesString::from("test_send_data_v04_trace_meta_struct_snapshot_01");
         root_span.r#type = BytesString::from("web");
         root_span.meta_struct =
-            HashMap::from([(BytesString::from("appsec"), Bytes::from(meta_struct_data))]);
+            vec![(BytesString::from("appsec"), Bytes::from(meta_struct_data))].into();
 
         let encoded_data = rmp_serde::to_vec_named(&vec![vec![root_span]]).unwrap();
 


### PR DESCRIPTION
Depends on #2022 and #2049.

# What does this PR do?

This PR continues the native span performance work required to land native spans in dd-trace-js. Follow-up of #2022. Actually use `VecMap` in the `Span` data structure.

# Motivation

Performance improvement following dd-trace-js native span experiments. See #2022.

# Additional considerations

There are some deduplication design choices. We deduplicate before serializing to the agent, because while the current agent implementation would support duplicate keys in a map (with the same semantics of "last one wins"), this is not part of the spec/API, so we can't rely on it. We also deduplicate defensively in the msgpack encoder, but it should already be deduped at this stage.

For byte estimate (`byte_size()`), we make the choice of not deduplicating. This means potentially overestimating the size of a chunk (and reaching the limit sooner), in exchange of delaying the deduplication to serialization time. 

# How to test the change?

Run tests.