### PR TITLE
feat(sidecar): expose default_service_name for svc.* process tags

### DIFF
--- a/datadog-sidecar-ffi/src/lib.rs
+++ b/datadog-sidecar-ffi/src/lib.rs
@@ -751,25 +751,38 @@ pub unsafe extern "C" fn ddog_sidecar_session_set_process_tags(
     MaybeError::None
 }
 
-/// Records the default service name for the session. Empty = user-defined
-/// (sidecar emits `svc.user:true`); non-empty = auto-resolved with that name
-/// (sidecar emits `svc.auto:<name>`).
+/// Records the tracer's auto-resolved default service name for the session
+/// (process-bound; sidecar emits `svc.auto:<name>` when `DD_SERVICE` is not
+/// currently set for the active request). Pass an empty `CharSlice` to clear.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn ddog_sidecar_session_set_default_service_name(
     transport: &mut Box<SidecarTransport>,
     default_service_name: ffi::CharSlice,
 ) -> MaybeError {
-    let source = if default_service_name.is_empty() {
-        datadog_sidecar::service::ServiceNameSource::UserDefined
+    let name = if default_service_name.is_empty() {
+        None
     } else {
-        datadog_sidecar::service::ServiceNameSource::AutoResolved(
-            default_service_name.to_utf8_lossy().into_owned(),
-        )
+        Some(default_service_name.to_utf8_lossy().into_owned())
     };
-    try_c!(blocking::set_session_default_service_name(
+    try_c!(blocking::set_session_default_service_name(transport, name));
+
+    MaybeError::None
+}
+
+/// Records whether `DD_SERVICE` is currently set for the session (per-request
+/// mutable; refresh on each RINIT). When `true` the sidecar emits
+/// `svc.user:true`; when `false` it falls back to the previously-recorded
+/// `svc.auto:<name>` (if any).
+#[no_mangle]
+#[allow(clippy::missing_safety_doc)]
+pub unsafe extern "C" fn ddog_sidecar_session_set_user_service_defined(
+    transport: &mut Box<SidecarTransport>,
+    is_user_defined: bool,
+) -> MaybeError {
+    try_c!(blocking::set_session_user_service_defined(
         transport,
-        Some(source),
+        is_user_defined,
     ));
 
     MaybeError::None

--- a/datadog-sidecar-ffi/src/lib.rs
+++ b/datadog-sidecar-ffi/src/lib.rs
@@ -751,12 +751,9 @@ pub unsafe extern "C" fn ddog_sidecar_session_set_process_tags(
     MaybeError::None
 }
 
-/// Records the source of the default service name for the session so the
-/// sidecar can inject svc.user:true or svc.auto:<default_service_name> into
-/// outgoing process tag payloads. Pass an empty `default_service_name` to
-/// signal the user explicitly set DD_SERVICE; pass a non-empty value (already
-/// normalized via `ddog_normalize_process_tag_value`) to signal the tracer
-/// auto-resolved that name.
+/// Records the default service name for the session. Empty = user-defined
+/// (sidecar emits `svc.user:true`); non-empty = auto-resolved with that name
+/// (sidecar emits `svc.auto:<name>`).
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn ddog_sidecar_session_set_default_service_name(

--- a/datadog-sidecar-ffi/src/lib.rs
+++ b/datadog-sidecar-ffi/src/lib.rs
@@ -751,6 +751,33 @@ pub unsafe extern "C" fn ddog_sidecar_session_set_process_tags(
     MaybeError::None
 }
 
+/// Records the source of the default service name for the session so the
+/// sidecar can inject svc.user:true or svc.auto:<default_service_name> into
+/// outgoing process tag payloads. Pass an empty `default_service_name` to
+/// signal the user explicitly set DD_SERVICE; pass a non-empty value (already
+/// normalized via `ddog_normalize_process_tag_value`) to signal the tracer
+/// auto-resolved that name.
+#[no_mangle]
+#[allow(clippy::missing_safety_doc)]
+pub unsafe extern "C" fn ddog_sidecar_session_set_default_service_name(
+    transport: &mut Box<SidecarTransport>,
+    default_service_name: ffi::CharSlice,
+) -> MaybeError {
+    let source = if default_service_name.is_empty() {
+        datadog_sidecar::service::ServiceNameSource::UserDefined
+    } else {
+        datadog_sidecar::service::ServiceNameSource::AutoResolved(
+            default_service_name.to_utf8_lossy().into_owned(),
+        )
+    };
+    try_c!(blocking::set_session_default_service_name(
+        transport,
+        Some(source),
+    ));
+
+    MaybeError::None
+}
+
 #[repr(C)]
 pub struct TracerHeaderTags<'a> {
     pub lang: ffi::CharSlice<'a>,

--- a/datadog-sidecar/src/service/blocking.rs
+++ b/datadog-sidecar/src/service/blocking.rs
@@ -271,6 +271,14 @@ pub fn set_session_process_tags(
     Ok(())
 }
 
+pub fn set_session_default_service_name(
+    transport: &mut SidecarTransport,
+    service_name_source: Option<crate::service::ServiceNameSource>,
+) -> io::Result<()> {
+    lock_sender(transport)?.set_session_default_service_name(service_name_source);
+    Ok(())
+}
+
 /// Sends a trace as bytes.
 pub fn send_trace_v04_bytes(
     transport: &mut SidecarTransport,

--- a/datadog-sidecar/src/service/blocking.rs
+++ b/datadog-sidecar/src/service/blocking.rs
@@ -273,9 +273,17 @@ pub fn set_session_process_tags(
 
 pub fn set_session_default_service_name(
     transport: &mut SidecarTransport,
-    service_name_source: Option<crate::service::ServiceNameSource>,
+    name: Option<String>,
 ) -> io::Result<()> {
-    lock_sender(transport)?.set_session_default_service_name(service_name_source);
+    lock_sender(transport)?.set_session_default_service_name(name);
+    Ok(())
+}
+
+pub fn set_session_user_service_defined(
+    transport: &mut SidecarTransport,
+    is_defined: bool,
+) -> io::Result<()> {
+    lock_sender(transport)?.set_session_user_service_defined(is_defined);
     Ok(())
 }
 

--- a/datadog-sidecar/src/service/mod.rs
+++ b/datadog-sidecar/src/service/mod.rs
@@ -101,3 +101,9 @@ pub enum SidecarAction {
         metrics: Vec<FfeEvaluationMetric>,
     },
 }
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub enum ServiceNameSource {
+    UserDefined,
+    AutoResolved(String),
+}

--- a/datadog-sidecar/src/service/mod.rs
+++ b/datadog-sidecar/src/service/mod.rs
@@ -101,9 +101,3 @@ pub enum SidecarAction {
         metrics: Vec<FfeEvaluationMetric>,
     },
 }
-
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
-pub enum ServiceNameSource {
-    UserDefined,
-    AutoResolved(String),
-}

--- a/datadog-sidecar/src/service/runtime_info.rs
+++ b/datadog-sidecar/src/service/runtime_info.rs
@@ -144,7 +144,10 @@ impl ActiveApplication {
             .expect("Expecting remote config invariants to be set early")
             .clone();
 
-        let process_tags = session.process_tags_with_svc_source();
+        // Target is hashed on the sidecar side and on the PHP read side
+        // (sidecar.c:ddog_remote_configs_service_env_change). PHP passes the
+        // bare process_tags Vec, so we must too — otherwise SHM lookups miss.
+        let process_tags = session.process_tags.lock_or_panic().clone();
 
         if *session.remote_config_enabled.lock_or_panic() {
             self.remote_config_guard = Some(

--- a/datadog-sidecar/src/service/runtime_info.rs
+++ b/datadog-sidecar/src/service/runtime_info.rs
@@ -144,7 +144,7 @@ impl ActiveApplication {
             .expect("Expecting remote config invariants to be set early")
             .clone();
 
-        let process_tags = session.process_tags.lock_or_panic().clone();
+        let process_tags = session.process_tags_with_svc_source();
 
         if *session.remote_config_enabled.lock_or_panic() {
             self.remote_config_guard = Some(

--- a/datadog-sidecar/src/service/sender.rs
+++ b/datadog-sidecar/src/service/sender.rs
@@ -36,6 +36,7 @@ struct SidecarOutbox {
     set_session_config: Option<SidecarInterfaceRequest>,
     set_session_process_tags: Option<SidecarInterfaceRequest>,
     set_session_default_service_name: Option<SidecarInterfaceRequest>,
+    set_session_user_service_defined: Option<SidecarInterfaceRequest>,
     set_universal_service_tags: Option<SidecarInterfaceRequest>,
     set_request_config: Option<SidecarInterfaceRequest>,
     clear_queue_id: Option<SidecarInterfaceRequest>,
@@ -44,11 +45,12 @@ struct SidecarOutbox {
 }
 
 impl SidecarOutbox {
-    fn slots_mut(&mut self) -> [&mut Option<SidecarInterfaceRequest>; 8] {
+    fn slots_mut(&mut self) -> [&mut Option<SidecarInterfaceRequest>; 9] {
         [
             &mut self.set_session_config,
             &mut self.set_session_process_tags,
             &mut self.set_session_default_service_name,
+            &mut self.set_session_user_service_defined,
             &mut self.set_universal_service_tags,
             &mut self.set_request_config,
             &mut self.clear_queue_id,
@@ -126,6 +128,9 @@ fn coalesce(outbox: &mut SidecarOutbox, incoming: SidecarInterfaceRequest) {
         }
         SidecarInterfaceRequest::SetSessionDefaultServiceName { .. } => {
             outbox.set_session_default_service_name = Some(incoming);
+        }
+        SidecarInterfaceRequest::SetSessionUserServiceDefined { .. } => {
+            outbox.set_session_user_service_defined = Some(incoming);
         }
         SidecarInterfaceRequest::SetUniversalServiceTags { .. } => {
             outbox.set_universal_service_tags = Some(incoming);
@@ -241,15 +246,18 @@ impl SidecarSender {
         self.try_drain_outbox();
     }
 
-    pub fn set_session_default_service_name(
-        &mut self,
-        service_name_source: Option<crate::service::ServiceNameSource>,
-    ) {
+    pub fn set_session_default_service_name(&mut self, name: Option<String>) {
         coalesce(
             &mut self.outbox,
-            SidecarInterfaceRequest::SetSessionDefaultServiceName {
-                service_name_source,
-            },
+            SidecarInterfaceRequest::SetSessionDefaultServiceName { name },
+        );
+        self.try_drain_outbox();
+    }
+
+    pub fn set_session_user_service_defined(&mut self, is_defined: bool) {
+        coalesce(
+            &mut self.outbox,
+            SidecarInterfaceRequest::SetSessionUserServiceDefined { is_defined },
         );
         self.try_drain_outbox();
     }

--- a/datadog-sidecar/src/service/sender.rs
+++ b/datadog-sidecar/src/service/sender.rs
@@ -35,6 +35,7 @@ use tracing::trace;
 struct SidecarOutbox {
     set_session_config: Option<SidecarInterfaceRequest>,
     set_session_process_tags: Option<SidecarInterfaceRequest>,
+    set_session_default_service_name: Option<SidecarInterfaceRequest>,
     set_universal_service_tags: Option<SidecarInterfaceRequest>,
     set_request_config: Option<SidecarInterfaceRequest>,
     clear_queue_id: Option<SidecarInterfaceRequest>,
@@ -43,10 +44,11 @@ struct SidecarOutbox {
 }
 
 impl SidecarOutbox {
-    fn slots_mut(&mut self) -> [&mut Option<SidecarInterfaceRequest>; 7] {
+    fn slots_mut(&mut self) -> [&mut Option<SidecarInterfaceRequest>; 8] {
         [
             &mut self.set_session_config,
             &mut self.set_session_process_tags,
+            &mut self.set_session_default_service_name,
             &mut self.set_universal_service_tags,
             &mut self.set_request_config,
             &mut self.clear_queue_id,
@@ -121,6 +123,9 @@ fn coalesce(outbox: &mut SidecarOutbox, incoming: SidecarInterfaceRequest) {
         }
         SidecarInterfaceRequest::SetSessionProcessTags { .. } => {
             outbox.set_session_process_tags = Some(incoming);
+        }
+        SidecarInterfaceRequest::SetSessionDefaultServiceName { .. } => {
+            outbox.set_session_default_service_name = Some(incoming);
         }
         SidecarInterfaceRequest::SetUniversalServiceTags { .. } => {
             outbox.set_universal_service_tags = Some(incoming);
@@ -232,6 +237,19 @@ impl SidecarSender {
         coalesce(
             &mut self.outbox,
             SidecarInterfaceRequest::SetSessionProcessTags { process_tags },
+        );
+        self.try_drain_outbox();
+    }
+
+    pub fn set_session_default_service_name(
+        &mut self,
+        service_name_source: Option<crate::service::ServiceNameSource>,
+    ) {
+        coalesce(
+            &mut self.outbox,
+            SidecarInterfaceRequest::SetSessionDefaultServiceName {
+                service_name_source,
+            },
         );
         self.try_drain_outbox();
     }

--- a/datadog-sidecar/src/service/session_info.rs
+++ b/datadog-sidecar/src/service/session_info.rs
@@ -146,6 +146,17 @@ impl SessionInfo {
         tags
     }
 
+    pub(crate) fn refresh_stats_process_tags(&self) {
+        if let Some(stats) = self.stats_config.lock_or_panic().as_mut() {
+            stats.process_tags = self
+                .process_tags_with_svc_source()
+                .iter()
+                .map(|t| t.to_string())
+                .collect::<Vec<_>>()
+                .join(",");
+        }
+    }
+
     pub(crate) fn get_telemetry_config(
         &self,
     ) -> MutexGuard<'_, Option<libdd_telemetry::config::Config>> {

--- a/datadog-sidecar/src/service/session_info.rs
+++ b/datadog-sidecar/src/service/session_info.rs
@@ -18,7 +18,7 @@ use libdd_remote_config::fetch::ConfigOptions;
 use tracing::{debug, error, info, trace, warn};
 
 use crate::service::agent_info::AgentInfoGuard;
-use crate::service::{InstanceId, QueueId, RuntimeInfo, ServiceNameSource};
+use crate::service::{InstanceId, QueueId, RuntimeInfo};
 
 /// `SessionInfo` holds information about a session.
 ///
@@ -45,7 +45,8 @@ pub(crate) struct SessionInfo {
     pub(crate) pid: Arc<AtomicI32>,
     pub(crate) remote_config_enabled: Arc<Mutex<bool>>,
     pub(crate) process_tags: Arc<Mutex<Vec<Tag>>>,
-    pub(crate) service_name_source: Arc<Mutex<Option<ServiceNameSource>>>,
+    pub(crate) auto_resolved_service_name: Arc<Mutex<Option<String>>>,
+    pub(crate) user_service_defined: Arc<Mutex<bool>>,
     pub(crate) stats_config: Arc<Mutex<Option<crate::service::stats_flusher::StatsConfig>>>,
     otlp_metrics_endpoint: Arc<Mutex<Option<Endpoint>>>,
 }
@@ -134,12 +135,12 @@ impl SessionInfo {
 
     pub(crate) fn process_tags_with_svc_source(&self) -> Vec<Tag> {
         let mut tags = self.process_tags.lock_or_panic().clone();
-        if let Some(source) = self.service_name_source.lock_or_panic().as_ref() {
-            let (key, value) = match source {
-                ServiceNameSource::UserDefined => ("svc.user", "true".to_string()),
-                ServiceNameSource::AutoResolved(name) => ("svc.auto", name.clone()),
-            };
-            if let Ok(tag) = Tag::new(key, value) {
+        if *self.user_service_defined.lock_or_panic() {
+            if let Ok(tag) = Tag::new("svc.user", "true") {
+                tags.push(tag);
+            }
+        } else if let Some(name) = self.auto_resolved_service_name.lock_or_panic().as_ref() {
+            if let Ok(tag) = Tag::new("svc.auto", name.clone()) {
                 tags.push(tag);
             }
         }

--- a/datadog-sidecar/src/service/session_info.rs
+++ b/datadog-sidecar/src/service/session_info.rs
@@ -18,7 +18,7 @@ use libdd_remote_config::fetch::ConfigOptions;
 use tracing::{debug, error, info, trace, warn};
 
 use crate::service::agent_info::AgentInfoGuard;
-use crate::service::{InstanceId, QueueId, RuntimeInfo};
+use crate::service::{InstanceId, QueueId, RuntimeInfo, ServiceNameSource};
 
 /// `SessionInfo` holds information about a session.
 ///
@@ -45,6 +45,7 @@ pub(crate) struct SessionInfo {
     pub(crate) pid: Arc<AtomicI32>,
     pub(crate) remote_config_enabled: Arc<Mutex<bool>>,
     pub(crate) process_tags: Arc<Mutex<Vec<Tag>>>,
+    pub(crate) service_name_source: Arc<Mutex<Option<ServiceNameSource>>>,
     pub(crate) stats_config: Arc<Mutex<Option<crate::service::stats_flusher::StatsConfig>>>,
     otlp_metrics_endpoint: Arc<Mutex<Option<Endpoint>>>,
 }
@@ -129,6 +130,20 @@ impl SessionInfo {
 
     pub(crate) fn lock_runtimes(&self) -> MutexGuard<'_, HashMap<String, RuntimeInfo>> {
         self.runtimes.lock_or_panic()
+    }
+
+    pub(crate) fn process_tags_with_svc_source(&self) -> Vec<Tag> {
+        let mut tags = self.process_tags.lock_or_panic().clone();
+        if let Some(source) = self.service_name_source.lock_or_panic().as_ref() {
+            let (key, value) = match source {
+                ServiceNameSource::UserDefined => ("svc.user", "true".to_string()),
+                ServiceNameSource::AutoResolved(name) => ("svc.auto", name.clone()),
+            };
+            if let Ok(tag) = Tag::new(key, value) {
+                tags.push(tag);
+            }
+        }
+        tags
     }
 
     pub(crate) fn get_telemetry_config(

--- a/datadog-sidecar/src/service/sidecar_interface.rs
+++ b/datadog-sidecar/src/service/sidecar_interface.rs
@@ -69,6 +69,11 @@ pub trait SidecarInterface {
     /// * `process_tags` - The process tags.
     async fn set_session_process_tags(process_tags: Vec<Tag>);
 
+    /// Records the source of the default service name for the session.
+    async fn set_session_default_service_name(
+        service_name_source: Option<crate::service::ServiceNameSource>,
+    );
+
     /// Removes the application entry for the given queue ID from the instance.
     ///
     /// # Arguments

--- a/datadog-sidecar/src/service/sidecar_interface.rs
+++ b/datadog-sidecar/src/service/sidecar_interface.rs
@@ -69,10 +69,14 @@ pub trait SidecarInterface {
     /// * `process_tags` - The process tags.
     async fn set_session_process_tags(process_tags: Vec<Tag>);
 
-    /// Records the source of the default service name for the session.
-    async fn set_session_default_service_name(
-        service_name_source: Option<crate::service::ServiceNameSource>,
-    );
+    /// Records the auto-resolved default service name for the session
+    /// (thread-bound; the tracer's fallback when `DD_SERVICE` is unset).
+    /// Pass `None` to clear it.
+    async fn set_session_default_service_name(name: Option<String>);
+
+    /// Records whether `DD_SERVICE` is currently set for the session
+    /// (per-request mutable; tracer should refresh on RINIT).
+    async fn set_session_user_service_defined(is_defined: bool);
 
     /// Removes the application entry for the given queue ID from the instance.
     ///

--- a/datadog-sidecar/src/service/sidecar_server.rs
+++ b/datadog-sidecar/src/service/sidecar_server.rs
@@ -831,18 +831,25 @@ impl SidecarInterface for ConnectionSidecarHandler {
         session.refresh_stats_process_tags();
     }
 
-    async fn set_session_default_service_name(
-        &self,
-        _peer: PeerCredentials,
-        service_name_source: Option<crate::service::ServiceNameSource>,
-    ) {
+    async fn set_session_default_service_name(&self, _peer: PeerCredentials, name: Option<String>) {
         let session_id = self
             .session_id
             .get()
             .map(|s| s.as_str())
             .unwrap_or_default();
         let session = self.server.get_session(session_id);
-        *session.service_name_source.lock_or_panic() = service_name_source;
+        *session.auto_resolved_service_name.lock_or_panic() = name;
+        session.refresh_stats_process_tags();
+    }
+
+    async fn set_session_user_service_defined(&self, _peer: PeerCredentials, is_defined: bool) {
+        let session_id = self
+            .session_id
+            .get()
+            .map(|s| s.as_str())
+            .unwrap_or_default();
+        let session = self.server.get_session(session_id);
+        *session.user_service_defined.lock_or_panic() = is_defined;
         session.refresh_stats_process_tags();
     }
 

--- a/datadog-sidecar/src/service/sidecar_server.rs
+++ b/datadog-sidecar/src/service/sidecar_server.rs
@@ -478,7 +478,7 @@ impl SidecarInterface for ConnectionSidecarHandler {
                 .unwrap_or("unknown-service");
             let env = entry.get().env.as_deref().unwrap_or("none");
 
-            let process_tags = session.process_tags.lock_or_panic().clone();
+            let process_tags = session.process_tags_with_svc_source();
 
             // Pre-compute session config so both the primary and retry get_or_create calls
             // can use it without re-locking the session.
@@ -828,6 +828,20 @@ impl SidecarInterface for ConnectionSidecarHandler {
             .unwrap_or_default();
         let session = self.server.get_session(session_id);
         *session.process_tags.lock_or_panic() = process_tags;
+    }
+
+    async fn set_session_default_service_name(
+        &self,
+        _peer: PeerCredentials,
+        service_name_source: Option<crate::service::ServiceNameSource>,
+    ) {
+        let session_id = self
+            .session_id
+            .get()
+            .map(|s| s.as_str())
+            .unwrap_or_default();
+        let session = self.server.get_session(session_id);
+        *session.service_name_source.lock_or_panic() = service_name_source;
     }
 
     async fn shutdown_runtime(&self, _peer: PeerCredentials, instance_id: InstanceId) {

--- a/datadog-sidecar/src/service/sidecar_server.rs
+++ b/datadog-sidecar/src/service/sidecar_server.rs
@@ -763,8 +763,8 @@ impl SidecarInterface for ConnectionSidecarHandler {
             } else {
                 config.hostname.clone()
             },
-            process_tags: config
-                .process_tags
+            process_tags: session
+                .process_tags_with_svc_source()
                 .iter()
                 .map(|t| t.to_string())
                 .collect::<Vec<_>>()
@@ -828,6 +828,7 @@ impl SidecarInterface for ConnectionSidecarHandler {
             .unwrap_or_default();
         let session = self.server.get_session(session_id);
         *session.process_tags.lock_or_panic() = process_tags;
+        session.refresh_stats_process_tags();
     }
 
     async fn set_session_default_service_name(
@@ -842,6 +843,7 @@ impl SidecarInterface for ConnectionSidecarHandler {
             .unwrap_or_default();
         let session = self.server.get_session(session_id);
         *session.service_name_source.lock_or_panic() = service_name_source;
+        session.refresh_stats_process_tags();
     }
 
     async fn shutdown_runtime(&self, _peer: PeerCredentials, instance_id: InstanceId) {

--- a/datadog-sidecar/src/service/telemetry.rs
+++ b/datadog-sidecar/src/service/telemetry.rs
@@ -703,7 +703,7 @@ fn get_telemetry_client(
         return None;
     };
 
-    let process_tags = session.process_tags.lock_or_panic().clone();
+    let process_tags = session.process_tags_with_svc_source();
 
     Some(sidecar.telemetry_clients.get_or_create(
         service_name,


### PR DESCRIPTION
## Summary

Adds `ddog_sidecar_session_set_default_service_name(transport, default_service_name)` so tracers can communicate whether the application's service name was user-set or tracer-auto-resolved.

The sidecar stores this per-session and **injects `svc.user:true`** or **`svc.auto:<default>`** into outgoing payloads (telemetry, remote config, runtime info) at emission time — eliminating the need for tracers to bake svc.* into their static process_tags string (which would conflict with request-local service mutations in languages like PHP).

Implements the sidecar half of the RFC ["Signal Service Name Source via Process Tags"](https://docs.google.com/document/d/1c47iSTWxIOHMHfZTF2nT9xfyQaIBP9KJvI9sRn5SvpM).

## FFI

```c
ddog_MaybeError ddog_sidecar_session_set_default_service_name(
    struct ddog_SidecarTransport **transport,
    struct ddog_CharSlice default_service_name);
```

- Empty `default_service_name` → `ServiceNameSource::UserDefined` → sidecar emits `svc.user:true`
- Non-empty `default_service_name` (pre-normalized via `ddog_normalize_process_tag_value`) → `ServiceNameSource::AutoResolved(name)` → sidecar emits `svc.auto:<name>`
- Never called → no svc.* tag emitted (matches the RFC: *"no conclusions should be drawn from the absence of both"*)

## Internals

- New `ServiceNameSource` enum in `service/mod.rs`
- New `Arc<Mutex<Option<ServiceNameSource>>>` field on `SessionInfo`
- New `SessionInfo::process_tags_with_svc_source()` helper — single source of truth used by all consumers of session process_tags (telemetry, RC, runtime_info, sidecar_server)
- RPC method + outbox slot + sender method + blocking helper, mirroring `set_session_process_tags`

## Companion PR

[DataDog/dd-trace-php#3921](https://github.com/DataDog/dd-trace-php/pull/3921) — PHP tracer wires `ddog_sidecar_session_set_default_service_name` in `ext/sidecar.c` and bumps the submodule to a commit including this change.