### PR TITLE
fix(crashtracking)!: flatten all threads object into a list of `ThreadData`

### DIFF
--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -199,10 +199,9 @@ fn test_crash_tracking_bin_runtime_callback_frame() {
 /// alive until the receiver completes, guaranteeing threads are valid ptrace targets.
 ///
 /// We verify:
-///   - `error.threads` is non-empty.
+///   - `error.threads` is a non-empty array of thread objects.
 ///   - Each thread entry is well-formed: `crashed=false`, `name`, and `stack` present.
-///   - None of the additional threads are marked as crashed (the crashing thread is in
-///     `error.stack`, not `error.threads`).
+///   - The crashing thread stack is in `error.stack`, not `error.threads`.
 ///   - Both worker threads are present by name (ct_worker_0, ct_worker_1).
 ///   - Each worker has their work frame in the stack trace.
 #[test]
@@ -218,28 +217,21 @@ fn test_crash_tracking_multi_thread_collection() {
     let artifacts_map = fetch_built_artifacts(&artifacts.as_slice()).unwrap();
 
     let validator: ValidatorFn = Box::new(|payload, _fixtures| {
-        let error = &payload["error"];
-        let threads = &error["threads"];
-
-        let thread_count = threads["count"]
-            .as_u64()
-            .expect("threads.count should be a number");
-        let all_threads = threads["threads"]
+        let all_threads = payload["error"]["threads"]
             .as_array()
-            .expect("threads.threads should be a JSON array");
+            .expect("error.threads should be a JSON array of thread objects");
+
+        assert!(
+            all_threads.len() >= 2,
+            "error.threads should be non-empty when collect_all_threads is enabled; got payload: {}",
+            serde_json::to_string_pretty(payload).unwrap_or_default()
+        );
 
         let thread_names: Vec<&str> = all_threads
             .iter()
             .map(|t| t["name"].as_str().unwrap_or("<none>"))
             .collect();
 
-        assert!(
-            !all_threads.is_empty(),
-            "error.threads should be non-empty when collect_all_threads is enabled; got payload: {}",
-            serde_json::to_string_pretty(payload).unwrap_or_default()
-        );
-
-        // Every thread entry must be structurally valid and non-crashing
         for thread in all_threads {
             assert!(
                 thread["name"].is_string(),
@@ -259,12 +251,10 @@ fn test_crash_tracking_multi_thread_collection() {
             );
         }
 
-        // Both named workers must be present; the behavior spawns exactly two
         for expected in ["ct_worker_0", "ct_worker_1"] {
             assert!(
                 thread_names.contains(&expected),
-                "Expected worker thread '{expected}' in error.threads; \
-                 got: {thread_names:?}"
+                "Expected worker thread '{expected}' in error.threads; got: {thread_names:?}"
             );
         }
 
@@ -295,12 +285,6 @@ fn test_crash_tracking_multi_thread_collection() {
             );
         }
 
-        assert!(
-            thread_count == 2,
-            "expected 2 threads, got {}",
-            thread_count
-        );
-
         Ok(())
     });
 
@@ -323,31 +307,29 @@ fn test_crash_tracking_thread_limit() {
     let artifacts_map = fetch_built_artifacts(&artifacts.as_slice()).unwrap();
 
     let validator: ValidatorFn = Box::new(move |payload, _fixtures| {
-        let threads = &payload["error"]["threads"];
-
-        let thread_array = threads["threads"]
+        let thread_array = payload["error"]["threads"]
             .as_array()
-            .expect("error.threads.threads should be a JSON array");
-        let count = threads["count"]
-            .as_u64()
-            .expect("error.threads.count should be a number") as usize;
+            .expect("error.threads should be a JSON array of thread objects");
 
         assert!(
             thread_array.len() >= THREAD_COUNT,
-            "expected at least {THREAD_COUNT} thread entries, got {} \
-             (count field: {})",
-            thread_array.len(),
-            count,
-        );
-        assert_eq!(
-            count,
-            thread_array.len(),
-            "threads.count ({count}) should equal the number of thread entries ({})",
+            "expected at least {THREAD_COUNT} thread entries, got {}",
             thread_array.len(),
         );
 
-        // All entries must be non-crashing
         for thread in thread_array {
+            assert!(
+                thread["name"].is_string(),
+                "thread entry missing 'name': {thread:?}"
+            );
+            assert!(
+                thread["crashed"].is_boolean(),
+                "thread entry missing 'crashed': {thread:?}"
+            );
+            assert!(
+                thread["stack"].is_object(),
+                "thread entry missing 'stack': {thread:?}"
+            );
             assert!(
                 !thread["crashed"].as_bool().unwrap_or(true),
                 "threads in error.threads must have crashed=false: {thread:?}"

--- a/docs/RFCs/0011-crashtracker-structured-log-format-V1_X.md
+++ b/docs/RFCs/0011-crashtracker-structured-log-format-V1_X.md
@@ -4,7 +4,7 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 ## Summary
 
-This document consolidates and describes the complete evolution of the crashinfo data format from version 1.0 through 1.6. It serves as the authoritative specification for the crashtracker structured log format, replacing RFCs 0005-0009. Future minor version modifications will be included in this revisable document.
+This document consolidates and describes the complete evolution of the crashinfo data format from version 1.0 through 1.8. It serves as the authoritative specification for the crashtracker structured log format, replacing RFCs 0005-0009. Future minor version modifications will be included in this revisable document.
 
 ## Motivation
 
@@ -18,9 +18,9 @@ As a structured format, it avoids the ambiguity of standard semi-structured stac
 Due to the use of native extensions, it is possible for a single stack-trace to include frames from multiple languages (e.g. python may call C code, which calls Rust code, etc).
 Having a single structured format allows us to work across languages.
 
-## Current Format (Version 1.7)
+## Current Format (Version 1.8)
 
-This section describes the current format (version 1.7), which incorporates all features from versions 1.0 through 1.7. A natural language description of the json format is given here. An example is given in Appendix A, and the schema is given in Appendix B.
+This section describes the current format (version 1.8), which incorporates all features from versions 1.0 through 1.8. A natural language description of the json format is given here. An example is given in Appendix A, and the schema is given in Appendix B.
 
 Any field not listed as "Required" is optional. Consumers MUST accept json with elided optional fields.
 
@@ -32,7 +32,7 @@ Parsers SHOULD therefore accept unexpected fields, either by ignoring them, or b
 
 ### Version Compatibility
 
-Consumers of the crash data format SHOULD be designed to handle all versions from 1.0 to 1.7. The version is indicated by the `data_schema_version` field. Key compatibility considerations:
+Consumers of the crash data format SHOULD be designed to handle all versions from 1.0 to 1.8. The version is indicated by the `data_schema_version` field. Key compatibility considerations:
 - Version 1.0: Base format
 - Version 1.1+: Stacktraces may include an `incomplete` field
 - Version 1.2+: Root level may include an `experimental` field
@@ -40,48 +40,43 @@ Consumers of the crash data format SHOULD be designed to handle all versions fro
 - Version 1.4+: Stackframes may include a `mangled_name` field
 - Version 1.5+: Error objects may include a `thread_name` field
 - Version 1.6+: Root level may include a `ucontext` field for UNIX signal crashes
-- Version 1.7+: `error.threads` is a `Threads` object (with `threads`, `count`, and `incomplete` fields) rather than a bare array
+- Version 1.7: `error.threads` is a `Threads` wrapper object (with nested `threads`, `count`, and `incomplete` fields) rather than a bare array
+- Version 1.8+: `error.threads` is a bare array of thread objects again; the wrapper is removed. Partial collection is indicated by `counters.threads_incomplete`
 
 ### Fields
 
 - `counters`: **[optional]**
   A map of names to integer values.
   At present, this is used by the profiler to track which operations were active at the time of the crash.
+  When multi-thread collection is enabled and stops before all eligible threads are visited, collectors MAY set `threads_incomplete` to `1`.
 - `data_schema_version`: **[required]**
-  A string containing the semver ID of the crashtracker data schema. Current versions: "1.0", "1.1", "1.2", "1.3", "1.4", "1.5", "1.6", "1.7".
+  A string containing the semver ID of the crashtracker data schema. Current versions: "1.0", "1.1", "1.2", "1.3", "1.4", "1.5", "1.6", "1.7", "1.8".
 - `experimental`: **[optional]** *[Added in v1.2]*
   Any valid JSON object can be used as the value here.
   Note that the object MUST be valid JSON.
   Consumers of the format SHOULD pass this field along unmodified as the report is processed.
   This field allows developers to collect experimental data without requiring schema changes.
 - `error`: **[required]**
-  - `threads`: **[optional]** *[Shape changed in v1.7]*
-    A `Threads` object describing the non-crashing threads collected at crash time.
-    In a multi-threaded program, the collector SHOULD collect the stacktraces of all active threads and report them here, if configured to do so.
-    The `Threads` object has the following fields:
-    - `threads`: **[optional]**
-      An array of `ThreadData` objects, one per collected thread.
-      May be absent or empty if no threads were collected.
-      Each `ThreadData` object has the following fields:
-      - `crashed`: **[required]**
-        A boolean which tells if the thread crashed.
-        Threads in this array represent non-crashing threads; the crashing thread's stack is in `error.stack`.
-      - `name`: **[required]**
-        Name of the thread (e.g. `'worker-0'`).
-      - `stack`: **[required]**
-        The `StackTrace` of the thread.
-        See below for more details on how stacktraces are formatted.
-      - `state`: **[optional]**
-        Platform-specific state of the thread when its state was captured.
-        Currently, this is the single-character state letter from `/proc/<pid>/task/<tid>/stat`
-        (e.g. `"R"` for running, `"S"` for sleeping, `"D"` for uninterruptible wait).
-    - `count`: **[required]**
-      The number of threads present in the `threads` array.
-      Consumers SHOULD treat this as authoritative; it equals `threads.length` when collection completed normally.
-    - `incomplete`: **[required]**
-      `true` if thread collection was cut short before all eligible threads were visited
-      (e.g. the receiver timeout expired or the `max_threads` cap was reached), `false` otherwise.
-      When `true`, consumers SHOULD note that additional threads may exist that are not represented in `threads`.
+  - `threads`: **[optional]** *[Shape changed in v1.7, simplified in v1.8]*
+    An array of thread objects describing non-crashing threads collected at crash time.
+    In a multi-threaded program, when `collect_all_threads` is enabled, the collector SHOULD collect the stacktraces of all active background threads and report them here.
+    The crashing thread's stack is in `error.stack`, not in this array.
+    The field MUST be omitted when multi-thread collection is disabled or when no background thread stacks were collected.
+    Each thread object has the following fields:
+    - `crashed`: **[required]**
+      A boolean which tells if the thread crashed.
+      Entries in this array represent non-crashing threads and MUST have `crashed` set to `false`.
+    - `name`: **[required]**
+      Name of the thread (e.g. `'ct_worker_0'`).
+      On Linux, this is typically the `comm` field from `/proc/<pid>/task/<tid>/stat`.
+    - `stack`: **[required]**
+      The `StackTrace` of the thread.
+      See below for more details on how stacktraces are formatted.
+    - `state`: **[optional]**
+      Platform-specific state of the thread when its state was captured (CPU registers dump for iOS, thread state enum for Android, etc.).
+      Currently on Linux this is the single-character state letter from `/proc/<pid>/task/<tid>/stat`
+      (e.g. `"R"` for running, `"S"` for sleeping, `"D"` for uninterruptible wait).
+    When collection was cut short (receiver timeout or `max_threads` cap), consumers SHOULD check `counters.threads_incomplete`.
   - `is_crash`: **[required]**
     Boolean true if the error was a crash, false otherwise.
   - `kind`: **[required]**
@@ -256,7 +251,7 @@ A stacktrace consists of
 
 ## Version History
 
-This section documents the evolution of the crashtracker structured log format across versions 1.0 through 1.7. The current specification above reflects version 1.7, which includes all features from previous versions.
+This section documents the evolution of the crashtracker structured log format across versions 1.0 through 1.8. The current specification above reflects version 1.8, which includes all features from previous versions.
 
 ### Version 1.0 (RFC 0005)
 *Initial version*
@@ -333,15 +328,27 @@ This section documents the evolution of the crashtracker structured log format a
 
 **Motivation:** Thread collection in the receiver is time-bounded (the overall receiver timeout is shared between stdin reading and ptrace-based collection). When the budget runs out, collection stops early and the resulting thread list is partial. Without an explicit `incomplete` flag there is no way for consumers to distinguish "no other threads existed" from "collection was cut short". The `count` field avoids an extra array-length computation and keeps the shape consistent with other counted collections in the schema.
 
+### Version 1.8
+*Flat thread array for downstream compatibility*
+
+**Changes from v1.7:**
+- `error.threads` is again a bare array of thread objects (each with `crashed`, `name`, `stack`, and optional `state`), not a `Threads` wrapper
+- The `Threads` wrapper fields (`threads`, `count`, `incomplete`) are removed from `error.threads`
+- `error.threads` is omitted entirely when multi-thread collection is disabled or when no background threads were collected
+- Partial thread collection is reported via `counters.threads_incomplete` set to `1` when collection was cut short
+- Updated `data_schema_version` to "1.8"
+
+**Motivation:** The v1.7 nested `Threads` object broke downstream pipelines that expect `error.threads` to be a flat array of thread records. Restoring the array shape while moving completeness metadata to `counters` keeps the report compatible with existing consumers and still allows distinguishing partial collection from "collection disabled or empty".
+
 ## Appendix A: Example output
 
 An example crash report in version 1.0 format is [available here](artifacts/0005-crashtracker-example.json).
 
-Note: This example uses version 1.0 format. Version 1.1+ may include additional fields such as `incomplete` in stacktraces, `experimental` at the root level, `comments` in stackframes, `mangled_name` in stackframes, `thread_name` in error objects, `ucontext` at the root level for UNIX signal crashes, and (v1.7+) `error.threads` as a `Threads` object with `threads`, `count`, and `incomplete` fields.
+Note: This example uses version 1.0 format. Version 1.1+ may include additional fields such as `incomplete` in stacktraces, `experimental` at the root level, `comments` in stackframes, `mangled_name` in stackframes, `thread_name` in error objects, `ucontext` at the root level for UNIX signal crashes, (v1.7) `error.threads` as a `Threads` wrapper object, and (v1.8+) `error.threads` as a flat array of thread objects with `counters.threads_incomplete` for partial collection.
 
 ## Appendix B: Json Schema
 
-The current JSON schema (version 1.7) is [available here](artifacts/crashtracker-unified-runtime-stack-schema-v1_7.json).
+The current JSON schema (version 1.8) is [available here](artifacts/crashtracker-unified-runtime-stack-schema-v1_8.json).
 
 Historical schemas are also available:
 - [Version 1.0 schema](artifacts/0005-crashtracker-schema.json)
@@ -351,3 +358,4 @@ Historical schemas are also available:
 - [Version 1.4 schema](artifacts/0009-crashtracker-schema.json)
 - [Version 1.5 schema](artifacts/crashtracker-unified-runtime-stack-schema-v1_5.json)
 - [Version 1.6 schema](artifacts/crashtracker-unified-runtime-stack-schema-v1_6.json)
+- [Version 1.7 schema](artifacts/crashtracker-unified-runtime-stack-schema-v1_7.json)

--- a/docs/RFCs/artifacts/crashtracker-unified-runtime-stack-schema-v1_8.json
+++ b/docs/RFCs/artifacts/crashtracker-unified-runtime-stack-schema-v1_8.json
@@ -1,0 +1,618 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CrashInfo",
+  "type": "object",
+  "required": [
+    "data_schema_version",
+    "error",
+    "incomplete",
+    "metadata",
+    "os_info",
+    "timestamp",
+    "uuid"
+  ],
+  "properties": {
+    "counters": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "integer",
+        "format": "int64"
+      }
+    },
+    "data_schema_version": {
+      "type": "string"
+    },
+    "error": {
+      "$ref": "#/definitions/ErrorData"
+    },
+    "experimental": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Experimental"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "files": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "fingerprint": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "incomplete": {
+      "type": "boolean"
+    },
+    "log_messages": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "metadata": {
+      "$ref": "#/definitions/Metadata"
+    },
+    "os_info": {
+      "$ref": "#/definitions/OsInfo"
+    },
+    "proc_info": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ProcInfo"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "sig_info": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SigInfo"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "span_ids": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Span"
+      }
+    },
+    "timestamp": {
+      "type": "string"
+    },
+    "trace_ids": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Span"
+      }
+    },
+    "ucontext": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Ucontext"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "uuid": {
+      "type": "string"
+    }
+  },
+  "definitions": {
+    "BuildIdType": {
+      "type": "string",
+      "enum": [
+        "GNU",
+        "GO",
+        "PDB",
+        "SHA1"
+      ]
+    },
+    "ErrorData": {
+      "type": "object",
+      "required": [
+        "is_crash",
+        "kind",
+        "source_type",
+        "stack"
+      ],
+      "properties": {
+        "is_crash": {
+          "type": "boolean"
+        },
+        "kind": {
+          "$ref": "#/definitions/ErrorKind"
+        },
+        "message": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source_type": {
+          "$ref": "#/definitions/SourceType"
+        },
+        "stack": {
+          "$ref": "#/definitions/StackTrace"
+        },
+        "thread_name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "threads": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "$ref": "#/definitions/ThreadData"
+          }
+        }
+      }
+    },
+    "ErrorKind": {
+      "type": "string",
+      "enum": [
+        "Panic",
+        "UnhandledException",
+        "UnixSignal"
+      ]
+    },
+    "Experimental": {
+      "type": "object",
+      "properties": {
+        "additional_tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "runtime_stack": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RuntimeStack"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "FileType": {
+      "type": "string",
+      "enum": [
+        "APK",
+        "ELF",
+        "PE"
+      ]
+    },
+    "Metadata": {
+      "type": "object",
+      "required": [
+        "family",
+        "library_name",
+        "library_version"
+      ],
+      "properties": {
+        "family": {
+          "type": "string"
+        },
+        "library_name": {
+          "type": "string"
+        },
+        "library_version": {
+          "type": "string"
+        },
+        "tags": {
+          "description": "A list of \"key:value\" tuples.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "OsInfo": {
+      "type": "object",
+      "required": [
+        "architecture",
+        "bitness",
+        "os_type",
+        "version"
+      ],
+      "properties": {
+        "architecture": {
+          "type": "string"
+        },
+        "bitness": {
+          "type": "string"
+        },
+        "os_type": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        }
+      }
+    },
+    "ProcInfo": {
+      "type": "object",
+      "required": [
+        "pid"
+      ],
+      "properties": {
+        "pid": {
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "tid": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
+        }
+      }
+    },
+    "RuntimeStack": {
+      "description": "Runtime stack representation for JSON serialization",
+      "type": "object",
+      "required": [
+        "format"
+      ],
+      "properties": {
+        "format": {
+          "type": "string"
+        },
+        "frames": {
+          "description": "Array of runtime-specific stack frames (optional, mutually exclusive with stacktrace_string)",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/StackFrame"
+          }
+        },
+        "stacktrace_string": {
+          "description": "Raw stacktrace string (optional, mutually exclusive with frames)",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "SiCodes": {
+      "description": "See https://man7.org/linux/man-pages/man2/sigaction.2.html MUST REMAIN IN SYNC WITH THE ENUM IN emit_sigcodes.c",
+      "type": "string",
+      "enum": [
+        "BUS_ADRALN",
+        "BUS_ADRERR",
+        "BUS_MCEERR_AO",
+        "BUS_MCEERR_AR",
+        "BUS_OBJERR",
+        "ILL_BADSTK",
+        "ILL_COPROC",
+        "ILL_ILLADR",
+        "ILL_ILLOPC",
+        "ILL_ILLOPN",
+        "ILL_ILLTRP",
+        "ILL_PRVOPC",
+        "ILL_PRVREG",
+        "SEGV_ACCERR",
+        "SEGV_BNDERR",
+        "SEGV_MAPERR",
+        "SEGV_PKUERR",
+        "SI_ASYNCIO",
+        "SI_KERNEL",
+        "SI_MESGQ",
+        "SI_QUEUE",
+        "SI_SIGIO",
+        "SI_TIMER",
+        "SI_TKILL",
+        "SI_USER",
+        "SYS_SECCOMP",
+        "UNKNOWN"
+      ]
+    },
+    "SigInfo": {
+      "type": "object",
+      "required": [
+        "si_code",
+        "si_code_human_readable",
+        "si_signo",
+        "si_signo_human_readable"
+      ],
+      "properties": {
+        "si_addr": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "si_code": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "si_code_human_readable": {
+          "$ref": "#/definitions/SiCodes"
+        },
+        "si_signo": {
+          "type": "integer",
+          "format": "int32"
+        },
+        "si_signo_human_readable": {
+          "$ref": "#/definitions/SignalNames"
+        }
+      }
+    },
+    "SignalNames": {
+      "description": "See https://man7.org/linux/man-pages/man7/signal.7.html",
+      "type": "string",
+      "enum": [
+        "SIGHUP",
+        "SIGINT",
+        "SIGQUIT",
+        "SIGILL",
+        "SIGTRAP",
+        "SIGABRT",
+        "SIGBUS",
+        "SIGFPE",
+        "SIGKILL",
+        "SIGUSR1",
+        "SIGSEGV",
+        "SIGUSR2",
+        "SIGPIPE",
+        "SIGALRM",
+        "SIGTERM",
+        "SIGCHLD",
+        "SIGCONT",
+        "SIGSTOP",
+        "SIGTSTP",
+        "SIGTTIN",
+        "SIGTTOU",
+        "SIGURG",
+        "SIGXCPU",
+        "SIGXFSZ",
+        "SIGVTALRM",
+        "SIGPROF",
+        "SIGWINCH",
+        "SIGIO",
+        "SIGSYS",
+        "SIGEMT",
+        "SIGINFO",
+        "UNKNOWN"
+      ]
+    },
+    "SourceType": {
+      "type": "string",
+      "enum": [
+        "Crashtracking"
+      ]
+    },
+    "Span": {
+      "type": "object",
+      "required": [
+        "id"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "thread_name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "StackFrame": {
+      "type": "object",
+      "properties": {
+        "build_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "build_id_type": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/BuildIdType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "column": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "comments": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "file": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "file_type": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FileType"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "function": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ip": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "line": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "mangled_name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "module_base_address": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "relative_address": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "sp": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "symbol_address": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "type_name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "StackTrace": {
+      "type": "object",
+      "required": [
+        "format",
+        "frames",
+        "incomplete"
+      ],
+      "properties": {
+        "format": {
+          "type": "string"
+        },
+        "frames": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/StackFrame"
+          }
+        },
+        "incomplete": {
+          "type": "boolean"
+        }
+      }
+    },
+    "ThreadData": {
+      "type": "object",
+      "required": [
+        "crashed",
+        "name",
+        "stack"
+      ],
+      "properties": {
+        "crashed": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "stack": {
+          "$ref": "#/definitions/StackTrace"
+        },
+        "state": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "Ucontext": {
+      "description": "Structured representation of the CPU register state captured from a `ucontext_t` at the time of a crash signal.",
+      "type": "object",
+      "required": [
+        "arch",
+        "registers"
+      ],
+      "properties": {
+        "arch": {
+          "description": "Target architecture: \"x86_64\" or \"aarch64\"",
+          "type": "string"
+        },
+        "raw": {
+          "description": "Full Debug-formatted ucontext string preserving FPU state, signal mask, and alternate-stack info that is not captured in `registers`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "registers": {
+          "description": "Named registers mapped to their hex-formatted values (\"rip\" -> \"0x00007f...\")",
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/libdd-crashtracker/src/collector_windows/api.rs
+++ b/libdd-crashtracker/src/collector_windows/api.rs
@@ -236,15 +236,17 @@ pub fn exception_event_callback(
                 .context("Failed to add crashed thread info")?;
         }
 
-        let thread_data = ThreadData {
-            crashed: thread == crash_tid,
-            name: thread.to_string(),
-            stack,
-            state: None,
-        };
+        if thread == crash_tid {
+            continue;
+        }
 
         builder
-            .with_thread(thread_data)
+            .with_thread(ThreadData {
+                crashed: false,
+                name: thread.to_string(),
+                stack,
+                state: None,
+            })
             .context("Failed to add thread info")?;
     }
     builder

--- a/libdd-crashtracker/src/crash_info/builder.rs
+++ b/libdd-crashtracker/src/crash_info/builder.rs
@@ -18,7 +18,7 @@ pub struct ErrorDataBuilder {
     pub message: Option<String>,
     pub thread_name: Option<String>,
     pub stack: Option<StackTrace>,
-    pub threads: Option<Threads>,
+    pub threads: Option<Vec<ThreadData>>,
 }
 
 impl ErrorDataBuilder {
@@ -30,7 +30,7 @@ impl ErrorDataBuilder {
         let thread_name = self.thread_name;
         let source_type = SourceType::Crashtracking;
         let stack = self.stack.unwrap_or_else(StackTrace::missing);
-        let threads = self.threads.unwrap_or_default();
+        let threads = self.threads;
         Ok((
             ErrorData {
                 is_crash,
@@ -94,8 +94,19 @@ impl ErrorDataBuilder {
         Ok(())
     }
 
-    pub fn with_threads(&mut self, threads: Threads) -> anyhow::Result<()> {
+    pub fn with_threads(&mut self, threads: Vec<ThreadData>) -> anyhow::Result<()> {
+        if threads.is_empty() {
+            return Ok(());
+        }
         self.threads = Some(threads);
+        Ok(())
+    }
+
+    pub fn with_thread(&mut self, thread: ThreadData) -> anyhow::Result<()> {
+        if thread.crashed {
+            return Ok(());
+        }
+        self.threads.get_or_insert_with(Vec::new).push(thread);
         Ok(())
     }
 }
@@ -360,22 +371,11 @@ impl CrashInfoBuilder {
     }
 
     pub fn with_thread(&mut self, thread: ThreadData) -> anyhow::Result<()> {
-        if let Some(ref mut threads) = &mut self.error.threads {
-            threads.threads.push(thread);
-            threads.count += 1;
-        } else {
-            self.error.threads = Some(Threads {
-                threads: vec![thread],
-                count: 1,
-                incomplete: false,
-            });
-        }
-        Ok(())
+        self.error.with_thread(thread)
     }
 
-    pub fn with_threads(&mut self, threads: Threads) -> anyhow::Result<()> {
-        self.error.threads = Some(threads);
-        Ok(())
+    pub fn with_threads(&mut self, threads: Vec<ThreadData>) -> anyhow::Result<()> {
+        self.error.with_threads(threads)
     }
 
     pub fn with_timestamp(&mut self, timestamp: DateTime<Utc>) -> anyhow::Result<()> {

--- a/libdd-crashtracker/src/crash_info/error_data.rs
+++ b/libdd-crashtracker/src/crash_info/error_data.rs
@@ -22,7 +22,8 @@ pub struct ErrorData {
     pub thread_name: Option<String>,
     pub source_type: SourceType,
     pub stack: StackTrace,
-    pub threads: Threads,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub threads: Option<Vec<ThreadData>>,
 }
 
 #[cfg(unix)]
@@ -97,11 +98,13 @@ impl ErrorData {
             .normalize_ips(normalizer, pid, elf_resolvers)
             .unwrap_or_else(|_| errors += 1);
 
-        for thread in &mut self.threads.threads {
-            thread
-                .stack
-                .normalize_ips(normalizer, pid, elf_resolvers)
-                .unwrap_or_else(|_| errors += 1);
+        if let Some(threads) = &mut self.threads {
+            for thread in threads {
+                thread
+                    .stack
+                    .normalize_ips(normalizer, pid, elf_resolvers)
+                    .unwrap_or_else(|_| errors += 1);
+            }
         }
         anyhow::ensure!(
             errors == 0,
@@ -143,11 +146,13 @@ impl ErrorData {
             .resolve_names(src, symbolizer)
             .unwrap_or_else(|_| errors += 1);
 
-        for thread in &mut self.threads.threads {
-            thread
-                .stack
-                .resolve_names(src, symbolizer)
-                .unwrap_or_else(|_| errors += 1);
+        if let Some(threads) = &mut self.threads {
+            for thread in threads {
+                thread
+                    .stack
+                    .resolve_names(src, symbolizer)
+                    .unwrap_or_else(|_| errors += 1);
+            }
         }
         anyhow::ensure!(
             errors == 0,
@@ -161,11 +166,13 @@ impl ErrorData {
     pub fn demangle_names(&mut self) -> anyhow::Result<()> {
         let mut errors = 0;
         self.stack.demangle_names().unwrap_or_else(|_| errors += 1);
-        for thread in &mut self.threads.threads {
-            thread
-                .stack
-                .demangle_names()
-                .unwrap_or_else(|_| errors += 1);
+        if let Some(threads) = &mut self.threads {
+            for thread in threads {
+                thread
+                    .stack
+                    .demangle_names()
+                    .unwrap_or_else(|_| errors += 1);
+            }
         }
         anyhow::ensure!(
             errors == 0,
@@ -188,14 +195,6 @@ pub enum ErrorKind {
     UnixSignal,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, Default)]
-pub struct Threads {
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub threads: Vec<ThreadData>,
-    pub count: usize,
-    pub incomplete: bool,
-}
-
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct ThreadData {
     pub crashed: bool,
@@ -215,11 +214,54 @@ impl super::test_utils::TestInstance for ErrorData {
             thread_name: Some(format!("test-thread-{seed}")),
             source_type: SourceType::Crashtracking,
             stack: StackTrace::test_instance(seed),
-            threads: Threads {
-                threads: vec![],
-                count: 0,
-                incomplete: false,
-            },
+            threads: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crash_info::test_utils::TestInstance;
+
+    #[test]
+    fn error_data_without_threads_omits_threads_field() {
+        let error = ErrorData {
+            is_crash: true,
+            kind: ErrorKind::UnixSignal,
+            message: None,
+            thread_name: None,
+            source_type: SourceType::Crashtracking,
+            stack: StackTrace::missing(),
+            threads: None,
+        };
+        let json = serde_json::to_value(&error).unwrap();
+        assert!(json.get("threads").is_none());
+    }
+
+    #[test]
+    fn error_data_threads_serializes_as_thread_array() {
+        let thread = ThreadData {
+            crashed: false,
+            name: "worker".to_string(),
+            stack: StackTrace::test_instance(1),
+            state: Some("S".to_string()),
+        };
+        let error = ErrorData {
+            is_crash: true,
+            kind: ErrorKind::UnixSignal,
+            message: None,
+            thread_name: None,
+            source_type: SourceType::Crashtracking,
+            stack: StackTrace::missing(),
+            threads: Some(vec![thread.clone()]),
+        };
+        let json = serde_json::to_value(&error).unwrap();
+        let threads = json["threads"].as_array().unwrap();
+        assert_eq!(threads.len(), 1);
+        assert_eq!(threads[0]["crashed"], false);
+        assert_eq!(threads[0]["name"], "worker");
+        assert_eq!(threads[0]["state"], "S");
+        assert!(threads[0]["stack"].is_object());
     }
 }

--- a/libdd-crashtracker/src/crash_info/errors_intake.rs
+++ b/libdd-crashtracker/src/crash_info/errors_intake.rs
@@ -3,10 +3,11 @@
 
 use std::time::SystemTime;
 
-use crate::{OsInfo, SigInfo, ThreadData, Ucontext};
+use crate::{OsInfo, SigInfo, Ucontext};
 
 use super::{
-    telemetry::CrashPing, CrashInfo, Experimental, Metadata, ProcInfo, StackTrace, TARGET_TRIPLE,
+    telemetry::CrashPing, CrashInfo, Experimental, Metadata, ProcInfo, StackTrace, ThreadData,
+    TARGET_TRIPLE,
 };
 use anyhow::Context;
 use chrono::{DateTime, Utc};
@@ -252,8 +253,8 @@ pub struct ErrorObject {
     pub stack: Option<StackTrace>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub thread_name: Option<String>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    pub threads: Vec<ThreadData>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub threads: Option<Vec<ThreadData>>,
 }
 
 #[derive(serde::Serialize, Debug)]
@@ -431,7 +432,7 @@ impl ErrorsIntakePayload {
                 is_crash: Some(true),
                 source_type: Some("Crashtracking".to_string()),
                 experimental: crash_info.experimental.clone(),
-                threads: crash_info.error.threads.threads.clone(),
+                threads: crash_info.error.threads.clone(),
             },
             trace_id: None,
             ucontext: crash_info.ucontext.clone(),
@@ -490,7 +491,7 @@ impl ErrorsIntakePayload {
                 is_crash: Some(false),
                 source_type: Some("Crashtracking".to_string()),
                 experimental: None,
-                threads: vec![],
+                threads: None,
             },
             sig_info: sig_info.cloned(),
             trace_id: None,
@@ -668,7 +669,7 @@ mod tests {
         assert!(ddtags.contains("version:bar"));
         assert!(ddtags.contains("language_name:native"));
 
-        assert!(ddtags.contains("data_schema_version:1.7"));
+        assert!(ddtags.contains("data_schema_version:1.8"));
         assert!(ddtags.contains("incomplete:true"));
         assert!(ddtags.contains("is_crash:true"));
         assert!(ddtags.contains("uuid:1d6b97cb-968c-40c9-af6e-e4b4d71e8781"));
@@ -731,7 +732,7 @@ mod tests {
         let payload = ErrorsIntakePayload::from_crash_info(&crash_info).unwrap();
 
         let expected_crash_tags = [
-            "data_schema_version:1.7",
+            "data_schema_version:1.8",
             "incomplete:true",
             "is_crash:true",
             "uuid:1d6b97cb-968c-40c9-af6e-e4b4d71e8781",

--- a/libdd-crashtracker/src/crash_info/mod.rs
+++ b/libdd-crashtracker/src/crash_info/mod.rs
@@ -73,7 +73,7 @@ pub struct CrashInfo {
 
 impl CrashInfo {
     pub fn current_schema_version() -> String {
-        "1.7".to_string()
+        "1.8".to_string()
     }
 
     pub fn demangle_names(&mut self) -> anyhow::Result<()> {
@@ -177,7 +177,7 @@ mod tests {
     fn test_schema_matches_rfc() {
         let rfc_schema_filename = concat!(
             env!("CARGO_MANIFEST_DIR"),
-            "/../docs/RFCs/artifacts/crashtracker-unified-runtime-stack-schema-v1_7.json"
+            "/../docs/RFCs/artifacts/crashtracker-unified-runtime-stack-schema-v1_8.json"
         );
         let schema = schemars::schema_for!(CrashInfo);
         let schema_json = serde_json::to_string_pretty(&schema).expect("Schema to serialize");

--- a/libdd-crashtracker/src/crash_info/telemetry.rs
+++ b/libdd-crashtracker/src/crash_info/telemetry.rs
@@ -548,7 +548,7 @@ mod tests {
         assert_eq!(
             HashSet::from_iter([
                 "collecting_sample:1",
-                "data_schema_version:1.7",
+                "data_schema_version:1.8",
                 "incomplete:true",
                 "is_crash:true",
                 "not_profiling:0",

--- a/libdd-crashtracker/src/receiver/receive_report.rs
+++ b/libdd-crashtracker/src/receiver/receive_report.rs
@@ -560,7 +560,7 @@ fn collect_and_add_thread_contexts(
     crashing_tid: Option<u32>,
     budget: Duration,
 ) -> anyhow::Result<()> {
-    use crate::crash_info::{ThreadData, Threads};
+    use crate::crash_info::{StackTrace, ThreadData};
     use crate::receiver::ptrace_collector::stream_thread_contexts;
 
     let crashing_tid = crashing_tid.unwrap_or(0) as i32;
@@ -585,7 +585,7 @@ fn collect_and_add_thread_contexts(
 
             let stack = match captured_context {
                 Some(ctx) => ctx.stack_trace.clone(),
-                None => crate::crash_info::StackTrace::empty(),
+                None => StackTrace::empty(),
             };
 
             collected_threads.push(ThreadData {
@@ -597,14 +597,11 @@ fn collect_and_add_thread_contexts(
         },
     )?;
 
-    if !collected_threads.is_empty() {
-        let count = collected_threads.len();
-        let _ = builder.with_threads(Threads {
-            threads: collected_threads,
-            count,
-            incomplete,
-        });
+    if incomplete {
+        let _ = builder.with_counter("threads_incomplete".to_string(), 1);
     }
+
+    let _ = builder.with_threads(collected_threads);
 
     Ok(())
 }


### PR DESCRIPTION
# What does this PR do?
[PROF-14817](https://datadoghq.atlassian.net/jira/software/c/projects/PROF/boards/11?selectedIssue=PROF-14817&useStoredSettings=true)

Flattens `error.threads` to an optional array of thread objects (schema 1.8) so crash reports match what downstream pipelines expect.

# Motivation

Product UI expects `[]ThreadData` for rendering

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Unit tests updated. Manual payload testing. 

[PROF-14817]: https://datadoghq.atlassian.net/browse/PROF-14817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ