### PR TITLE
feat(trace-utils)!: change buffer implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3471,7 +3471,6 @@ dependencies = [
  "rmp",
  "rmp-serde",
  "rmpv",
- "rustc-hash",
  "serde",
  "serde_json",
  "tempfile",

--- a/libdd-trace-utils/Cargo.toml
+++ b/libdd-trace-utils/Cargo.toml
@@ -45,7 +45,6 @@ libdd-tinybytes = { version = "1.1.1", path = "../libdd-tinybytes", features = [
     "serialization",
 ] }
 indexmap = "2.11"
-rustc-hash = "2"
 
 # Compression feature
 flate2 = { version = "1.0", optional = true }

--- a/libdd-trace-utils/src/change_buffer/buffer.rs
+++ b/libdd-trace-utils/src/change_buffer/buffer.rs
@@ -80,15 +80,17 @@ impl ChangeBuffer {
         Ok(())
     }
 
-    pub(crate) fn read_arg<T: Clone>(
+    /// Read a string index from the buffer, fetch the string from the string table, clone it and
+    /// return it.
+    pub(crate) fn read_string<T: Clone>(
         &self,
         string_table: &super::StringTable<T>,
         index: &mut usize,
     ) -> Result<T> {
-        let num: u32 = self.read(index)?;
+        let idx: u32 = self.read(index)?;
         string_table
-            .get(num)
-            .ok_or(ChangeBufferError::StringNotFound(num))
+            .get(idx)
+            .ok_or(ChangeBufferError::StringNotFound(idx))
     }
 
     /// Clear the op count, which is stored in the first 4 bytes of the buffer. This effectively

--- a/libdd-trace-utils/src/change_buffer/buffer.rs
+++ b/libdd-trace-utils/src/change_buffer/buffer.rs
@@ -3,11 +3,12 @@
 
 use crate::change_buffer::utils::*;
 use crate::change_buffer::{ChangeBufferError, Result};
+use std::ptr::NonNull;
 
-/// A handle to a change buffer shared with another runtime. The memory is shared, meaning that
-/// cloning is cheap (copying the pointer and length).
+/// A handle to a fixed-size change buffer shared with another runtime. The memory is shared and
+/// owned/managed by the external runtime. The size of the buffer must not change once instantiated.
 pub struct ChangeBuffer {
-    ptr: *mut u8,
+    ptr: NonNull<u8>,
     len: usize,
 }
 
@@ -19,25 +20,22 @@ impl ChangeBuffer {
     /// The underlying raw memory must not be freed until after this struct's
     /// lifetime. Having the calling code manage the memory makes it simpler to
     /// integrate with managed runtimes.
-    pub unsafe fn from_raw_parts(ptr: *const u8, len: usize) -> Self {
-        Self {
-            ptr: ptr as *mut u8,
-            len,
-        }
+    pub unsafe fn from_raw_parts(ptr: NonNull<u8>, len: usize) -> Self {
+        Self { ptr, len }
     }
 
     /// # Safety
     ///
     /// Same safety conditions as [std::slice::from_raw_parts].
     unsafe fn as_slice(&self) -> &[u8] {
-        unsafe { std::slice::from_raw_parts(self.ptr, self.len) }
+        unsafe { std::slice::from_raw_parts(self.ptr.as_ptr(), self.len) }
     }
 
     /// # Safety
     ///
     /// Same safety conditions as [std::slice::from_raw_parts_mut].
     unsafe fn as_mut_slice(&mut self) -> &mut [u8] {
-        unsafe { std::slice::from_raw_parts_mut(self.ptr, self.len) }
+        unsafe { std::slice::from_raw_parts_mut(self.ptr.as_ptr(), self.len) }
     }
 
     /// Read a value of type `T` starting at offset `index`.
@@ -82,6 +80,17 @@ impl ChangeBuffer {
         Ok(())
     }
 
+    pub(crate) fn read_arg<T: Clone>(
+        &self,
+        string_table: &super::StringTable<T>,
+        index: &mut usize,
+    ) -> Result<T> {
+        let num: u32 = self.read(index)?;
+        string_table
+            .get(num)
+            .ok_or(ChangeBufferError::StringNotFound(num))
+    }
+
     /// Clear the op count, which is stored in the first 4 bytes of the buffer. This effectively
     /// reset the buffer (semantically), but without actually zeroing the rest.
     pub fn clear_count(&mut self) -> Result<()> {
@@ -92,13 +101,14 @@ impl ChangeBuffer {
 #[cfg(test)]
 mod tests {
     use super::ChangeBuffer;
+    use super::NonNull;
     use crate::change_buffer::Result;
 
     #[test]
     fn buffer_creation_and_slices() {
         let mut buf = unsafe {
-            let buf: [u8; 256] = std::mem::zeroed();
-            ChangeBuffer::from_raw_parts(buf.as_ptr(), 256)
+            let mut buf: [u8; 256] = std::mem::zeroed();
+            ChangeBuffer::from_raw_parts(NonNull::new(buf.as_mut_ptr()).unwrap(), 256)
         };
         {
             // Safety: slice is the only reference to the buffer in its scope.
@@ -117,7 +127,9 @@ mod tests {
         let example =
             b"This is an example string, long enough to get 16 bytes out of it, without issue.";
         let mut ex_buf = example.to_vec();
-        let mut buf = unsafe { ChangeBuffer::from_raw_parts(ex_buf.as_mut_ptr(), ex_buf.len()) };
+        let mut buf = unsafe {
+            ChangeBuffer::from_raw_parts(NonNull::new(ex_buf.as_mut_ptr()).unwrap(), ex_buf.len())
+        };
         let mut index = 8;
         assert_eq!(8101238474429984353, buf.read::<u64>(&mut index)?);
         assert_eq!(7956016061199967596, buf.read::<u64>(&mut index)?);
@@ -132,7 +144,9 @@ mod tests {
     #[test]
     fn clear_count() -> Result<()> {
         let mut buffer = vec![0xFFu8; 64];
-        let mut buf = unsafe { ChangeBuffer::from_raw_parts(buffer.as_mut_ptr(), buffer.len()) };
+        let mut buf = unsafe {
+            ChangeBuffer::from_raw_parts(NonNull::new(buffer.as_mut_ptr()).unwrap(), buffer.len())
+        };
         buf.clear_count()?;
         let mut index = 0;
         assert_eq!(0, buf.read::<u32>(&mut index)?);
@@ -146,7 +160,9 @@ mod tests {
         buffer[8..24].copy_from_slice(&123456789u128.to_le_bytes());
         buffer[24..32].copy_from_slice(&1.5f64.to_le_bytes());
 
-        let buf = unsafe { ChangeBuffer::from_raw_parts(buffer.as_mut_ptr(), buffer.len()) };
+        let buf = unsafe {
+            ChangeBuffer::from_raw_parts(NonNull::new(buffer.as_mut_ptr()).unwrap(), buffer.len())
+        };
 
         let mut index = 0;
         assert_eq!(42, buf.read::<u32>(&mut index)?);
@@ -163,7 +179,9 @@ mod tests {
     #[test]
     fn read_out_of_bounds() {
         let mut buffer = vec![0u8; 8];
-        let buf = unsafe { ChangeBuffer::from_raw_parts(buffer.as_mut_ptr(), buffer.len()) };
+        let buf = unsafe {
+            ChangeBuffer::from_raw_parts(NonNull::new(buffer.as_mut_ptr()).unwrap(), buffer.len())
+        };
         let mut index = 4;
         assert!(buf.read::<u64>(&mut index).is_err());
     }
@@ -171,7 +189,9 @@ mod tests {
     #[test]
     fn write_out_of_bounds() {
         let mut buffer = vec![0u8; 8];
-        let mut buf = unsafe { ChangeBuffer::from_raw_parts(buffer.as_mut_ptr(), buffer.len()) };
+        let mut buf = unsafe {
+            ChangeBuffer::from_raw_parts(NonNull::new(buffer.as_mut_ptr()).unwrap(), buffer.len())
+        };
         // 8-byte buffer, u32 at offset 5 needs bytes 5..9 — out of bounds
         assert!(buf.write_u32(5, 123).is_err());
     }

--- a/libdd-trace-utils/src/change_buffer/mod.rs
+++ b/libdd-trace-utils/src/change_buffer/mod.rs
@@ -201,24 +201,6 @@ fn span_at_mut<T: TraceData>(spans: &mut [Option<Span<T>>], slot: usize) -> Resu
         .ok_or(ChangeBufferError::SpanNotFound(slot as u64))
 }
 
-fn deferred_meta_at(
-    deferred_meta: &mut [VecMap<u32, u32>],
-    slot: usize,
-) -> Result<&mut VecMap<u32, u32>> {
-    deferred_meta
-        .get_mut(slot)
-        .ok_or(ChangeBufferError::SpanNotFound(slot as u64))
-}
-
-fn deferred_metrics_at(
-    deferred_metrics: &mut [VecMap<u32, f64>],
-    slot: usize,
-) -> Result<&mut VecMap<u32, f64>> {
-    deferred_metrics
-        .get_mut(slot)
-        .ok_or(ChangeBufferError::SpanNotFound(slot as u64))
-}
-
 impl<T: TraceData> ChangeBufferState<T>
 where
     T::Text: Clone,
@@ -292,8 +274,6 @@ where
                 .and_then(|opt| opt.take());
 
             let mut span = maybe_span.ok_or(ChangeBufferError::SpanNotFound(*slot as u64))?;
-
-            self.materialize_deferred_tags(*slot, &mut span);
 
             if is_local_root {
                 self.copy_in_sampling_tags(&mut span);
@@ -420,7 +400,8 @@ where
     ) -> Result<()> {
         let slot = op.slot_index as usize;
         let buf = &self.change_buffer;
-        let span = self.spans
+        let span = self
+            .spans
             .get_mut(slot)
             .and_then(|opt| opt.as_mut())
             .ok_or(ChangeBufferError::SpanNotFound(slot as u64))?;
@@ -432,39 +413,35 @@ where
                 span.meta.insert(key, val);
             }
             OpCode::SetMetricAttr => {
-                let key_id: u32 = buf.read(index)?;
+                let key = buf.read_string(&self.string_table, index)?;
                 let val: f64 = buf.read(index)?;
-                deferred_metrics_at(&mut self.deferred_metrics, slot)?.insert(key_id, val);
+                span.metrics.insert(key, val);
             }
             OpCode::SetServiceName => {
-                let service = buf.read_string(&self.string_table, index)?;
-                span_at_mut(&mut self.spans, slot)?.service = service;
+                span.service = buf.read_string(&self.string_table, index)?;
             }
             OpCode::SetResourceName => {
-                let resource = buf.read_string(&self.string_table, index)?;
-                span_at_mut(&mut self.spans, slot)?.resource = resource;
+                span.resource = buf.read_string(&self.string_table, index)?;
             }
             OpCode::SetError => {
-                span_at_mut(&mut self.spans, slot)?.error = buf.read(index)?;
+                span.error = buf.read(index)?;
             }
             OpCode::SetStart => {
-                span_at_mut(&mut self.spans, slot)?.start = buf.read(index)?;
+                span.start = buf.read(index)?;
             }
             OpCode::SetDuration => {
-                span_at_mut(&mut self.spans, slot)?.duration = buf.read(index)?;
+                span.duration = buf.read(index)?;
             }
             OpCode::SetType => {
-                let r#type = buf.read_string(&self.string_table, index)?;
-                span_at_mut(&mut self.spans, slot)?.r#type = r#type;
+                span.r#type = buf.read_string(&self.string_table, index)?;
             }
             OpCode::SetName => {
-                let name = buf.read_string(&self.string_table, index)?;
-                span_at_mut(&mut self.spans, slot)?.name = name;
+                span.name = buf.read_string(&self.string_table, index)?;
             }
             OpCode::SetTraceMetaAttr => {
                 let name = buf.read_string(&self.string_table, index)?;
                 let val = buf.read_string(&self.string_table, index)?;
-                let trace_id = span_at_mut(&mut self.spans, slot)?.trace_id;
+                let trace_id = span.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
                     trace.meta.insert(name, val);
                 }
@@ -472,14 +449,14 @@ where
             OpCode::SetTraceMetricsAttr => {
                 let name = buf.read_string(&self.string_table, index)?;
                 let val = buf.read(index)?;
-                let trace_id = span_at_mut(&mut self.spans, slot)?.trace_id;
+                let trace_id = span.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
                     trace.metrics.insert(name, val);
                 }
             }
             OpCode::SetTraceOrigin => {
                 let origin = buf.read_string(&self.string_table, index)?;
-                let trace_id = span_at_mut(&mut self.spans, slot)?.trace_id;
+                let trace_id = span.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
                     trace.origin = Some(origin);
                 }
@@ -487,17 +464,17 @@ where
             OpCode::BatchSetMeta => {
                 let count: u32 = buf.read(index)?;
                 for _ in 0..count {
-                    let key_id: u32 = buf.read(index)?;
-                    let val_id: u32 = buf.read(index)?;
-                    deferred_meta_at(&mut self.deferred_meta, slot)?.insert(key_id, val_id);
+                    let key = buf.read_string(&self.string_table, index)?;
+                    let val = buf.read_string(&self.string_table, index)?;
+                    span.meta.insert(key, val);
                 }
             }
             OpCode::BatchSetMetric => {
                 let count: u32 = buf.read(index)?;
                 for _ in 0..count {
-                    let key_id: u32 = buf.read(index)?;
+                    let key = buf.read_string(&self.string_table, index)?;
                     let val: f64 = buf.read(index)?;
-                    deferred_metrics_at(&mut self.deferred_metrics, slot)?.insert(key_id, val);
+                    span.metrics.insert(key, val);
                 }
             }
             OpCode::Create | OpCode::CreateSpan | OpCode::CreateSpanFull => unreachable!(),
@@ -571,12 +548,7 @@ where
             existing.parent_id = span.parent_id;
             existing.meta.extend(self.default_meta.iter().cloned());
         } else {
-            let slot_idx = self.spans.len();
             self.spans.push(Some(span));
-            if slot_idx >= self.deferred_meta.len() {
-                self.deferred_meta.resize_with(slot_idx + 1, VecMap::new);
-                self.deferred_metrics.resize_with(slot_idx + 1, VecMap::new);
-            }
         }
 
         self.traces.get_or_insert_default(trace_id).span_count += 1;
@@ -603,64 +575,10 @@ where
         }
     }
 
-    fn materialize_deferred_tags(&mut self, slot: u32, span: &mut Span<T>) {
-        let idx = slot as usize;
-        if idx < self.deferred_meta.len() {
-            let pairs: Vec<(u32, u32)> = self.deferred_meta[idx].drain(..).collect();
-
-            for (key_id, val_id) in pairs {
-                if let (Some(key), Some(val)) =
-                    (self.string_table.get(key_id), self.string_table.get(val_id))
-                {
-                    span.meta.insert(key, val);
-                }
-            }
-        }
-        if idx < self.deferred_metrics.len() {
-            let pairs: Vec<(u32, f64)> = self.deferred_metrics[idx].drain(..).collect();
-
-            for (key_id, val) in pairs {
-                if let Some(key) = self.string_table.get(key_id) {
-                    span.metrics.insert(key, val);
-                }
-            }
-        }
-    }
-
-    pub fn materialize_slot(&mut self, slot: u32) {
-        let idx = slot as usize;
-
-        if let Some(Some(span)) = self.spans.get_mut(idx) {
-            if idx < self.deferred_meta.len() {
-                for &(key_id, val_id) in &self.deferred_meta[idx] {
-                    if let (Some(key), Some(val)) =
-                        (self.string_table.get(key_id), self.string_table.get(val_id))
-                    {
-                        span.meta.insert(key, val);
-                    }
-                }
-                self.deferred_meta[idx].clear();
-            }
-
-            if idx < self.deferred_metrics.len() {
-                for &(key_id, val) in &self.deferred_metrics[idx] {
-                    if let Some(key) = self.string_table.get(key_id) {
-                        span.metrics.insert(key, val);
-                    }
-                }
-                self.deferred_metrics[idx].clear();
-            }
-        }
-    }
-
     fn ensure_slot(&mut self, slot: u32) {
         let idx = slot as usize;
         if idx >= self.spans.len() {
             self.spans.resize_with(idx + 1, || None);
-        }
-        if idx >= self.deferred_meta.len() {
-            self.deferred_meta.resize_with(idx + 1, VecMap::new);
-            self.deferred_metrics.resize_with(idx + 1, VecMap::new);
         }
     }
 
@@ -677,19 +595,17 @@ where
                 self.apply_default_meta(&mut span);
                 self.ensure_slot(op.slot_index);
                 self.spans[slot] = Some(span);
-                self.deferred_meta[slot].clear();
-                self.deferred_metrics[slot].clear();
                 self.traces.get_or_insert_default(trace_id).span_count += 1;
             }
             OpCode::SetMetaAttr => {
-                let key_id: u32 = buf.read(index)?;
-                let val_id: u32 = buf.read(index)?;
-                deferred_meta_at(&mut self.deferred_meta, slot)?.insert(key_id, val_id);
+                let key = buf.read_string(&self.string_table, index)?;
+                let val = buf.read_string(&self.string_table, index)?;
+                span_at_mut(&mut self.spans, slot)?.meta.insert(key, val);
             }
             OpCode::SetMetricAttr => {
-                let key_id: u32 = buf.read(index)?;
+                let key = buf.read_string(&self.string_table, index)?;
                 let val: f64 = buf.read(index)?;
-                deferred_metrics_at(&mut self.deferred_metrics, slot)?.insert(key_id, val);
+                span_at_mut(&mut self.spans, slot)?.metrics.insert(key, val);
             }
             OpCode::SetServiceName => {
                 let service = buf.read_string(&self.string_table, index)?;
@@ -754,8 +670,6 @@ where
                 self.apply_default_meta(&mut span);
                 self.ensure_slot(op.slot_index);
                 self.spans[slot] = Some(span);
-                self.deferred_meta[slot].clear();
-                self.deferred_metrics[slot].clear();
                 self.traces.get_or_insert_default(trace_id).span_count += 1;
             }
             OpCode::CreateSpanFull => {
@@ -776,24 +690,24 @@ where
                 self.apply_default_meta(&mut span);
                 self.ensure_slot(op.slot_index);
                 self.spans[slot] = Some(span);
-                self.deferred_meta[slot].clear();
-                self.deferred_metrics[slot].clear();
                 self.traces.get_or_insert_default(trace_id).span_count += 1;
             }
             OpCode::BatchSetMeta => {
                 let count: u32 = buf.read(index)?;
+                let span = span_at_mut(&mut self.spans, slot)?;
                 for _ in 0..count {
-                    let key_id: u32 = buf.read(index)?;
-                    let val_id: u32 = buf.read(index)?;
-                    deferred_meta_at(&mut self.deferred_meta, slot)?.insert(key_id, val_id);
+                    let key = buf.read_string(&self.string_table, index)?;
+                    let val = buf.read_string(&self.string_table, index)?;
+                    span.meta.insert(key, val);
                 }
             }
             OpCode::BatchSetMetric => {
                 let count: u32 = buf.read(index)?;
+                let span = span_at_mut(&mut self.spans, slot)?;
                 for _ in 0..count {
-                    let key_id: u32 = buf.read(index)?;
+                    let key = buf.read_string(&self.string_table, index)?;
                     let val: f64 = buf.read(index)?;
-                    deferred_metrics_at(&mut self.deferred_metrics, slot)?.insert(key_id, val);
+                    span.metrics.insert(key, val);
                 }
             }
         };

--- a/libdd-trace-utils/src/change_buffer/mod.rs
+++ b/libdd-trace-utils/src/change_buffer/mod.rs
@@ -111,11 +111,6 @@ impl<T: Clone> StringTable<T> {
         self.0.get(id as usize).and_then(|opt| opt.clone())
     }
 
-    pub(crate) fn read_arg(&self, buf: &ChangeBuffer, index: &mut usize) -> Result<T> {
-        let num: u32 = buf.read(index)?;
-        self.get(num).ok_or(ChangeBufferError::StringNotFound(num))
-    }
-
     pub(crate) fn insert(&mut self, key: u32, val: T) {
         let idx = key as usize;
         if idx >= self.0.len() {
@@ -444,43 +439,40 @@ where
                 deferred_metrics_at(&mut self.deferred_metrics, slot)?.insert(key_id, val);
             }
             OpCode::SetServiceName => {
-                let service = self.string_table.read_arg(&self.change_buffer, index)?;
+                let service = buf.read_arg(&self.string_table, index)?;
                 span_at_mut(&mut self.spans, slot)?.service = service;
             }
             OpCode::SetResourceName => {
-                let resource = self.string_table.read_arg(&self.change_buffer, index)?;
+                let resource = buf.read_arg(&self.string_table, index)?;
                 span_at_mut(&mut self.spans, slot)?.resource = resource;
             }
             OpCode::SetError => {
-                let error = buf.read(index)?;
-                span_at_mut(&mut self.spans, slot)?.error = error;
+                span_at_mut(&mut self.spans, slot)?.error = buf.read(index)?;
             }
             OpCode::SetStart => {
-                let start = buf.read(index)?;
-                span_at_mut(&mut self.spans, slot)?.start = start;
+                span_at_mut(&mut self.spans, slot)?.start = buf.read(index)?;
             }
             OpCode::SetDuration => {
-                let duration = buf.read(index)?;
-                span_at_mut(&mut self.spans, slot)?.duration = duration;
+                span_at_mut(&mut self.spans, slot)?.duration = buf.read(index)?;
             }
             OpCode::SetType => {
-                let r#type = self.string_table.read_arg(&self.change_buffer, index)?;
+                let r#type = buf.read_arg(&self.string_table, index)?;
                 span_at_mut(&mut self.spans, slot)?.r#type = r#type;
             }
             OpCode::SetName => {
-                let name = self.string_table.read_arg(&self.change_buffer, index)?;
+                let name = buf.read_arg(&self.string_table, index)?;
                 span_at_mut(&mut self.spans, slot)?.name = name;
             }
             OpCode::SetTraceMetaAttr => {
-                let name = self.string_table.read_arg(&self.change_buffer, index)?;
-                let val = self.string_table.read_arg(&self.change_buffer, index)?;
+                let name = buf.read_arg(&self.string_table, index)?;
+                let val = buf.read_arg(&self.string_table, index)?;
                 let trace_id = span_at_mut(&mut self.spans, slot)?.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
                     trace.meta.insert(name, val);
                 }
             }
             OpCode::SetTraceMetricsAttr => {
-                let name = self.string_table.read_arg(&self.change_buffer, index)?;
+                let name = buf.read_arg(&self.string_table, index)?;
                 let val = buf.read(index)?;
                 let trace_id = span_at_mut(&mut self.spans, slot)?.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
@@ -488,7 +480,7 @@ where
                 }
             }
             OpCode::SetTraceOrigin => {
-                let origin = self.string_table.read_arg(&self.change_buffer, index)?;
+                let origin = buf.read_arg(&self.string_table, index)?;
                 let trace_id = span_at_mut(&mut self.spans, slot)?.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
                     trace.origin = Some(origin);
@@ -710,11 +702,11 @@ where
                 deferred_metrics_at(&mut self.deferred_metrics, slot)?.insert(key_id, val);
             }
             OpCode::SetServiceName => {
-                let service = self.string_table.read_arg(&self.change_buffer, index)?;
+                let service = buf.read_arg(&self.string_table, index)?;
                 span_at_mut(&mut self.spans, slot)?.service = service;
             }
             OpCode::SetResourceName => {
-                let resource = self.string_table.read_arg(&self.change_buffer, index)?;
+                let resource = buf.read_arg(&self.string_table, index)?;
                 span_at_mut(&mut self.spans, slot)?.resource = resource;
             }
             OpCode::SetError => {
@@ -730,23 +722,23 @@ where
                 span_at_mut(&mut self.spans, slot)?.duration = duration;
             }
             OpCode::SetType => {
-                let r#type = self.string_table.read_arg(&self.change_buffer, index)?;
+                let r#type = buf.read_arg(&self.string_table, index)?;
                 span_at_mut(&mut self.spans, slot)?.r#type = r#type;
             }
             OpCode::SetName => {
-                let name = self.string_table.read_arg(&self.change_buffer, index)?;
+                let name = buf.read_arg(&self.string_table, index)?;
                 span_at_mut(&mut self.spans, slot)?.name = name;
             }
             OpCode::SetTraceMetaAttr => {
-                let name = self.string_table.read_arg(&self.change_buffer, index)?;
-                let val = self.string_table.read_arg(&self.change_buffer, index)?;
+                let name = buf.read_arg(&self.string_table, index)?;
+                let val = buf.read_arg(&self.string_table, index)?;
                 let trace_id = span_at_mut(&mut self.spans, slot)?.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
                     trace.meta.insert(name, val);
                 }
             }
             OpCode::SetTraceMetricsAttr => {
-                let name = self.string_table.read_arg(&self.change_buffer, index)?;
+                let name = buf.read_arg(&self.string_table, index)?;
                 let val = buf.read(index)?;
                 let trace_id = span_at_mut(&mut self.spans, slot)?.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
@@ -754,7 +746,7 @@ where
                 }
             }
             OpCode::SetTraceOrigin => {
-                let origin = self.string_table.read_arg(&self.change_buffer, index)?;
+                let origin = buf.read_arg(&self.string_table, index)?;
                 let trace_id = span_at_mut(&mut self.spans, slot)?.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
                     trace.origin = Some(origin);
@@ -764,7 +756,7 @@ where
                 let span_id: u64 = buf.read(index)?;
                 let trace_id: u128 = buf.read(index)?;
                 let parent_id: u64 = buf.read(index)?;
-                let name = self.string_table.read_arg(&self.change_buffer, index)?;
+                let name = buf.read_arg(&self.string_table, index)?;
                 let start: i64 = buf.read(index)?;
                 let mut span = new_span_pooled(&mut self.span_pool, span_id, parent_id, trace_id);
                 span.name = name;
@@ -780,10 +772,10 @@ where
                 let span_id: u64 = buf.read(index)?;
                 let trace_id: u128 = buf.read(index)?;
                 let parent_id: u64 = buf.read(index)?;
-                let name = self.string_table.read_arg(&self.change_buffer, index)?;
-                let service = self.string_table.read_arg(&self.change_buffer, index)?;
-                let resource = self.string_table.read_arg(&self.change_buffer, index)?;
-                let r#type = self.string_table.read_arg(&self.change_buffer, index)?;
+                let name = buf.read_arg(&self.string_table, index)?;
+                let service = buf.read_arg(&self.string_table, index)?;
+                let resource = buf.read_arg(&self.string_table, index)?;
+                let r#type = buf.read_arg(&self.string_table, index)?;
                 let start: i64 = buf.read(index)?;
                 let mut span = new_span_pooled(&mut self.span_pool, span_id, parent_id, trace_id);
                 span.name = name;
@@ -819,10 +811,12 @@ where
         Ok(())
     }
 
+    #[inline]
     pub fn string_table_insert_one(&mut self, key: u32, val: T::Text) {
         self.string_table.insert(key, val);
     }
 
+    #[inline]
     pub fn string_table_evict_one(&mut self, key: u32) {
         self.string_table.evict(key);
     }

--- a/libdd-trace-utils/src/change_buffer/mod.rs
+++ b/libdd-trace-utils/src/change_buffer/mod.rs
@@ -89,46 +89,8 @@ pub mod span_header;
 pub use span_header::{SpanHeader, SPAN_HEADER_SIZE};
 
 use crate::span::v04::Span;
+use crate::span::vec_map::VecMap;
 use crate::span::{SpanText, TraceData};
-
-fn vec_insert<K: PartialEq, V>(vec: &mut Vec<(K, V)>, key: K, value: V) {
-    for entry in vec.iter_mut() {
-        if entry.0 == key {
-            entry.1 = value;
-            return;
-        }
-    }
-    vec.push((key, value));
-}
-
-fn vec_get<'a, K: PartialEq, V>(vec: &'a [(K, V)], key: &K) -> Option<&'a V> {
-    for entry in vec {
-        if entry.0 == *key {
-            return Some(&entry.1);
-        }
-    }
-    None
-}
-
-fn deferred_meta_insert(vec: &mut Vec<(u32, u32)>, key_id: u32, val_id: u32) {
-    for entry in vec.iter_mut() {
-        if entry.0 == key_id {
-            entry.1 = val_id;
-            return;
-        }
-    }
-    vec.push((key_id, val_id));
-}
-
-fn deferred_metric_insert(vec: &mut Vec<(u32, f64)>, key_id: u32, val: f64) {
-    for entry in vec.iter_mut() {
-        if entry.0 == key_id {
-            entry.1 = val;
-            return;
-        }
-    }
-    vec.push((key_id, val));
-}
 
 pub struct ChangeBufferState<T: TraceData> {
     change_buffer: ChangeBuffer,
@@ -141,14 +103,13 @@ pub struct ChangeBufferState<T: TraceData> {
     pid: u32,
     /// Default meta tags automatically applied to every new span via create_span.
     default_meta: Vec<(T::Text, T::Text)>,
-    /// Contiguous array of span headers for direct JS DataView access.
-    /// JS writes numeric and string-ID fields directly here. Rust reads
-    /// them during flush_chunk.
+    /// Contiguous array of span headers for direct JS DataView access. JS writes numeric and
+    /// string-ID fields directly here. Rust reads them during flush_chunk.
     pub span_headers: Vec<SpanHeader>,
     /// Free list of recycled header indices (from finished spans).
     header_free_list: Vec<u32>,
-    // Cached static strings to avoid repeated heap allocations (e.g. Arc<str>)
-    // on every span flush. These are created once and cloned (cheap ref bump).
+    // Cached static strings to avoid repeated heap allocations (e.g. Arc<str>) on every span
+    // flush. These are created once and cloned (cheap ref bump).
     str_top_level: T::Text,
     str_measured: T::Text,
     str_base_service: T::Text,
@@ -159,14 +120,14 @@ pub struct ChangeBufferState<T: TraceData> {
     str_limit_psr: T::Text,
     str_agent_psr: T::Text,
     str_internal: T::Text,
-    /// Pool of recycled Span objects. Reusing spans (with their pre-allocated
-    /// Vec buffers) eliminates the alloc/dealloc churn that fragments the
-    /// WASM linear memory allocator over time.
+    /// Pool of recycled Span objects. Reusing spans (with their pre-allocated Vec buffers)
+    /// eliminates the alloc/dealloc churn that fragments the WASM linear memory allocator over
+    /// time.
     span_pool: Vec<Span<T>>,
     /// Deferred meta tags: indexed by slot, stores (key_string_id, val_string_id) pairs.
-    deferred_meta: Vec<Vec<(u32, u32)>>,
+    deferred_meta: Vec<VecMap<u32, u32>>,
     /// Deferred metric tags: indexed by slot, stores (key_string_id, f64_value) pairs.
-    deferred_metrics: Vec<Vec<(u32, f64)>>,
+    deferred_metrics: Vec<VecMap<u32, f64>>,
 }
 
 fn new_span_pooled<T: TraceData>(
@@ -197,8 +158,8 @@ fn new_span_pooled<T: TraceData>(
             span_id,
             trace_id,
             parent_id,
-            meta: Vec::with_capacity(8),
-            metrics: Vec::with_capacity(4),
+            meta: VecMap::with_capacity(8),
+            metrics: VecMap::with_capacity(4),
             ..Default::default()
         }
     }
@@ -288,7 +249,7 @@ where
 
             if is_local_root {
                 self.copy_in_sampling_tags(&mut span);
-                vec_insert(&mut span.metrics, self.str_top_level.clone(), 1.0);
+                span.metrics.insert(self.str_top_level.clone(), 1.0);
                 is_local_root = false;
             }
             if is_chunk_root {
@@ -303,7 +264,10 @@ where
 
         let mut seen_trace_ids: Vec<(u128, usize)> = Vec::new();
         for span in &spans_vec {
-            if let Some(entry) = seen_trace_ids.iter_mut().find(|(id, _)| *id == span.trace_id) {
+            if let Some(entry) = seen_trace_ids
+                .iter_mut()
+                .find(|(id, _)| *id == span.trace_id)
+            {
                 entry.1 += 1;
             } else {
                 seen_trace_ids.push((span.trace_id, 1));
@@ -333,60 +297,46 @@ where
     fn copy_in_sampling_tags(&self, span: &mut Span<T>) {
         if let Some(trace) = self.traces.get(&span.trace_id) {
             if let Some(rule) = trace.sampling_rule_decision {
-                vec_insert(&mut span.metrics, self.str_rule_psr.clone(), rule);
+                span.metrics.insert(self.str_rule_psr.clone(), rule);
             }
             if let Some(rule) = trace.sampling_limit_decision {
-                vec_insert(&mut span.metrics, self.str_limit_psr.clone(), rule);
+                span.metrics.insert(self.str_limit_psr.clone(), rule);
             }
             if let Some(rule) = trace.sampling_agent_decision {
-                vec_insert(&mut span.metrics, self.str_agent_psr.clone(), rule);
+                span.metrics.insert(self.str_agent_psr.clone(), rule);
             }
         }
     }
 
     fn copy_in_chunk_tags(&self, span: &mut Span<T>) {
         if let Some(trace) = self.traces.get(&span.trace_id) {
-            span.meta.reserve(trace.meta.len());
-            for (k, v) in &trace.meta {
-                vec_insert(&mut span.meta, k.clone(), v.clone());
-            }
-            span.metrics.reserve(trace.metrics.len());
-            for (k, v) in &trace.metrics {
-                vec_insert(&mut span.metrics, k.clone(), *v);
-            }
+            span.meta
+                .extend(trace.meta.iter().map(|(k, v)| (k.clone(), v.clone())));
+            span.metrics
+                .extend(trace.metrics.iter().map(|(k, v)| (k.clone(), *v)));
         }
     }
 
     fn process_one_span(&self, span: &mut Span<T>) {
-        let kind_key = T::Text::from_static_str("kind");
-        if let Some(kind) = vec_get(&span.meta, &kind_key) {
+        if let Some(kind) = span.meta.get("kind") {
             if *kind != self.str_internal {
-                vec_insert(&mut span.metrics, self.str_measured.clone(), 1.0);
+                span.metrics.insert(self.str_measured.clone(), 1.0);
             }
         }
 
         if span.service != self.tracer_service {
-            vec_insert(
-                &mut span.meta,
-                self.str_base_service.clone(),
-                self.tracer_service.clone(),
-            );
+            span.meta
+                .insert(self.str_base_service.clone(), self.tracer_service.clone());
         }
 
-        vec_insert(
-            &mut span.meta,
-            self.str_language.clone(),
-            self.tracer_language.clone(),
-        );
-        vec_insert(
-            &mut span.metrics,
-            self.str_process_id.clone(),
-            f64::from(self.pid),
-        );
+        span.meta
+            .insert(self.str_language.clone(), self.tracer_language.clone());
+        span.metrics
+            .insert(self.str_process_id.clone(), f64::from(self.pid));
 
         if let Some(trace) = self.traces.get(&span.trace_id) {
             if let Some(origin) = trace.origin.clone() {
-                vec_insert(&mut span.meta, self.str_origin.clone(), origin);
+                span.meta.insert(self.str_origin.clone(), origin);
             }
         }
     }
@@ -397,8 +347,8 @@ where
 
         let mut cached_slot: u32 = u32::MAX;
         let mut cached_span_ptr: *mut Span<T> = std::ptr::null_mut();
-        let mut cached_deferred_meta: *mut Vec<(u32, u32)> = std::ptr::null_mut();
-        let mut cached_deferred_metrics: *mut Vec<(u32, f64)> = std::ptr::null_mut();
+        let mut cached_deferred_meta: *mut VecMap<u32, u32> = std::ptr::null_mut();
+        let mut cached_deferred_metrics: *mut VecMap<u32, f64> = std::ptr::null_mut();
 
         while count > 0 {
             let op = BufferedOperation::from_buf(&self.change_buffer, &mut index)?;
@@ -437,8 +387,8 @@ where
         op: &BufferedOperation,
         cached_slot: &mut u32,
         cached_span_ptr: &mut *mut Span<T>,
-        cached_deferred_meta: &mut *mut Vec<(u32, u32)>,
-        cached_deferred_metrics: &mut *mut Vec<(u32, f64)>,
+        cached_deferred_meta: &mut *mut VecMap<u32, u32>,
+        cached_deferred_metrics: &mut *mut VecMap<u32, f64>,
     ) -> Result<()> {
         let span_ptr = if op.slot_index == *cached_slot && !cached_span_ptr.is_null() {
             *cached_span_ptr
@@ -452,8 +402,8 @@ where
                 as *mut Span<T>;
             *cached_slot = op.slot_index;
             *cached_span_ptr = span;
-            *cached_deferred_meta = &mut self.deferred_meta[slot] as *mut Vec<(u32, u32)>;
-            *cached_deferred_metrics = &mut self.deferred_metrics[slot] as *mut Vec<(u32, f64)>;
+            *cached_deferred_meta = &mut self.deferred_meta[slot] as *mut VecMap<u32, u32>;
+            *cached_deferred_metrics = &mut self.deferred_metrics[slot] as *mut VecMap<u32, f64>;
             span
         };
 
@@ -467,13 +417,13 @@ where
                 let key_id: u32 = self.get_num_arg(index)?;
                 let val_id: u32 = self.get_num_arg(index)?;
                 let dm = unsafe { &mut **cached_deferred_meta };
-                deferred_meta_insert(dm, key_id, val_id);
+                dm.insert(key_id, val_id);
             }
             OpCode::SetMetricAttr => {
                 let key_id: u32 = self.get_num_arg(index)?;
                 let val: f64 = self.get_num_arg(index)?;
                 let dm = unsafe { &mut **cached_deferred_metrics };
-                deferred_metric_insert(dm, key_id, val);
+                dm.insert(key_id, val);
             }
             OpCode::SetServiceName => {
                 span.service = unsafe { self.get_string_arg_unchecked(index) };
@@ -501,7 +451,7 @@ where
                 let val = self.get_string_arg(index)?;
                 let trace_id = span.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
-                    vec_insert(&mut trace.meta, name, val);
+                    trace.meta.insert(name, val);
                 }
             }
             OpCode::SetTraceMetricsAttr => {
@@ -509,7 +459,7 @@ where
                 let val = self.get_num_arg(index)?;
                 let trace_id = span.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
-                    vec_insert(&mut trace.metrics, name, val);
+                    trace.metrics.insert(name, val);
                 }
             }
             OpCode::SetTraceOrigin => {
@@ -525,7 +475,7 @@ where
                 for _ in 0..count {
                     let key_id: u32 = self.get_num_arg(index)?;
                     let val_id: u32 = self.get_num_arg(index)?;
-                    deferred_meta_insert(dm, key_id, val_id);
+                    dm.insert(key_id, val_id);
                 }
             }
             OpCode::BatchSetMetric => {
@@ -534,7 +484,7 @@ where
                 for _ in 0..count {
                     let key_id: u32 = self.get_num_arg(index)?;
                     let val: f64 = self.get_num_arg(index)?;
-                    deferred_metric_insert(dm, key_id, val);
+                    dm.insert(key_id, val);
                 }
             }
             OpCode::Create | OpCode::CreateSpan | OpCode::CreateSpanFull => unreachable!(),
@@ -652,15 +602,13 @@ where
             existing.r#type = span.r#type;
             existing.trace_id = span.trace_id;
             existing.parent_id = span.parent_id;
-            for (k, v) in &self.default_meta {
-                vec_insert(&mut existing.meta, k.clone(), v.clone());
-            }
+            existing.meta.extend(self.default_meta.iter().cloned());
         } else {
             let slot_idx = self.spans.len();
             self.spans.push(Some(span));
             if slot_idx >= self.deferred_meta.len() {
-                self.deferred_meta.resize_with(slot_idx + 1, Vec::new);
-                self.deferred_metrics.resize_with(slot_idx + 1, Vec::new);
+                self.deferred_meta.resize_with(slot_idx + 1, VecMap::new);
+                self.deferred_metrics.resize_with(slot_idx + 1, VecMap::new);
             }
         }
 
@@ -691,7 +639,7 @@ where
 
     fn apply_default_meta(&self, span: &mut Span<T>) {
         for (key, value) in &self.default_meta {
-            vec_insert(&mut span.meta, key.clone(), value.clone());
+            span.meta.insert(key.clone(), value.clone());
         }
     }
 
@@ -700,9 +648,8 @@ where
         if idx < self.deferred_meta.len() {
             let pairs: Vec<(u32, u32)> = self.deferred_meta[idx].drain(..).collect();
             for (key_id, val_id) in pairs {
-                if let (Some(key), Some(val)) = (self.get_string(key_id), self.get_string(val_id))
-                {
-                    vec_insert(&mut span.meta, key, val);
+                if let (Some(key), Some(val)) = (self.get_string(key_id), self.get_string(val_id)) {
+                    span.meta.insert(key, val);
                 }
             }
         }
@@ -710,7 +657,7 @@ where
             let pairs: Vec<(u32, f64)> = self.deferred_metrics[idx].drain(..).collect();
             for (key_id, val) in pairs {
                 if let Some(key) = self.get_string(key_id) {
-                    vec_insert(&mut span.metrics, key, val);
+                    span.metrics.insert(key, val);
                 }
             }
         }
@@ -723,8 +670,7 @@ where
 
         if idx < self.deferred_meta.len() {
             for &(key_id, val_id) in &self.deferred_meta[idx] {
-                if let (Some(key), Some(val)) = (self.get_string(key_id), self.get_string(val_id))
-                {
+                if let (Some(key), Some(val)) = (self.get_string(key_id), self.get_string(val_id)) {
                     meta_pairs.push((key, val));
                 }
             }
@@ -741,10 +687,10 @@ where
 
         if let Some(Some(span)) = self.spans.get_mut(idx) {
             for (k, v) in meta_pairs {
-                vec_insert(&mut span.meta, k, v);
+                span.meta.insert(k, v);
             }
             for (k, v) in metric_pairs {
-                vec_insert(&mut span.metrics, k, v);
+                span.metrics.insert(k, v);
             }
         }
     }
@@ -755,8 +701,8 @@ where
             self.spans.resize_with(idx + 1, || None);
         }
         if idx >= self.deferred_meta.len() {
-            self.deferred_meta.resize_with(idx + 1, Vec::new);
-            self.deferred_metrics.resize_with(idx + 1, Vec::new);
+            self.deferred_meta.resize_with(idx + 1, VecMap::new);
+            self.deferred_metrics.resize_with(idx + 1, VecMap::new);
         }
     }
 
@@ -766,8 +712,7 @@ where
                 let span_id: u64 = self.change_buffer.read(index)?;
                 let trace_id: u128 = self.change_buffer.read(index)?;
                 let parent_id = self.get_num_arg(index)?;
-                let mut span =
-                    new_span_pooled(&mut self.span_pool, span_id, parent_id, trace_id);
+                let mut span = new_span_pooled(&mut self.span_pool, span_id, parent_id, trace_id);
                 self.apply_default_meta(&mut span);
                 self.ensure_slot(op.slot_index);
                 self.spans[op.slot_index as usize] = Some(span);
@@ -780,7 +725,7 @@ where
                 let val_id: u32 = self.get_num_arg(index)?;
                 let idx = op.slot_index as usize;
                 if idx < self.deferred_meta.len() {
-                    deferred_meta_insert(&mut self.deferred_meta[idx], key_id, val_id);
+                    self.deferred_meta[idx].insert(key_id, val_id);
                 }
             }
             OpCode::SetMetricAttr => {
@@ -788,7 +733,7 @@ where
                 let val: f64 = self.get_num_arg(index)?;
                 let idx = op.slot_index as usize;
                 if idx < self.deferred_metrics.len() {
-                    deferred_metric_insert(&mut self.deferred_metrics[idx], key_id, val);
+                    self.deferred_metrics[idx].insert(key_id, val);
                 }
             }
             OpCode::SetServiceName => {
@@ -817,7 +762,7 @@ where
                 let val = self.get_string_arg(index)?;
                 let trace_id = self.get_span(op.slot_index)?.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
-                    vec_insert(&mut trace.meta, name, val);
+                    trace.meta.insert(name, val);
                 }
             }
             OpCode::SetTraceMetricsAttr => {
@@ -825,7 +770,7 @@ where
                 let val = self.get_num_arg(index)?;
                 let trace_id = self.get_span(op.slot_index)?.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
-                    vec_insert(&mut trace.metrics, name, val);
+                    trace.metrics.insert(name, val);
                 }
             }
             OpCode::SetTraceOrigin => {
@@ -841,8 +786,7 @@ where
                 let parent_id: u64 = self.get_num_arg(index)?;
                 let name = self.get_string_arg(index)?;
                 let start: i64 = self.get_num_arg(index)?;
-                let mut span =
-                    new_span_pooled(&mut self.span_pool, span_id, parent_id, trace_id);
+                let mut span = new_span_pooled(&mut self.span_pool, span_id, parent_id, trace_id);
                 span.name = name;
                 span.start = start;
                 self.apply_default_meta(&mut span);
@@ -861,8 +805,7 @@ where
                 let resource = self.get_string_arg(index)?;
                 let r#type = self.get_string_arg(index)?;
                 let start: i64 = self.get_num_arg(index)?;
-                let mut span =
-                    new_span_pooled(&mut self.span_pool, span_id, parent_id, trace_id);
+                let mut span = new_span_pooled(&mut self.span_pool, span_id, parent_id, trace_id);
                 span.name = name;
                 span.service = service;
                 span.resource = resource;
@@ -882,7 +825,7 @@ where
                     let key_id: u32 = self.get_num_arg(index)?;
                     let val_id: u32 = self.get_num_arg(index)?;
                     if idx < self.deferred_meta.len() {
-                        deferred_meta_insert(&mut self.deferred_meta[idx], key_id, val_id);
+                        self.deferred_meta[idx].insert(key_id, val_id);
                     }
                 }
             }
@@ -893,7 +836,7 @@ where
                     let key_id: u32 = self.get_num_arg(index)?;
                     let val: f64 = self.get_num_arg(index)?;
                     if idx < self.deferred_metrics.len() {
-                        deferred_metric_insert(&mut self.deferred_metrics[idx], key_id, val);
+                        self.deferred_metrics[idx].insert(key_id, val);
                     }
                 }
             }

--- a/libdd-trace-utils/src/change_buffer/mod.rs
+++ b/libdd-trace-utils/src/change_buffer/mod.rs
@@ -92,11 +92,16 @@ use crate::span::v04::Span;
 use crate::span::vec_map::VecMap;
 use crate::span::{SpanText, TraceData};
 
+/// A stateful wrapper around a change buffer for processing and span reconstructions.
 pub struct ChangeBufferState<T: TraceData> {
     change_buffer: ChangeBuffer,
     spans: Vec<Option<Span<T>>>,
     traces: SmallTraceMap<T::Text>,
-    /// String table indexed by sequential u32 IDs (O(1) lookup vs HashMap).
+    /// Interned string table (O(1) lookup vs HashMap).
+    ///
+    /// Note: currently the string table never shrinks (it is never compacted). When entries are
+    /// evicted (freeing the backing strings), a small amount of memory is leaked (to hold the
+    /// `None` value).
     string_table: Vec<Option<T::Text>>,
     tracer_service: T::Text,
     tracer_language: T::Text,
@@ -175,10 +180,6 @@ where
         tracer_language: T::Text,
         pid: u32,
     ) -> Self {
-        eprintln!(
-            "[libdatadog pipeline] experiment: baseline (commit: {})",
-            env!("GIT_COMMIT")
-        );
         ChangeBufferState {
             change_buffer,
             spans: Vec::with_capacity(256),
@@ -346,6 +347,11 @@ where
         let mut count = self.change_buffer.read::<u64>(&mut index)? as u32;
 
         let mut cached_slot: u32 = u32::MAX;
+        // We keep a bunch of cached internal pointers. They are safe to use as long as we don't
+        // modify their parent vector and keep a unique borrow to `self` overall.
+        //
+        // Using mutable references instead would be better, but is not possible (or very hard)
+        // given we iterate and nest calls to different submethods taking a `&mut self`.
         let mut cached_span_ptr: *mut Span<T> = std::ptr::null_mut();
         let mut cached_deferred_meta: *mut VecMap<u32, u32> = std::ptr::null_mut();
         let mut cached_deferred_metrics: *mut VecMap<u32, f64> = std::ptr::null_mut();
@@ -407,11 +413,18 @@ where
             span
         };
 
-        // SAFETY: span_ptr is valid — it was obtained from self.spans above
-        // or from the cache which was set in a previous iteration of the same loop.
-        // self.spans is not modified during this function (no inserts/removes).
+        // SAFETY: span_ptr is valid for read and writes: it was obtained from self.spans above or
+        // from the cache which was set in a previous iteration of the same loop. self.spans is not
+        // modified during this function (no inserts/removes).
         let span = unsafe { &mut *span_ptr };
 
+        // SAFETY:
+        //
+        // - `cached_deferred_xxx`: they point to writable memory (derived from self), and we don't
+        //   modify, move nor drop the parent `deferred_xxx` vec, so the pointer should remain
+        //   valid.
+        // - `xxx_unchecked`: we rely on the encoder side to write the correct arguments to an
+        //   opcode.
         match op.opcode {
             OpCode::SetMetaAttr => {
                 let key_id: u32 = self.get_num_arg(index)?;
@@ -501,6 +514,9 @@ where
             .ok_or(ChangeBufferError::StringNotFound(num))
     }
 
+    /// # Safety
+    ///
+    /// Caller must ensure `*index + size_of::<T::Tex>() <= self.change_buffer.len`.
     #[inline(always)]
     unsafe fn get_string_arg_unchecked(&self, index: &mut usize) -> T::Text {
         let num: u32 = self.change_buffer.read_unchecked(index);
@@ -514,12 +530,16 @@ where
         self.change_buffer.read(index)
     }
 
+    /// # Safety
+    ///
+    /// Caller must ensure `*index + size_of::<U>() <= self.change_buffer.len`.
     #[inline(always)]
     unsafe fn get_num_arg_unchecked<U: Copy + FromBytes>(&self, index: &mut usize) -> U {
-        self.change_buffer.read_unchecked(index)
+        // Safety: this function's pre-condition
+        unsafe { self.change_buffer.read_unchecked(index) }
     }
 
-    fn get_mut_span(&mut self, slot: u32) -> Result<&mut Span<T>> {
+    fn get_span_mut(&mut self, slot: u32) -> Result<&mut Span<T>> {
         self.spans
             .get_mut(slot as usize)
             .and_then(|opt| opt.as_mut())
@@ -533,6 +553,7 @@ where
             .ok_or(ChangeBufferError::SpanNotFound(slot as u64))
     }
 
+    #[inline]
     pub fn get_trace(&self, id: &u128) -> Option<&Trace<T::Text>> {
         self.traces.get(id)
     }
@@ -627,12 +648,14 @@ where
             .ok_or(ChangeBufferError::SpanNotFound(*slot as u64))
     }
 
+    #[inline]
     pub fn get_string(&self, id: u32) -> Option<T::Text> {
         self.string_table
             .get(id as usize)
             .and_then(|opt| opt.clone())
     }
 
+    #[inline]
     pub fn set_default_meta(&mut self, tags: Vec<(T::Text, T::Text)>) {
         self.default_meta = tags;
     }
@@ -647,6 +670,7 @@ where
         let idx = slot as usize;
         if idx < self.deferred_meta.len() {
             let pairs: Vec<(u32, u32)> = self.deferred_meta[idx].drain(..).collect();
+
             for (key_id, val_id) in pairs {
                 if let (Some(key), Some(val)) = (self.get_string(key_id), self.get_string(val_id)) {
                     span.meta.insert(key, val);
@@ -655,6 +679,7 @@ where
         }
         if idx < self.deferred_metrics.len() {
             let pairs: Vec<(u32, f64)> = self.deferred_metrics[idx].drain(..).collect();
+
             for (key_id, val) in pairs {
                 if let Some(key) = self.get_string(key_id) {
                     span.metrics.insert(key, val);
@@ -737,25 +762,25 @@ where
                 }
             }
             OpCode::SetServiceName => {
-                self.get_mut_span(op.slot_index)?.service = self.get_string_arg(index)?;
+                self.get_span_mut(op.slot_index)?.service = self.get_string_arg(index)?;
             }
             OpCode::SetResourceName => {
-                self.get_mut_span(op.slot_index)?.resource = self.get_string_arg(index)?;
+                self.get_span_mut(op.slot_index)?.resource = self.get_string_arg(index)?;
             }
             OpCode::SetError => {
-                self.get_mut_span(op.slot_index)?.error = self.get_num_arg(index)?;
+                self.get_span_mut(op.slot_index)?.error = self.get_num_arg(index)?;
             }
             OpCode::SetStart => {
-                self.get_mut_span(op.slot_index)?.start = self.get_num_arg(index)?;
+                self.get_span_mut(op.slot_index)?.start = self.get_num_arg(index)?;
             }
             OpCode::SetDuration => {
-                self.get_mut_span(op.slot_index)?.duration = self.get_num_arg(index)?;
+                self.get_span_mut(op.slot_index)?.duration = self.get_num_arg(index)?;
             }
             OpCode::SetType => {
-                self.get_mut_span(op.slot_index)?.r#type = self.get_string_arg(index)?;
+                self.get_span_mut(op.slot_index)?.r#type = self.get_string_arg(index)?;
             }
             OpCode::SetName => {
-                self.get_mut_span(op.slot_index)?.name = self.get_string_arg(index)?;
+                self.get_span_mut(op.slot_index)?.name = self.get_string_arg(index)?;
             }
             OpCode::SetTraceMetaAttr => {
                 let name = self.get_string_arg(index)?;

--- a/libdd-trace-utils/src/change_buffer/mod.rs
+++ b/libdd-trace-utils/src/change_buffer/mod.rs
@@ -347,8 +347,14 @@ where
         let mut count = self.change_buffer.read::<u64>(&mut index)? as u32;
 
         let mut cached_slot: u32 = u32::MAX;
-        // We keep a bunch of cached internal pointers. They are safe to use as long as we don't
-        // modify their parent vector and keep a unique borrow to `self` overall.
+        // Cached elements for the current span.
+        //
+        // When applying span operations, we cache the last span index (cached_slot) and the
+        // corresponding elements in `deffered_meta`, `deferred_metrics`, and `span`. We use direct
+        // pointers to save intermediate dereferences.
+        //
+        // They are safe to use as long as we don't modify their parent vector and keep a unique
+        // borrow to `self` overall.
         //
         // Using mutable references instead would be better, but is not possible (or very hard)
         // given we iterate and nest calls to different submethods taking a `&mut self`.
@@ -368,14 +374,19 @@ where
                     self.interpret_operation(&mut index, &op)?;
                 }
                 _ => {
-                    self.interpret_operation_cached(
-                        &mut index,
-                        &op,
-                        &mut cached_slot,
-                        &mut cached_span_ptr,
-                        &mut cached_deferred_meta,
-                        &mut cached_deferred_metrics,
-                    )?;
+                    // SAFETY: at the first iteration of the loop, all pointers are null and
+                    // `*cached_slot` is `u32::MAX`. In subsequent iterations,
+                    // `interpret_operation_cached` maintains its own safety invariant.
+                    unsafe {
+                      self.interpret_operation_cached(
+                          &mut index,
+                          &op,
+                          &mut cached_slot,
+                          &mut cached_span_ptr,
+                          &mut cached_deferred_meta,
+                          &mut cached_deferred_metrics,
+                      )?;
+                    }
                 }
             }
             count -= 1;
@@ -387,7 +398,15 @@ where
         Ok(())
     }
 
-    fn interpret_operation_cached(
+    /// # Safety
+    ///
+    /// The pointer arguments provided to this function: `*cached_slot`, `*cached_span_ptr`,
+    /// `*cached_deferred_meta` and `*cached_deferred_metrics` must either:
+    ///
+    /// - be all `null` if `*cached_slot` is `u32::MAX`
+    /// - point to `self.spans[*cached_slot]`, `self.deferred_meta[*cached_slot]` and
+    ///   `self.deferred_metrics[*cached_slot]` respectively otherwise.
+    unsafe fn interpret_operation_cached(
         &mut self,
         index: &mut usize,
         op: &BufferedOperation,
@@ -418,13 +437,9 @@ where
         // modified during this function (no inserts/removes).
         let span = unsafe { &mut *span_ptr };
 
-        // SAFETY:
-        //
-        // - `cached_deferred_xxx`: they point to writable memory (derived from self), and we don't
-        //   modify, move nor drop the parent `deferred_xxx` vec, so the pointer should remain
-        //   valid.
-        // - `xxx_unchecked`: we rely on the encoder side to write the correct arguments to an
-        //   opcode.
+        // SAFETY: `cached_deferred_xxx`: they point to writable memory, and we don't shrink, move
+        // nor drop the parent `deferred_xxx` vec, so the pointers remain valid. We keep a mutable
+        // borrow on `self`, which ensures ownership/uniqueness.
         match op.opcode {
             OpCode::SetMetaAttr => {
                 let key_id: u32 = self.get_num_arg(index)?;
@@ -439,25 +454,25 @@ where
                 dm.insert(key_id, val);
             }
             OpCode::SetServiceName => {
-                span.service = unsafe { self.get_string_arg_unchecked(index) };
+                span.service = self.get_string_arg(index)?;
             }
             OpCode::SetResourceName => {
-                span.resource = unsafe { self.get_string_arg_unchecked(index) };
+                span.resource = self.get_string_arg(index)?;
             }
             OpCode::SetError => {
-                span.error = unsafe { self.get_num_arg_unchecked(index) };
+                span.error = self.get_num_arg(index)?;
             }
             OpCode::SetStart => {
-                span.start = unsafe { self.get_num_arg_unchecked(index) };
+                span.start = self.get_num_arg(index)?;
             }
             OpCode::SetDuration => {
-                span.duration = unsafe { self.get_num_arg_unchecked(index) };
+                span.duration = self.get_num_arg(index)?;
             }
             OpCode::SetType => {
-                span.r#type = unsafe { self.get_string_arg_unchecked(index) };
+                span.r#type = self.get_string_arg(index)?;
             }
             OpCode::SetName => {
-                span.name = unsafe { self.get_string_arg_unchecked(index) };
+                span.name = self.get_string_arg(index)?;
             }
             OpCode::SetTraceMetaAttr => {
                 let name = self.get_string_arg(index)?;
@@ -514,29 +529,8 @@ where
             .ok_or(ChangeBufferError::StringNotFound(num))
     }
 
-    /// # Safety
-    ///
-    /// Caller must ensure `*index + size_of::<T::Tex>() <= self.change_buffer.len`.
-    #[inline(always)]
-    unsafe fn get_string_arg_unchecked(&self, index: &mut usize) -> T::Text {
-        let num: u32 = self.change_buffer.read_unchecked(index);
-        self.string_table
-            .get_unchecked(num as usize)
-            .clone()
-            .unwrap_unchecked()
-    }
-
     fn get_num_arg<U: Copy + FromBytes>(&self, index: &mut usize) -> Result<U> {
         self.change_buffer.read(index)
-    }
-
-    /// # Safety
-    ///
-    /// Caller must ensure `*index + size_of::<U>() <= self.change_buffer.len`.
-    #[inline(always)]
-    unsafe fn get_num_arg_unchecked<U: Copy + FromBytes>(&self, index: &mut usize) -> U {
-        // Safety: this function's pre-condition
-        unsafe { self.change_buffer.read_unchecked(index) }
     }
 
     fn get_span_mut(&mut self, slot: u32) -> Result<&mut Span<T>> {

--- a/libdd-trace-utils/src/change_buffer/mod.rs
+++ b/libdd-trace-utils/src/change_buffer/mod.rs
@@ -73,7 +73,6 @@ impl std::error::Error for ChangeBufferError {}
 pub type Result<T> = std::result::Result<T, ChangeBufferError>;
 
 mod utils;
-use utils::*;
 
 mod trace;
 pub use trace::*;
@@ -91,17 +90,54 @@ use crate::span::v04::Span;
 use crate::span::vec_map::VecMap;
 use crate::span::{SpanText, TraceData};
 
+/// Interned string table (O(1) lookup vs HashMap).
+///
+/// Note: currently the string table never shrinks (it is never compacted). When entries are
+/// evicted (freeing the backing strings), a small amount of memory is leaked (to hold the
+/// `None` value).
+pub(crate) struct StringTable<T>(Vec<Option<T>>);
+
+impl<T: Clone> StringTable<T> {
+    fn with_capacity(cap: usize) -> Self {
+        Self(Vec::with_capacity(cap))
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    #[inline]
+    pub(crate) fn get(&self, id: u32) -> Option<T> {
+        self.0.get(id as usize).and_then(|opt| opt.clone())
+    }
+
+    pub(crate) fn read_arg(&self, buf: &ChangeBuffer, index: &mut usize) -> Result<T> {
+        let num: u32 = buf.read(index)?;
+        self.get(num).ok_or(ChangeBufferError::StringNotFound(num))
+    }
+
+    pub(crate) fn insert(&mut self, key: u32, val: T) {
+        let idx = key as usize;
+        if idx >= self.0.len() {
+            self.0.resize_with(idx + 1, || None);
+        }
+        self.0[idx] = Some(val);
+    }
+
+    pub(crate) fn evict(&mut self, key: u32) {
+        let idx = key as usize;
+        if idx < self.0.len() {
+            self.0[idx] = None;
+        }
+    }
+}
+
 /// A stateful wrapper around a change buffer for processing and span reconstructions.
 pub struct ChangeBufferState<T: TraceData> {
     change_buffer: ChangeBuffer,
     spans: Vec<Option<Span<T>>>,
     traces: SmallTraceMap<T::Text>,
-    /// Interned string table (O(1) lookup vs HashMap).
-    ///
-    /// Note: currently the string table never shrinks (it is never compacted). When entries are
-    /// evicted (freeing the backing strings), a small amount of memory is leaked (to hold the
-    /// `None` value).
-    string_table: Vec<Option<T::Text>>,
+    string_table: StringTable<T::Text>,
     tracer_service: T::Text,
     tracer_language: T::Text,
     pid: u32,
@@ -210,7 +246,7 @@ where
             change_buffer,
             spans: Vec::with_capacity(256),
             traces: SmallTraceMap::default(),
-            string_table: Vec::with_capacity(256),
+            string_table: StringTable::with_capacity(256),
             tracer_service,
             tracer_language,
             pid,
@@ -256,7 +292,6 @@ where
         slot_indices: &[u32],
         first_is_local_root: bool,
     ) -> Result<Vec<Span<T>>> {
-        let mut chunk_trace_id: Option<u128> = None;
         let mut is_local_root = first_is_local_root;
         let mut is_chunk_root = true;
 
@@ -270,8 +305,6 @@ where
             let mut span = maybe_span.ok_or(ChangeBufferError::SpanNotFound(*slot as u64))?;
 
             self.materialize_deferred_tags(*slot, &mut span);
-
-            chunk_trace_id = Some(span.trace_id);
 
             if is_local_root {
                 self.copy_in_sampling_tags(&mut span);
@@ -397,82 +430,83 @@ where
         op: &BufferedOperation,
     ) -> Result<()> {
         let slot = op.slot_index as usize;
+        let buf = &self.change_buffer;
 
         match op.opcode {
             OpCode::SetMetaAttr => {
-                let key_id: u32 = self.get_num_arg(index)?;
-                let val_id: u32 = self.get_num_arg(index)?;
+                let key_id: u32 = buf.read(index)?;
+                let val_id: u32 = buf.read(index)?;
                 deferred_meta_at(&mut self.deferred_meta, slot)?.insert(key_id, val_id);
             }
             OpCode::SetMetricAttr => {
-                let key_id: u32 = self.get_num_arg(index)?;
-                let val: f64 = self.get_num_arg(index)?;
+                let key_id: u32 = buf.read(index)?;
+                let val: f64 = buf.read(index)?;
                 deferred_metrics_at(&mut self.deferred_metrics, slot)?.insert(key_id, val);
             }
             OpCode::SetServiceName => {
-                let service = self.get_string_arg(index)?;
+                let service = self.string_table.read_arg(&self.change_buffer, index)?;
                 span_at_mut(&mut self.spans, slot)?.service = service;
             }
             OpCode::SetResourceName => {
-                let resource = self.get_string_arg(index)?;
+                let resource = self.string_table.read_arg(&self.change_buffer, index)?;
                 span_at_mut(&mut self.spans, slot)?.resource = resource;
             }
             OpCode::SetError => {
-                let error = self.get_num_arg(index)?;
+                let error = buf.read(index)?;
                 span_at_mut(&mut self.spans, slot)?.error = error;
             }
             OpCode::SetStart => {
-                let start = self.get_num_arg(index)?;
+                let start = buf.read(index)?;
                 span_at_mut(&mut self.spans, slot)?.start = start;
             }
             OpCode::SetDuration => {
-                let duration = self.get_num_arg(index)?;
+                let duration = buf.read(index)?;
                 span_at_mut(&mut self.spans, slot)?.duration = duration;
             }
             OpCode::SetType => {
-                let r#type = self.get_string_arg(index)?;
+                let r#type = self.string_table.read_arg(&self.change_buffer, index)?;
                 span_at_mut(&mut self.spans, slot)?.r#type = r#type;
             }
             OpCode::SetName => {
-                let name = self.get_string_arg(index)?;
+                let name = self.string_table.read_arg(&self.change_buffer, index)?;
                 span_at_mut(&mut self.spans, slot)?.name = name;
             }
             OpCode::SetTraceMetaAttr => {
-                let name = self.get_string_arg(index)?;
-                let val = self.get_string_arg(index)?;
+                let name = self.string_table.read_arg(&self.change_buffer, index)?;
+                let val = self.string_table.read_arg(&self.change_buffer, index)?;
                 let trace_id = span_at_mut(&mut self.spans, slot)?.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
                     trace.meta.insert(name, val);
                 }
             }
             OpCode::SetTraceMetricsAttr => {
-                let name = self.get_string_arg(index)?;
-                let val = self.get_num_arg(index)?;
+                let name = self.string_table.read_arg(&self.change_buffer, index)?;
+                let val = buf.read(index)?;
                 let trace_id = span_at_mut(&mut self.spans, slot)?.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
                     trace.metrics.insert(name, val);
                 }
             }
             OpCode::SetTraceOrigin => {
-                let origin = self.get_string_arg(index)?;
+                let origin = self.string_table.read_arg(&self.change_buffer, index)?;
                 let trace_id = span_at_mut(&mut self.spans, slot)?.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
                     trace.origin = Some(origin);
                 }
             }
             OpCode::BatchSetMeta => {
-                let count: u32 = self.get_num_arg(index)?;
+                let count: u32 = buf.read(index)?;
                 for _ in 0..count {
-                    let key_id: u32 = self.get_num_arg(index)?;
-                    let val_id: u32 = self.get_num_arg(index)?;
+                    let key_id: u32 = buf.read(index)?;
+                    let val_id: u32 = buf.read(index)?;
                     deferred_meta_at(&mut self.deferred_meta, slot)?.insert(key_id, val_id);
                 }
             }
             OpCode::BatchSetMetric => {
-                let count: u32 = self.get_num_arg(index)?;
+                let count: u32 = buf.read(index)?;
                 for _ in 0..count {
-                    let key_id: u32 = self.get_num_arg(index)?;
-                    let val: f64 = self.get_num_arg(index)?;
+                    let key_id: u32 = buf.read(index)?;
+                    let val: f64 = buf.read(index)?;
                     deferred_metrics_at(&mut self.deferred_metrics, slot)?.insert(key_id, val);
                 }
             }
@@ -480,18 +514,6 @@ where
         }
 
         Ok(())
-    }
-
-    fn get_string_arg(&self, index: &mut usize) -> Result<T::Text> {
-        let num: u32 = self.get_num_arg(index)?;
-        self.string_table
-            .get(num as usize)
-            .and_then(|opt| opt.clone())
-            .ok_or(ChangeBufferError::StringNotFound(num))
-    }
-
-    fn get_num_arg<U: Copy + FromBytes>(&self, index: &mut usize) -> Result<U> {
-        self.change_buffer.read(index)
     }
 
     pub fn get_span(&self, slot: u32) -> Result<&Span<T>> {
@@ -520,16 +542,16 @@ where
         span.duration = h.duration;
         span.error = h.error;
 
-        if let Some(name) = self.get_string(h.name_id) {
+        if let Some(name) = self.string_table.get(h.name_id) {
             span.name = name;
         }
-        if let Some(service) = self.get_string(h.service_id) {
+        if let Some(service) = self.string_table.get(h.service_id) {
             span.service = service;
         }
-        if let Some(resource) = self.get_string(h.resource_id) {
+        if let Some(resource) = self.string_table.get(h.resource_id) {
             span.resource = resource;
         }
-        if let Some(r#type) = self.get_string(h.type_id) {
+        if let Some(r#type) = self.string_table.get(h.type_id) {
             span.r#type = r#type;
         }
 
@@ -581,13 +603,6 @@ where
     }
 
     #[inline]
-    pub fn get_string(&self, id: u32) -> Option<T::Text> {
-        self.string_table
-            .get(id as usize)
-            .and_then(|opt| opt.clone())
-    }
-
-    #[inline]
     pub fn set_default_meta(&mut self, tags: Vec<(T::Text, T::Text)>) {
         self.default_meta = tags;
     }
@@ -604,7 +619,9 @@ where
             let pairs: Vec<(u32, u32)> = self.deferred_meta[idx].drain(..).collect();
 
             for (key_id, val_id) in pairs {
-                if let (Some(key), Some(val)) = (self.get_string(key_id), self.get_string(val_id)) {
+                if let (Some(key), Some(val)) =
+                    (self.string_table.get(key_id), self.string_table.get(val_id))
+                {
                     span.meta.insert(key, val);
                 }
             }
@@ -613,7 +630,7 @@ where
             let pairs: Vec<(u32, f64)> = self.deferred_metrics[idx].drain(..).collect();
 
             for (key_id, val) in pairs {
-                if let Some(key) = self.get_string(key_id) {
+                if let Some(key) = self.string_table.get(key_id) {
                     span.metrics.insert(key, val);
                 }
             }
@@ -627,7 +644,9 @@ where
 
         if idx < self.deferred_meta.len() {
             for &(key_id, val_id) in &self.deferred_meta[idx] {
-                if let (Some(key), Some(val)) = (self.get_string(key_id), self.get_string(val_id)) {
+                if let (Some(key), Some(val)) =
+                    (self.string_table.get(key_id), self.string_table.get(val_id))
+                {
                     meta_pairs.push((key, val));
                 }
             }
@@ -635,7 +654,7 @@ where
         }
         if idx < self.deferred_metrics.len() {
             for &(key_id, val) in &self.deferred_metrics[idx] {
-                if let Some(key) = self.get_string(key_id) {
+                if let Some(key) = self.string_table.get(key_id) {
                     metric_pairs.push((key, val));
                 }
             }
@@ -665,12 +684,13 @@ where
 
     fn interpret_operation(&mut self, index: &mut usize, op: &BufferedOperation) -> Result<()> {
         let slot = op.slot_index as usize;
+        let buf = &self.change_buffer;
 
         match op.opcode {
             OpCode::Create => {
-                let span_id: u64 = self.change_buffer.read(index)?;
-                let trace_id: u128 = self.change_buffer.read(index)?;
-                let parent_id = self.get_num_arg(index)?;
+                let span_id: u64 = buf.read(index)?;
+                let trace_id: u128 = buf.read(index)?;
+                let parent_id = buf.read(index)?;
                 let mut span = new_span_pooled(&mut self.span_pool, span_id, parent_id, trace_id);
                 self.apply_default_meta(&mut span);
                 self.ensure_slot(op.slot_index);
@@ -680,72 +700,72 @@ where
                 self.traces.get_or_insert_default(trace_id).span_count += 1;
             }
             OpCode::SetMetaAttr => {
-                let key_id: u32 = self.get_num_arg(index)?;
-                let val_id: u32 = self.get_num_arg(index)?;
+                let key_id: u32 = buf.read(index)?;
+                let val_id: u32 = buf.read(index)?;
                 deferred_meta_at(&mut self.deferred_meta, slot)?.insert(key_id, val_id);
             }
             OpCode::SetMetricAttr => {
-                let key_id: u32 = self.get_num_arg(index)?;
-                let val: f64 = self.get_num_arg(index)?;
+                let key_id: u32 = buf.read(index)?;
+                let val: f64 = buf.read(index)?;
                 deferred_metrics_at(&mut self.deferred_metrics, slot)?.insert(key_id, val);
             }
             OpCode::SetServiceName => {
-                let service = self.get_string_arg(index)?;
+                let service = self.string_table.read_arg(&self.change_buffer, index)?;
                 span_at_mut(&mut self.spans, slot)?.service = service;
             }
             OpCode::SetResourceName => {
-                let resource = self.get_string_arg(index)?;
+                let resource = self.string_table.read_arg(&self.change_buffer, index)?;
                 span_at_mut(&mut self.spans, slot)?.resource = resource;
             }
             OpCode::SetError => {
-                let error = self.get_num_arg(index)?;
+                let error = buf.read(index)?;
                 span_at_mut(&mut self.spans, slot)?.error = error;
             }
             OpCode::SetStart => {
-                let start = self.get_num_arg(index)?;
+                let start = buf.read(index)?;
                 span_at_mut(&mut self.spans, slot)?.start = start;
             }
             OpCode::SetDuration => {
-                let duration = self.get_num_arg(index)?;
+                let duration = buf.read(index)?;
                 span_at_mut(&mut self.spans, slot)?.duration = duration;
             }
             OpCode::SetType => {
-                let r#type = self.get_string_arg(index)?;
+                let r#type = self.string_table.read_arg(&self.change_buffer, index)?;
                 span_at_mut(&mut self.spans, slot)?.r#type = r#type;
             }
             OpCode::SetName => {
-                let name = self.get_string_arg(index)?;
+                let name = self.string_table.read_arg(&self.change_buffer, index)?;
                 span_at_mut(&mut self.spans, slot)?.name = name;
             }
             OpCode::SetTraceMetaAttr => {
-                let name = self.get_string_arg(index)?;
-                let val = self.get_string_arg(index)?;
+                let name = self.string_table.read_arg(&self.change_buffer, index)?;
+                let val = self.string_table.read_arg(&self.change_buffer, index)?;
                 let trace_id = span_at_mut(&mut self.spans, slot)?.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
                     trace.meta.insert(name, val);
                 }
             }
             OpCode::SetTraceMetricsAttr => {
-                let name = self.get_string_arg(index)?;
-                let val = self.get_num_arg(index)?;
+                let name = self.string_table.read_arg(&self.change_buffer, index)?;
+                let val = buf.read(index)?;
                 let trace_id = span_at_mut(&mut self.spans, slot)?.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
                     trace.metrics.insert(name, val);
                 }
             }
             OpCode::SetTraceOrigin => {
-                let origin = self.get_string_arg(index)?;
+                let origin = self.string_table.read_arg(&self.change_buffer, index)?;
                 let trace_id = span_at_mut(&mut self.spans, slot)?.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
                     trace.origin = Some(origin);
                 }
             }
             OpCode::CreateSpan => {
-                let span_id: u64 = self.change_buffer.read(index)?;
-                let trace_id: u128 = self.change_buffer.read(index)?;
-                let parent_id: u64 = self.get_num_arg(index)?;
-                let name = self.get_string_arg(index)?;
-                let start: i64 = self.get_num_arg(index)?;
+                let span_id: u64 = buf.read(index)?;
+                let trace_id: u128 = buf.read(index)?;
+                let parent_id: u64 = buf.read(index)?;
+                let name = self.string_table.read_arg(&self.change_buffer, index)?;
+                let start: i64 = buf.read(index)?;
                 let mut span = new_span_pooled(&mut self.span_pool, span_id, parent_id, trace_id);
                 span.name = name;
                 span.start = start;
@@ -757,14 +777,14 @@ where
                 self.traces.get_or_insert_default(trace_id).span_count += 1;
             }
             OpCode::CreateSpanFull => {
-                let span_id: u64 = self.change_buffer.read(index)?;
-                let trace_id: u128 = self.change_buffer.read(index)?;
-                let parent_id: u64 = self.get_num_arg(index)?;
-                let name = self.get_string_arg(index)?;
-                let service = self.get_string_arg(index)?;
-                let resource = self.get_string_arg(index)?;
-                let r#type = self.get_string_arg(index)?;
-                let start: i64 = self.get_num_arg(index)?;
+                let span_id: u64 = buf.read(index)?;
+                let trace_id: u128 = buf.read(index)?;
+                let parent_id: u64 = buf.read(index)?;
+                let name = self.string_table.read_arg(&self.change_buffer, index)?;
+                let service = self.string_table.read_arg(&self.change_buffer, index)?;
+                let resource = self.string_table.read_arg(&self.change_buffer, index)?;
+                let r#type = self.string_table.read_arg(&self.change_buffer, index)?;
+                let start: i64 = buf.read(index)?;
                 let mut span = new_span_pooled(&mut self.span_pool, span_id, parent_id, trace_id);
                 span.name = name;
                 span.service = service;
@@ -779,18 +799,18 @@ where
                 self.traces.get_or_insert_default(trace_id).span_count += 1;
             }
             OpCode::BatchSetMeta => {
-                let count: u32 = self.get_num_arg(index)?;
+                let count: u32 = buf.read(index)?;
                 for _ in 0..count {
-                    let key_id: u32 = self.get_num_arg(index)?;
-                    let val_id: u32 = self.get_num_arg(index)?;
+                    let key_id: u32 = buf.read(index)?;
+                    let val_id: u32 = buf.read(index)?;
                     deferred_meta_at(&mut self.deferred_meta, slot)?.insert(key_id, val_id);
                 }
             }
             OpCode::BatchSetMetric => {
-                let count: u32 = self.get_num_arg(index)?;
+                let count: u32 = buf.read(index)?;
                 for _ in 0..count {
-                    let key_id: u32 = self.get_num_arg(index)?;
-                    let val: f64 = self.get_num_arg(index)?;
+                    let key_id: u32 = buf.read(index)?;
+                    let val: f64 = buf.read(index)?;
                     deferred_metrics_at(&mut self.deferred_metrics, slot)?.insert(key_id, val);
                 }
             }
@@ -800,17 +820,10 @@ where
     }
 
     pub fn string_table_insert_one(&mut self, key: u32, val: T::Text) {
-        let idx = key as usize;
-        if idx >= self.string_table.len() {
-            self.string_table.resize_with(idx + 1, || None);
-        }
-        self.string_table[idx] = Some(val);
+        self.string_table.insert(key, val);
     }
 
     pub fn string_table_evict_one(&mut self, key: u32) {
-        let idx = key as usize;
-        if idx < self.string_table.len() {
-            self.string_table[idx] = None;
-        }
+        self.string_table.evict(key);
     }
 }

--- a/libdd-trace-utils/src/change_buffer/mod.rs
+++ b/libdd-trace-utils/src/change_buffer/mod.rs
@@ -157,10 +157,6 @@ pub struct ChangeBufferState<T: TraceData> {
     /// eliminates the alloc/dealloc churn that fragments the WASM linear memory allocator over
     /// time.
     span_pool: Vec<Span<T>>,
-    /// Deferred meta tags: indexed by slot, stores (key_string_id, val_string_id) pairs.
-    deferred_meta: Vec<VecMap<u32, u32>>,
-    /// Deferred metric tags: indexed by slot, stores (key_string_id, f64_value) pairs.
-    deferred_metrics: Vec<VecMap<u32, f64>>,
 }
 
 fn new_span_pooled<T: TraceData>(
@@ -258,8 +254,6 @@ where
             str_agent_psr: T::Text::from_static_str("_dd.agent_psr"),
             str_internal: T::Text::from_static_str("internal"),
             span_pool: Vec::new(),
-            deferred_meta: Vec::with_capacity(256),
-            deferred_metrics: Vec::with_capacity(256),
         }
     }
 
@@ -426,12 +420,16 @@ where
     ) -> Result<()> {
         let slot = op.slot_index as usize;
         let buf = &self.change_buffer;
+        let span = self.spans
+            .get_mut(slot)
+            .and_then(|opt| opt.as_mut())
+            .ok_or(ChangeBufferError::SpanNotFound(slot as u64))?;
 
         match op.opcode {
             OpCode::SetMetaAttr => {
-                let key_id: u32 = buf.read(index)?;
-                let val_id: u32 = buf.read(index)?;
-                deferred_meta_at(&mut self.deferred_meta, slot)?.insert(key_id, val_id);
+                let key = buf.read_string(&self.string_table, index)?;
+                let val = buf.read_string(&self.string_table, index)?;
+                span.meta.insert(key, val);
             }
             OpCode::SetMetricAttr => {
                 let key_id: u32 = buf.read(index)?;
@@ -439,11 +437,11 @@ where
                 deferred_metrics_at(&mut self.deferred_metrics, slot)?.insert(key_id, val);
             }
             OpCode::SetServiceName => {
-                let service = buf.read_arg(&self.string_table, index)?;
+                let service = buf.read_string(&self.string_table, index)?;
                 span_at_mut(&mut self.spans, slot)?.service = service;
             }
             OpCode::SetResourceName => {
-                let resource = buf.read_arg(&self.string_table, index)?;
+                let resource = buf.read_string(&self.string_table, index)?;
                 span_at_mut(&mut self.spans, slot)?.resource = resource;
             }
             OpCode::SetError => {
@@ -456,23 +454,23 @@ where
                 span_at_mut(&mut self.spans, slot)?.duration = buf.read(index)?;
             }
             OpCode::SetType => {
-                let r#type = buf.read_arg(&self.string_table, index)?;
+                let r#type = buf.read_string(&self.string_table, index)?;
                 span_at_mut(&mut self.spans, slot)?.r#type = r#type;
             }
             OpCode::SetName => {
-                let name = buf.read_arg(&self.string_table, index)?;
+                let name = buf.read_string(&self.string_table, index)?;
                 span_at_mut(&mut self.spans, slot)?.name = name;
             }
             OpCode::SetTraceMetaAttr => {
-                let name = buf.read_arg(&self.string_table, index)?;
-                let val = buf.read_arg(&self.string_table, index)?;
+                let name = buf.read_string(&self.string_table, index)?;
+                let val = buf.read_string(&self.string_table, index)?;
                 let trace_id = span_at_mut(&mut self.spans, slot)?.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
                     trace.meta.insert(name, val);
                 }
             }
             OpCode::SetTraceMetricsAttr => {
-                let name = buf.read_arg(&self.string_table, index)?;
+                let name = buf.read_string(&self.string_table, index)?;
                 let val = buf.read(index)?;
                 let trace_id = span_at_mut(&mut self.spans, slot)?.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
@@ -480,7 +478,7 @@ where
                 }
             }
             OpCode::SetTraceOrigin => {
-                let origin = buf.read_arg(&self.string_table, index)?;
+                let origin = buf.read_string(&self.string_table, index)?;
                 let trace_id = span_at_mut(&mut self.spans, slot)?.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
                     trace.origin = Some(origin);
@@ -631,34 +629,26 @@ where
 
     pub fn materialize_slot(&mut self, slot: u32) {
         let idx = slot as usize;
-        let mut meta_pairs: Vec<(T::Text, T::Text)> = Vec::new();
-        let mut metric_pairs: Vec<(T::Text, f64)> = Vec::new();
-
-        if idx < self.deferred_meta.len() {
-            for &(key_id, val_id) in &self.deferred_meta[idx] {
-                if let (Some(key), Some(val)) =
-                    (self.string_table.get(key_id), self.string_table.get(val_id))
-                {
-                    meta_pairs.push((key, val));
-                }
-            }
-            self.deferred_meta[idx].clear();
-        }
-        if idx < self.deferred_metrics.len() {
-            for &(key_id, val) in &self.deferred_metrics[idx] {
-                if let Some(key) = self.string_table.get(key_id) {
-                    metric_pairs.push((key, val));
-                }
-            }
-            self.deferred_metrics[idx].clear();
-        }
 
         if let Some(Some(span)) = self.spans.get_mut(idx) {
-            for (k, v) in meta_pairs {
-                span.meta.insert(k, v);
+            if idx < self.deferred_meta.len() {
+                for &(key_id, val_id) in &self.deferred_meta[idx] {
+                    if let (Some(key), Some(val)) =
+                        (self.string_table.get(key_id), self.string_table.get(val_id))
+                    {
+                        span.meta.insert(key, val);
+                    }
+                }
+                self.deferred_meta[idx].clear();
             }
-            for (k, v) in metric_pairs {
-                span.metrics.insert(k, v);
+
+            if idx < self.deferred_metrics.len() {
+                for &(key_id, val) in &self.deferred_metrics[idx] {
+                    if let Some(key) = self.string_table.get(key_id) {
+                        span.metrics.insert(key, val);
+                    }
+                }
+                self.deferred_metrics[idx].clear();
             }
         }
     }
@@ -702,11 +692,11 @@ where
                 deferred_metrics_at(&mut self.deferred_metrics, slot)?.insert(key_id, val);
             }
             OpCode::SetServiceName => {
-                let service = buf.read_arg(&self.string_table, index)?;
+                let service = buf.read_string(&self.string_table, index)?;
                 span_at_mut(&mut self.spans, slot)?.service = service;
             }
             OpCode::SetResourceName => {
-                let resource = buf.read_arg(&self.string_table, index)?;
+                let resource = buf.read_string(&self.string_table, index)?;
                 span_at_mut(&mut self.spans, slot)?.resource = resource;
             }
             OpCode::SetError => {
@@ -722,23 +712,23 @@ where
                 span_at_mut(&mut self.spans, slot)?.duration = duration;
             }
             OpCode::SetType => {
-                let r#type = buf.read_arg(&self.string_table, index)?;
+                let r#type = buf.read_string(&self.string_table, index)?;
                 span_at_mut(&mut self.spans, slot)?.r#type = r#type;
             }
             OpCode::SetName => {
-                let name = buf.read_arg(&self.string_table, index)?;
+                let name = buf.read_string(&self.string_table, index)?;
                 span_at_mut(&mut self.spans, slot)?.name = name;
             }
             OpCode::SetTraceMetaAttr => {
-                let name = buf.read_arg(&self.string_table, index)?;
-                let val = buf.read_arg(&self.string_table, index)?;
+                let name = buf.read_string(&self.string_table, index)?;
+                let val = buf.read_string(&self.string_table, index)?;
                 let trace_id = span_at_mut(&mut self.spans, slot)?.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
                     trace.meta.insert(name, val);
                 }
             }
             OpCode::SetTraceMetricsAttr => {
-                let name = buf.read_arg(&self.string_table, index)?;
+                let name = buf.read_string(&self.string_table, index)?;
                 let val = buf.read(index)?;
                 let trace_id = span_at_mut(&mut self.spans, slot)?.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
@@ -746,7 +736,7 @@ where
                 }
             }
             OpCode::SetTraceOrigin => {
-                let origin = buf.read_arg(&self.string_table, index)?;
+                let origin = buf.read_string(&self.string_table, index)?;
                 let trace_id = span_at_mut(&mut self.spans, slot)?.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
                     trace.origin = Some(origin);
@@ -756,7 +746,7 @@ where
                 let span_id: u64 = buf.read(index)?;
                 let trace_id: u128 = buf.read(index)?;
                 let parent_id: u64 = buf.read(index)?;
-                let name = buf.read_arg(&self.string_table, index)?;
+                let name = buf.read_string(&self.string_table, index)?;
                 let start: i64 = buf.read(index)?;
                 let mut span = new_span_pooled(&mut self.span_pool, span_id, parent_id, trace_id);
                 span.name = name;
@@ -772,10 +762,10 @@ where
                 let span_id: u64 = buf.read(index)?;
                 let trace_id: u128 = buf.read(index)?;
                 let parent_id: u64 = buf.read(index)?;
-                let name = buf.read_arg(&self.string_table, index)?;
-                let service = buf.read_arg(&self.string_table, index)?;
-                let resource = buf.read_arg(&self.string_table, index)?;
-                let r#type = buf.read_arg(&self.string_table, index)?;
+                let name = buf.read_string(&self.string_table, index)?;
+                let service = buf.read_string(&self.string_table, index)?;
+                let resource = buf.read_string(&self.string_table, index)?;
+                let r#type = buf.read_string(&self.string_table, index)?;
                 let start: i64 = buf.read(index)?;
                 let mut span = new_span_pooled(&mut self.span_pool, span_id, parent_id, trace_id);
                 span.name = name;

--- a/libdd-trace-utils/src/change_buffer/mod.rs
+++ b/libdd-trace-utils/src/change_buffer/mod.rs
@@ -377,14 +377,14 @@ where
                     // `*cached_slot` is `u32::MAX`. In subsequent iterations,
                     // `interpret_operation_cached` maintains its own safety invariant.
                     unsafe {
-                      self.interpret_operation_cached(
-                          &mut index,
-                          &op,
-                          &mut cached_slot,
-                          &mut cached_span_ptr,
-                          &mut cached_deferred_meta,
-                          &mut cached_deferred_metrics,
-                      )?;
+                        self.interpret_operation_cached(
+                            &mut index,
+                            &op,
+                            &mut cached_slot,
+                            &mut cached_span_ptr,
+                            &mut cached_deferred_meta,
+                            &mut cached_deferred_metrics,
+                        )?;
                     }
                 }
             }

--- a/libdd-trace-utils/src/change_buffer/mod.rs
+++ b/libdd-trace-utils/src/change_buffer/mod.rs
@@ -267,6 +267,7 @@ where
         let mut is_chunk_root = true;
 
         let mut spans_vec = Vec::with_capacity(slot_indices.len());
+
         for slot in slot_indices {
             let maybe_span = self
                 .spans
@@ -280,6 +281,7 @@ where
                 span.metrics.insert(self.str_top_level.clone(), 1.0);
                 is_local_root = false;
             }
+
             if is_chunk_root {
                 self.copy_in_chunk_tags(&mut span);
                 is_chunk_root = false;
@@ -549,9 +551,8 @@ where
             existing.meta.extend(self.default_meta.iter().cloned());
         } else {
             self.spans.push(Some(span));
+            self.traces.get_or_insert_default(trace_id).span_count += 1;
         }
-
-        self.traces.get_or_insert_default(trace_id).span_count += 1;
         self.span_headers[header_idx as usize].active = 0;
 
         Ok(span_id)

--- a/libdd-trace-utils/src/change_buffer/mod.rs
+++ b/libdd-trace-utils/src/change_buffer/mod.rs
@@ -267,6 +267,18 @@ where
         let mut is_chunk_root = true;
 
         let mut spans_vec = Vec::with_capacity(slot_indices.len());
+        // Fetch the trace_id corresponding to this chunk. It must be the same for all the spans in
+        // the chunk.
+        let Some(trace_id) = slot_indices
+            .first()
+            .map(|idx| span_at_mut(&mut self.spans, *idx as usize))
+            .transpose()?
+            .map(|span| span.trace_id)
+        else {
+            return Ok(vec![]);
+        };
+
+        let trace = self.traces.get(&trace_id);
 
         for slot in slot_indices {
             let maybe_span = self
@@ -277,55 +289,43 @@ where
             let mut span = maybe_span.ok_or(ChangeBufferError::SpanNotFound(*slot as u64))?;
 
             if is_local_root {
-                self.copy_in_sampling_tags(&mut span);
+                self.copy_in_sampling_tags(trace, &mut span);
                 span.metrics.insert(self.str_top_level.clone(), 1.0);
                 is_local_root = false;
             }
 
             if is_chunk_root {
-                self.copy_in_chunk_tags(&mut span);
+                Self::copy_in_chunk_tags(trace, &mut span);
                 is_chunk_root = false;
             }
 
-            self.process_span(&mut span);
+            self.process_span(trace, &mut span);
 
             spans_vec.push(span);
         }
 
-        let mut seen_trace_ids: Vec<(u128, usize)> = Vec::new();
-        for span in &spans_vec {
-            if let Some(entry) = seen_trace_ids
-                .iter_mut()
-                .find(|(id, _)| *id == span.trace_id)
-            {
-                entry.1 += 1;
-            } else {
-                seen_trace_ids.push((span.trace_id, 1));
-            }
-        }
-        for (trace_id, flushed_count) in seen_trace_ids {
-            let should_remove = self
-                .traces
-                .get_mut(&trace_id)
-                .map(|trace| {
-                    if trace.span_count <= flushed_count {
-                        true
-                    } else {
-                        trace.span_count -= flushed_count;
-                        false
-                    }
-                })
-                .unwrap_or(false);
-            if should_remove {
-                self.traces.remove(&trace_id);
-            }
+        let trace = self.traces.get_mut(&trace_id);
+
+        let should_remove = trace
+            .map(|trace| {
+                if trace.span_count <= spans_vec.len() {
+                    true
+                } else {
+                    trace.span_count -= spans_vec.len();
+                    false
+                }
+            })
+            .unwrap_or(false);
+
+        if should_remove {
+            self.traces.remove(&trace_id);
         }
 
         Ok(spans_vec)
     }
 
-    fn copy_in_sampling_tags(&self, span: &mut Span<T>) {
-        if let Some(trace) = self.traces.get(&span.trace_id) {
+    fn copy_in_sampling_tags(&self, trace: Option<&Trace<T::Text>>, span: &mut Span<T>) {
+        if let Some(trace) = trace {
             if let Some(rule) = trace.sampling_rule_decision {
                 span.metrics.insert(self.str_rule_psr.clone(), rule);
             }
@@ -338,8 +338,8 @@ where
         }
     }
 
-    fn copy_in_chunk_tags(&self, span: &mut Span<T>) {
-        if let Some(trace) = self.traces.get(&span.trace_id) {
+    fn copy_in_chunk_tags(trace: Option<&Trace<T::Text>>, span: &mut Span<T>) {
+        if let Some(trace) = trace {
             span.meta
                 .extend(trace.meta.iter().map(|(k, v)| (k.clone(), v.clone())));
             span.metrics
@@ -347,7 +347,7 @@ where
         }
     }
 
-    fn process_span(&self, span: &mut Span<T>) {
+    fn process_span(&self, trace: Option<&Trace<T::Text>>, span: &mut Span<T>) {
         if let Some(kind) = span.meta.get("kind") {
             if *kind != self.str_internal {
                 span.metrics.insert(self.str_measured.clone(), 1.0);
@@ -364,7 +364,7 @@ where
         span.metrics
             .insert(self.str_process_id.clone(), f64::from(self.pid));
 
-        if let Some(trace) = self.traces.get(&span.trace_id) {
+        if let Some(trace) = trace {
             if let Some(origin) = trace.origin.clone() {
                 span.meta.insert(self.str_origin.clone(), origin);
             }

--- a/libdd-trace-utils/src/change_buffer/mod.rs
+++ b/libdd-trace-utils/src/change_buffer/mod.rs
@@ -11,7 +11,6 @@
 //!
 //! The change buffer is currently designed and used for dd-trace-js, but the idea could be extended
 //! to other runtime where the FFI cost is high.
-#![allow(dead_code)]
 
 /// Errors that can occur when operating on a [`ChangeBuffer`] or [`ChangeBufferState`].
 #[derive(Debug)]

--- a/libdd-trace-utils/src/change_buffer/mod.rs
+++ b/libdd-trace-utils/src/change_buffer/mod.rs
@@ -110,8 +110,6 @@ pub struct ChangeBufferState<T: TraceData> {
     /// Contiguous array of span headers for direct JS DataView access. JS writes numeric and
     /// string-ID fields directly here. Rust reads them during flush_chunk.
     pub span_headers: Vec<SpanHeader>,
-    /// Free list of recycled header indices (from finished spans).
-    header_free_list: Vec<u32>,
     // Cached static strings to avoid repeated heap allocations (e.g. Arc<str>) on every span
     // flush. These are created once and cloned (cheap ref bump).
     str_top_level: T::Text,
@@ -169,10 +167,39 @@ fn new_span_pooled<T: TraceData>(
     }
 }
 
+fn span_at_mut<T: TraceData>(spans: &mut [Option<Span<T>>], slot: usize) -> Result<&mut Span<T>> {
+    spans
+        .get_mut(slot)
+        .and_then(|opt| opt.as_mut())
+        .ok_or(ChangeBufferError::SpanNotFound(slot as u64))
+}
+
+fn deferred_meta_at(
+    deferred_meta: &mut [VecMap<u32, u32>],
+    slot: usize,
+) -> Result<&mut VecMap<u32, u32>> {
+    deferred_meta
+        .get_mut(slot)
+        .ok_or(ChangeBufferError::SpanNotFound(slot as u64))
+}
+
+fn deferred_metrics_at(
+    deferred_metrics: &mut [VecMap<u32, f64>],
+    slot: usize,
+) -> Result<&mut VecMap<u32, f64>> {
+    deferred_metrics
+        .get_mut(slot)
+        .ok_or(ChangeBufferError::SpanNotFound(slot as u64))
+}
+
 impl<T: TraceData> ChangeBufferState<T>
 where
     T::Text: Clone,
 {
+    /// The maximun size of the recycled span pool, beyond which we don't recycle spans anymore but
+    /// drop them.
+    const SPANS_POOL_MAX_SIZE: usize = 128;
+
     pub fn new(
         change_buffer: ChangeBuffer,
         tracer_service: T::Text,
@@ -189,7 +216,6 @@ where
             pid,
             default_meta: Vec::new(),
             span_headers: Vec::with_capacity(256),
-            header_free_list: Vec::new(),
             str_top_level: T::Text::from_static_str("_dd.top_level"),
             str_measured: T::Text::from_static_str("_dd.measured"),
             str_base_service: T::Text::from_static_str("_dd.base_service"),
@@ -219,7 +245,7 @@ where
     }
 
     pub fn recycle_spans(&mut self, spans: Vec<Span<T>>) {
-        let available = 128usize.saturating_sub(self.span_pool.len());
+        let available = Self::SPANS_POOL_MAX_SIZE.saturating_sub(self.span_pool.len());
         for span in spans.into_iter().take(available) {
             self.span_pool.push(span);
         }
@@ -227,7 +253,7 @@ where
 
     pub fn flush_chunk(
         &mut self,
-        slot_indices: Vec<u32>,
+        slot_indices: &[u32],
         first_is_local_root: bool,
     ) -> Result<Vec<Span<T>>> {
         let mut chunk_trace_id: Option<u128> = None;
@@ -235,7 +261,7 @@ where
         let mut is_chunk_root = true;
 
         let mut spans_vec = Vec::with_capacity(slot_indices.len());
-        for slot in &slot_indices {
+        for slot in slot_indices {
             let maybe_span = self
                 .spans
                 .get_mut(*slot as usize)
@@ -257,7 +283,7 @@ where
                 is_chunk_root = false;
             }
 
-            self.process_one_span(&mut span);
+            self.process_span(&mut span);
 
             spans_vec.push(span);
         }
@@ -317,7 +343,7 @@ where
         }
     }
 
-    fn process_one_span(&self, span: &mut Span<T>) {
+    fn process_span(&self, span: &mut Span<T>) {
         if let Some(kind) = span.meta.get("kind") {
             if *kind != self.str_internal {
                 span.metrics.insert(self.str_measured.clone(), 1.0);
@@ -345,47 +371,15 @@ where
         let mut index = 0;
         let mut count = self.change_buffer.read::<u64>(&mut index)? as u32;
 
-        let mut cached_slot: u32 = u32::MAX;
-        // Cached elements for the current span.
-        //
-        // When applying span operations, we cache the last span index (cached_slot) and the
-        // corresponding elements in `deffered_meta`, `deferred_metrics`, and `span`. We use direct
-        // pointers to save intermediate dereferences.
-        //
-        // They are safe to use as long as we don't modify their parent vector and keep a unique
-        // borrow to `self` overall.
-        //
-        // Using mutable references instead would be better, but is not possible (or very hard)
-        // given we iterate and nest calls to different submethods taking a `&mut self`.
-        let mut cached_span_ptr: *mut Span<T> = std::ptr::null_mut();
-        let mut cached_deferred_meta: *mut VecMap<u32, u32> = std::ptr::null_mut();
-        let mut cached_deferred_metrics: *mut VecMap<u32, f64> = std::ptr::null_mut();
-
         while count > 0 {
             let op = BufferedOperation::from_buf(&self.change_buffer, &mut index)?;
 
             match op.opcode {
                 OpCode::Create | OpCode::CreateSpan | OpCode::CreateSpanFull => {
-                    cached_span_ptr = std::ptr::null_mut();
-                    cached_slot = u32::MAX;
-                    cached_deferred_meta = std::ptr::null_mut();
-                    cached_deferred_metrics = std::ptr::null_mut();
                     self.interpret_operation(&mut index, &op)?;
                 }
                 _ => {
-                    // SAFETY: at the first iteration of the loop, all pointers are null and
-                    // `*cached_slot` is `u32::MAX`. In subsequent iterations,
-                    // `interpret_operation_cached` maintains its own safety invariant.
-                    unsafe {
-                        self.interpret_operation_cached(
-                            &mut index,
-                            &op,
-                            &mut cached_slot,
-                            &mut cached_span_ptr,
-                            &mut cached_deferred_meta,
-                            &mut cached_deferred_metrics,
-                        )?;
-                    }
+                    self.interpret_operation_cached(&mut index, &op)?;
                 }
             }
             count -= 1;
@@ -397,86 +391,56 @@ where
         Ok(())
     }
 
-    /// # Safety
-    ///
-    /// The pointer arguments provided to this function: `*cached_slot`, `*cached_span_ptr`,
-    /// `*cached_deferred_meta` and `*cached_deferred_metrics` must either:
-    ///
-    /// - be all `null` if `*cached_slot` is `u32::MAX`
-    /// - point to `self.spans[*cached_slot]`, `self.deferred_meta[*cached_slot]` and
-    ///   `self.deferred_metrics[*cached_slot]` respectively otherwise.
-    unsafe fn interpret_operation_cached(
+    fn interpret_operation_cached(
         &mut self,
         index: &mut usize,
         op: &BufferedOperation,
-        cached_slot: &mut u32,
-        cached_span_ptr: &mut *mut Span<T>,
-        cached_deferred_meta: &mut *mut VecMap<u32, u32>,
-        cached_deferred_metrics: &mut *mut VecMap<u32, f64>,
     ) -> Result<()> {
-        let span_ptr = if op.slot_index == *cached_slot && !cached_span_ptr.is_null() {
-            *cached_span_ptr
-        } else {
-            let slot = op.slot_index as usize;
-            let span = self
-                .spans
-                .get_mut(slot)
-                .and_then(|opt| opt.as_mut())
-                .ok_or(ChangeBufferError::SpanNotFound(op.slot_index as u64))?
-                as *mut Span<T>;
-            *cached_slot = op.slot_index;
-            *cached_span_ptr = span;
-            *cached_deferred_meta = &mut self.deferred_meta[slot] as *mut VecMap<u32, u32>;
-            *cached_deferred_metrics = &mut self.deferred_metrics[slot] as *mut VecMap<u32, f64>;
-            span
-        };
+        let slot = op.slot_index as usize;
 
-        // SAFETY: span_ptr is valid for read and writes: it was obtained from self.spans above or
-        // from the cache which was set in a previous iteration of the same loop. self.spans is not
-        // modified during this function (no inserts/removes).
-        let span = unsafe { &mut *span_ptr };
-
-        // SAFETY: `cached_deferred_xxx`: they point to writable memory, and we don't shrink, move
-        // nor drop the parent `deferred_xxx` vec, so the pointers remain valid. We keep a mutable
-        // borrow on `self`, which ensures ownership/uniqueness.
         match op.opcode {
             OpCode::SetMetaAttr => {
                 let key_id: u32 = self.get_num_arg(index)?;
                 let val_id: u32 = self.get_num_arg(index)?;
-                let dm = unsafe { &mut **cached_deferred_meta };
-                dm.insert(key_id, val_id);
+                deferred_meta_at(&mut self.deferred_meta, slot)?.insert(key_id, val_id);
             }
             OpCode::SetMetricAttr => {
                 let key_id: u32 = self.get_num_arg(index)?;
                 let val: f64 = self.get_num_arg(index)?;
-                let dm = unsafe { &mut **cached_deferred_metrics };
-                dm.insert(key_id, val);
+                deferred_metrics_at(&mut self.deferred_metrics, slot)?.insert(key_id, val);
             }
             OpCode::SetServiceName => {
-                span.service = self.get_string_arg(index)?;
+                let service = self.get_string_arg(index)?;
+                span_at_mut(&mut self.spans, slot)?.service = service;
             }
             OpCode::SetResourceName => {
-                span.resource = self.get_string_arg(index)?;
+                let resource = self.get_string_arg(index)?;
+                span_at_mut(&mut self.spans, slot)?.resource = resource;
             }
             OpCode::SetError => {
-                span.error = self.get_num_arg(index)?;
+                let error = self.get_num_arg(index)?;
+                span_at_mut(&mut self.spans, slot)?.error = error;
             }
             OpCode::SetStart => {
-                span.start = self.get_num_arg(index)?;
+                let start = self.get_num_arg(index)?;
+                span_at_mut(&mut self.spans, slot)?.start = start;
             }
             OpCode::SetDuration => {
-                span.duration = self.get_num_arg(index)?;
+                let duration = self.get_num_arg(index)?;
+                span_at_mut(&mut self.spans, slot)?.duration = duration;
             }
             OpCode::SetType => {
-                span.r#type = self.get_string_arg(index)?;
+                let r#type = self.get_string_arg(index)?;
+                span_at_mut(&mut self.spans, slot)?.r#type = r#type;
             }
             OpCode::SetName => {
-                span.name = self.get_string_arg(index)?;
+                let name = self.get_string_arg(index)?;
+                span_at_mut(&mut self.spans, slot)?.name = name;
             }
             OpCode::SetTraceMetaAttr => {
                 let name = self.get_string_arg(index)?;
                 let val = self.get_string_arg(index)?;
-                let trace_id = span.trace_id;
+                let trace_id = span_at_mut(&mut self.spans, slot)?.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
                     trace.meta.insert(name, val);
                 }
@@ -484,34 +448,32 @@ where
             OpCode::SetTraceMetricsAttr => {
                 let name = self.get_string_arg(index)?;
                 let val = self.get_num_arg(index)?;
-                let trace_id = span.trace_id;
+                let trace_id = span_at_mut(&mut self.spans, slot)?.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
                     trace.metrics.insert(name, val);
                 }
             }
             OpCode::SetTraceOrigin => {
                 let origin = self.get_string_arg(index)?;
-                let trace_id = span.trace_id;
+                let trace_id = span_at_mut(&mut self.spans, slot)?.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
                     trace.origin = Some(origin);
                 }
             }
             OpCode::BatchSetMeta => {
                 let count: u32 = self.get_num_arg(index)?;
-                let dm = unsafe { &mut **cached_deferred_meta };
                 for _ in 0..count {
                     let key_id: u32 = self.get_num_arg(index)?;
                     let val_id: u32 = self.get_num_arg(index)?;
-                    dm.insert(key_id, val_id);
+                    deferred_meta_at(&mut self.deferred_meta, slot)?.insert(key_id, val_id);
                 }
             }
             OpCode::BatchSetMetric => {
                 let count: u32 = self.get_num_arg(index)?;
-                let dm = unsafe { &mut **cached_deferred_metrics };
                 for _ in 0..count {
                     let key_id: u32 = self.get_num_arg(index)?;
                     let val: f64 = self.get_num_arg(index)?;
-                    dm.insert(key_id, val);
+                    deferred_metrics_at(&mut self.deferred_metrics, slot)?.insert(key_id, val);
                 }
             }
             OpCode::Create | OpCode::CreateSpan | OpCode::CreateSpanFull => unreachable!(),
@@ -532,13 +494,6 @@ where
         self.change_buffer.read(index)
     }
 
-    fn get_span_mut(&mut self, slot: u32) -> Result<&mut Span<T>> {
-        self.spans
-            .get_mut(slot as usize)
-            .and_then(|opt| opt.as_mut())
-            .ok_or(ChangeBufferError::SpanNotFound(slot as u64))
-    }
-
     pub fn get_span(&self, slot: u32) -> Result<&Span<T>> {
         self.spans
             .get(slot as usize)
@@ -549,20 +504,6 @@ where
     #[inline]
     pub fn get_trace(&self, id: &u128) -> Option<&Trace<T::Text>> {
         self.traces.get(id)
-    }
-
-    pub fn alloc_header(&mut self) -> u32 {
-        if let Some(idx) = self.header_free_list.pop() {
-            self.span_headers[idx as usize] = SpanHeader::default();
-            self.span_headers[idx as usize].active = 1;
-            idx
-        } else {
-            let idx = self.span_headers.len() as u32;
-            let mut header = SpanHeader::default();
-            header.active = 1;
-            self.span_headers.push(header);
-            idx
-        }
     }
 
     pub fn materialize_header(&mut self, header_idx: u32) -> Result<u64> {
@@ -627,9 +568,7 @@ where
         }
 
         self.traces.get_or_insert_default(trace_id).span_count += 1;
-
         self.span_headers[header_idx as usize].active = 0;
-        self.header_free_list.push(header_idx);
 
         Ok(span_id)
     }
@@ -725,6 +664,8 @@ where
     }
 
     fn interpret_operation(&mut self, index: &mut usize, op: &BufferedOperation) -> Result<()> {
+        let slot = op.slot_index as usize;
+
         match op.opcode {
             OpCode::Create => {
                 let span_id: u64 = self.change_buffer.read(index)?;
@@ -733,52 +674,53 @@ where
                 let mut span = new_span_pooled(&mut self.span_pool, span_id, parent_id, trace_id);
                 self.apply_default_meta(&mut span);
                 self.ensure_slot(op.slot_index);
-                self.spans[op.slot_index as usize] = Some(span);
-                self.deferred_meta[op.slot_index as usize].clear();
-                self.deferred_metrics[op.slot_index as usize].clear();
+                self.spans[slot] = Some(span);
+                self.deferred_meta[slot].clear();
+                self.deferred_metrics[slot].clear();
                 self.traces.get_or_insert_default(trace_id).span_count += 1;
             }
             OpCode::SetMetaAttr => {
                 let key_id: u32 = self.get_num_arg(index)?;
                 let val_id: u32 = self.get_num_arg(index)?;
-                let idx = op.slot_index as usize;
-                if idx < self.deferred_meta.len() {
-                    self.deferred_meta[idx].insert(key_id, val_id);
-                }
+                deferred_meta_at(&mut self.deferred_meta, slot)?.insert(key_id, val_id);
             }
             OpCode::SetMetricAttr => {
                 let key_id: u32 = self.get_num_arg(index)?;
                 let val: f64 = self.get_num_arg(index)?;
-                let idx = op.slot_index as usize;
-                if idx < self.deferred_metrics.len() {
-                    self.deferred_metrics[idx].insert(key_id, val);
-                }
+                deferred_metrics_at(&mut self.deferred_metrics, slot)?.insert(key_id, val);
             }
             OpCode::SetServiceName => {
-                self.get_span_mut(op.slot_index)?.service = self.get_string_arg(index)?;
+                let service = self.get_string_arg(index)?;
+                span_at_mut(&mut self.spans, slot)?.service = service;
             }
             OpCode::SetResourceName => {
-                self.get_span_mut(op.slot_index)?.resource = self.get_string_arg(index)?;
+                let resource = self.get_string_arg(index)?;
+                span_at_mut(&mut self.spans, slot)?.resource = resource;
             }
             OpCode::SetError => {
-                self.get_span_mut(op.slot_index)?.error = self.get_num_arg(index)?;
+                let error = self.get_num_arg(index)?;
+                span_at_mut(&mut self.spans, slot)?.error = error;
             }
             OpCode::SetStart => {
-                self.get_span_mut(op.slot_index)?.start = self.get_num_arg(index)?;
+                let start = self.get_num_arg(index)?;
+                span_at_mut(&mut self.spans, slot)?.start = start;
             }
             OpCode::SetDuration => {
-                self.get_span_mut(op.slot_index)?.duration = self.get_num_arg(index)?;
+                let duration = self.get_num_arg(index)?;
+                span_at_mut(&mut self.spans, slot)?.duration = duration;
             }
             OpCode::SetType => {
-                self.get_span_mut(op.slot_index)?.r#type = self.get_string_arg(index)?;
+                let r#type = self.get_string_arg(index)?;
+                span_at_mut(&mut self.spans, slot)?.r#type = r#type;
             }
             OpCode::SetName => {
-                self.get_span_mut(op.slot_index)?.name = self.get_string_arg(index)?;
+                let name = self.get_string_arg(index)?;
+                span_at_mut(&mut self.spans, slot)?.name = name;
             }
             OpCode::SetTraceMetaAttr => {
                 let name = self.get_string_arg(index)?;
                 let val = self.get_string_arg(index)?;
-                let trace_id = self.get_span(op.slot_index)?.trace_id;
+                let trace_id = span_at_mut(&mut self.spans, slot)?.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
                     trace.meta.insert(name, val);
                 }
@@ -786,14 +728,14 @@ where
             OpCode::SetTraceMetricsAttr => {
                 let name = self.get_string_arg(index)?;
                 let val = self.get_num_arg(index)?;
-                let trace_id = self.get_span(op.slot_index)?.trace_id;
+                let trace_id = span_at_mut(&mut self.spans, slot)?.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
                     trace.metrics.insert(name, val);
                 }
             }
             OpCode::SetTraceOrigin => {
                 let origin = self.get_string_arg(index)?;
-                let trace_id = self.get_span(op.slot_index)?.trace_id;
+                let trace_id = span_at_mut(&mut self.spans, slot)?.trace_id;
                 if let Some(trace) = self.traces.get_mut(&trace_id) {
                     trace.origin = Some(origin);
                 }
@@ -809,9 +751,9 @@ where
                 span.start = start;
                 self.apply_default_meta(&mut span);
                 self.ensure_slot(op.slot_index);
-                self.spans[op.slot_index as usize] = Some(span);
-                self.deferred_meta[op.slot_index as usize].clear();
-                self.deferred_metrics[op.slot_index as usize].clear();
+                self.spans[slot] = Some(span);
+                self.deferred_meta[slot].clear();
+                self.deferred_metrics[slot].clear();
                 self.traces.get_or_insert_default(trace_id).span_count += 1;
             }
             OpCode::CreateSpanFull => {
@@ -831,31 +773,25 @@ where
                 span.start = start;
                 self.apply_default_meta(&mut span);
                 self.ensure_slot(op.slot_index);
-                self.spans[op.slot_index as usize] = Some(span);
-                self.deferred_meta[op.slot_index as usize].clear();
-                self.deferred_metrics[op.slot_index as usize].clear();
+                self.spans[slot] = Some(span);
+                self.deferred_meta[slot].clear();
+                self.deferred_metrics[slot].clear();
                 self.traces.get_or_insert_default(trace_id).span_count += 1;
             }
             OpCode::BatchSetMeta => {
                 let count: u32 = self.get_num_arg(index)?;
-                let idx = op.slot_index as usize;
                 for _ in 0..count {
                     let key_id: u32 = self.get_num_arg(index)?;
                     let val_id: u32 = self.get_num_arg(index)?;
-                    if idx < self.deferred_meta.len() {
-                        self.deferred_meta[idx].insert(key_id, val_id);
-                    }
+                    deferred_meta_at(&mut self.deferred_meta, slot)?.insert(key_id, val_id);
                 }
             }
             OpCode::BatchSetMetric => {
                 let count: u32 = self.get_num_arg(index)?;
-                let idx = op.slot_index as usize;
                 for _ in 0..count {
                     let key_id: u32 = self.get_num_arg(index)?;
                     let val: f64 = self.get_num_arg(index)?;
-                    if idx < self.deferred_metrics.len() {
-                        self.deferred_metrics[idx].insert(key_id, val);
-                    }
+                    deferred_metrics_at(&mut self.deferred_metrics, slot)?.insert(key_id, val);
                 }
             }
         };

--- a/libdd-trace-utils/src/change_buffer/mod.rs
+++ b/libdd-trace-utils/src/change_buffer/mod.rs
@@ -11,8 +11,7 @@
 //!
 //! The change buffer is currently designed and used for dd-trace-js, but the idea could be extended
 //! to other runtime where the FFI cost is high.
-
-#![allow(unused)]
+#![allow(dead_code)]
 
 /// Errors that can occur when operating on a [`ChangeBuffer`] or [`ChangeBufferState`].
 #[derive(Debug)]
@@ -129,4 +128,792 @@ fn deferred_metric_insert(vec: &mut Vec<(u32, f64)>, key_id: u32, val: f64) {
         }
     }
     vec.push((key_id, val));
+}
+
+pub struct ChangeBufferState<T: TraceData> {
+    change_buffer: ChangeBuffer,
+    spans: Vec<Option<Span<T>>>,
+    traces: SmallTraceMap<T::Text>,
+    /// String table indexed by sequential u32 IDs (O(1) lookup vs HashMap).
+    string_table: Vec<Option<T::Text>>,
+    tracer_service: T::Text,
+    tracer_language: T::Text,
+    pid: u32,
+    /// Default meta tags automatically applied to every new span via create_span.
+    default_meta: Vec<(T::Text, T::Text)>,
+    /// Contiguous array of span headers for direct JS DataView access.
+    /// JS writes numeric and string-ID fields directly here. Rust reads
+    /// them during flush_chunk.
+    pub span_headers: Vec<SpanHeader>,
+    /// Free list of recycled header indices (from finished spans).
+    header_free_list: Vec<u32>,
+    // Cached static strings to avoid repeated heap allocations (e.g. Arc<str>)
+    // on every span flush. These are created once and cloned (cheap ref bump).
+    str_top_level: T::Text,
+    str_measured: T::Text,
+    str_base_service: T::Text,
+    str_language: T::Text,
+    str_process_id: T::Text,
+    str_origin: T::Text,
+    str_rule_psr: T::Text,
+    str_limit_psr: T::Text,
+    str_agent_psr: T::Text,
+    str_internal: T::Text,
+    /// Pool of recycled Span objects. Reusing spans (with their pre-allocated
+    /// Vec buffers) eliminates the alloc/dealloc churn that fragments the
+    /// WASM linear memory allocator over time.
+    span_pool: Vec<Span<T>>,
+    /// Deferred meta tags: indexed by slot, stores (key_string_id, val_string_id) pairs.
+    deferred_meta: Vec<Vec<(u32, u32)>>,
+    /// Deferred metric tags: indexed by slot, stores (key_string_id, f64_value) pairs.
+    deferred_metrics: Vec<Vec<(u32, f64)>>,
+}
+
+fn new_span_pooled<T: TraceData>(
+    pool: &mut Vec<Span<T>>,
+    span_id: u64,
+    parent_id: u64,
+    trace_id: u128,
+) -> Span<T> {
+    if let Some(mut span) = pool.pop() {
+        span.span_id = span_id;
+        span.trace_id = trace_id;
+        span.parent_id = parent_id;
+        span.start = 0;
+        span.duration = 0;
+        span.error = 0;
+        span.service = Default::default();
+        span.name = Default::default();
+        span.resource = Default::default();
+        span.r#type = Default::default();
+        span.meta.clear();
+        span.metrics.clear();
+        span.meta_struct.clear();
+        span.span_links.clear();
+        span.span_events.clear();
+        span
+    } else {
+        Span {
+            span_id,
+            trace_id,
+            parent_id,
+            meta: Vec::with_capacity(8),
+            metrics: Vec::with_capacity(4),
+            ..Default::default()
+        }
+    }
+}
+
+impl<T: TraceData> ChangeBufferState<T>
+where
+    T::Text: Clone,
+{
+    pub fn new(
+        change_buffer: ChangeBuffer,
+        tracer_service: T::Text,
+        tracer_language: T::Text,
+        pid: u32,
+    ) -> Self {
+        eprintln!(
+            "[libdatadog pipeline] experiment: baseline (commit: {})",
+            env!("GIT_COMMIT")
+        );
+        ChangeBufferState {
+            change_buffer,
+            spans: Vec::with_capacity(256),
+            traces: SmallTraceMap::default(),
+            string_table: Vec::with_capacity(256),
+            tracer_service,
+            tracer_language,
+            pid,
+            default_meta: Vec::new(),
+            span_headers: Vec::with_capacity(256),
+            header_free_list: Vec::new(),
+            str_top_level: T::Text::from_static_str("_dd.top_level"),
+            str_measured: T::Text::from_static_str("_dd.measured"),
+            str_base_service: T::Text::from_static_str("_dd.base_service"),
+            str_language: T::Text::from_static_str("language"),
+            str_process_id: T::Text::from_static_str("process_id"),
+            str_origin: T::Text::from_static_str("_dd.origin"),
+            str_rule_psr: T::Text::from_static_str("_dd.rule_psr"),
+            str_limit_psr: T::Text::from_static_str("_dd.limit_psr"),
+            str_agent_psr: T::Text::from_static_str("_dd.agent_psr"),
+            str_internal: T::Text::from_static_str("internal"),
+            span_pool: Vec::new(),
+            deferred_meta: Vec::with_capacity(256),
+            deferred_metrics: Vec::with_capacity(256),
+        }
+    }
+
+    pub fn spans_count(&self) -> usize {
+        self.spans.iter().filter(|s| s.is_some()).count()
+    }
+
+    pub fn string_table_len(&self) -> usize {
+        self.string_table.len()
+    }
+
+    pub fn span_pool_len(&self) -> usize {
+        self.span_pool.len()
+    }
+
+    pub fn recycle_spans(&mut self, spans: Vec<Span<T>>) {
+        let available = 128usize.saturating_sub(self.span_pool.len());
+        for span in spans.into_iter().take(available) {
+            self.span_pool.push(span);
+        }
+    }
+
+    pub fn flush_chunk(
+        &mut self,
+        slot_indices: Vec<u32>,
+        first_is_local_root: bool,
+    ) -> Result<Vec<Span<T>>> {
+        let mut chunk_trace_id: Option<u128> = None;
+        let mut is_local_root = first_is_local_root;
+        let mut is_chunk_root = true;
+
+        let mut spans_vec = Vec::with_capacity(slot_indices.len());
+        for slot in &slot_indices {
+            let maybe_span = self
+                .spans
+                .get_mut(*slot as usize)
+                .and_then(|opt| opt.take());
+
+            let mut span = maybe_span.ok_or(ChangeBufferError::SpanNotFound(*slot as u64))?;
+
+            self.materialize_deferred_tags(*slot, &mut span);
+
+            chunk_trace_id = Some(span.trace_id);
+
+            if is_local_root {
+                self.copy_in_sampling_tags(&mut span);
+                vec_insert(&mut span.metrics, self.str_top_level.clone(), 1.0);
+                is_local_root = false;
+            }
+            if is_chunk_root {
+                self.copy_in_chunk_tags(&mut span);
+                is_chunk_root = false;
+            }
+
+            self.process_one_span(&mut span);
+
+            spans_vec.push(span);
+        }
+
+        let mut seen_trace_ids: Vec<(u128, usize)> = Vec::new();
+        for span in &spans_vec {
+            if let Some(entry) = seen_trace_ids.iter_mut().find(|(id, _)| *id == span.trace_id) {
+                entry.1 += 1;
+            } else {
+                seen_trace_ids.push((span.trace_id, 1));
+            }
+        }
+        for (trace_id, flushed_count) in seen_trace_ids {
+            let should_remove = self
+                .traces
+                .get_mut(&trace_id)
+                .map(|trace| {
+                    if trace.span_count <= flushed_count {
+                        true
+                    } else {
+                        trace.span_count -= flushed_count;
+                        false
+                    }
+                })
+                .unwrap_or(false);
+            if should_remove {
+                self.traces.remove(&trace_id);
+            }
+        }
+
+        Ok(spans_vec)
+    }
+
+    fn copy_in_sampling_tags(&self, span: &mut Span<T>) {
+        if let Some(trace) = self.traces.get(&span.trace_id) {
+            if let Some(rule) = trace.sampling_rule_decision {
+                vec_insert(&mut span.metrics, self.str_rule_psr.clone(), rule);
+            }
+            if let Some(rule) = trace.sampling_limit_decision {
+                vec_insert(&mut span.metrics, self.str_limit_psr.clone(), rule);
+            }
+            if let Some(rule) = trace.sampling_agent_decision {
+                vec_insert(&mut span.metrics, self.str_agent_psr.clone(), rule);
+            }
+        }
+    }
+
+    fn copy_in_chunk_tags(&self, span: &mut Span<T>) {
+        if let Some(trace) = self.traces.get(&span.trace_id) {
+            span.meta.reserve(trace.meta.len());
+            for (k, v) in &trace.meta {
+                vec_insert(&mut span.meta, k.clone(), v.clone());
+            }
+            span.metrics.reserve(trace.metrics.len());
+            for (k, v) in &trace.metrics {
+                vec_insert(&mut span.metrics, k.clone(), *v);
+            }
+        }
+    }
+
+    fn process_one_span(&self, span: &mut Span<T>) {
+        let kind_key = T::Text::from_static_str("kind");
+        if let Some(kind) = vec_get(&span.meta, &kind_key) {
+            if *kind != self.str_internal {
+                vec_insert(&mut span.metrics, self.str_measured.clone(), 1.0);
+            }
+        }
+
+        if span.service != self.tracer_service {
+            vec_insert(
+                &mut span.meta,
+                self.str_base_service.clone(),
+                self.tracer_service.clone(),
+            );
+        }
+
+        vec_insert(
+            &mut span.meta,
+            self.str_language.clone(),
+            self.tracer_language.clone(),
+        );
+        vec_insert(
+            &mut span.metrics,
+            self.str_process_id.clone(),
+            f64::from(self.pid),
+        );
+
+        if let Some(trace) = self.traces.get(&span.trace_id) {
+            if let Some(origin) = trace.origin.clone() {
+                vec_insert(&mut span.meta, self.str_origin.clone(), origin);
+            }
+        }
+    }
+
+    pub fn flush_change_buffer(&mut self) -> Result<()> {
+        let mut index = 0;
+        let mut count = self.change_buffer.read::<u64>(&mut index)? as u32;
+
+        let mut cached_slot: u32 = u32::MAX;
+        let mut cached_span_ptr: *mut Span<T> = std::ptr::null_mut();
+        let mut cached_deferred_meta: *mut Vec<(u32, u32)> = std::ptr::null_mut();
+        let mut cached_deferred_metrics: *mut Vec<(u32, f64)> = std::ptr::null_mut();
+
+        while count > 0 {
+            let op = BufferedOperation::from_buf(&self.change_buffer, &mut index)?;
+
+            match op.opcode {
+                OpCode::Create | OpCode::CreateSpan | OpCode::CreateSpanFull => {
+                    cached_span_ptr = std::ptr::null_mut();
+                    cached_slot = u32::MAX;
+                    cached_deferred_meta = std::ptr::null_mut();
+                    cached_deferred_metrics = std::ptr::null_mut();
+                    self.interpret_operation(&mut index, &op)?;
+                }
+                _ => {
+                    self.interpret_operation_cached(
+                        &mut index,
+                        &op,
+                        &mut cached_slot,
+                        &mut cached_span_ptr,
+                        &mut cached_deferred_meta,
+                        &mut cached_deferred_metrics,
+                    )?;
+                }
+            }
+            count -= 1;
+        }
+
+        self.change_buffer.write_u32(0, 0)?;
+        self.change_buffer.write_u32(4, 0)?;
+
+        Ok(())
+    }
+
+    fn interpret_operation_cached(
+        &mut self,
+        index: &mut usize,
+        op: &BufferedOperation,
+        cached_slot: &mut u32,
+        cached_span_ptr: &mut *mut Span<T>,
+        cached_deferred_meta: &mut *mut Vec<(u32, u32)>,
+        cached_deferred_metrics: &mut *mut Vec<(u32, f64)>,
+    ) -> Result<()> {
+        let span_ptr = if op.slot_index == *cached_slot && !cached_span_ptr.is_null() {
+            *cached_span_ptr
+        } else {
+            let slot = op.slot_index as usize;
+            let span = self
+                .spans
+                .get_mut(slot)
+                .and_then(|opt| opt.as_mut())
+                .ok_or(ChangeBufferError::SpanNotFound(op.slot_index as u64))?
+                as *mut Span<T>;
+            *cached_slot = op.slot_index;
+            *cached_span_ptr = span;
+            *cached_deferred_meta = &mut self.deferred_meta[slot] as *mut Vec<(u32, u32)>;
+            *cached_deferred_metrics = &mut self.deferred_metrics[slot] as *mut Vec<(u32, f64)>;
+            span
+        };
+
+        // SAFETY: span_ptr is valid — it was obtained from self.spans above
+        // or from the cache which was set in a previous iteration of the same loop.
+        // self.spans is not modified during this function (no inserts/removes).
+        let span = unsafe { &mut *span_ptr };
+
+        match op.opcode {
+            OpCode::SetMetaAttr => {
+                let key_id: u32 = self.get_num_arg(index)?;
+                let val_id: u32 = self.get_num_arg(index)?;
+                let dm = unsafe { &mut **cached_deferred_meta };
+                deferred_meta_insert(dm, key_id, val_id);
+            }
+            OpCode::SetMetricAttr => {
+                let key_id: u32 = self.get_num_arg(index)?;
+                let val: f64 = self.get_num_arg(index)?;
+                let dm = unsafe { &mut **cached_deferred_metrics };
+                deferred_metric_insert(dm, key_id, val);
+            }
+            OpCode::SetServiceName => {
+                span.service = unsafe { self.get_string_arg_unchecked(index) };
+            }
+            OpCode::SetResourceName => {
+                span.resource = unsafe { self.get_string_arg_unchecked(index) };
+            }
+            OpCode::SetError => {
+                span.error = unsafe { self.get_num_arg_unchecked(index) };
+            }
+            OpCode::SetStart => {
+                span.start = unsafe { self.get_num_arg_unchecked(index) };
+            }
+            OpCode::SetDuration => {
+                span.duration = unsafe { self.get_num_arg_unchecked(index) };
+            }
+            OpCode::SetType => {
+                span.r#type = unsafe { self.get_string_arg_unchecked(index) };
+            }
+            OpCode::SetName => {
+                span.name = unsafe { self.get_string_arg_unchecked(index) };
+            }
+            OpCode::SetTraceMetaAttr => {
+                let name = self.get_string_arg(index)?;
+                let val = self.get_string_arg(index)?;
+                let trace_id = span.trace_id;
+                if let Some(trace) = self.traces.get_mut(&trace_id) {
+                    vec_insert(&mut trace.meta, name, val);
+                }
+            }
+            OpCode::SetTraceMetricsAttr => {
+                let name = self.get_string_arg(index)?;
+                let val = self.get_num_arg(index)?;
+                let trace_id = span.trace_id;
+                if let Some(trace) = self.traces.get_mut(&trace_id) {
+                    vec_insert(&mut trace.metrics, name, val);
+                }
+            }
+            OpCode::SetTraceOrigin => {
+                let origin = self.get_string_arg(index)?;
+                let trace_id = span.trace_id;
+                if let Some(trace) = self.traces.get_mut(&trace_id) {
+                    trace.origin = Some(origin);
+                }
+            }
+            OpCode::BatchSetMeta => {
+                let count: u32 = self.get_num_arg(index)?;
+                let dm = unsafe { &mut **cached_deferred_meta };
+                for _ in 0..count {
+                    let key_id: u32 = self.get_num_arg(index)?;
+                    let val_id: u32 = self.get_num_arg(index)?;
+                    deferred_meta_insert(dm, key_id, val_id);
+                }
+            }
+            OpCode::BatchSetMetric => {
+                let count: u32 = self.get_num_arg(index)?;
+                let dm = unsafe { &mut **cached_deferred_metrics };
+                for _ in 0..count {
+                    let key_id: u32 = self.get_num_arg(index)?;
+                    let val: f64 = self.get_num_arg(index)?;
+                    deferred_metric_insert(dm, key_id, val);
+                }
+            }
+            OpCode::Create | OpCode::CreateSpan | OpCode::CreateSpanFull => unreachable!(),
+        }
+
+        Ok(())
+    }
+
+    fn get_string_arg(&self, index: &mut usize) -> Result<T::Text> {
+        let num: u32 = self.get_num_arg(index)?;
+        self.string_table
+            .get(num as usize)
+            .and_then(|opt| opt.clone())
+            .ok_or(ChangeBufferError::StringNotFound(num))
+    }
+
+    #[inline(always)]
+    unsafe fn get_string_arg_unchecked(&self, index: &mut usize) -> T::Text {
+        let num: u32 = self.change_buffer.read_unchecked(index);
+        self.string_table
+            .get_unchecked(num as usize)
+            .clone()
+            .unwrap_unchecked()
+    }
+
+    fn get_num_arg<U: Copy + FromBytes>(&self, index: &mut usize) -> Result<U> {
+        self.change_buffer.read(index)
+    }
+
+    #[inline(always)]
+    unsafe fn get_num_arg_unchecked<U: Copy + FromBytes>(&self, index: &mut usize) -> U {
+        self.change_buffer.read_unchecked(index)
+    }
+
+    fn get_mut_span(&mut self, slot: u32) -> Result<&mut Span<T>> {
+        self.spans
+            .get_mut(slot as usize)
+            .and_then(|opt| opt.as_mut())
+            .ok_or(ChangeBufferError::SpanNotFound(slot as u64))
+    }
+
+    pub fn get_span(&self, slot: u32) -> Result<&Span<T>> {
+        self.spans
+            .get(slot as usize)
+            .and_then(|opt| opt.as_ref())
+            .ok_or(ChangeBufferError::SpanNotFound(slot as u64))
+    }
+
+    pub fn get_trace(&self, id: &u128) -> Option<&Trace<T::Text>> {
+        self.traces.get(id)
+    }
+
+    pub fn alloc_header(&mut self) -> u32 {
+        if let Some(idx) = self.header_free_list.pop() {
+            self.span_headers[idx as usize] = SpanHeader::default();
+            self.span_headers[idx as usize].active = 1;
+            idx
+        } else {
+            let idx = self.span_headers.len() as u32;
+            let mut header = SpanHeader::default();
+            header.active = 1;
+            self.span_headers.push(header);
+            idx
+        }
+    }
+
+    pub fn materialize_header(&mut self, header_idx: u32) -> Result<u64> {
+        let h = &self.span_headers[header_idx as usize];
+        if h.active == 0 {
+            return Err(ChangeBufferError::SpanNotFound(0));
+        }
+        let span_id = h.span_id;
+        let trace_id = (h.trace_id_hi as u128) << 64 | h.trace_id_lo as u128;
+        let parent_id = h.parent_id;
+
+        let mut span = new_span_pooled(&mut self.span_pool, span_id, parent_id, trace_id);
+        span.start = h.start;
+        span.duration = h.duration;
+        span.error = h.error;
+
+        if let Some(name) = self.get_string(h.name_id) {
+            span.name = name;
+        }
+        if let Some(service) = self.get_string(h.service_id) {
+            span.service = service;
+        }
+        if let Some(resource) = self.get_string(h.resource_id) {
+            span.resource = resource;
+        }
+        if let Some(r#type) = self.get_string(h.type_id) {
+            span.r#type = r#type;
+        }
+
+        self.apply_default_meta(&mut span);
+
+        let mut found_slot = None;
+        for (i, opt) in self.spans.iter().enumerate() {
+            if let Some(ref s) = opt {
+                if s.span_id == span_id {
+                    found_slot = Some(i);
+                    break;
+                }
+            }
+        }
+
+        if let Some(slot) = found_slot {
+            #[allow(clippy::unwrap_used)]
+            let existing = self.spans[slot].as_mut().unwrap();
+            existing.start = span.start;
+            existing.duration = span.duration;
+            existing.error = span.error;
+            existing.name = span.name;
+            existing.service = span.service;
+            existing.resource = span.resource;
+            existing.r#type = span.r#type;
+            existing.trace_id = span.trace_id;
+            existing.parent_id = span.parent_id;
+            for (k, v) in &self.default_meta {
+                vec_insert(&mut existing.meta, k.clone(), v.clone());
+            }
+        } else {
+            let slot_idx = self.spans.len();
+            self.spans.push(Some(span));
+            if slot_idx >= self.deferred_meta.len() {
+                self.deferred_meta.resize_with(slot_idx + 1, Vec::new);
+                self.deferred_metrics.resize_with(slot_idx + 1, Vec::new);
+            }
+        }
+
+        self.traces.get_or_insert_default(trace_id).span_count += 1;
+
+        self.span_headers[header_idx as usize].active = 0;
+        self.header_free_list.push(header_idx);
+
+        Ok(span_id)
+    }
+
+    pub fn span_mut(&mut self, slot: &u32) -> Result<&mut Span<T>> {
+        self.spans
+            .get_mut(*slot as usize)
+            .and_then(|opt| opt.as_mut())
+            .ok_or(ChangeBufferError::SpanNotFound(*slot as u64))
+    }
+
+    pub fn get_string(&self, id: u32) -> Option<T::Text> {
+        self.string_table
+            .get(id as usize)
+            .and_then(|opt| opt.clone())
+    }
+
+    pub fn set_default_meta(&mut self, tags: Vec<(T::Text, T::Text)>) {
+        self.default_meta = tags;
+    }
+
+    fn apply_default_meta(&self, span: &mut Span<T>) {
+        for (key, value) in &self.default_meta {
+            vec_insert(&mut span.meta, key.clone(), value.clone());
+        }
+    }
+
+    fn materialize_deferred_tags(&mut self, slot: u32, span: &mut Span<T>) {
+        let idx = slot as usize;
+        if idx < self.deferred_meta.len() {
+            let pairs: Vec<(u32, u32)> = self.deferred_meta[idx].drain(..).collect();
+            for (key_id, val_id) in pairs {
+                if let (Some(key), Some(val)) = (self.get_string(key_id), self.get_string(val_id))
+                {
+                    vec_insert(&mut span.meta, key, val);
+                }
+            }
+        }
+        if idx < self.deferred_metrics.len() {
+            let pairs: Vec<(u32, f64)> = self.deferred_metrics[idx].drain(..).collect();
+            for (key_id, val) in pairs {
+                if let Some(key) = self.get_string(key_id) {
+                    vec_insert(&mut span.metrics, key, val);
+                }
+            }
+        }
+    }
+
+    pub fn materialize_slot(&mut self, slot: u32) {
+        let idx = slot as usize;
+        let mut meta_pairs: Vec<(T::Text, T::Text)> = Vec::new();
+        let mut metric_pairs: Vec<(T::Text, f64)> = Vec::new();
+
+        if idx < self.deferred_meta.len() {
+            for &(key_id, val_id) in &self.deferred_meta[idx] {
+                if let (Some(key), Some(val)) = (self.get_string(key_id), self.get_string(val_id))
+                {
+                    meta_pairs.push((key, val));
+                }
+            }
+            self.deferred_meta[idx].clear();
+        }
+        if idx < self.deferred_metrics.len() {
+            for &(key_id, val) in &self.deferred_metrics[idx] {
+                if let Some(key) = self.get_string(key_id) {
+                    metric_pairs.push((key, val));
+                }
+            }
+            self.deferred_metrics[idx].clear();
+        }
+
+        if let Some(Some(span)) = self.spans.get_mut(idx) {
+            for (k, v) in meta_pairs {
+                vec_insert(&mut span.meta, k, v);
+            }
+            for (k, v) in metric_pairs {
+                vec_insert(&mut span.metrics, k, v);
+            }
+        }
+    }
+
+    fn ensure_slot(&mut self, slot: u32) {
+        let idx = slot as usize;
+        if idx >= self.spans.len() {
+            self.spans.resize_with(idx + 1, || None);
+        }
+        if idx >= self.deferred_meta.len() {
+            self.deferred_meta.resize_with(idx + 1, Vec::new);
+            self.deferred_metrics.resize_with(idx + 1, Vec::new);
+        }
+    }
+
+    fn interpret_operation(&mut self, index: &mut usize, op: &BufferedOperation) -> Result<()> {
+        match op.opcode {
+            OpCode::Create => {
+                let span_id: u64 = self.change_buffer.read(index)?;
+                let trace_id: u128 = self.change_buffer.read(index)?;
+                let parent_id = self.get_num_arg(index)?;
+                let mut span =
+                    new_span_pooled(&mut self.span_pool, span_id, parent_id, trace_id);
+                self.apply_default_meta(&mut span);
+                self.ensure_slot(op.slot_index);
+                self.spans[op.slot_index as usize] = Some(span);
+                self.deferred_meta[op.slot_index as usize].clear();
+                self.deferred_metrics[op.slot_index as usize].clear();
+                self.traces.get_or_insert_default(trace_id).span_count += 1;
+            }
+            OpCode::SetMetaAttr => {
+                let key_id: u32 = self.get_num_arg(index)?;
+                let val_id: u32 = self.get_num_arg(index)?;
+                let idx = op.slot_index as usize;
+                if idx < self.deferred_meta.len() {
+                    deferred_meta_insert(&mut self.deferred_meta[idx], key_id, val_id);
+                }
+            }
+            OpCode::SetMetricAttr => {
+                let key_id: u32 = self.get_num_arg(index)?;
+                let val: f64 = self.get_num_arg(index)?;
+                let idx = op.slot_index as usize;
+                if idx < self.deferred_metrics.len() {
+                    deferred_metric_insert(&mut self.deferred_metrics[idx], key_id, val);
+                }
+            }
+            OpCode::SetServiceName => {
+                self.get_mut_span(op.slot_index)?.service = self.get_string_arg(index)?;
+            }
+            OpCode::SetResourceName => {
+                self.get_mut_span(op.slot_index)?.resource = self.get_string_arg(index)?;
+            }
+            OpCode::SetError => {
+                self.get_mut_span(op.slot_index)?.error = self.get_num_arg(index)?;
+            }
+            OpCode::SetStart => {
+                self.get_mut_span(op.slot_index)?.start = self.get_num_arg(index)?;
+            }
+            OpCode::SetDuration => {
+                self.get_mut_span(op.slot_index)?.duration = self.get_num_arg(index)?;
+            }
+            OpCode::SetType => {
+                self.get_mut_span(op.slot_index)?.r#type = self.get_string_arg(index)?;
+            }
+            OpCode::SetName => {
+                self.get_mut_span(op.slot_index)?.name = self.get_string_arg(index)?;
+            }
+            OpCode::SetTraceMetaAttr => {
+                let name = self.get_string_arg(index)?;
+                let val = self.get_string_arg(index)?;
+                let trace_id = self.get_span(op.slot_index)?.trace_id;
+                if let Some(trace) = self.traces.get_mut(&trace_id) {
+                    vec_insert(&mut trace.meta, name, val);
+                }
+            }
+            OpCode::SetTraceMetricsAttr => {
+                let name = self.get_string_arg(index)?;
+                let val = self.get_num_arg(index)?;
+                let trace_id = self.get_span(op.slot_index)?.trace_id;
+                if let Some(trace) = self.traces.get_mut(&trace_id) {
+                    vec_insert(&mut trace.metrics, name, val);
+                }
+            }
+            OpCode::SetTraceOrigin => {
+                let origin = self.get_string_arg(index)?;
+                let trace_id = self.get_span(op.slot_index)?.trace_id;
+                if let Some(trace) = self.traces.get_mut(&trace_id) {
+                    trace.origin = Some(origin);
+                }
+            }
+            OpCode::CreateSpan => {
+                let span_id: u64 = self.change_buffer.read(index)?;
+                let trace_id: u128 = self.change_buffer.read(index)?;
+                let parent_id: u64 = self.get_num_arg(index)?;
+                let name = self.get_string_arg(index)?;
+                let start: i64 = self.get_num_arg(index)?;
+                let mut span =
+                    new_span_pooled(&mut self.span_pool, span_id, parent_id, trace_id);
+                span.name = name;
+                span.start = start;
+                self.apply_default_meta(&mut span);
+                self.ensure_slot(op.slot_index);
+                self.spans[op.slot_index as usize] = Some(span);
+                self.deferred_meta[op.slot_index as usize].clear();
+                self.deferred_metrics[op.slot_index as usize].clear();
+                self.traces.get_or_insert_default(trace_id).span_count += 1;
+            }
+            OpCode::CreateSpanFull => {
+                let span_id: u64 = self.change_buffer.read(index)?;
+                let trace_id: u128 = self.change_buffer.read(index)?;
+                let parent_id: u64 = self.get_num_arg(index)?;
+                let name = self.get_string_arg(index)?;
+                let service = self.get_string_arg(index)?;
+                let resource = self.get_string_arg(index)?;
+                let r#type = self.get_string_arg(index)?;
+                let start: i64 = self.get_num_arg(index)?;
+                let mut span =
+                    new_span_pooled(&mut self.span_pool, span_id, parent_id, trace_id);
+                span.name = name;
+                span.service = service;
+                span.resource = resource;
+                span.r#type = r#type;
+                span.start = start;
+                self.apply_default_meta(&mut span);
+                self.ensure_slot(op.slot_index);
+                self.spans[op.slot_index as usize] = Some(span);
+                self.deferred_meta[op.slot_index as usize].clear();
+                self.deferred_metrics[op.slot_index as usize].clear();
+                self.traces.get_or_insert_default(trace_id).span_count += 1;
+            }
+            OpCode::BatchSetMeta => {
+                let count: u32 = self.get_num_arg(index)?;
+                let idx = op.slot_index as usize;
+                for _ in 0..count {
+                    let key_id: u32 = self.get_num_arg(index)?;
+                    let val_id: u32 = self.get_num_arg(index)?;
+                    if idx < self.deferred_meta.len() {
+                        deferred_meta_insert(&mut self.deferred_meta[idx], key_id, val_id);
+                    }
+                }
+            }
+            OpCode::BatchSetMetric => {
+                let count: u32 = self.get_num_arg(index)?;
+                let idx = op.slot_index as usize;
+                for _ in 0..count {
+                    let key_id: u32 = self.get_num_arg(index)?;
+                    let val: f64 = self.get_num_arg(index)?;
+                    if idx < self.deferred_metrics.len() {
+                        deferred_metric_insert(&mut self.deferred_metrics[idx], key_id, val);
+                    }
+                }
+            }
+        };
+
+        Ok(())
+    }
+
+    pub fn string_table_insert_one(&mut self, key: u32, val: T::Text) {
+        let idx = key as usize;
+        if idx >= self.string_table.len() {
+            self.string_table.resize_with(idx + 1, || None);
+        }
+        self.string_table[idx] = Some(val);
+    }
+
+    pub fn string_table_evict_one(&mut self, key: u32) {
+        let idx = key as usize;
+        if idx < self.string_table.len() {
+            self.string_table[idx] = None;
+        }
+    }
 }

--- a/libdd-trace-utils/src/change_buffer/operation.rs
+++ b/libdd-trace-utils/src/change_buffer/operation.rs
@@ -88,7 +88,12 @@ mod tests {
     ///
     /// The original mutable borrowed vec must survive for the lifetime of the change buffer.
     unsafe fn change_buffer_from_vec(buffer: &mut Vec<u8>) -> ChangeBuffer {
-        unsafe { ChangeBuffer::from_raw_parts(buffer.as_mut_ptr(), buffer.len()) }
+        unsafe {
+            ChangeBuffer::from_raw_parts(
+                std::ptr::NonNull::new(buffer.as_mut_ptr()).unwrap(),
+                buffer.len(),
+            )
+        }
     }
 
     #[test]

--- a/libdd-trace-utils/src/change_buffer/trace.rs
+++ b/libdd-trace-utils/src/change_buffer/trace.rs
@@ -1,10 +1,12 @@
 // Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::span::vec_map::VecMap;
+
 #[derive(Default)]
 pub struct Trace<T> {
-    pub meta: Vec<(T, T)>,
-    pub metrics: Vec<(T, f64)>,
+    pub meta: VecMap<T, T>,
+    pub metrics: VecMap<T, f64>,
     pub origin: Option<T>,
     pub sampling_rule_decision: Option<f64>,
     pub sampling_limit_decision: Option<f64>,

--- a/libdd-trace-utils/src/span/vec_map.rs
+++ b/libdd-trace-utils/src/span/vec_map.rs
@@ -183,6 +183,19 @@ impl<K, V> VecMap<K, V> {
     pub fn is_deduped(&self) -> bool {
         self.deduped
     }
+
+    #[inline]
+    pub fn clear(&mut self) {
+        self.data.clear()
+    }
+
+    #[inline]
+    pub fn drain<R: std::ops::RangeBounds<usize>>(
+        &mut self,
+        range: R,
+    ) -> std::vec::Drain<'_, (K, V)> {
+        self.data.drain(range)
+    }
 }
 
 impl<K: Eq + Hash, V> VecMap<K, V> {


### PR DESCRIPTION
# What does this PR do?

This PR backports the change buffer implementation required for dd-trace-js adoption of native spans. Follow-up of #2046.

The change buffer is a contiguous region of memory where span operations are encoded from the JS runtime, similar to a byte code. The implementation decode all those span events and reconstruct the corresponding span objects.

# Motivation

Required to land native spans dd-trace-js.

# How to test the change?

tests included.