### PR TITLE
fix(sampling): disable libdd-common default features

### DIFF
--- a/libdd-sampling/Cargo.toml
+++ b/libdd-sampling/Cargo.toml
@@ -32,7 +32,7 @@ required-features = ["bench-internals"]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 lru = "0.16.3"
-libdd-common = { path = "../libdd-common", version = "4.1.0" }
+libdd-common = { path = "../libdd-common", version = "4.1.0", default-features = false }
 libdd-trace-utils = { path = "../libdd-trace-utils", version = "5.0.0", optional = true }
 
 [features]


### PR DESCRIPTION
# What does this PR do?

Set `default-features = false` flag for `libdd-common` dep

# Motivation

`libdd-common`'s defaults include `https`, which expands to ` rustls` + `hyper-rustls` + `tokio-rustls` + `rustls-native-certs` + `ring`. 
So `libdd-sampling`'s dep declaration silently pulls the whole TLS stack into every build.

