### PR TITLE
fix(ci): pin cargo version in release-proposal-test.yml

### DIFF
--- a/.github/workflows/release-proposal-test.yml
+++ b/.github/workflows/release-proposal-test.yml
@@ -65,7 +65,10 @@ jobs:
             echo "Skipping cargo package: no crates had a version bump vs the base ref (PKG_ARGS is empty)."
             exit 0
           fi
-          cargo package "${PKG_ARGS[@]}" --all-features
+          # cargo 1.92+ required: earlier versions (incl. the workspace MSRV 1.87) fail to
+          # resolve sibling crates by version requirement when those versions are not yet on
+          # crates.io
+          cargo +1.92.0 package "${PKG_ARGS[@]}" --all-features
           echo "upload_artifact=true" >> "$GITHUB_OUTPUT"
 
       - name: Upload crates


### PR DESCRIPTION
# What does this PR do?

Pin cargo version to fix problems with `cargo package` after setting rust version `1.87.0` in `rust-toolchain.toml`