### PR TITLE
chore: bump workspace version to 35.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,7 +695,7 @@ checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "build_common"
-version = "34.0.0"
+version = "35.0.0"
 dependencies = [
  "cbindgen",
  "serde",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "builder"
-version = "34.0.0"
+version = "35.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1382,7 +1382,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-ffe-test-suite"
-version = "34.0.0"
+version = "35.0.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-replayer"
-version = "34.0.0"
+version = "35.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2911,7 +2911,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-common-ffi"
-version = "34.0.0"
+version = "35.0.0"
 dependencies = [
  "anyhow",
  "assert_no_alloc",
@@ -2964,7 +2964,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-crashtracker-ffi"
-version = "34.0.0"
+version = "35.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -3025,7 +3025,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-data-pipeline-ffi"
-version = "34.0.0"
+version = "35.0.0"
 dependencies = [
  "build_common",
  "httpmock",
@@ -3050,7 +3050,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-ddsketch-ffi"
-version = "34.0.0"
+version = "35.0.0"
 dependencies = [
  "build_common",
  "libdd-common-ffi",
@@ -3072,7 +3072,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-http-client"
-version = "34.0.0"
+version = "35.0.0"
 dependencies = [
  "bytes",
  "fastrand",
@@ -3143,7 +3143,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-log-ffi"
-version = "34.0.0"
+version = "35.0.0"
 dependencies = [
  "build_common",
  "libdd-common-ffi",
@@ -3279,7 +3279,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-shared-runtime-ffi"
-version = "34.0.0"
+version = "35.0.0"
 dependencies = [
  "build_common",
  "libdd-shared-runtime",
@@ -3316,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-telemetry-ffi"
-version = "34.0.0"
+version = "35.0.0"
 dependencies = [
  "build_common",
  "function_name",
@@ -5579,7 +5579,7 @@ dependencies = [
 
 [[package]]
 name = "symbolizer-ffi"
-version = "34.0.0"
+version = "35.0.0"
 dependencies = [
  "blazesym-c",
  "build_common",
@@ -6021,7 +6021,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "34.0.0"
+version = "35.0.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.87.0"
 edition = "2021"
-version = "34.0.0"
+version = "35.0.0"
 license = "Apache-2.0"
 authors = ["Datadog Inc. <info@datadoghq.com>"]
 


### PR DESCRIPTION
#What does this PR do?

  Bumps the libdatadog workspace version from 34.0.0 → 35.0.0 (Cargo.toml + regenerated Cargo.lock) to cut the 35.0.0 release.

  Breaking changes affecting the FFI layer (34.0.0 → 35.0.0)

  1. Tracer FFI: response body now returned as ByteSlice (#2029) — feat!
  - ddog_trace_exporter_response_get_body no longer takes an out_len: *mut usize out-parameter and returns *const u8. It now returns a single ByteSlice value, matching the slice
  conventions in libdd-common-ffi.
  - Tracer constructor functions now validate nullable pointers and return ErrorCode::InvalidArgument instead of risking UB; panics across the boundary are caught and surfaced as
  ErrorCode::Panic.
  - C consumers (e.g. dd-trace-rb) can now reuse the standard read_ddogerr_string_and_drop / get_error_details_and_drop helpers from datadog_ruby_common.h.
  - Action for callers: drop the out_len argument and read length/pointer from the returned ByteSlice.

  2. Crashtracker: error.threads flattened to []ThreadData (#2054) — fix(crashtracking)!
  - The crash-report payload now emits error.threads as an optional flat array of thread objects (unified runtime stack schema 1.8) instead of the previous nested threads object.
  - This is a wire/payload-format change consumed by downstream pipelines and the product UI.
  - Action for callers: consumers parsing crash reports must update to the 1.8 thread layout.

  Other breaking changes since 34.0.0 (Rust API, not C ABI)

  These are !-marked breaking changes in libdd-trace-utils that affect Rust consumers of the library but do not change the C FFI surface or generated headers:

  - feat(trace-utils)!: introduce VecMap datastructure (#2022) — adds a HashMap replacement optimized for span construction (not yet wired into span fields).
  - feat(trace-utils)!: add from_string to span text (#2011) — requires From<String> on SpanText and switches SpanSlice to Cow<str> to allow span-field mutation/normalization.

  Notable new FFI surface (additive)

  - feat: Add FFI for trace exporter (#1952) — new tracer FFI surface in libdd-data-pipeline-ffi (the change above, #2029, refines it).
