### PR TITLE
fix: memory ordering issue in otel thread ctx

### DIFF
--- a/libdd-otel-thread-ctx/src/lib.rs
+++ b/libdd-otel-thread-ctx/src/lib.rs
@@ -429,15 +429,13 @@ pub mod linux {
                     compiler_fence(Ordering::SeqCst);
                     current.valid.store(1, Ordering::Relaxed);
                 } else {
+                    let ctxt = ThreadContext::new(trace_id, span_id, local_root_span_id, attrs)
+                        .into_ptr()
+                        .as_ptr();
                     // No need for `AcqRel`, see [^tls-slot-ordering].
                     compiler_fence(Ordering::Release);
                     // `ThreadContext::new` already initialises `valid = 1`.
-                    let _ = Self::swap(
-                        slot,
-                        ThreadContext::new(trace_id, span_id, local_root_span_id, attrs)
-                            .into_ptr()
-                            .as_ptr(),
-                    );
+                    let _ = Self::swap(slot, ctxt);
                 }
             })
         }


### PR DESCRIPTION
# What does this PR do?

Fix a memory ordering issue in the OTel thread context publication.

# Motivation

External review of this code (upstreamed to Polar Signals) spotted this error. As originally written, it's not guaranteed that a reader of the TLS slot see a fully initialized context, because the `ThreadContext::new` method is called _after_ the fence. We want that context initialization happens-before storing the pointer in the TLS slot from the reader's perspective, which requires to move context initialization before the fence.

# Additional Notes

N/A

# How to test the change?

N/A