### PR TITLE
revert!: add from_string to span text (#2011)

### DIFF
--- a/libdd-data-pipeline/src/trace_exporter/trace_serializer.rs
+++ b/libdd-data-pipeline/src/trace_exporter/trace_serializer.rs
@@ -292,10 +292,10 @@ mod tests {
         let original_span = &original_traces[0][0];
         let deserialized_span = &deserialized_traces[0][0];
 
-        assert_eq!(original_span.name, deserialized_span.name.as_ref());
-        assert_eq!(original_span.service, deserialized_span.service.as_ref());
-        assert_eq!(original_span.resource, deserialized_span.resource.as_ref());
-        assert_eq!(original_span.r#type, deserialized_span.r#type.as_ref());
+        assert_eq!(original_span.name, deserialized_span.name);
+        assert_eq!(original_span.service, deserialized_span.service);
+        assert_eq!(original_span.resource, deserialized_span.resource);
+        assert_eq!(original_span.r#type, deserialized_span.r#type);
         assert_eq!(original_span.start, deserialized_span.start);
         assert_eq!(original_span.duration, deserialized_span.duration);
         assert_eq!(original_span.span_id, deserialized_span.span_id);
@@ -327,10 +327,10 @@ mod tests {
         let original_span = &original_traces[0][0];
         let deserialized_span = &deserialized_traces[0][0];
 
-        assert_eq!(original_span.name, deserialized_span.name.as_ref());
-        assert_eq!(original_span.service, deserialized_span.service.as_ref());
-        assert_eq!(original_span.resource, deserialized_span.resource.as_ref());
-        assert_eq!(original_span.r#type, deserialized_span.r#type.as_ref());
+        assert_eq!(original_span.name, deserialized_span.name);
+        assert_eq!(original_span.service, deserialized_span.service);
+        assert_eq!(original_span.resource, deserialized_span.resource);
+        assert_eq!(original_span.r#type, deserialized_span.r#type);
         assert_eq!(original_span.start, deserialized_span.start);
         assert_eq!(original_span.duration, deserialized_span.duration);
         assert_eq!(original_span.span_id, deserialized_span.span_id);

--- a/libdd-sampling/benches/sampling_bench.rs
+++ b/libdd-sampling/benches/sampling_bench.rs
@@ -31,9 +31,9 @@ fn make_span(
     resource: &'static str,
 ) -> Span<SliceData<'static>> {
     Span {
-        name: name.into(),
-        service: service.into(),
-        resource: resource.into(),
+        name,
+        service,
+        resource,
         trace_id: 0x1234_5678_9012_3456_7890_1234_5678_9012_u128,
         ..Default::default()
     }
@@ -170,7 +170,7 @@ fn make_configs() -> Vec<BenchConfig> {
         // 9. Tag rule — matching
         {
             let mut span = make_span("test-operation", "my-service", "test");
-            span.meta.insert("environment".into(), "production".into());
+            span.meta.insert("environment", "production");
             BenchConfig {
                 name: "tag_rule_matching",
                 sampler: DatadogSampler::new(
@@ -194,7 +194,7 @@ fn make_configs() -> Vec<BenchConfig> {
         // 10. Tag rule — not matching
         {
             let mut span = make_span("test-operation", "my-service", "test");
-            span.meta.insert("environment".into(), "staging".into());
+            span.meta.insert("environment", "staging");
             BenchConfig {
                 name: "tag_rule_not_matching",
                 sampler: DatadogSampler::new(
@@ -218,10 +218,9 @@ fn make_configs() -> Vec<BenchConfig> {
         // 11. Complex rule — all fields matching
         {
             let mut span = make_span("http.request", "api-service", "/api/v1/users");
-            span.meta.insert("environment".into(), "production".into());
-            span.meta.insert("http.method".into(), "POST".into());
-            span.meta
-                .insert("http.route".into(), "/api/v1/users".into());
+            span.meta.insert("environment", "production");
+            span.meta.insert("http.method", "POST");
+            span.meta.insert("http.route", "/api/v1/users");
             BenchConfig {
                 name: "complex_rule_matching",
                 sampler: DatadogSampler::new(
@@ -245,9 +244,9 @@ fn make_configs() -> Vec<BenchConfig> {
         // 12. Complex rule — partial match (resource doesn't match)
         {
             let mut span = make_span("http.request", "api-service", "/health");
-            span.meta.insert("environment".into(), "staging".into());
-            span.meta.insert("http.method".into(), "POST".into());
-            span.meta.insert("http.route".into(), "/health".into());
+            span.meta.insert("environment", "staging");
+            span.meta.insert("http.method", "POST");
+            span.meta.insert("http.route", "/health");
             BenchConfig {
                 name: "complex_rule_partial_match",
                 sampler: DatadogSampler::new(
@@ -300,7 +299,7 @@ fn make_configs() -> Vec<BenchConfig> {
         {
             let mut span = make_span("test-operation", "my-service", "test");
             for (k, v) in MANY_ATTR_PAIRS {
-                span.meta.insert((*k).into(), (*v).into());
+                span.meta.insert(k, v);
             }
             BenchConfig {
                 name: "many_attributes_tag_rule",

--- a/libdd-sampling/src/v04_span.rs
+++ b/libdd-sampling/src/v04_span.rs
@@ -17,8 +17,8 @@
 //! use libdd_trace_utils::span::{v04::Span, SliceData};
 //!
 //! let mut span = Span::<SliceData<'_>>::default();
-//! span.name = "my-operation".into();
-//! span.service = "my-service".into();
+//! span.name = "my-operation";
+//! span.service = "my-service";
 //! span.trace_id = 1234567890u128;
 //!
 //! let sampler = DatadogSampler::new(vec![], 100);
@@ -260,9 +260,9 @@ mod tests {
         resource: &'static str,
     ) -> Span<SliceData<'static>> {
         Span {
-            name: name.into(),
-            service: service.into(),
-            resource: resource.into(),
+            name,
+            service,
+            resource,
             ..Default::default()
         }
     }
@@ -324,9 +324,8 @@ mod tests {
     #[test]
     fn test_v04_span_properties_with_meta() {
         let mut span = make_span("op", "svc", "res");
-        span.meta.insert("env".into(), "staging".into());
-        span.meta
-            .insert("http.url".into(), "https://example.com".into());
+        span.meta.insert("env", "staging");
+        span.meta.insert("http.url", "https://example.com");
 
         let props = V04SpanProperties::from_span(&span);
         assert_eq!(props.env(), "staging");
@@ -339,7 +338,7 @@ mod tests {
     #[test]
     fn test_v04_span_properties_status_code_from_metrics() {
         let mut span = make_span("op", "svc", "res");
-        span.metrics.insert("http.status_code".into(), 200.0);
+        span.metrics.insert("http.status_code", 200.0);
 
         let props = V04SpanProperties::from_span(&span);
         assert_eq!(props.status_code(), Some(200));
@@ -349,7 +348,7 @@ mod tests {
     #[test]
     fn test_v04_span_properties_status_code_from_meta() {
         let mut span = make_span("op", "svc", "res");
-        span.meta.insert("http.status_code".into(), "404".into());
+        span.meta.insert("http.status_code", "404");
 
         let props = V04SpanProperties::from_span(&span);
         assert_eq!(props.status_code(), Some(404));
@@ -358,7 +357,7 @@ mod tests {
     #[test]
     fn test_v04_span_properties_metrics_in_attributes() {
         let mut span = make_span("op", "svc", "res");
-        span.metrics.insert("_sampling_priority_v1".into(), 1.0);
+        span.metrics.insert("_sampling_priority_v1", 1.0);
 
         let props = V04SpanProperties::from_span(&span);
         let attr = props
@@ -399,7 +398,7 @@ mod tests {
         // compiler resolves correctly.
         let sampler = DatadogSampler::new(vec![], 100);
         let mut span = make_span("op", "my-service", "my-resource");
-        span.meta.insert("env".into(), "prod".into());
+        span.meta.insert("env", "prod");
         let data = V04SamplingData {
             is_parent_sampled: None,
             span: &span,
@@ -517,8 +516,8 @@ mod tests {
     fn test_integration_tags_apply_to_span() {
         let sampler = DatadogSampler::new(vec![], 100);
         let span = Span::<SliceData<'static>> {
-            name: "op".into(),
-            service: "svc".into(),
+            name: "op",
+            service: "svc",
             ..Default::default()
         };
 
@@ -539,7 +538,7 @@ mod tests {
                         assert!(!value.is_empty());
                     }
                     V04SamplingTag::Metric { key, value } => {
-                        out_span.metrics.insert(key.into(), value);
+                        out_span.metrics.insert(key, value);
                     }
                 }
             }

--- a/libdd-trace-stats/src/span_concentrator/aggregation.rs
+++ b/libdd-trace-stats/src/span_concentrator/aggregation.rs
@@ -8,6 +8,7 @@
 use hashbrown::HashMap;
 use libdd_trace_obfuscation::ip_address::quantize_peer_ip_addresses;
 use libdd_trace_protobuf::pb;
+use libdd_trace_utils::span::SpanText;
 use std::borrow::{Borrow, Cow};
 
 use crate::span_concentrator::StatSpan;
@@ -304,9 +305,12 @@ impl From<pb::ClientGroupedStats> for OwnedAggregationKey {
 }
 
 /// Return true if we care about peer tags on the span
-fn should_track_peer_tags(span_kind: &str) -> bool {
+fn should_track_peer_tags<T>(span_kind: T) -> bool
+where
+    T: SpanText,
+{
     matches!(
-        span_kind.to_lowercase().as_str(),
+        span_kind.borrow().to_lowercase().as_str(),
         "client" | "producer" | "consumer"
     )
 }
@@ -874,15 +878,12 @@ mod tests {
             // Span with peer tags with peertags aggregation enabled
             (
                 SpanSlice {
-                    service: "service".into(),
-                    name: "op".into(),
-                    resource: "res".into(),
+                    service: "service",
+                    name: "op",
+                    resource: "res",
                     span_id: 1,
                     parent_id: 0,
-                    meta: HashMap::from([
-                        ("span.kind".into(), "client".into()),
-                        ("aws.s3.bucket".into(), "bucket-a".into()),
-                    ]),
+                    meta: HashMap::from([("span.kind", "client"), ("aws.s3.bucket", "bucket-a")]),
                     ..Default::default()
                 },
                 FixedAggregationKey {
@@ -898,16 +899,16 @@ mod tests {
             // Span with multiple peer tags with peertags aggregation enabled
             (
                 SpanSlice {
-                    service: "service".into(),
-                    name: "op".into(),
-                    resource: "res".into(),
+                    service: "service",
+                    name: "op",
+                    resource: "res",
                     span_id: 1,
                     parent_id: 0,
                     meta: HashMap::from([
-                        ("span.kind".into(), "producer".into()),
-                        ("aws.s3.bucket".into(), "bucket-a".into()),
-                        ("db.instance".into(), "dynamo.test.us1".into()),
-                        ("db.system".into(), "dynamodb".into()),
+                        ("span.kind", "producer"),
+                        ("aws.s3.bucket", "bucket-a"),
+                        ("db.instance", "dynamo.test.us1"),
+                        ("db.system", "dynamodb"),
                     ]),
                     ..Default::default()
                 },
@@ -929,16 +930,16 @@ mod tests {
             // server
             (
                 SpanSlice {
-                    service: "service".into(),
-                    name: "op".into(),
-                    resource: "res".into(),
+                    service: "service",
+                    name: "op",
+                    resource: "res",
                     span_id: 1,
                     parent_id: 0,
                     meta: HashMap::from([
-                        ("span.kind".into(), "server".into()),
-                        ("aws.s3.bucket".into(), "bucket-a".into()),
-                        ("db.instance".into(), "dynamo.test.us1".into()),
-                        ("db.system".into(), "dynamodb".into()),
+                        ("span.kind", "server"),
+                        ("aws.s3.bucket", "bucket-a"),
+                        ("db.instance", "dynamo.test.us1"),
+                        ("db.system", "dynamodb"),
                     ]),
                     ..Default::default()
                 },
@@ -983,15 +984,15 @@ mod tests {
 
         // IPv4 address peer tag gets replaced with blocked-ip-address
         let span_ipv4 = SpanSlice {
-            service: "service".into(),
-            name: "op".into(),
-            resource: "res".into(),
+            service: "service",
+            name: "op",
+            resource: "res",
             span_id: 1,
             parent_id: 0,
             meta: HashMap::from([
-                ("span.kind".into(), "client".into()),
-                ("peer.hostname".into(), "10.1.2.3".into()),
-                ("db.instance".into(), "my-db".into()),
+                ("span.kind", "client"),
+                ("peer.hostname", "10.1.2.3"),
+                ("db.instance", "my-db"),
             ]),
             ..Default::default()
         };
@@ -1010,17 +1011,14 @@ mod tests {
 
         // IPv6 address peer tag gets replaced with blocked-ip-address
         let span_ipv6 = SpanSlice {
-            service: "service".into(),
-            name: "op".into(),
-            resource: "res".into(),
+            service: "service",
+            name: "op",
+            resource: "res",
             span_id: 1,
             parent_id: 0,
             meta: HashMap::from([
-                ("span.kind".into(), "client".into()),
-                (
-                    "peer.hostname".into(),
-                    "2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF".into(),
-                ),
+                ("span.kind", "client"),
+                ("peer.hostname", "2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF"),
             ]),
             ..Default::default()
         };
@@ -1037,15 +1035,12 @@ mod tests {
 
         // Non-IP peer tags pass through unchanged
         let span_non_ip = SpanSlice {
-            service: "service".into(),
-            name: "op".into(),
-            resource: "res".into(),
+            service: "service",
+            name: "op",
+            resource: "res",
             span_id: 1,
             parent_id: 0,
-            meta: HashMap::from([
-                ("span.kind".into(), "client".into()),
-                ("db.instance".into(), "dynamo.test.us1".into()),
-            ]),
+            meta: HashMap::from([("span.kind", "client"), ("db.instance", "dynamo.test.us1")]),
             ..Default::default()
         };
         let non_ip_keys = vec!["db.instance".to_string()];

--- a/libdd-trace-stats/src/span_concentrator/tests.rs
+++ b/libdd-trace-stats/src/span_concentrator/tests.rs
@@ -6,7 +6,6 @@ use crate::span_concentrator::aggregation::OwnedAggregationKey;
 use super::*;
 use libdd_trace_utils::span::{trace_utils::compute_top_level_span, v04::SpanSlice};
 use rand::{thread_rng, Rng};
-use std::borrow::Cow;
 
 const BUCKET_SIZE: u64 = Duration::from_secs(2).as_nanos() as u64;
 
@@ -45,11 +44,11 @@ fn get_test_span<'a>(
         parent_id,
         duration,
         start: get_timestamp_in_bucket(aligned_now, BUCKET_SIZE, offset) as i64 - duration,
-        service: service.into(),
-        name: "query".into(),
-        resource: resource.into(),
+        service,
+        name: "query",
+        resource,
         error,
-        r#type: "db".into(),
+        r#type: "db",
         ..Default::default()
     }
 }
@@ -71,11 +70,11 @@ fn get_test_span_with_meta<'a>(
         now, span_id, parent_id, duration, offset, service, resource, error,
     );
     for (k, v) in meta {
-        span.meta.insert(Cow::Borrowed(*k), Cow::Borrowed(*v));
+        span.meta.insert(*k, *v);
     }
     span.metrics = HashMap::new();
     for (k, v) in metrics {
-        span.metrics.insert(Cow::Borrowed(*k), *v);
+        span.metrics.insert(*k, *v);
     }
     span
 }
@@ -676,7 +675,7 @@ fn test_ignore_partial_spans() {
         .get_mut(0)
         .unwrap()
         .metrics
-        .insert("_dd.partial_version".into(), 830604.0);
+        .insert("_dd.partial_version", 830604.0);
     compute_top_level_span(spans.as_mut_slice());
     let mut concentrator = SpanConcentrator::new(
         Duration::from_nanos(BUCKET_SIZE),
@@ -1198,112 +1197,112 @@ fn test_compute_stats_for_span_kind() {
     let test_cases: Vec<(SpanSlice, bool)> = vec![
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind".into(), "server".into())]),
+                meta: HashMap::from([("span.kind", "server")]),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind".into(), "consumer".into())]),
+                meta: HashMap::from([("span.kind", "consumer")]),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind".into(), "client".into())]),
+                meta: HashMap::from([("span.kind", "client")]),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind".into(), "producer".into())]),
+                meta: HashMap::from([("span.kind", "producer")]),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind".into(), "internal".into())]),
+                meta: HashMap::from([("span.kind", "internal")]),
                 ..Default::default()
             },
             false,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind".into(), "SERVER".into())]),
+                meta: HashMap::from([("span.kind", "SERVER")]),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind".into(), "CONSUMER".into())]),
+                meta: HashMap::from([("span.kind", "CONSUMER")]),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind".into(), "CLIENT".into())]),
+                meta: HashMap::from([("span.kind", "CLIENT")]),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind".into(), "PRODUCER".into())]),
+                meta: HashMap::from([("span.kind", "PRODUCER")]),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind".into(), "INTERNAL".into())]),
+                meta: HashMap::from([("span.kind", "INTERNAL")]),
                 ..Default::default()
             },
             false,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind".into(), "SerVER".into())]),
+                meta: HashMap::from([("span.kind", "SerVER")]),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind".into(), "ConSUMeR".into())]),
+                meta: HashMap::from([("span.kind", "ConSUMeR")]),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind".into(), "CLiENT".into())]),
+                meta: HashMap::from([("span.kind", "CLiENT")]),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind".into(), "PROducER".into())]),
+                meta: HashMap::from([("span.kind", "PROducER")]),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind".into(), "INtERNAL".into())]),
+                meta: HashMap::from([("span.kind", "INtERNAL")]),
                 ..Default::default()
             },
             false,
         ),
         (
             SpanSlice {
-                meta: HashMap::from([("span.kind".into(), "".into())]),
+                meta: HashMap::from([("span.kind", "")]),
                 ..Default::default()
             },
             false,

--- a/libdd-trace-stats/src/stats_exporter.rs
+++ b/libdd-trace-stats/src/stats_exporter.rs
@@ -316,7 +316,7 @@ mod tests {
 
         for i in 1..100 {
             trace.push(SpanSlice {
-                service: "libdatadog-test".into(),
+                service: "libdatadog-test",
                 duration: i,
                 ..Default::default()
             })

--- a/libdd-trace-utils/src/msgpack_encoder/v04/mod.rs
+++ b/libdd-trace-utils/src/msgpack_encoder/v04/mod.rs
@@ -50,7 +50,7 @@ fn to_writer<W: RmpWrite, T: TraceData, S: AsRef<[Span<T>]>>(
 ///
 /// let mut buffer = vec![0u8; 1024];
 /// let span = SpanSlice {
-///     name: "test-span".into(),
+///     name: "test-span",
 ///     ..Default::default()
 /// };
 /// let traces = vec![vec![span]];
@@ -81,7 +81,7 @@ pub fn write_to_slice<T: TraceData, S: AsRef<[Span<T>]>>(
 /// use libdd_trace_utils::span::v04::SpanSlice;
 ///
 /// let span = SpanSlice {
-///     name: "test-span".into(),
+///     name: "test-span",
 ///     ..Default::default()
 /// };
 /// let traces = vec![vec![span]];
@@ -111,7 +111,7 @@ pub fn to_vec<T: TraceData, S: AsRef<[Span<T>]>>(traces: &[S]) -> Vec<u8> {
 /// use libdd_trace_utils::span::v04::SpanSlice;
 ///
 /// let span = SpanSlice {
-///     name: "test-span".into(),
+///     name: "test-span",
 ///     ..Default::default()
 /// };
 /// let traces = vec![vec![span]];
@@ -150,7 +150,7 @@ pub fn to_vec_with_capacity<T: TraceData, S: AsRef<[Span<T>]>>(
 /// use libdd_trace_utils::span::v04::SpanSlice;
 ///
 /// let span = SpanSlice {
-///     name: "test-span".into(),
+///     name: "test-span",
 ///     ..Default::default()
 /// };
 /// let traces = vec![vec![span]];

--- a/libdd-trace-utils/src/span/mod.rs
+++ b/libdd-trace-utils/src/span/mod.rs
@@ -11,7 +11,7 @@ use crate::msgpack_decoder::decode::error::DecodeError;
 use crate::span::v05::dict::SharedDict;
 use libdd_tinybytes::{Bytes, BytesString};
 use serde::Serialize;
-use std::borrow::{Borrow, Cow};
+use std::borrow::Borrow;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::marker::PhantomData;
@@ -21,13 +21,13 @@ use std::{fmt, ptr};
 /// Trait representing the requirements for a type to be used as a Span "string" type.
 /// Note: Borrow<str> is not required by the derived traits, but allows to access HashMap elements
 /// from a static str and check if the string is empty.
-pub trait SpanText: Debug + Eq + Hash + Borrow<str> + Serialize + Default + From<String> {
+pub trait SpanText: Debug + Eq + Hash + Borrow<str> + Serialize + Default {
     fn from_static_str(value: &'static str) -> Self;
 }
 
-impl SpanText for Cow<'_, str> {
+impl SpanText for &str {
     fn from_static_str(value: &'static str) -> Self {
-        Cow::Borrowed(value)
+        value
     }
 }
 
@@ -118,11 +118,11 @@ impl DeserializableTraceData for BytesData {
     }
 }
 
-/// TraceData implementation using `Cow<'a, str>` and `&[u8]`.
+/// TraceData implementation using `&str` and `&[u8]`.
 #[derive(Clone, Default, Debug, PartialEq, Serialize)]
 pub struct SliceData<'a>(PhantomData<&'a u8>);
 impl<'a> TraceData for SliceData<'a> {
-    type Text = Cow<'a, str>;
+    type Text = &'a str;
     type Bytes = &'a [u8];
 }
 
@@ -140,10 +140,10 @@ impl<'a> DeserializableTraceData for SliceData<'a> {
     }
 
     #[inline]
-    fn read_string(buf: &mut &'a [u8]) -> Result<Cow<'a, str>, DecodeError> {
+    fn read_string(buf: &mut &'a [u8]) -> Result<&'a str, DecodeError> {
         read_string_ref_nomut(buf).map(|(str, newbuf)| {
             *buf = newbuf;
-            Cow::Borrowed(str)
+            str
         })
     }
 }

--- a/libdd-trace-utils/src/span/v04/mod.rs
+++ b/libdd-trace-utils/src/span/v04/mod.rs
@@ -340,50 +340,42 @@ mod tests {
     #[test]
     fn serialize_deserialize_test() {
         let span: Span<SliceData<'_>> = Span {
-            name: "tracing.operation".into(),
-            resource: "MyEndpoint".into(),
+            name: "tracing.operation",
+            resource: "MyEndpoint",
             span_links: vec![SpanLink {
                 trace_id: 42,
-                attributes: HashMap::from([("span".into(), "link".into())]),
-                tracestate: "running".into(),
+                attributes: HashMap::from([("span", "link")]),
+                tracestate: "running",
                 ..Default::default()
             }],
             span_events: vec![SpanEvent {
                 time_unix_nano: 1727211691770716000,
-                name: "exception".into(),
+                name: "exception",
                 attributes: HashMap::from([
                     (
-                        "exception.message".into(),
+                        "exception.message",
                         AttributeAnyValue::SingleValue(AttributeArrayValue::String(
-                            "Cannot divide by zero".into(),
+                            "Cannot divide by zero",
                         )),
                     ),
                     (
-                        "exception.type".into(),
-                        AttributeAnyValue::SingleValue(AttributeArrayValue::String(
-                            "RuntimeError".into(),
-                        )),
+                        "exception.type",
+                        AttributeAnyValue::SingleValue(AttributeArrayValue::String("RuntimeError")),
                     ),
                     (
-                        "exception.escaped".into(),
+                        "exception.escaped",
                         AttributeAnyValue::SingleValue(AttributeArrayValue::Boolean(false)),
                     ),
                     (
-                        "exception.count".into(),
+                        "exception.count",
                         AttributeAnyValue::SingleValue(AttributeArrayValue::Integer(1)),
                     ),
                     (
-                        "exception.lines".into(),
+                        "exception.lines",
                         AttributeAnyValue::Array(vec![
-                            AttributeArrayValue::String(
-                                "  File \"<string>\", line 1, in <module>".into(),
-                            ),
-                            AttributeArrayValue::String(
-                                "  File \"<string>\", line 1, in divide".into(),
-                            ),
-                            AttributeArrayValue::String(
-                                "RuntimeError: Cannot divide by zero".into(),
-                            ),
+                            AttributeArrayValue::String("  File \"<string>\", line 1, in <module>"),
+                            AttributeArrayValue::String("  File \"<string>\", line 1, in divide"),
+                            AttributeArrayValue::String("RuntimeError: Cannot divide by zero"),
                         ]),
                     ),
                 ]),
@@ -424,9 +416,9 @@ mod tests {
         let span: Span<SliceData<'_>> = Span {
             span_events: vec![SpanEvent {
                 time_unix_nano: 1727211691770716000,
-                name: "test".into(),
+                name: "test",
                 attributes: HashMap::from([(
-                    "test.event".into(),
+                    "test.event",
                     AttributeAnyValue::SingleValue(AttributeArrayValue::Double(4.2)),
                 )]),
             }],


### PR DESCRIPTION
This reverts commit ecdca7d4ef4e7f11c0194ed2f4e25173973404e7.

# What does this PR do?

!1985 is using an alternative way which doesn't require to normalize fields. Since this is not needed right an introduce some overhead, this can be reverted. It may be reintroduced in the future if we need to mutate span fields.

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
