### PR TITLE
feat(live-debugger): agentless intake forwarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1447,6 +1447,7 @@ dependencies = [
  "bytes",
  "constcat",
  "datadog-remote-config",
+ "futures",
  "http",
  "http-body-util",
  "libdd-common",

--- a/datadog-live-debugger-ffi/src/sender.rs
+++ b/datadog-live-debugger-ffi/src/sender.rs
@@ -4,7 +4,9 @@
 use crate::send_data::serialize_debugger_payload;
 use datadog_live_debugger::debugger_defs::DebuggerPayload;
 use datadog_live_debugger::sender;
-use datadog_live_debugger::sender::{generate_tags, Config, DebuggerType};
+use datadog_live_debugger::sender::{
+    debugger_intake_endpoint, generate_tags, Config, DebuggerType,
+};
 use libdd_common::tag::Tag;
 use libdd_common::Endpoint;
 use libdd_common_ffi::slice::AsBytes;
@@ -42,6 +44,10 @@ impl Drop for OwnedCharSlice {
 enum SendData {
     Raw(Vec<u8>, DebuggerType),
     Wrapped(OwnedCharSlice, DebuggerType),
+    SymDB {
+        data: OwnedCharSlice,
+        content_type: String,
+    },
 }
 
 async fn sender_routine(config: Arc<Config>, tags: String, mut receiver: mpsc::Receiver<SendData>) {
@@ -56,18 +62,37 @@ async fn sender_routine(config: Arc<Config>, tags: String, mut receiver: mpsc::R
         let config = config.clone();
         let tags = tags.clone();
         tracker.spawn(async move {
-            let (debugger_type, data) = match data {
-                SendData::Raw(ref vec, r#type) => (r#type, vec.as_slice()),
-                SendData::Wrapped(ref wrapped, r#type) => (r#type, wrapped.slice.as_bytes()),
+            let (kind, len, result) = match data {
+                SendData::Raw(ref vec, r#type) => (
+                    format!("{type:?}"),
+                    vec.len(),
+                    sender::send(vec.as_slice(), &config, r#type, &tags).await,
+                ),
+                SendData::Wrapped(ref wrapped, r#type) => {
+                    let bytes = wrapped.slice.as_bytes();
+                    (
+                        format!("{type:?}"),
+                        bytes.len(),
+                        sender::send(bytes, &config, r#type, &tags).await,
+                    )
+                }
+                SendData::SymDB {
+                    ref data,
+                    ref content_type,
+                } => {
+                    let bytes = data.slice.as_bytes();
+                    (
+                        "SymDB".to_string(),
+                        bytes.len(),
+                        sender::send_symdb(bytes, content_type, &config, &tags).await,
+                    )
+                }
             };
 
-            if let Err(e) = sender::send(data, &config, debugger_type, &tags).await {
-                warn!("Failed to send {debugger_type:?} debugger data: {e:?}");
+            if let Err(e) = result {
+                warn!("Failed to send {kind} debugger data: {e:?}");
             } else {
-                debug!(
-                    "Successfully sent {} debugger data byte {debugger_type:?} payload",
-                    data.len()
-                );
+                debug!("Successfully sent {len} byte {kind} debugger data payload");
             }
         });
     }
@@ -102,30 +127,112 @@ pub extern "C" fn ddog_live_debugger_tags_from_raw(tags: CharSlice) -> Box<Strin
     Box::new(percent_encode(tags.as_bytes(), CONTROLS).to_string())
 }
 
-#[no_mangle]
-pub extern "C" fn ddog_live_debugger_spawn_sender(
-    endpoint: &Endpoint,
-    tags: Box<String>,
-    handle: &mut *mut SenderHandle,
-) -> MaybeError {
+fn spawn_sender_inner(config: Config, tags: String, handle: &mut *mut SenderHandle) -> MaybeError {
     let runtime = try_c!(tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build());
 
     let (tx, mailbox) = mpsc::channel(5000);
-    let mut config = Config::default();
-    try_c!(config.set_endpoint(endpoint.clone()));
     let config = Arc::new(config);
 
     *handle = Box::into_raw(Box::new(SenderHandle {
         join: std::thread::spawn(move || {
-            runtime.block_on(sender_routine(config, *tags, mailbox));
+            runtime.block_on(sender_routine(config, tags, mailbox));
             runtime.shutdown_background();
         }),
         channel: tx,
     }));
 
     MaybeError::None
+}
+
+#[no_mangle]
+pub extern "C" fn ddog_live_debugger_spawn_sender(
+    endpoint: &Endpoint,
+    tags: Box<String>,
+    handle: &mut *mut SenderHandle,
+) -> MaybeError {
+    let mut config = Config::default();
+    try_c!(config.set_endpoint(endpoint.clone()));
+    spawn_sender_inner(config, *tags, handle)
+}
+
+/// Builds an [`Endpoint`] for sending debugger and SymDB payloads directly to
+/// the Datadog intake (agentless), targeting `debugger-intake.{site}`. The
+/// returned endpoint must be freed with `ddog_endpoint_drop`.
+#[no_mangle]
+pub extern "C" fn ddog_live_debugger_endpoint_from_site_and_api_key(
+    site: CharSlice,
+    api_key: CharSlice,
+    endpoint: &mut *mut Endpoint,
+) -> MaybeError {
+    let site = site.to_utf8_lossy();
+    let built = try_c!(debugger_intake_endpoint(
+        site.as_ref(),
+        api_key.to_utf8_lossy().to_string()
+    ));
+    *endpoint = Box::into_raw(Box::new(built));
+    MaybeError::None
+}
+
+/// Creates an empty sender config. Configure it with the
+/// `ddog_live_debugger_sender_config_*` functions, then hand it to
+/// `ddog_live_debugger_spawn_sender_with_config` (which consumes it). If the
+/// config is not spawned, free it with `ddog_live_debugger_sender_config_drop`.
+#[no_mangle]
+pub extern "C" fn ddog_live_debugger_sender_config_new() -> Box<Config> {
+    Box::new(Config::default())
+}
+
+#[no_mangle]
+pub extern "C" fn ddog_live_debugger_sender_config_set_endpoint(
+    config: &mut Config,
+    endpoint: &Endpoint,
+) -> MaybeError {
+    try_c!(config.set_endpoint(endpoint.clone()));
+    MaybeError::None
+}
+
+#[no_mangle]
+pub extern "C" fn ddog_live_debugger_sender_config_set_symdb_endpoint(
+    config: &mut Config,
+    endpoint: &Endpoint,
+) -> MaybeError {
+    try_c!(config.set_symdb_endpoint(endpoint.clone()));
+    MaybeError::None
+}
+
+#[no_mangle]
+pub extern "C" fn ddog_live_debugger_sender_config_add_additional_endpoint(
+    config: &mut Config,
+    endpoint: &Endpoint,
+) -> MaybeError {
+    try_c!(config.add_additional_debugger_endpoint(endpoint.clone()));
+    MaybeError::None
+}
+
+#[no_mangle]
+pub extern "C" fn ddog_live_debugger_sender_config_add_additional_symdb_endpoint(
+    config: &mut Config,
+    endpoint: &Endpoint,
+) -> MaybeError {
+    try_c!(config.add_additional_symdb_endpoint(endpoint.clone()));
+    MaybeError::None
+}
+
+#[no_mangle]
+pub extern "C" fn ddog_live_debugger_sender_config_drop(_: Box<Config>) {}
+
+/// Spawns a sender from a fully-configured [`Config`], consuming it. Supports
+/// SymDB and additional dual-ship endpoints, unlike
+/// `ddog_live_debugger_spawn_sender`.
+#[no_mangle]
+pub extern "C" fn ddog_live_debugger_spawn_sender_with_config(
+    config: Box<Config>,
+    tags: Box<String>,
+    handle: &mut *mut SenderHandle,
+) -> MaybeError {
+    spawn_sender_inner(*config, *tags, handle)
 }
 
 #[no_mangle]
@@ -137,6 +244,24 @@ pub extern "C" fn ddog_live_debugger_send_raw_data(
     handle
         .channel
         .try_send(SendData::Wrapped(data, debugger_type))
+        .is_ok()
+}
+
+/// Enqueues a raw SymDB (symbol database) payload to be forwarded to the SymDB
+/// intake. The body is sent verbatim with the given `content_type`; `data` is
+/// owned and freed once sent. Returns `true` if the payload was enqueued.
+#[no_mangle]
+pub extern "C" fn ddog_live_debugger_send_symdb_data(
+    handle: &mut SenderHandle,
+    content_type: CharSlice,
+    data: OwnedCharSlice,
+) -> bool {
+    handle
+        .channel
+        .try_send(SendData::SymDB {
+            data,
+            content_type: content_type.to_utf8_lossy().to_string(),
+        })
         .is_ok()
 }
 

--- a/datadog-live-debugger-ffi/src/sender.rs
+++ b/datadog-live-debugger-ffi/src/sender.rs
@@ -50,6 +50,16 @@ enum SendData {
     },
 }
 
+/// Returns a static name for a debugger track, used for logging without
+/// allocating a string on every send.
+fn debugger_type_name(debugger_type: DebuggerType) -> &'static str {
+    match debugger_type {
+        DebuggerType::Diagnostics => "Diagnostics",
+        DebuggerType::Snapshots => "Snapshots",
+        DebuggerType::Logs => "Logs",
+    }
+}
+
 async fn sender_routine(config: Arc<Config>, tags: String, mut receiver: mpsc::Receiver<SendData>) {
     let tags = Arc::new(tags);
     let tracker = TaskTracker::new();
@@ -64,14 +74,14 @@ async fn sender_routine(config: Arc<Config>, tags: String, mut receiver: mpsc::R
         tracker.spawn(async move {
             let (kind, len, result) = match data {
                 SendData::Raw(ref vec, r#type) => (
-                    format!("{type:?}"),
+                    debugger_type_name(r#type),
                     vec.len(),
                     sender::send(vec.as_slice(), &config, r#type, &tags).await,
                 ),
                 SendData::Wrapped(ref wrapped, r#type) => {
                     let bytes = wrapped.slice.as_bytes();
                     (
-                        format!("{type:?}"),
+                        debugger_type_name(r#type),
                         bytes.len(),
                         sender::send(bytes, &config, r#type, &tags).await,
                     )
@@ -82,7 +92,7 @@ async fn sender_routine(config: Arc<Config>, tags: String, mut receiver: mpsc::R
                 } => {
                     let bytes = data.slice.as_bytes();
                     (
-                        "SymDB".to_string(),
+                        "SymDB",
                         bytes.len(),
                         sender::send_symdb(bytes, content_type, &config, &tags).await,
                     )

--- a/datadog-live-debugger/Cargo.toml
+++ b/datadog-live-debugger/Cargo.toml
@@ -13,6 +13,7 @@ libdd-data-pipeline = { path = "../libdd-data-pipeline" }
 http-body-util = "0.1"
 "http" = "1"
 bytes =  "1.11.1"
+futures = "0.3"
 
 percent-encoding = "2.1"
 serde = { version = "1.0", features = ["derive"] }

--- a/datadog-live-debugger/src/sender.rs
+++ b/datadog-live-debugger/src/sender.rs
@@ -13,6 +13,7 @@ use libdd_common::Endpoint;
 use libdd_data_pipeline::agent_info::schema::AgentInfoStruct;
 use percent_encoding::{percent_encode, CONTROLS};
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::fmt::Display;
 use std::hash::Hash;
 use std::str::FromStr;
@@ -25,54 +26,176 @@ const DIRECT_DEBUGGER_DIAGNOSTICS_URL_PATH: &str = "/api/v2/debugger";
 const AGENT_DEBUGGER_SNAPSHOTS_URL_PATH: &str = "/debugger/v2/input";
 const AGENT_DEBUGGER_DIAGNOSTICS_URL_PATH: &str = "/debugger/v1/diagnostics";
 
+// The symbol database (SymDB) intake shares the debugger-intake host. Direct
+// (agentless) uploads target /api/v2/debugger, while the agent exposes the
+// /symdb/v1/input proxy route.
+const DIRECT_SYMDB_URL_PATH: &str = "/api/v2/debugger";
+const AGENT_SYMDB_URL_PATH: &str = "/symdb/v1/input";
+
+/// Creates an [`Endpoint`] for sending debugger and SymDB payloads directly to
+/// the Datadog intake without going through the agent (agentless mode).
+///
+/// This mirrors the agent's debugger proxy, which forwards to
+/// `https://debugger-intake.{site}`. The per-track path (diagnostics, snapshots
+/// or SymDB) is applied later by [`Config::set_endpoint`] /
+/// [`Config::set_symdb_endpoint`].
+///
+/// # Arguments
+/// * `site` - e.g. "datadoghq.com".
+/// * `api_key`
+pub fn debugger_intake_endpoint(
+    site: &str,
+    api_key: impl Into<Cow<'static, str>>,
+) -> anyhow::Result<Endpoint> {
+    Ok(Endpoint {
+        url: Uri::from_str(&format!(
+            "https://{PROD_DIAGNOSTICS_INTAKE_SUBDOMAIN}.{site}"
+        ))?,
+        api_key: Some(api_key.into()),
+        ..Default::default()
+    })
+}
+
+/// Derives the per-track intake path for an endpoint, returning a clone with
+/// the path applied. Endpoints with an API key are treated as agentless (direct
+/// intake) and use `direct_path`; otherwise the agent proxy `agent_path` is
+/// used. `file://` endpoints (used for tests) are left untouched.
+fn derive_endpoint_path(
+    endpoint: &Endpoint,
+    direct_path: &'static str,
+    agent_path: &'static str,
+) -> anyhow::Result<Endpoint> {
+    let mut endpoint = endpoint.clone();
+    let has_api_key = endpoint.api_key.is_some();
+    let mut parts = endpoint.url.into_parts();
+    let is_remote = parts
+        .scheme
+        .as_ref()
+        .map(|scheme| scheme.as_str() != "file")
+        .unwrap_or(false);
+    if is_remote {
+        let path = if has_api_key { direct_path } else { agent_path };
+        parts.path_and_query = Some(PathAndQuery::from_static(path));
+    }
+    endpoint.url = Uri::from_parts(parts)?;
+    Ok(endpoint)
+}
+
 #[derive(Clone, Default)]
 pub struct Config {
     pub logs_endpoint: Option<Endpoint>,
     pub snapshots_endpoint: Option<Endpoint>,
     pub diagnostics_endpoint: Option<Endpoint>,
+    pub symdb_endpoint: Option<Endpoint>,
+    /// Additional debugger-intake endpoints to dual-ship logs/snapshots/diagnostics
+    /// payloads to, mirroring the agent's `debugger_*_additional_endpoints`. Each
+    /// entry holds the per-track path already derived.
+    pub additional_logs_endpoints: Vec<Endpoint>,
+    pub additional_snapshots_endpoints: Vec<Endpoint>,
+    pub additional_diagnostics_endpoints: Vec<Endpoint>,
+    /// Additional SymDB intake endpoints, mirroring the agent's
+    /// `symdb_additional_endpoints`.
+    pub additional_symdb_endpoints: Vec<Endpoint>,
 }
 
 impl Config {
-    pub fn set_endpoint(&mut self, mut diagnostics_endpoint: Endpoint) -> anyhow::Result<()> {
-        let mut logs_endpoint = diagnostics_endpoint.clone();
-        let mut snapshots_endpoint = diagnostics_endpoint.clone();
+    pub fn set_endpoint(&mut self, diagnostics_endpoint: Endpoint) -> anyhow::Result<()> {
+        self.logs_endpoint = Some(derive_endpoint_path(
+            &diagnostics_endpoint,
+            DIRECT_DEBUGGER_DIAGNOSTICS_URL_PATH,
+            AGENT_DEBUGGER_SNAPSHOTS_URL_PATH,
+        )?);
+        self.snapshots_endpoint = Some(derive_endpoint_path(
+            &diagnostics_endpoint,
+            DIRECT_DEBUGGER_DIAGNOSTICS_URL_PATH,
+            AGENT_DEBUGGER_SNAPSHOTS_URL_PATH,
+        )?);
+        self.diagnostics_endpoint = Some(derive_endpoint_path(
+            &diagnostics_endpoint,
+            DIRECT_DEBUGGER_DIAGNOSTICS_URL_PATH,
+            AGENT_DEBUGGER_DIAGNOSTICS_URL_PATH,
+        )?);
+        Ok(())
+    }
 
-        let mut logs_uri_parts = logs_endpoint.url.into_parts();
-        let mut snapshots_uri_parts = snapshots_endpoint.url.into_parts();
-        let mut diagnostics_uri_parts = diagnostics_endpoint.url.into_parts();
+    /// Sets the SymDB (symbol database) intake endpoint, deriving the
+    /// `/api/v2/debugger` (agentless) or `/symdb/v1/input` (agent) path.
+    pub fn set_symdb_endpoint(&mut self, symdb_endpoint: Endpoint) -> anyhow::Result<()> {
+        self.symdb_endpoint = Some(derive_endpoint_path(
+            &symdb_endpoint,
+            DIRECT_SYMDB_URL_PATH,
+            AGENT_SYMDB_URL_PATH,
+        )?);
+        Ok(())
+    }
 
-        #[allow(clippy::unwrap_used)]
-        if diagnostics_uri_parts.scheme.is_some()
-            && diagnostics_uri_parts.scheme.as_ref().unwrap().as_str() != "file"
-        {
-            let v2_path = PathAndQuery::from_static(if diagnostics_endpoint.api_key.is_some() {
-                DIRECT_DEBUGGER_DIAGNOSTICS_URL_PATH
-            } else {
-                AGENT_DEBUGGER_SNAPSHOTS_URL_PATH
-            });
-            logs_uri_parts.path_and_query = Some(v2_path.clone());
-            snapshots_uri_parts.path_and_query = Some(v2_path);
-            diagnostics_uri_parts.path_and_query = Some(PathAndQuery::from_static(
-                if diagnostics_endpoint.api_key.is_some() {
-                    DIRECT_DEBUGGER_DIAGNOSTICS_URL_PATH
-                } else {
-                    AGENT_DEBUGGER_DIAGNOSTICS_URL_PATH
-                },
-            ));
-        }
+    /// Adds an additional debugger-intake endpoint to dual-ship every
+    /// logs/snapshots/diagnostics payload to, mirroring the agent's
+    /// `debugger_*_additional_endpoints`.
+    pub fn add_additional_debugger_endpoint(&mut self, endpoint: Endpoint) -> anyhow::Result<()> {
+        self.additional_logs_endpoints.push(derive_endpoint_path(
+            &endpoint,
+            DIRECT_DEBUGGER_DIAGNOSTICS_URL_PATH,
+            AGENT_DEBUGGER_SNAPSHOTS_URL_PATH,
+        )?);
+        self.additional_snapshots_endpoints
+            .push(derive_endpoint_path(
+                &endpoint,
+                DIRECT_DEBUGGER_DIAGNOSTICS_URL_PATH,
+                AGENT_DEBUGGER_SNAPSHOTS_URL_PATH,
+            )?);
+        self.additional_diagnostics_endpoints
+            .push(derive_endpoint_path(
+                &endpoint,
+                DIRECT_DEBUGGER_DIAGNOSTICS_URL_PATH,
+                AGENT_DEBUGGER_DIAGNOSTICS_URL_PATH,
+            )?);
+        Ok(())
+    }
 
-        logs_endpoint.url = Uri::from_parts(logs_uri_parts)?;
-        snapshots_endpoint.url = Uri::from_parts(snapshots_uri_parts)?;
-        diagnostics_endpoint.url = Uri::from_parts(diagnostics_uri_parts)?;
-        self.logs_endpoint = Some(logs_endpoint);
-        self.snapshots_endpoint = Some(snapshots_endpoint);
-        self.diagnostics_endpoint = Some(diagnostics_endpoint);
+    /// Adds an additional SymDB intake endpoint, mirroring the agent's
+    /// `symdb_additional_endpoints`.
+    pub fn add_additional_symdb_endpoint(&mut self, endpoint: Endpoint) -> anyhow::Result<()> {
+        self.additional_symdb_endpoints.push(derive_endpoint_path(
+            &endpoint,
+            DIRECT_SYMDB_URL_PATH,
+            AGENT_SYMDB_URL_PATH,
+        )?);
         Ok(())
     }
 
     pub fn downgrade_to_diagnostics_endpoint(&mut self) {
         self.snapshots_endpoint = self.diagnostics_endpoint.clone();
         self.logs_endpoint = self.diagnostics_endpoint.clone();
+    }
+
+    /// Returns the endpoints for a debugger track: the primary endpoint first,
+    /// followed by any additional dual-ship endpoints.
+    fn debugger_endpoints_for(&self, debugger_type: DebuggerType) -> Vec<&Endpoint> {
+        let (primary, additional) = match debugger_type {
+            DebuggerType::Diagnostics => (
+                &self.diagnostics_endpoint,
+                &self.additional_diagnostics_endpoints,
+            ),
+            DebuggerType::Snapshots => (
+                &self.snapshots_endpoint,
+                &self.additional_snapshots_endpoints,
+            ),
+            DebuggerType::Logs => (&self.logs_endpoint, &self.additional_logs_endpoints),
+        };
+        let mut endpoints = Vec::with_capacity(1 + additional.len());
+        endpoints.extend(primary.as_ref());
+        endpoints.extend(additional.iter());
+        endpoints
+    }
+
+    /// Returns the SymDB endpoints: the primary endpoint first, followed by any
+    /// additional dual-ship endpoints.
+    fn symdb_endpoints(&self) -> Vec<&Endpoint> {
+        let mut endpoints = Vec::with_capacity(1 + self.additional_symdb_endpoints.len());
+        endpoints.extend(self.symdb_endpoint.as_ref());
+        endpoints.extend(self.additional_symdb_endpoints.iter());
+        endpoints
     }
 }
 
@@ -160,15 +283,23 @@ impl PayloadSender {
         debugger_type: DebuggerType,
         percent_encoded_tags: &str,
     ) -> anyhow::Result<Self> {
-        #[allow(clippy::unwrap_used)]
         let endpoint = match debugger_type {
             DebuggerType::Diagnostics => &config.diagnostics_endpoint,
             DebuggerType::Snapshots => &config.snapshots_endpoint,
             DebuggerType::Logs => &config.logs_endpoint,
         }
         .as_ref()
-        .unwrap();
+        .ok_or_else(|| anyhow::anyhow!("missing endpoint for {debugger_type:?}"))?;
+        Self::new_to_endpoint(endpoint, debugger_type, percent_encoded_tags)
+    }
 
+    /// Creates a sender targeting a specific endpoint. Used to fan a payload out
+    /// to the primary plus any additional dual-ship endpoints.
+    pub fn new_to_endpoint(
+        endpoint: &Endpoint,
+        debugger_type: DebuggerType,
+        percent_encoded_tags: &str,
+    ) -> anyhow::Result<Self> {
         let mut url = endpoint.url.clone();
         let mut parts = url.into_parts();
 
@@ -287,9 +418,79 @@ pub async fn send(
     debugger_type: DebuggerType,
     percent_encoded_tags: &str,
 ) -> anyhow::Result<()> {
-    let mut batch = PayloadSender::new(config, debugger_type, percent_encoded_tags)?;
+    let endpoints = config.debugger_endpoints_for(debugger_type);
+    let (primary, additional) = endpoints
+        .split_first()
+        .ok_or_else(|| anyhow::anyhow!("no endpoint configured for {debugger_type:?}"))?;
+
+    // Best-effort dual-shipping to any additional endpoints, mirroring the
+    // agent's `*_additional_endpoints` fan-out where non-primary responses are
+    // discarded. Only the primary endpoint's result is returned to the caller.
+    for &endpoint in additional {
+        let _ = send_to_endpoint(payload, endpoint, debugger_type, percent_encoded_tags).await;
+    }
+    send_to_endpoint(payload, primary, debugger_type, percent_encoded_tags).await
+}
+
+async fn send_to_endpoint(
+    payload: &[u8],
+    endpoint: &Endpoint,
+    debugger_type: DebuggerType,
+    percent_encoded_tags: &str,
+) -> anyhow::Result<()> {
+    let mut batch = PayloadSender::new_to_endpoint(endpoint, debugger_type, percent_encoded_tags)?;
     batch.append(payload).await?;
     batch.finish().await?;
+    Ok(())
+}
+
+/// Forwards a raw SymDB (symbol database) payload to the configured SymDB intake,
+/// mirroring the agent's `/symdb/v1/input` proxy. Unlike debugger payloads, the
+/// body is forwarded verbatim, the tags ride in the `X-Datadog-Additional-Tags`
+/// header (not the `ddtags` query string), and the origin is `agent-symdb`.
+pub async fn send_symdb(
+    payload: &[u8],
+    content_type: &str,
+    config: &Config,
+    tags: &str,
+) -> anyhow::Result<()> {
+    let endpoints = config.symdb_endpoints();
+    let (primary, additional) = endpoints
+        .split_first()
+        .ok_or_else(|| anyhow::anyhow!("no symdb endpoint configured"))?;
+
+    for &endpoint in additional {
+        let _ = send_symdb_to_endpoint(payload, content_type, endpoint, tags).await;
+    }
+    send_symdb_to_endpoint(payload, content_type, primary, tags).await
+}
+
+async fn send_symdb_to_endpoint(
+    payload: &[u8],
+    content_type: &str,
+    endpoint: &Endpoint,
+    tags: &str,
+) -> anyhow::Result<()> {
+    let req = endpoint
+        .to_request_builder(concat!("Tracer/", env!("CARGO_PKG_VERSION")))?
+        .method(Method::POST)
+        .header("DD-EVP-ORIGIN", "agent-symdb")
+        .header("X-Datadog-Additional-Tags", tags)
+        .header("Content-type", content_type);
+
+    let body = http_common::Body::from(payload.to_vec());
+    let response = http_common::into_response(
+        http_common::new_default_client()
+            .request(req.body(body)?)
+            .await?,
+    );
+
+    let status = response.status().as_u16();
+    if status >= 400 {
+        let body_bytes = response.into_body().collect().await?.to_bytes();
+        let response_body = String::from_utf8(body_bytes.to_vec()).unwrap_or_default();
+        anyhow::bail!("Server did not accept symdb payload ({status}): {response_body}");
+    }
     Ok(())
 }
 
@@ -374,6 +575,43 @@ mod tests {
             endpoint_path(&config.diagnostics_endpoint),
             "/debugger/v1/diagnostics"
         );
+    }
+
+    #[test]
+    fn test_debugger_intake_endpoint() {
+        let endpoint = debugger_intake_endpoint("datadoghq.com", "test-api-key").unwrap();
+        assert_eq!(endpoint.url.host(), Some("debugger-intake.datadoghq.com"));
+        assert_eq!(endpoint.url.scheme_str(), Some("https"));
+        assert_eq!(endpoint.api_key.as_deref(), Some("test-api-key"));
+    }
+
+    #[test]
+    fn test_set_symdb_endpoint_direct_mode() {
+        let mut config = Config::default();
+        config.set_symdb_endpoint(direct_endpoint()).unwrap();
+        assert_eq!(endpoint_path(&config.symdb_endpoint), "/api/v2/debugger");
+    }
+
+    #[test]
+    fn test_set_symdb_endpoint_agent_mode() {
+        let mut config = Config::default();
+        config.set_symdb_endpoint(agent_endpoint()).unwrap();
+        assert_eq!(endpoint_path(&config.symdb_endpoint), "/symdb/v1/input");
+    }
+
+    #[test]
+    fn test_additional_debugger_endpoints_derive_paths() {
+        let mut config = Config::default();
+        config.set_endpoint(direct_endpoint()).unwrap();
+        config
+            .add_additional_debugger_endpoint(direct_endpoint())
+            .unwrap();
+
+        let diagnostics = config.debugger_endpoints_for(DebuggerType::Diagnostics);
+        assert_eq!(diagnostics.len(), 2);
+        for endpoint in diagnostics {
+            assert_eq!(endpoint.url.path(), "/api/v2/debugger");
+        }
     }
 
     #[test]

--- a/datadog-live-debugger/src/sender.rs
+++ b/datadog-live-debugger/src/sender.rs
@@ -4,6 +4,7 @@
 use crate::debugger_defs::{DebuggerData, DebuggerPayload};
 use bytes::Bytes;
 use constcat::concat;
+use futures::future;
 use http::uri::PathAndQuery;
 use http::{Method, Uri};
 use http_body_util::BodyExt;
@@ -13,6 +14,7 @@ use libdd_common::Endpoint;
 use libdd_data_pipeline::agent_info::schema::AgentInfoStruct;
 use percent_encoding::{percent_encode, CONTROLS};
 use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
 use std::borrow::Cow;
 use std::fmt::Display;
 use std::hash::Hash;
@@ -26,10 +28,13 @@ const DIRECT_DEBUGGER_DIAGNOSTICS_URL_PATH: &str = "/api/v2/debugger";
 const AGENT_DEBUGGER_SNAPSHOTS_URL_PATH: &str = "/debugger/v2/input";
 const AGENT_DEBUGGER_DIAGNOSTICS_URL_PATH: &str = "/debugger/v1/diagnostics";
 
-// The symbol database (SymDB) intake shares the debugger-intake host. Direct
-// (agentless) uploads target /api/v2/debugger, while the agent exposes the
-// /symdb/v1/input proxy route.
-const DIRECT_SYMDB_URL_PATH: &str = "/api/v2/debugger";
+// The symbol database (SymDB) intake shares the debugger-intake host. For
+// agentless uploads SymDB intentionally reuses the same `/api/v2/debugger`
+// route as the diagnostics track (the intake demultiplexes by payload, not
+// path) - this equality is deliberate, not a copy-paste, so it is derived from
+// the diagnostics constant to keep the two in lockstep. The agent, by contrast,
+// exposes a distinct `/symdb/v1/input` proxy route.
+const DIRECT_SYMDB_URL_PATH: &str = DIRECT_DEBUGGER_DIAGNOSTICS_URL_PATH;
 const AGENT_SYMDB_URL_PATH: &str = "/symdb/v1/input";
 
 /// Creates an [`Endpoint`] for sending debugger and SymDB payloads directly to
@@ -170,8 +175,9 @@ impl Config {
     }
 
     /// Returns the endpoints for a debugger track: the primary endpoint first,
-    /// followed by any additional dual-ship endpoints.
-    fn debugger_endpoints_for(&self, debugger_type: DebuggerType) -> Vec<&Endpoint> {
+    /// followed by any additional dual-ship endpoints. Inlined for the common
+    /// single-endpoint case so the hot send path does not allocate.
+    fn debugger_endpoints_for(&self, debugger_type: DebuggerType) -> SmallVec<[&Endpoint; 1]> {
         let (primary, additional) = match debugger_type {
             DebuggerType::Diagnostics => (
                 &self.diagnostics_endpoint,
@@ -183,16 +189,17 @@ impl Config {
             ),
             DebuggerType::Logs => (&self.logs_endpoint, &self.additional_logs_endpoints),
         };
-        let mut endpoints = Vec::with_capacity(1 + additional.len());
+        let mut endpoints = SmallVec::new();
         endpoints.extend(primary.as_ref());
         endpoints.extend(additional.iter());
         endpoints
     }
 
     /// Returns the SymDB endpoints: the primary endpoint first, followed by any
-    /// additional dual-ship endpoints.
-    fn symdb_endpoints(&self) -> Vec<&Endpoint> {
-        let mut endpoints = Vec::with_capacity(1 + self.additional_symdb_endpoints.len());
+    /// additional dual-ship endpoints. Inlined for the common single-endpoint
+    /// case so the hot send path does not allocate.
+    fn symdb_endpoints(&self) -> SmallVec<[&Endpoint; 1]> {
+        let mut endpoints = SmallVec::new();
         endpoints.extend(self.symdb_endpoint.as_ref());
         endpoints.extend(self.additional_symdb_endpoints.iter());
         endpoints
@@ -423,16 +430,17 @@ pub async fn send(
         .split_first()
         .ok_or_else(|| anyhow::anyhow!("no endpoint configured for {debugger_type:?}"))?;
 
-    // Send the primary first so a slow or stalled additional endpoint cannot
-    // delay the intake whose result the caller actually depends on.
-    let result = send_to_endpoint(payload, primary, debugger_type, percent_encoded_tags).await;
-
-    // Best-effort dual-shipping to any additional endpoints, mirroring the
-    // agent's `*_additional_endpoints` fan-out where non-primary responses are
-    // discarded. Only the primary endpoint's result is returned to the caller.
-    for &endpoint in additional {
-        let _ = send_to_endpoint(payload, endpoint, debugger_type, percent_encoded_tags).await;
-    }
+    // Send the primary and any additional dual-ship endpoints concurrently,
+    // mirroring the agent's `*_additional_endpoints` fan-out. Additional
+    // responses are best-effort and discarded; only the primary endpoint's
+    // result is returned to the caller. Running concurrently keeps a slow or
+    // stalled additional endpoint from delaying the primary.
+    let primary_send = send_to_endpoint(payload, primary, debugger_type, percent_encoded_tags);
+    let additional_sends =
+        future::join_all(additional.iter().map(|&endpoint| {
+            send_to_endpoint(payload, endpoint, debugger_type, percent_encoded_tags)
+        }));
+    let (result, _) = future::join(primary_send, additional_sends).await;
     result
 }
 
@@ -463,13 +471,15 @@ pub async fn send_symdb(
         .split_first()
         .ok_or_else(|| anyhow::anyhow!("no symdb endpoint configured"))?;
 
-    // Send the primary first so a slow or stalled additional endpoint cannot
-    // delay the intake whose result the caller actually depends on.
-    let result = send_symdb_to_endpoint(payload, content_type, primary, tags).await;
-
-    for &endpoint in additional {
-        let _ = send_symdb_to_endpoint(payload, content_type, endpoint, tags).await;
-    }
+    // Send the primary and any additional dual-ship endpoints concurrently;
+    // additional responses are best-effort and discarded.
+    let primary_send = send_symdb_to_endpoint(payload, content_type, primary, tags);
+    let additional_sends = future::join_all(
+        additional
+            .iter()
+            .map(|&endpoint| send_symdb_to_endpoint(payload, content_type, endpoint, tags)),
+    );
+    let (result, _) = future::join(primary_send, additional_sends).await;
     result
 }
 

--- a/datadog-live-debugger/src/sender.rs
+++ b/datadog-live-debugger/src/sender.rs
@@ -423,13 +423,17 @@ pub async fn send(
         .split_first()
         .ok_or_else(|| anyhow::anyhow!("no endpoint configured for {debugger_type:?}"))?;
 
+    // Send the primary first so a slow or stalled additional endpoint cannot
+    // delay the intake whose result the caller actually depends on.
+    let result = send_to_endpoint(payload, primary, debugger_type, percent_encoded_tags).await;
+
     // Best-effort dual-shipping to any additional endpoints, mirroring the
     // agent's `*_additional_endpoints` fan-out where non-primary responses are
     // discarded. Only the primary endpoint's result is returned to the caller.
     for &endpoint in additional {
         let _ = send_to_endpoint(payload, endpoint, debugger_type, percent_encoded_tags).await;
     }
-    send_to_endpoint(payload, primary, debugger_type, percent_encoded_tags).await
+    result
 }
 
 async fn send_to_endpoint(
@@ -459,10 +463,14 @@ pub async fn send_symdb(
         .split_first()
         .ok_or_else(|| anyhow::anyhow!("no symdb endpoint configured"))?;
 
+    // Send the primary first so a slow or stalled additional endpoint cannot
+    // delay the intake whose result the caller actually depends on.
+    let result = send_symdb_to_endpoint(payload, content_type, primary, tags).await;
+
     for &endpoint in additional {
         let _ = send_symdb_to_endpoint(payload, content_type, endpoint, tags).await;
     }
-    send_symdb_to_endpoint(payload, content_type, primary, tags).await
+    result
 }
 
 async fn send_symdb_to_endpoint(

--- a/datadog-live-debugger/src/sender.rs
+++ b/datadog-live-debugger/src/sender.rs
@@ -471,12 +471,18 @@ async fn send_symdb_to_endpoint(
     endpoint: &Endpoint,
     tags: &str,
 ) -> anyhow::Result<()> {
-    let req = endpoint
+    let mut req = endpoint
         .to_request_builder(concat!("Tracer/", env!("CARGO_PKG_VERSION")))?
         .method(Method::POST)
-        .header("DD-EVP-ORIGIN", "agent-symdb")
         .header("X-Datadog-Additional-Tags", tags)
         .header("Content-type", content_type);
+
+    // The EVP origin only matters on the direct intake (agentless). In agent
+    // mode the agent sets it when proxying, so gate it on the API key to match
+    // the debugger tracks.
+    if endpoint.api_key.is_some() {
+        req = req.header("DD-EVP-ORIGIN", "agent-symdb");
+    }
 
     let body = http_common::Body::from(payload.to_vec());
     let response = http_common::into_response(


### PR DESCRIPTION
## What

Adds a transparent path for tracers to send Live Debugger and Symbol Database (SymDB) data **directly to the Datadog intake** when no agent is present, matching the behavior of the agent's debugger proxy routes (`/debugger/v1/diagnostics`, `/debugger/v2/input`, `/symdb/v1/input`). This extends the existing `datadog-live-debugger` crate and its FFI rather than adding a new crate.

## Why

In agentless mode the tracer has no local agent to enrich and forward debugger/SymDB payloads to intake. This gives `libdatadog` the agent's forwarding behavior so tracers (e.g. dd-trace) can ship the same payloads transparently, choosing agent vs. agentless based on whether an API key is present.

## Changes

**Core (`datadog-live-debugger/src/sender.rs`)**
- `debugger_intake_endpoint(site, api_key)` builds an agentless endpoint targeting `debugger-intake.{site}` (mirrors profiling's `agentless()`).
- Factored the per-track path derivation into `derive_endpoint_path()`; agentless requests use `/api/v2/debugger`, agent requests use the proxy paths. `file://` endpoints (tests) are left untouched.
- `Config` gained `symdb_endpoint` plus dual-ship endpoint vectors, with `set_symdb_endpoint`, `add_additional_debugger_endpoint`, and `add_additional_symdb_endpoint`.
- `send()` and `send_symdb()` send the primary endpoint first, then fan out best-effort to any additional endpoints (mirroring the agent's `*_additional_endpoints`, where non-primary responses are discarded). Sending the primary first keeps a slow or stalled additional endpoint from delaying the intake the caller depends on.
- `send_symdb()` forwards raw bytes verbatim with `DD-EVP-ORIGIN: agent-symdb` and tags carried in the `X-Datadog-Additional-Tags` header (matching `symdb.go`).
- `PayloadSender::new` split into `new` / `new_to_endpoint`; existing callers (e.g. `datadog-sidecar`) are unaffected.

**FFI (`datadog-live-debugger-ffi/src/sender.rs`)**
- `ddog_live_debugger_endpoint_from_site_and_api_key` for the agentless endpoint (freed via the existing `ddog_endpoint_drop`).
- A config-builder surface (`..._sender_config_new` / `..._set_endpoint` / `..._set_symdb_endpoint` / `..._add_additional_endpoint` / `..._add_additional_symdb_endpoint` / `..._drop`) and `ddog_live_debugger_spawn_sender_with_config`. The existing `ddog_live_debugger_spawn_sender` is unchanged.
- `ddog_live_debugger_send_symdb_data` to enqueue a raw SymDB body (zero-copy across the boundary via `OwnedCharSlice`).
- The sender routine logs the track name via a static `&str` instead of formatting one per send, dropping an allocation on the hot path.

`DebuggerType` is intentionally left unchanged (SymDB is handled as a separate path) because `datadog-sidecar` does an exhaustive match on it.

## Testing

- `cargo check` on both crates and `datadog-sidecar`
- `cargo +nightly-2026-02-08 fmt --check`, `cargo clippy --all-targets --all-features -D warnings`
- `cargo test -p datadog-live-debugger -p datadog-live-debugger-ffi` (14 pass, 4 new)
- cbindgen header verified; `cargo ffi-test` (only pre-existing `crashtracking`/`ffe` env failures, unrelated to this change)
- No new dependencies; `Cargo.lock` untouched.
