### PR TITLE
fix(sidecar): configure OTLP endpoint for FFE metrics

### DIFF
--- a/datadog-sidecar-ffi/src/lib.rs
+++ b/datadog-sidecar-ffi/src/lib.rs
@@ -64,6 +64,19 @@ use std::time::Duration;
 
 use datadog_sidecar::setup::{connect_to_master, MasterListener};
 
+fn otlp_metrics_endpoint_with_agent_test_token(
+    mut otlp_metrics_endpoint: Option<Endpoint>,
+    agent_endpoint: &Endpoint,
+) -> Option<Endpoint> {
+    if let Some(endpoint) = &mut otlp_metrics_endpoint {
+        if endpoint.test_token.is_none() {
+            endpoint.test_token = agent_endpoint.test_token.clone();
+        }
+    }
+
+    otlp_metrics_endpoint
+}
+
 #[no_mangle]
 #[cfg(target_os = "windows")]
 pub extern "C" fn ddog_setup_crashtracking(
@@ -639,12 +652,10 @@ pub unsafe extern "C" fn ddog_sidecar_session_set_config(
     parent_session_id: ffi::CharSlice,
 ) -> MaybeError {
     let session_id_str: String = session_id.to_utf8_lossy().into();
-    let mut otlp_metrics_endpoint = unsafe { otlp_metrics_endpoint.as_ref().cloned() };
-    if let Some(endpoint) = &mut otlp_metrics_endpoint {
-        if endpoint.test_token.is_none() {
-            endpoint.test_token = agent_endpoint.test_token.clone();
-        }
-    }
+    let otlp_metrics_endpoint: Option<Endpoint> =
+        unsafe { otlp_metrics_endpoint.as_ref().cloned() };
+    let otlp_metrics_endpoint =
+        otlp_metrics_endpoint_with_agent_test_token(otlp_metrics_endpoint, agent_endpoint);
     let session_config = SessionConfig {
         endpoint: agent_endpoint.clone(),
         dogstatsd_endpoint: dogstatsd_endpoint.clone(),
@@ -1730,4 +1741,44 @@ pub unsafe extern "C" fn ddog_drop_agent_info_reader(_: Box<AgentInfoReader>) {}
 pub unsafe extern "C" fn ddog_sidecar_send_garbage(transport: &mut Box<SidecarTransport>) {
     // This shall fail.
     let _ = transport.send_garbage();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::borrow::Cow;
+
+    #[test]
+    fn otlp_metrics_endpoint_inherits_agent_test_token_when_missing() {
+        let agent_endpoint = Endpoint {
+            test_token: Some(Cow::Borrowed("agent-token")),
+            ..Endpoint::default()
+        };
+
+        let endpoint =
+            otlp_metrics_endpoint_with_agent_test_token(Some(Endpoint::default()), &agent_endpoint)
+                .expect("expected OTLP metrics endpoint");
+
+        assert_eq!(endpoint.test_token.as_deref(), Some("agent-token"));
+    }
+
+    #[test]
+    fn otlp_metrics_endpoint_keeps_explicit_test_token() {
+        let agent_endpoint = Endpoint {
+            test_token: Some(Cow::Borrowed("agent-token")),
+            ..Endpoint::default()
+        };
+        let otlp_metrics_endpoint = Endpoint {
+            test_token: Some(Cow::Borrowed("metrics-token")),
+            ..Endpoint::default()
+        };
+
+        let endpoint = otlp_metrics_endpoint_with_agent_test_token(
+            Some(otlp_metrics_endpoint),
+            &agent_endpoint,
+        )
+        .expect("expected OTLP metrics endpoint");
+
+        assert_eq!(endpoint.test_token.as_deref(), Some("metrics-token"));
+    }
 }

--- a/datadog-sidecar-ffi/src/lib.rs
+++ b/datadog-sidecar-ffi/src/lib.rs
@@ -613,6 +613,7 @@ pub unsafe extern "C" fn ddog_sidecar_session_set_config(
     session_id: ffi::CharSlice,
     agent_endpoint: &Endpoint,
     dogstatsd_endpoint: &Endpoint,
+    otlp_metrics_endpoint: *const Endpoint,
     language: ffi::CharSlice,
     language_version: ffi::CharSlice,
     tracer_version: ffi::CharSlice,
@@ -638,9 +639,16 @@ pub unsafe extern "C" fn ddog_sidecar_session_set_config(
     parent_session_id: ffi::CharSlice,
 ) -> MaybeError {
     let session_id_str: String = session_id.to_utf8_lossy().into();
+    let mut otlp_metrics_endpoint = unsafe { otlp_metrics_endpoint.as_ref().cloned() };
+    if let Some(endpoint) = &mut otlp_metrics_endpoint {
+        if endpoint.test_token.is_none() {
+            endpoint.test_token = agent_endpoint.test_token.clone();
+        }
+    }
     let session_config = SessionConfig {
         endpoint: agent_endpoint.clone(),
         dogstatsd_endpoint: dogstatsd_endpoint.clone(),
+        otlp_metrics_endpoint,
         language: language.to_utf8_lossy().into(),
         language_version: language_version.to_utf8_lossy().into(),
         tracer_version: tracer_version.to_utf8_lossy().into(),
@@ -1223,23 +1231,21 @@ fn ddog_sidecar_send_ffe_exposure_batch_impl(
 /// safely coexist until they explicitly migrate.
 ///
 /// # Safety
-/// `endpoint`, `context`, and every element in `metrics` must contain valid
-/// UTF-8 `CharSlice` values. Empty `endpoint` or `metrics` is a no-op.
+/// `context` and every element in `metrics` must contain valid UTF-8
+/// `CharSlice` values. Empty `metrics` is a no-op.
 #[no_mangle]
 #[allow(clippy::missing_safety_doc)]
 pub unsafe extern "C" fn ddog_sidecar_send_ffe_evaluation_metrics(
     transport: &mut Box<SidecarTransport>,
     instance_id: &InstanceId,
     queue_id: &QueueId,
-    endpoint: CharSlice,
     context: &FfeTelemetryContext<'_>,
     metrics: Slice<FfeEvaluationMetric<'_>>,
 ) -> MaybeError {
-    if endpoint.is_empty() || metrics.is_empty() {
+    if metrics.is_empty() {
         return MaybeError::None;
     }
 
-    let endpoint = try_c!(char_slice_to_string(endpoint));
     let context = try_c!(ffe_context_from_ffi(context));
     let metrics = try_c!(metrics
         .try_as_slice()
@@ -1257,11 +1263,7 @@ pub unsafe extern "C" fn ddog_sidecar_send_ffe_evaluation_metrics(
         transport,
         instance_id,
         queue_id,
-        vec![SidecarAction::FfeEvaluationMetrics {
-            endpoint,
-            context,
-            metrics,
-        }],
+        vec![SidecarAction::FfeEvaluationMetrics { context, metrics }],
     ));
     MaybeError::None
 }

--- a/datadog-sidecar-ffi/tests/sidecar.rs
+++ b/datadog-sidecar-ffi/tests/sidecar.rs
@@ -92,6 +92,7 @@ fn test_ddog_sidecar_register_app() {
                 ..Default::default()
             },
             &Endpoint::default(),
+            null(),
             "".into(),
             "".into(),
             "".into(),
@@ -148,6 +149,7 @@ fn test_ddog_sidecar_register_app() {
                 ..Default::default()
             },
             &Endpoint::default(),
+            null(),
             "".into(),
             "".into(),
             "".into(),

--- a/datadog-sidecar-ffi/tests/sidecar.rs
+++ b/datadog-sidecar-ffi/tests/sidecar.rs
@@ -84,15 +84,21 @@ fn test_ddog_sidecar_register_app() {
 
     unsafe {
         let process_tags = libdd_common_ffi::Vec::default();
+        let agent_endpoint = Endpoint {
+            url: http::Uri::from_static("http://localhost:8082/"),
+            test_token: Some("agent-token".into()),
+            ..Default::default()
+        };
+        let otlp_metrics_endpoint = Endpoint {
+            url: http::Uri::from_static("http://localhost:4318/v1/metrics"),
+            ..Default::default()
+        };
         ddog_sidecar_session_set_config(
             &mut transport,
             "session_id".into(),
-            &Endpoint {
-                url: http::Uri::from_static("http://localhost:8082/"),
-                ..Default::default()
-            },
+            &agent_endpoint,
             &Endpoint::default(),
-            null(),
+            &otlp_metrics_endpoint,
             "".into(),
             "".into(),
             "".into(),

--- a/datadog-sidecar/src/service/ffe_metrics_flusher.rs
+++ b/datadog-sidecar/src/service/ffe_metrics_flusher.rs
@@ -14,21 +14,6 @@ use tracing::{debug, warn};
 
 const USER_AGENT: &str = concat!("ddtrace-sidecar/", env!("CARGO_PKG_VERSION"));
 
-/// Build an `Endpoint` for an OTLP metrics intake from a fully-qualified URL.
-///
-/// Production callers supply the URL via the FFI (typically the value of
-/// `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`; the OpenTelemetry spec default is
-/// `http://localhost:4318/v1/metrics`).
-/// Returns `None` if the URL is unparseable. The OTLP endpoint is unrelated
-/// to the Agent base, so we don't preserve any session fields here.
-pub(crate) fn otlp_metrics_endpoint(url: &str) -> Option<Endpoint> {
-    let url = url.parse().ok()?;
-    Some(Endpoint {
-        url,
-        ..Endpoint::default()
-    })
-}
-
 /// POST structured FFE metric events as OTLP/protobuf to the configured intake.
 /// Fire-and-forget: non-2xx responses and network errors are logged and
 /// dropped (matches dd-trace-go/py OTLP exporter behavior).
@@ -140,8 +125,10 @@ mod tests {
             })
             .await;
 
-        let url = server.url("/v1/metrics");
-        let ep = otlp_metrics_endpoint(&url).unwrap();
+        let ep = Endpoint {
+            url: server.url("/v1/metrics").parse().unwrap(),
+            ..Endpoint::default()
+        };
         let client = NativeCapabilities::new_client();
 
         send_metrics(
@@ -168,8 +155,10 @@ mod tests {
             })
             .await;
 
-        let url = server.url("/v1/metrics");
-        let ep = otlp_metrics_endpoint(&url).unwrap();
+        let ep = Endpoint {
+            url: server.url("/v1/metrics").parse().unwrap(),
+            ..Endpoint::default()
+        };
         let client = NativeCapabilities::new_client();
         send_metrics(
             &client,
@@ -195,18 +184,6 @@ mod tests {
             vec![metric("flag", "variant", "TARGETING_MATCH")],
         )
         .await;
-    }
-
-    #[test]
-    fn default_endpoint_is_parseable() {
-        let ep = otlp_metrics_endpoint("http://localhost:4318/v1/metrics").unwrap();
-        assert_eq!(ep.url.scheme_str(), Some("http"));
-        assert_eq!(ep.url.path(), "/v1/metrics");
-    }
-
-    #[test]
-    fn invalid_url_returns_none() {
-        assert!(otlp_metrics_endpoint("not a url").is_none());
     }
 
     #[derive(Clone, Debug)]

--- a/datadog-sidecar/src/service/mod.rs
+++ b/datadog-sidecar/src/service/mod.rs
@@ -80,6 +80,8 @@ pub struct SessionConfig {
     pub root_service: String,
     pub root_session_id: Option<String>,
     pub parent_session_id: Option<String>,
+    /// Optional OTLP metrics intake endpoint.
+    pub otlp_metrics_endpoint: Option<Endpoint>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -94,7 +96,6 @@ pub enum SidecarAction {
     /// aggregation, serialization, and delivery. This action must be sent only
     /// by SDKs that explicitly opted into native FFE metric ownership.
     FfeEvaluationMetrics {
-        endpoint: String,
         context: FfeTelemetryContext,
         metrics: Vec<FfeEvaluationMetric>,
     },

--- a/datadog-sidecar/src/service/session_info.rs
+++ b/datadog-sidecar/src/service/session_info.rs
@@ -14,7 +14,7 @@ use crate::log::{MultiEnvFilterGuard, MultiWriterGuard};
 use crate::{spawn_map_err, tracer};
 use datadog_live_debugger::sender::{DebuggerType, PayloadSender};
 use datadog_remote_config::fetch::ConfigOptions;
-use libdd_common::{tag::Tag, MutexExt};
+use libdd_common::{tag::Tag, Endpoint, MutexExt};
 use tracing::{debug, error, info, trace, warn};
 
 use crate::service::agent_info::AgentInfoGuard;
@@ -46,6 +46,7 @@ pub(crate) struct SessionInfo {
     pub(crate) remote_config_enabled: Arc<Mutex<bool>>,
     pub(crate) process_tags: Arc<Mutex<Vec<Tag>>>,
     pub(crate) stats_config: Arc<Mutex<Option<crate::service::stats_flusher::StatsConfig>>>,
+    otlp_metrics_endpoint: Arc<Mutex<Option<Endpoint>>>,
 }
 
 impl SessionInfo {
@@ -158,6 +159,17 @@ impl SessionInfo {
         if let Some(cfg) = &mut *self.stats_config.lock_or_panic() {
             f(cfg)
         }
+    }
+
+    pub(crate) fn get_otlp_metrics_endpoint(&self) -> MutexGuard<'_, Option<Endpoint>> {
+        self.otlp_metrics_endpoint.lock_or_panic()
+    }
+
+    pub(crate) fn modify_otlp_metrics_endpoint<F>(&self, f: F)
+    where
+        F: FnOnce(&mut Option<Endpoint>),
+    {
+        f(&mut self.get_otlp_metrics_endpoint());
     }
 
     pub(crate) fn get_trace_config(&self) -> MutexGuard<'_, tracer::Config> {

--- a/datadog-sidecar/src/service/sidecar_server.rs
+++ b/datadog-sidecar/src/service/sidecar_server.rs
@@ -1243,11 +1243,12 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     async fn ffe_metric_actions_dispatch_without_registered_application() {
         let http_server = MockServer::start_async().await;
+        let test_session_token = "ffe/evaluation_metrics_sidecar";
         let metrics_mock = http_server
             .mock_async(|when, then| {
                 when.method(POST)
                     .path("/v1/metrics")
-                    .header("x-datadog-test-session-token", "ffe-metrics-token");
+                    .header("x-datadog-test-session-token", test_session_token);
                 then.status(202);
             })
             .await;
@@ -1265,7 +1266,7 @@ mod tests {
                     ..Endpoint::default()
                 };
                 cfg.set_endpoint(endpoint).unwrap();
-                cfg.set_endpoint_test_token(Some("ffe-metrics-token"));
+                cfg.set_endpoint_test_token(Some(test_session_token));
             });
 
         assert!(!handler

--- a/datadog-sidecar/src/service/sidecar_server.rs
+++ b/datadog-sidecar/src/service/sidecar_server.rs
@@ -446,7 +446,12 @@ impl SidecarInterface for ConnectionSidecarHandler {
                     context,
                     metrics,
                 } => {
-                    if let Some(ep) = ffe_metrics_flusher::otlp_metrics_endpoint(endpoint) {
+                    if let Some(mut ep) = ffe_metrics_flusher::otlp_metrics_endpoint(endpoint) {
+                        if ep.test_token.is_none() {
+                            if let Some(base) = trace_config.endpoint.as_ref() {
+                                ep.test_token = base.test_token.clone();
+                            }
+                        }
                         let client = ffe_http_client.clone();
                         let context = context.clone();
                         let metrics = metrics.clone();
@@ -1240,7 +1245,9 @@ mod tests {
         let http_server = MockServer::start_async().await;
         let metrics_mock = http_server
             .mock_async(|when, then| {
-                when.method(POST).path("/v1/metrics");
+                when.method(POST)
+                    .path("/v1/metrics")
+                    .header("x-datadog-test-session-token", "ffe-metrics-token");
                 then.status(202);
             })
             .await;
@@ -1248,6 +1255,18 @@ mod tests {
         let handler = ConnectionSidecarHandler::new(SidecarServer::default());
         let instance_id = InstanceId::new("session", "runtime");
         let queue_id = QueueId::from(42);
+
+        handler
+            .server
+            .get_session(&instance_id.session_id)
+            .modify_trace_config(|cfg| {
+                let endpoint = Endpoint {
+                    url: http_server.url("/").parse().unwrap(),
+                    ..Endpoint::default()
+                };
+                cfg.set_endpoint(endpoint).unwrap();
+                cfg.set_endpoint_test_token(Some("ffe-metrics-token"));
+            });
 
         assert!(!handler
             .server

--- a/datadog-sidecar/src/service/sidecar_server.rs
+++ b/datadog-sidecar/src/service/sidecar_server.rs
@@ -441,17 +441,8 @@ impl SidecarInterface for ConnectionSidecarHandler {
                     }
                     false
                 }
-                SidecarAction::FfeEvaluationMetrics {
-                    endpoint,
-                    context,
-                    metrics,
-                } => {
-                    if let Some(mut ep) = ffe_metrics_flusher::otlp_metrics_endpoint(endpoint) {
-                        if ep.test_token.is_none() {
-                            if let Some(base) = trace_config.endpoint.as_ref() {
-                                ep.test_token = base.test_token.clone();
-                            }
-                        }
+                SidecarAction::FfeEvaluationMetrics { context, metrics } => {
+                    if let Some(ep) = session.get_otlp_metrics_endpoint().clone() {
                         let client = ffe_http_client.clone();
                         let context = context.clone();
                         let metrics = metrics.clone();
@@ -459,9 +450,7 @@ impl SidecarInterface for ConnectionSidecarHandler {
                             ffe_metrics_flusher::send_metrics(&client, &ep, context, metrics).await;
                         });
                     } else {
-                        debug!(
-                            "ffe_metrics_flusher: unparseable endpoint {endpoint:?}, dropping batch"
-                        );
+                        debug!("ffe_metrics_flusher: no configured endpoint, dropping batch");
                     }
                     false
                 }
@@ -732,6 +721,9 @@ impl SidecarInterface for ConnectionSidecarHandler {
             cfg.language.clone_from(&config.language);
             cfg.language_version.clone_from(&config.language_version);
             cfg.tracer_version.clone_from(&config.tracer_version);
+        });
+        session.modify_otlp_metrics_endpoint(|endpoint| {
+            *endpoint = config.otlp_metrics_endpoint.clone();
         });
         session.configure_dogstatsd(|dogstatsd| {
             let d = new(config.dogstatsd_endpoint.clone()).ok();
@@ -1120,6 +1112,11 @@ impl SidecarInterface for ConnectionSidecarHandler {
         session.modify_trace_config(|trace_cfg| {
             trace_cfg.set_endpoint_test_token(token.clone());
         });
+        session.modify_otlp_metrics_endpoint(|endpoint| {
+            if let Some(endpoint) = endpoint {
+                endpoint.test_token = token.clone();
+            }
+        });
         // Update the stats config so newly created concentrators carry the test token.
         session.modify_stats_config(|cfg| {
             cfg.endpoint.test_token = token.clone();
@@ -1260,13 +1257,12 @@ mod tests {
         handler
             .server
             .get_session(&instance_id.session_id)
-            .modify_trace_config(|cfg| {
-                let endpoint = Endpoint {
-                    url: http_server.url("/").parse().unwrap(),
+            .modify_otlp_metrics_endpoint(|endpoint| {
+                *endpoint = Some(Endpoint {
+                    url: http_server.url("/v1/metrics").parse().unwrap(),
+                    test_token: Some(test_session_token.into()),
                     ..Endpoint::default()
-                };
-                cfg.set_endpoint(endpoint).unwrap();
-                cfg.set_endpoint_test_token(Some(test_session_token));
+                });
             });
 
         assert!(!handler
@@ -1281,7 +1277,6 @@ mod tests {
                 instance_id.clone(),
                 queue_id,
                 vec![SidecarAction::FfeEvaluationMetrics {
-                    endpoint: http_server.url("/v1/metrics"),
                     context: ffe_context(),
                     metrics: vec![ffe_metric()],
                 }],


### PR DESCRIPTION
## Motivation

Companion PHP evaluation-metrics work needs FFE metrics to follow the sidecar architecture used by the rest of the tracer: configure endpoints once on the session, then send typed sidecar actions without carrying endpoint strings on every flush.

The previous FFE metrics path accepted an OTLP endpoint alongside each metrics batch. That diverged from the normal `Endpoint` flow, made test-session-token propagation easy to miss, and forced PHP to keep fetching endpoint configuration during request flushes.

Design context: https://docs.google.com/document/d/1NvMfTpZWLBlFmEFNjdnlMyeVpy5l7KD8qujGFco6w2w/edit?tab=t.0

Companion PHP PR: https://github.com/DataDog/dd-trace-php/pull/3911

## Changes

- Add an optional OTLP metrics `Endpoint` to sidecar session configuration.
- Thread that endpoint through `ddog_sidecar_session_set_config` and session state.
- Dispatch `SidecarAction::FfeEvaluationMetrics` through the session's configured OTLP metrics endpoint instead of an endpoint passed with each metrics batch.
- Preserve request-replayer test-session routing by inheriting the agent endpoint `test_token` when the OTLP metrics endpoint does not already have one.
- Update runtime test-token changes so the configured OTLP metrics endpoint is updated with the rest of the session endpoints.
- Extend the sidecar FFE metrics dispatch test to assert the outgoing OTLP request carries `x-datadog-test-session-token` through `Endpoint` standard headers.

## Decisions

FFE metrics remain caller-driven. This PR does not make shared evaluator calls auto-emit metrics, so SDKs that still log metrics in host language implementations can continue to coexist without double counting.

The sidecar owns metrics transport, aggregation, OTLP/protobuf encoding, and endpoint/header handling. PHP remains responsible for constructing the appropriate OTLP metrics endpoint from its existing configuration resolver and supplying it once during sidecar session setup.

The test-session-token behavior is intentionally implemented through `Endpoint`, not by manually adding FFE-specific headers. Production endpoints normally have no test token, so production behavior is unchanged.

## Validation

Local targeted test:

```sh
cargo test -p datadog-sidecar ffe_metric_actions_dispatch_without_registered_application
```

Result: passed locally.

PHP integration smoke test:

Companion PHP PR: https://github.com/DataDog/dd-trace-php/pull/3911

The local PHP branch backing that PR was updated to this libdatadog PR head (`091c98df6`): PHP passes the OTLP metrics `Endpoint` once during sidecar session setup, and FFE metric flushes send only context plus metric payloads.

```sh
docker-compose run --no-deps 8.3-bookworm bash -lc \
  'export PATH=/rust/cargo/bin:$PATH TMPDIR=/home/circleci/app/tmp TMP=/home/circleci/app/tmp TEMP=/home/circleci/app/tmp; make MAX_TEST_PARALLELISM=1 test_c TESTS=tests/ext/ffe/evaluation_metrics_unix_agent_endpoint.phpt'
```

Result: `tests/ext/ffe/evaluation_metrics_unix_agent_endpoint.phpt` passed locally under Docker on PHP 8.3/Linux aarch64: `Tests passed 1 (100.0%)`.

That PHPT validates the PHP sidecar integration over `DD_TRACE_AGENT_URL=unix://...`: the request reaches `/v1/metrics`, uses `application/x-protobuf`, and carries the request-replayer test-session token through the configured endpoint path.

Negative validation during review:

- Removing only the mock header matcher still allows the request through, but stops proving token propagation.
- Keeping the matcher and removing `Endpoint.test_token` fails with a missing `x-datadog-test-session-token` header.
- Restoring both passes, confirming the request uses `Endpoint` standard headers.

CI on commit `091c98d` reports all tests passed and no new flaky tests.


## End-to-End Evidence

The companion PHP branch for https://github.com/DataDog/dd-trace-php/pull/3911 was validated locally against this libdatadog PR head (`091c98df6`). That path exercises the full PHP metrics flow:

`PHP API -> tracer request buffer -> sidecar session-configured OTLP metrics Endpoint -> sidecar FFE metrics action -> request-replayer UDS intake`

Docker command used from the PHP repo:

```sh
docker-compose run --no-deps 8.3-bookworm bash -lc \
  'export PATH=/rust/cargo/bin:$PATH TMPDIR=/home/circleci/app/tmp TMP=/home/circleci/app/tmp TEMP=/home/circleci/app/tmp; make MAX_TEST_PARALLELISM=1 test_c TESTS=tests/ext/ffe/evaluation_metrics_unix_agent_endpoint.phpt'
```

Observed result:

```text
Number of tests :     1                 1
Tests failed    :     0 (  0.0%) (  0.0%)
Tests passed    :     1 (100.0%) (100.0%)
```

The passing PHPT confirms PHP can record and flush an FFE evaluation metric through the sidecar over `DD_TRACE_AGENT_URL=unix://...`, and that the captured request reaches `/v1/metrics` with `Content-Type: application/x-protobuf` plus the request-replayer test-session token propagated through the configured `Endpoint`.
