### PR TITLE
fix(libdd-common): Add fallback logic for resolving Azure Functions instance name [SVLS-8931]

### DIFF
--- a/libdd-common/src/azure_app_services.rs
+++ b/libdd-common/src/azure_app_services.rs
@@ -259,9 +259,8 @@ impl AzureMetadata {
         let pod_name = query.get_var(WEBSITE_POD_NAME);
         let computer_name = query.get_var(INSTANCE_NAME);
         let instance_name = resolve_instance_name(
-            website_sku.as_deref(),
-            container_name.as_deref(),
             pod_name.as_deref(),
+            container_name.as_deref(),
             computer_name.as_deref(),
         );
 
@@ -411,31 +410,19 @@ impl AzureMetadata {
     }
 }
 
-/// Resolves the instance name using the env var that provides an instance value
-/// that matches the Azure integration metric's `instance` tag for the current hosting plan
-/// with fallback logic if the preferred source is empty.
+/// Resolves the instance name to match the Azure integration metric's `instance` tag.
 fn resolve_instance_name(
-    website_sku: Option<&str>,
-    container_name: Option<&str>,
     pod_name: Option<&str>,
+    container_name: Option<&str>,
     computer_name: Option<&str>,
 ) -> Option<String> {
     fn non_empty(s: Option<&str>) -> Option<&str> {
         s.map(|v| v.trim()).filter(|v| !v.is_empty())
     }
 
-    let sku_preferred = match website_sku {
-        Some("FlexConsumption") | Some("Dynamic") => {
-            non_empty(container_name).or_else(|| non_empty(pod_name))
-        }
-        Some(_) => non_empty(computer_name),
-        None => None,
-    };
-
-    sku_preferred
-        .or_else(|| non_empty(computer_name))
-        .or_else(|| non_empty(container_name))
+    non_empty(computer_name)
         .or_else(|| non_empty(pod_name))
+        .or_else(|| non_empty(container_name))
         .map(|s| s.to_string())
 }
 
@@ -1049,68 +1036,43 @@ mod tests {
     }
 
     #[test]
-    fn test_instance_name_flex_consumption_uses_container_name() {
+    fn test_instance_name_computer_name_wins_over_pod_and_container() {
         let mocked_env = MockEnv::new(&[
             (FUNCTIONS_WORKER_RUNTIME, "node"),
-            (WEBSITE_SKU, "FlexConsumption"),
-            ("CONTAINER_NAME", "0--abc-DEF"),
-            ("WEBSITE_POD_NAME", "0--abc-test"),
+            (INSTANCE_NAME, "10-20-30-40"),
+            (CONTAINER_NAME, "container-1"),
         ]);
         let metadata = AzureMetadata::new_function(mocked_env).unwrap();
-        assert_eq!(metadata.get_instance_name(), "0--abc-DEF");
+        assert_eq!(metadata.get_instance_name(), "10-20-30-40");
     }
 
     #[test]
-    fn test_instance_name_flex_consumption_falls_back_to_pod_name() {
+    fn test_instance_name_pod_name_preferred_over_container_name() {
         let mocked_env = MockEnv::new(&[
             (FUNCTIONS_WORKER_RUNTIME, "node"),
-            (WEBSITE_SKU, "FlexConsumption"),
-            ("WEBSITE_POD_NAME", "0--abc-def"),
+            (WEBSITE_POD_NAME, "0--abc-test"),
+            (CONTAINER_NAME, "container-1"),
         ]);
         let metadata = AzureMetadata::new_function(mocked_env).unwrap();
-        assert_eq!(metadata.get_instance_name(), "0--abc-def");
+        assert_eq!(metadata.get_instance_name(), "0--abc-test");
     }
 
     #[test]
-    fn test_instance_name_dynamic_uses_container_name() {
+    fn test_instance_name_falls_back_to_container_name() {
         let mocked_env = MockEnv::new(&[
             (FUNCTIONS_WORKER_RUNTIME, "node"),
-            (WEBSITE_SKU, "Dynamic"),
-            ("CONTAINER_NAME", "ABCD1234-111122223333444455"),
+            (CONTAINER_NAME, "0--abc-test"),
         ]);
         let metadata = AzureMetadata::new_function(mocked_env).unwrap();
-        assert_eq!(metadata.get_instance_name(), "ABCD1234-111122223333444455");
-    }
-
-    #[test]
-    fn test_instance_name_elastic_premium_uses_computer_name() {
-        let mocked_env = MockEnv::new(&[
-            (FUNCTIONS_WORKER_RUNTIME, "node"),
-            (WEBSITE_SKU, "ElasticPremium"),
-            (INSTANCE_NAME, "ep0fakewk0000A1"),
-        ]);
-        let metadata = AzureMetadata::new_function(mocked_env).unwrap();
-        assert_eq!(metadata.get_instance_name(), "ep0fakewk0000A1");
-    }
-
-    #[test]
-    fn test_instance_name_dedicated_uses_computer_name() {
-        let mocked_env = MockEnv::new(&[
-            (FUNCTIONS_WORKER_RUNTIME, "node"),
-            (WEBSITE_SKU, "PremiumV3"),
-            (INSTANCE_NAME, "p3fakewk0000B2"),
-        ]);
-        let metadata = AzureMetadata::new_function(mocked_env).unwrap();
-        assert_eq!(metadata.get_instance_name(), "p3fakewk0000B2");
+        assert_eq!(metadata.get_instance_name(), "0--abc-test");
     }
 
     #[test]
     fn test_instance_name_empty_string_treated_as_missing() {
         let mocked_env = MockEnv::new(&[
             (FUNCTIONS_WORKER_RUNTIME, "node"),
-            (WEBSITE_SKU, "ElasticPremium"),
-            ("CONTAINER_NAME", ""),
-            ("WEBSITE_POD_NAME", ""),
+            (CONTAINER_NAME, ""),
+            (WEBSITE_POD_NAME, ""),
             (INSTANCE_NAME, "worker-1"),
         ]);
         let metadata = AzureMetadata::new_function(mocked_env).unwrap();
@@ -1121,56 +1083,12 @@ mod tests {
     fn test_instance_name_whitespace_only_treated_as_missing() {
         let mocked_env = MockEnv::new(&[
             (FUNCTIONS_WORKER_RUNTIME, "node"),
-            (WEBSITE_SKU, "ElasticPremium"),
-            ("CONTAINER_NAME", "   "),
-            ("WEBSITE_POD_NAME", "   "),
+            (CONTAINER_NAME, "   "),
+            (WEBSITE_POD_NAME, "   "),
             (INSTANCE_NAME, "worker-2"),
         ]);
         let metadata = AzureMetadata::new_function(mocked_env).unwrap();
         assert_eq!(metadata.get_instance_name(), "worker-2");
-    }
-
-    #[test]
-    fn test_instance_name_unknown_sku_falls_back_to_container_name() {
-        let mocked_env = MockEnv::new(&[
-            (FUNCTIONS_WORKER_RUNTIME, "node"),
-            (WEBSITE_SKU, "PremiumV4"),
-            ("CONTAINER_NAME", "container-1"),
-        ]);
-        let metadata = AzureMetadata::new_function(mocked_env).unwrap();
-        assert_eq!(metadata.get_instance_name(), "container-1");
-    }
-
-    #[test]
-    fn test_instance_name_windows_consumption_falls_through_to_computer_name() {
-        let mocked_env = MockEnv::new(&[
-            (FUNCTIONS_WORKER_RUNTIME, "node"),
-            (WEBSITE_SKU, "Dynamic"),
-            (INSTANCE_NAME, "10-20-30-40"),
-        ]);
-        let metadata = AzureMetadata::new_function(mocked_env).unwrap();
-        assert_eq!(metadata.get_instance_name(), "10-20-30-40");
-    }
-
-    #[test]
-    fn test_instance_name_no_sku_prefers_computer_name() {
-        let mocked_env = MockEnv::new(&[
-            (FUNCTIONS_WORKER_RUNTIME, "node"),
-            ("CONTAINER_NAME", "container-1"),
-            (INSTANCE_NAME, "worker-1"),
-        ]);
-        let metadata = AzureMetadata::new_function(mocked_env).unwrap();
-        assert_eq!(metadata.get_instance_name(), "worker-1");
-    }
-
-    #[test]
-    fn test_instance_name_no_sku_falls_back_to_container_name() {
-        let mocked_env = MockEnv::new(&[
-            (FUNCTIONS_WORKER_RUNTIME, "node"),
-            ("CONTAINER_NAME", "container-1"),
-        ]);
-        let metadata = AzureMetadata::new_function(mocked_env).unwrap();
-        assert_eq!(metadata.get_instance_name(), "container-1");
     }
 
     #[test]

--- a/libdd-common/src/azure_app_services.rs
+++ b/libdd-common/src/azure_app_services.rs
@@ -1049,13 +1049,6 @@ mod tests {
     }
 
     #[test]
-    fn test_public_consts_are_accessible() {
-        assert_eq!(super::WEBSITE_SKU, "WEBSITE_SKU");
-        assert_eq!(super::UNKNOWN_VALUE, "unknown");
-        assert_eq!(super::REGION_NAME, "REGION_NAME");
-    }
-
-    #[test]
     fn test_instance_name_flex_consumption_uses_container_name() {
         let mocked_env = MockEnv::new(&[
             (FUNCTIONS_WORKER_RUNTIME, "node"),

--- a/libdd-common/src/azure_app_services.rs
+++ b/libdd-common/src/azure_app_services.rs
@@ -11,7 +11,9 @@ const WEBSITE_SITE_NAME: &str = "WEBSITE_SITE_NAME";
 const WEBSITE_RESOURCE_GROUP: &str = "WEBSITE_RESOURCE_GROUP";
 const SITE_EXTENSION_VERSION: &str = "DD_AAS_DOTNET_EXTENSION_VERSION";
 const WEBSITE_OS: &str = "WEBSITE_OS";
-const INSTANCE_NAME: &str = "COMPUTERNAME";
+const COMPUTERNAME: &str = "COMPUTERNAME";
+const CONTAINER_NAME: &str = "CONTAINER_NAME";
+const WEBSITE_POD_NAME: &str = "WEBSITE_POD_NAME";
 const INSTANCE_ID: &str = "WEBSITE_INSTANCE_ID";
 const SERVICE_CONTEXT: &str = "DD_AZURE_APP_SERVICES";
 const FUNCTIONS_WORKER_RUNTIME: &str = "FUNCTIONS_WORKER_RUNTIME";
@@ -20,8 +22,6 @@ const FUNCTIONS_EXTENSION_VERSION: &str = "FUNCTIONS_EXTENSION_VERSION";
 const DD_AZURE_RESOURCE_GROUP: &str = "DD_AZURE_RESOURCE_GROUP";
 pub const WEBSITE_SKU: &str = "WEBSITE_SKU";
 pub const REGION_NAME: &str = "REGION_NAME";
-const CONTAINER_NAME: &str = "CONTAINER_NAME";
-const WEBSITE_POD_NAME: &str = "WEBSITE_POD_NAME";
 
 pub const UNKNOWN_VALUE: &str = "unknown";
 
@@ -66,7 +66,9 @@ const AAS_VAR_NAMES: &[&str] = &[
     WEBSITE_RESOURCE_GROUP,
     SITE_EXTENSION_VERSION,
     WEBSITE_OS,
-    INSTANCE_NAME,
+    COMPUTERNAME,
+    CONTAINER_NAME,
+    WEBSITE_POD_NAME,
     INSTANCE_ID,
     SERVICE_CONTEXT,
     FUNCTIONS_WORKER_RUNTIME,
@@ -74,8 +76,6 @@ const AAS_VAR_NAMES: &[&str] = &[
     FUNCTIONS_EXTENSION_VERSION,
     DD_AZURE_RESOURCE_GROUP,
     WEBSITE_SKU,
-    CONTAINER_NAME,
-    WEBSITE_POD_NAME,
 ];
 
 #[cfg(target_os = "linux")]
@@ -255,9 +255,9 @@ impl AzureMetadata {
             .get_var(WEBSITE_OS)
             .unwrap_or(std::env::consts::OS.to_string());
 
-        let container_name = query.get_var(CONTAINER_NAME);
+        let computer_name = query.get_var(COMPUTERNAME);
         let pod_name = query.get_var(WEBSITE_POD_NAME);
-        let computer_name = query.get_var(INSTANCE_NAME);
+        let container_name = query.get_var(CONTAINER_NAME);
         let instance_name = resolve_instance_name(
             computer_name.as_deref(),
             pod_name.as_deref(),
@@ -843,7 +843,7 @@ mod tests {
             (WEBSITE_RESOURCE_GROUP, expected_resource_group.as_str()),
             (SITE_EXTENSION_VERSION, expected_site_version.as_str()),
             (WEBSITE_OS, expected_operating_system.as_str()),
-            (INSTANCE_NAME, expected_instance_name.as_str()),
+            (COMPUTERNAME, expected_instance_name.as_str()),
             (INSTANCE_ID, expected_instance_id.as_str()),
             (SERVICE_CONTEXT, "1"),
             (
@@ -889,7 +889,7 @@ mod tests {
             (WEBSITE_RESOURCE_GROUP, expected_resource_group),
             (SITE_EXTENSION_VERSION, expected_site_version),
             (WEBSITE_OS, expected_operating_system),
-            (INSTANCE_NAME, expected_instance_name),
+            (COMPUTERNAME, expected_instance_name),
             (INSTANCE_ID, expected_instance_id),
             (SERVICE_CONTEXT, "1"),
             (
@@ -961,7 +961,7 @@ mod tests {
             (WEBSITE_SITE_NAME, expected_site_name),
             (WEBSITE_RESOURCE_GROUP, expected_resource_group),
             (WEBSITE_OS, expected_operating_system),
-            (INSTANCE_NAME, expected_instance_name),
+            (COMPUTERNAME, expected_instance_name),
             (INSTANCE_ID, expected_instance_id),
             (SERVICE_CONTEXT, "1"),
             (
@@ -1039,7 +1039,7 @@ mod tests {
     fn test_instance_name_computer_name_wins_over_pod_and_container() {
         let mocked_env = MockEnv::new(&[
             (FUNCTIONS_WORKER_RUNTIME, "node"),
-            (INSTANCE_NAME, "10-20-30-40"),
+            (COMPUTERNAME, "10-20-30-40"),
             (WEBSITE_POD_NAME, "pod-1"),
             (CONTAINER_NAME, "container-1"),
         ]);
@@ -1074,7 +1074,7 @@ mod tests {
             (FUNCTIONS_WORKER_RUNTIME, "node"),
             (CONTAINER_NAME, ""),
             (WEBSITE_POD_NAME, ""),
-            (INSTANCE_NAME, "worker-1"),
+            (COMPUTERNAME, "worker-1"),
         ]);
         let metadata = AzureMetadata::new_function(mocked_env).unwrap();
         assert_eq!(metadata.get_instance_name(), "worker-1");
@@ -1086,7 +1086,7 @@ mod tests {
             (FUNCTIONS_WORKER_RUNTIME, "node"),
             (CONTAINER_NAME, "   "),
             (WEBSITE_POD_NAME, "   "),
-            (INSTANCE_NAME, "worker-2"),
+            (COMPUTERNAME, "worker-2"),
         ]);
         let metadata = AzureMetadata::new_function(mocked_env).unwrap();
         assert_eq!(metadata.get_instance_name(), "worker-2");

--- a/libdd-common/src/azure_app_services.rs
+++ b/libdd-common/src/azure_app_services.rs
@@ -259,9 +259,9 @@ impl AzureMetadata {
         let pod_name = query.get_var(WEBSITE_POD_NAME);
         let computer_name = query.get_var(INSTANCE_NAME);
         let instance_name = resolve_instance_name(
+            computer_name.as_deref(),
             pod_name.as_deref(),
             container_name.as_deref(),
-            computer_name.as_deref(),
         );
 
         let instance_id = query.get_var(INSTANCE_ID);
@@ -412,9 +412,9 @@ impl AzureMetadata {
 
 /// Resolves the instance name to match the Azure integration metric's `instance` tag.
 fn resolve_instance_name(
+    computer_name: Option<&str>,
     pod_name: Option<&str>,
     container_name: Option<&str>,
-    computer_name: Option<&str>,
 ) -> Option<String> {
     fn non_empty(s: Option<&str>) -> Option<&str> {
         s.map(|v| v.trim()).filter(|v| !v.is_empty())
@@ -1040,6 +1040,7 @@ mod tests {
         let mocked_env = MockEnv::new(&[
             (FUNCTIONS_WORKER_RUNTIME, "node"),
             (INSTANCE_NAME, "10-20-30-40"),
+            (WEBSITE_POD_NAME, "pod-1"),
             (CONTAINER_NAME, "container-1"),
         ]);
         let metadata = AzureMetadata::new_function(mocked_env).unwrap();

--- a/libdd-common/src/azure_app_services.rs
+++ b/libdd-common/src/azure_app_services.rs
@@ -681,10 +681,10 @@ mod tests {
                 "00000000-0000-0000-0000-000000000000+flex-EastUSwebspace-Linux",
             ),
             (WEBSITE_SKU, "FlexConsumption"),
-            (SERVICE_CONTEXT, "1"),
+            (FUNCTIONS_WORKER_RUNTIME, "node"),
         ]);
 
-        let metadata = AzureMetadata::new(mocked_env).unwrap();
+        let metadata = AzureMetadata::new_function(mocked_env).unwrap();
 
         assert_eq!(metadata.get_resource_group(), UNKNOWN_VALUE);
     }
@@ -698,10 +698,10 @@ mod tests {
             ),
             (DD_AZURE_RESOURCE_GROUP, "test-flex-rg"),
             (WEBSITE_SKU, "FlexConsumption"),
-            (SERVICE_CONTEXT, "1"),
+            (FUNCTIONS_WORKER_RUNTIME, "node"),
         ]);
 
-        let metadata = AzureMetadata::new(mocked_env).unwrap();
+        let metadata = AzureMetadata::new_function(mocked_env).unwrap();
 
         // Should use the DD_AZURE_RESOURCE_GROUP value instead of extracting from
         // WEBSITE_OWNER_NAME

--- a/libdd-common/src/azure_app_services.rs
+++ b/libdd-common/src/azure_app_services.rs
@@ -18,9 +18,12 @@ const FUNCTIONS_WORKER_RUNTIME: &str = "FUNCTIONS_WORKER_RUNTIME";
 const FUNCTIONS_WORKER_RUNTIME_VERSION: &str = "FUNCTIONS_WORKER_RUNTIME_VERSION";
 const FUNCTIONS_EXTENSION_VERSION: &str = "FUNCTIONS_EXTENSION_VERSION";
 const DD_AZURE_RESOURCE_GROUP: &str = "DD_AZURE_RESOURCE_GROUP";
-const WEBSITE_SKU: &str = "WEBSITE_SKU";
+pub const WEBSITE_SKU: &str = "WEBSITE_SKU";
+pub const REGION_NAME: &str = "REGION_NAME";
+const CONTAINER_NAME: &str = "CONTAINER_NAME";
+const WEBSITE_POD_NAME: &str = "WEBSITE_POD_NAME";
 
-const UNKNOWN_VALUE: &str = "unknown";
+pub const UNKNOWN_VALUE: &str = "unknown";
 
 enum AzureContext {
     AzureFunctions,
@@ -71,6 +74,8 @@ const AAS_VAR_NAMES: &[&str] = &[
     FUNCTIONS_EXTENSION_VERSION,
     DD_AZURE_RESOURCE_GROUP,
     WEBSITE_SKU,
+    CONTAINER_NAME,
+    WEBSITE_POD_NAME,
 ];
 
 #[cfg(target_os = "linux")]
@@ -223,12 +228,14 @@ impl AzureMetadata {
             _ => ("app".to_owned(), "app".to_owned()),
         };
 
+        let website_sku = query.get_var(WEBSITE_SKU);
+
         let resource_group = query
             .get_var(DD_AZURE_RESOURCE_GROUP)
             .or_else(|| query.get_var(WEBSITE_RESOURCE_GROUP))
             .or_else(|| {
                 // Check if we're in flex consumption plan first
-                match query.get_var(WEBSITE_SKU).as_deref() {
+                match website_sku.as_deref() {
                     Some("FlexConsumption") => None,
                     /* Flex Consumption plans need the `DD_AZURE_RESOURCE_GROUP` env var. If this
                      * logic ever changes, update the logic in
@@ -247,7 +254,17 @@ impl AzureMetadata {
         let operating_system = query
             .get_var(WEBSITE_OS)
             .unwrap_or(std::env::consts::OS.to_string());
-        let instance_name = query.get_var(INSTANCE_NAME);
+
+        let container_name = query.get_var(CONTAINER_NAME);
+        let pod_name = query.get_var(WEBSITE_POD_NAME);
+        let computer_name = query.get_var(INSTANCE_NAME);
+        let instance_name = resolve_instance_name(
+            website_sku.as_deref(),
+            container_name.as_deref(),
+            pod_name.as_deref(),
+            computer_name.as_deref(),
+        );
+
         let instance_id = query.get_var(INSTANCE_ID);
 
         let runtime = query.get_var(FUNCTIONS_WORKER_RUNTIME);
@@ -392,6 +409,34 @@ impl AzureMetadata {
         ]
         .into_iter()
     }
+}
+
+/// Resolves the instance name using the env var that provides an instance value
+/// that matches the Azure integration metric's `instance` tag for the current hosting plan
+/// with fallback logic if the preferred source is empty.
+fn resolve_instance_name(
+    website_sku: Option<&str>,
+    container_name: Option<&str>,
+    pod_name: Option<&str>,
+    computer_name: Option<&str>,
+) -> Option<String> {
+    fn non_empty(s: Option<&str>) -> Option<&str> {
+        s.filter(|v| !v.trim().is_empty())
+    }
+
+    let sku_preferred = match website_sku {
+        Some("FlexConsumption") | Some("Dynamic") => {
+            non_empty(container_name).or_else(|| non_empty(pod_name))
+        }
+        Some(_) => non_empty(computer_name),
+        None => None,
+    };
+
+    sku_preferred
+        .or_else(|| non_empty(container_name))
+        .or_else(|| non_empty(pod_name))
+        .or_else(|| non_empty(computer_name))
+        .map(|s| s.to_lowercase())
 }
 
 pub static AAS_METADATA: LazyLock<Option<AzureMetadata>> =
@@ -1001,5 +1046,123 @@ mod tests {
             get_trimmed_env_var!("__LIBDD_AAS_DEFINITELY_NOT_SET__"),
             None
         );
+    }
+
+    #[test]
+    fn test_public_consts_are_accessible() {
+        assert_eq!(super::WEBSITE_SKU, "WEBSITE_SKU");
+        assert_eq!(super::UNKNOWN_VALUE, "unknown");
+        assert_eq!(super::REGION_NAME, "REGION_NAME");
+    }
+
+    #[test]
+    fn test_instance_name_flex_consumption_uses_container_name() {
+        let mocked_env = MockEnv::new(&[
+            (FUNCTIONS_WORKER_RUNTIME, "node"),
+            (WEBSITE_SKU, "FlexConsumption"),
+            ("CONTAINER_NAME", "0--abc-DEF"),
+            ("WEBSITE_POD_NAME", "0--abc-test"),
+        ]);
+        let metadata = AzureMetadata::new_function(mocked_env).unwrap();
+        assert_eq!(metadata.get_instance_name(), "0--abc-def");
+    }
+
+    #[test]
+    fn test_instance_name_flex_consumption_falls_back_to_pod_name() {
+        let mocked_env = MockEnv::new(&[
+            (FUNCTIONS_WORKER_RUNTIME, "node"),
+            (WEBSITE_SKU, "FlexConsumption"),
+            ("WEBSITE_POD_NAME", "0--abc-def"),
+        ]);
+        let metadata = AzureMetadata::new_function(mocked_env).unwrap();
+        assert_eq!(metadata.get_instance_name(), "0--abc-def");
+    }
+
+    #[test]
+    fn test_instance_name_dynamic_uses_container_name() {
+        let mocked_env = MockEnv::new(&[
+            (FUNCTIONS_WORKER_RUNTIME, "node"),
+            (WEBSITE_SKU, "Dynamic"),
+            ("CONTAINER_NAME", "ABCD1234-111122223333444455"),
+        ]);
+        let metadata = AzureMetadata::new_function(mocked_env).unwrap();
+        assert_eq!(metadata.get_instance_name(), "abcd1234-111122223333444455");
+    }
+
+    #[test]
+    fn test_instance_name_elastic_premium_uses_computer_name() {
+        let mocked_env = MockEnv::new(&[
+            (FUNCTIONS_WORKER_RUNTIME, "node"),
+            (WEBSITE_SKU, "ElasticPremium"),
+            (INSTANCE_NAME, "ep0fakewk0000A1"),
+        ]);
+        let metadata = AzureMetadata::new_function(mocked_env).unwrap();
+        assert_eq!(metadata.get_instance_name(), "ep0fakewk0000a1");
+    }
+
+    #[test]
+    fn test_instance_name_dedicated_uses_computer_name() {
+        let mocked_env = MockEnv::new(&[
+            (FUNCTIONS_WORKER_RUNTIME, "node"),
+            (WEBSITE_SKU, "PremiumV3"),
+            (INSTANCE_NAME, "p3fakewk0000B2"),
+        ]);
+        let metadata = AzureMetadata::new_function(mocked_env).unwrap();
+        assert_eq!(metadata.get_instance_name(), "p3fakewk0000b2");
+    }
+
+    #[test]
+    fn test_instance_name_empty_string_treated_as_missing() {
+        let mocked_env = MockEnv::new(&[
+            (FUNCTIONS_WORKER_RUNTIME, "node"),
+            (WEBSITE_SKU, "ElasticPremium"),
+            ("CONTAINER_NAME", ""),
+            ("WEBSITE_POD_NAME", ""),
+            (INSTANCE_NAME, "worker-1"),
+        ]);
+        let metadata = AzureMetadata::new_function(mocked_env).unwrap();
+        assert_eq!(metadata.get_instance_name(), "worker-1");
+    }
+
+    #[test]
+    fn test_instance_name_whitespace_only_treated_as_missing() {
+        let mocked_env = MockEnv::new(&[
+            (FUNCTIONS_WORKER_RUNTIME, "node"),
+            (WEBSITE_SKU, "ElasticPremium"),
+            ("CONTAINER_NAME", "   "),
+            ("WEBSITE_POD_NAME", "   "),
+            (INSTANCE_NAME, "worker-2"),
+        ]);
+        let metadata = AzureMetadata::new_function(mocked_env).unwrap();
+        assert_eq!(metadata.get_instance_name(), "worker-2");
+    }
+
+    #[test]
+    fn test_instance_name_unknown_sku_falls_back_to_container_name() {
+        let mocked_env = MockEnv::new(&[
+            (FUNCTIONS_WORKER_RUNTIME, "node"),
+            (WEBSITE_SKU, "PremiumV4"),
+            ("CONTAINER_NAME", "container-1"),
+        ]);
+        let metadata = AzureMetadata::new_function(mocked_env).unwrap();
+        assert_eq!(metadata.get_instance_name(), "container-1");
+    }
+
+    #[test]
+    fn test_instance_name_windows_consumption_falls_through_to_computer_name() {
+        let mocked_env = MockEnv::new(&[
+            (FUNCTIONS_WORKER_RUNTIME, "node"),
+            (WEBSITE_SKU, "Dynamic"),
+            (INSTANCE_NAME, "10-20-30-40"),
+        ]);
+        let metadata = AzureMetadata::new_function(mocked_env).unwrap();
+        assert_eq!(metadata.get_instance_name(), "10-20-30-40");
+    }
+
+    #[test]
+    fn test_instance_name_no_instance_vars_is_unknown() {
+        let mocked_env = MockEnv::new(&[(FUNCTIONS_WORKER_RUNTIME, "node")]);
+        let metadata = AzureMetadata::new_function(mocked_env).unwrap();
+        assert_eq!(metadata.get_instance_name(), UNKNOWN_VALUE);
     }
 }

--- a/libdd-common/src/azure_app_services.rs
+++ b/libdd-common/src/azure_app_services.rs
@@ -433,10 +433,10 @@ fn resolve_instance_name(
     };
 
     sku_preferred
+        .or_else(|| non_empty(computer_name))
         .or_else(|| non_empty(container_name))
         .or_else(|| non_empty(pod_name))
-        .or_else(|| non_empty(computer_name))
-        .map(|s| s.to_lowercase())
+        .map(|s| s.to_string())
 }
 
 pub static AAS_METADATA: LazyLock<Option<AzureMetadata>> =
@@ -1064,7 +1064,7 @@ mod tests {
             ("WEBSITE_POD_NAME", "0--abc-test"),
         ]);
         let metadata = AzureMetadata::new_function(mocked_env).unwrap();
-        assert_eq!(metadata.get_instance_name(), "0--abc-def");
+        assert_eq!(metadata.get_instance_name(), "0--abc-DEF");
     }
 
     #[test]
@@ -1086,7 +1086,7 @@ mod tests {
             ("CONTAINER_NAME", "ABCD1234-111122223333444455"),
         ]);
         let metadata = AzureMetadata::new_function(mocked_env).unwrap();
-        assert_eq!(metadata.get_instance_name(), "abcd1234-111122223333444455");
+        assert_eq!(metadata.get_instance_name(), "ABCD1234-111122223333444455");
     }
 
     #[test]
@@ -1097,7 +1097,7 @@ mod tests {
             (INSTANCE_NAME, "ep0fakewk0000A1"),
         ]);
         let metadata = AzureMetadata::new_function(mocked_env).unwrap();
-        assert_eq!(metadata.get_instance_name(), "ep0fakewk0000a1");
+        assert_eq!(metadata.get_instance_name(), "ep0fakewk0000A1");
     }
 
     #[test]
@@ -1108,7 +1108,7 @@ mod tests {
             (INSTANCE_NAME, "p3fakewk0000B2"),
         ]);
         let metadata = AzureMetadata::new_function(mocked_env).unwrap();
-        assert_eq!(metadata.get_instance_name(), "p3fakewk0000b2");
+        assert_eq!(metadata.get_instance_name(), "p3fakewk0000B2");
     }
 
     #[test]
@@ -1157,6 +1157,27 @@ mod tests {
         ]);
         let metadata = AzureMetadata::new_function(mocked_env).unwrap();
         assert_eq!(metadata.get_instance_name(), "10-20-30-40");
+    }
+
+    #[test]
+    fn test_instance_name_no_sku_prefers_computer_name() {
+        let mocked_env = MockEnv::new(&[
+            (FUNCTIONS_WORKER_RUNTIME, "node"),
+            ("CONTAINER_NAME", "container-1"),
+            (INSTANCE_NAME, "worker-1"),
+        ]);
+        let metadata = AzureMetadata::new_function(mocked_env).unwrap();
+        assert_eq!(metadata.get_instance_name(), "worker-1");
+    }
+
+    #[test]
+    fn test_instance_name_no_sku_falls_back_to_container_name() {
+        let mocked_env = MockEnv::new(&[
+            (FUNCTIONS_WORKER_RUNTIME, "node"),
+            ("CONTAINER_NAME", "container-1"),
+        ]);
+        let metadata = AzureMetadata::new_function(mocked_env).unwrap();
+        assert_eq!(metadata.get_instance_name(), "container-1");
     }
 
     #[test]

--- a/libdd-common/src/azure_app_services.rs
+++ b/libdd-common/src/azure_app_services.rs
@@ -421,7 +421,7 @@ fn resolve_instance_name(
     computer_name: Option<&str>,
 ) -> Option<String> {
     fn non_empty(s: Option<&str>) -> Option<&str> {
-        s.filter(|v| !v.trim().is_empty())
+        s.map(|v| v.trim()).filter(|v| !v.is_empty())
     }
 
     let sku_preferred = match website_sku {


### PR DESCRIPTION
# What does this PR do?
- Moves logic for resolving Azure Functions instance name from [serverless-components](https://github.com/DataDog/serverless-components/blob/da82dd574ac4eae73afc7201b9781e057643c2d6/crates/datadog-metrics-collector/src/azure_instance.rs#L21) to libdd-common.
- Logic for resolving instance name: `COMPUTERNAME` -> `WEBSITE_POD_NAME` -> `CONTAINER_NAME`
  - This matches the `instance` tag of `azure.functions.function_execution_count` integration metric
  - Before, we only checked `COMPUTERNAME`. The investigation to determine which env vars should be used is in the Instance tab of [Enhanced Metrics in the Serverless Compatibility Layer](https://docs.google.com/document/d/1uMT4fphW7C31JLmf5KY1CdrXGPkn2QLfIvHZK3CJD40/edit?usp=sharing)
- This has the added benefit of populating the instance name span attribute `aas.environment.instance_name` in hosting plans where the attribute was `unknown` before
  - Before, we only looked at `COMPUTERNAME` for instance name, which was empty for Linux Flex Consumption and Consumption functions
- This PR also makes some consts public so that they can be used by serverless-components; see https://github.com/DataDog/serverless-components/pull/134 for usage

# Motivation
https://datadoghq.atlassian.net/browse/SVLS-8931
https://datadoghq.atlassian.net/browse/SVLS-9015

# Additional Notes

Once this PR is merged, we plan to make a new PR in serverless-components to update the libdatadog commit hash and remove the redundant consts and instance name logic. Draft PR: https://github.com/DataDog/serverless-components/pull/134

# How to test the change?

Unit tests: Run `cargo test -p libdd-common azure_app_services`

1. Use git log to find this PR's most recent commit hash
2. Clone [serverless-components](https://github.com/DataDog/serverless-components/tree/main) and update the commit hash in [datadog-trace-agent/Cargo.toml](https://github.com/DataDog/serverless-components/blob/main/crates/datadog-trace-agent/Cargo.toml) everywhere that libdatadog is used
3. Follow the instructions in the [Serverless Compatibility Layer docs](https://datadoghq.atlassian.net/wiki/spaces/SLS/pages/2977497119/Serverless+Compatibility+Layer) to deploy sample apps

Flex Consumption function with fix:
<img width="956" height="568" alt="image" src="https://github.com/user-attachments/assets/b11585cf-7e1c-4d89-a60d-490bfe6bf45e" />

Flex Consumption function without fix:
<img width="1267" height="504" alt="Screenshot 2026-06-03 at 4 33 58 PM" src="https://github.com/user-attachments/assets/252c9ffa-3918-457f-95b5-adc1b794aa2b" />

Consumption function with fix:
<img width="974" height="564" alt="image" src="https://github.com/user-attachments/assets/2d92d604-be97-4eb1-8e6a-9d048420c715" />

Consumption function without fix:
<img width="1276" height="534" alt="image" src="https://github.com/user-attachments/assets/b9918da9-c177-45df-8432-92f7eee001eb" />

I tested by deploying with [serverless-compat-self-monitoring](https://github.com/DataDog/serverless-compat-self-monitoring):
- FC1 and Y1 linux functions get the `aas.environment.instance_name` span attribute populated 
- The span attributes for all other functions still look the same (same shape and casing)