### PR TITLE
fix(crashtracker): set failed thread stack collection as incomplete empty stack

### DIFF
--- a/libdd-crashtracker/src/receiver/receive_report.rs
+++ b/libdd-crashtracker/src/receiver/receive_report.rs
@@ -585,7 +585,7 @@ fn collect_and_add_thread_contexts(
 
             let stack = match captured_context {
                 Some(ctx) => ctx.stack_trace.clone(),
-                None => StackTrace::empty(),
+                None => StackTrace::new_incomplete(),
             };
 
             collected_threads.push(ThreadData {


### PR DESCRIPTION
# What does this PR do?

While investigating PHP a[ll thread collection missing stacktraces](https://app.datadoghq.com/logs?query=source%3Aphp%20data_schema_version%3A1.7&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZ6S4MvogBSm0wAAABhBWjZTNE12b0FBQVYxTk12alFUelNBQUIAAAAkZDE5ZTkyZTAtZGJmZi00YmQxLWE3OTktMTJmOTUzZGJkZDgxAAAE4w&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1780533489582&to_ts=1780534389582&live=true), I noticed that the `ThreadData` stacks are marked as complete. However, the crashtracker simply failed to attach to the thread, so this should be marked as incomplete. 

# Motivation

Investigating [this](https://app.datadoghq.com/logs?query=source%3Aphp%20data_schema_version%3A1.7&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAZ6S4MvogBSm0wAAABhBWjZTNE12b0FBQVYxTk12alFUelNBQUIAAAAkZDE5ZTkyZTAtZGJmZi00YmQxLWE3OTktMTJmOTUzZGJkZDgxAAAE4w&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1780533489582&to_ts=1780534389582&live=true)

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
