### PR TITLE
fix(crashtracker): support socket based receiver for all thread collection

### DIFF
--- a/bin_tests/Cargo.toml
+++ b/bin_tests/Cargo.toml
@@ -53,6 +53,10 @@ name = "crashing_test_app"
 bench = false
 
 [[bin]]
+name = "crashtracker_unix_socket_receiver"
+bench = false
+
+[[bin]]
 name = "prebuild"
 path = "src/bin/prebuild.rs"
 bench = false

--- a/bin_tests/src/artifacts.rs
+++ b/bin_tests/src/artifacts.rs
@@ -39,6 +39,16 @@ pub fn crashing_app(profile: BuildProfile, panic_abort: bool) -> ArtifactsBuild 
     }
 }
 
+/// Creates an ArtifactsBuild for the Unix socket receiver binary (sidecar-style).
+pub fn crashtracker_unix_socket_receiver(profile: BuildProfile) -> ArtifactsBuild {
+    ArtifactsBuild {
+        name: "crashtracker_unix_socket_receiver".to_owned(),
+        build_profile: profile,
+        artifact_type: ArtifactType::Bin,
+        ..Default::default()
+    }
+}
+
 /// Creates an ArtifactsBuild for the test_the_tests binary.
 pub fn test_the_tests(profile: BuildProfile) -> ArtifactsBuild {
     ArtifactsBuild {
@@ -87,6 +97,7 @@ pub fn all_prebuild_artifacts() -> Vec<ArtifactsBuild> {
     for profile in [BuildProfile::Debug, BuildProfile::Release] {
         artifacts.push(crashtracker_bin_test(profile, false));
         artifacts.push(crashtracker_receiver(profile));
+        artifacts.push(crashtracker_unix_socket_receiver(profile));
         artifacts.push(test_the_tests(profile));
         artifacts.push(profiling_ffi(profile));
         artifacts.push(crashing_app(profile, false));

--- a/bin_tests/src/bin/crashtracker_unix_socket_receiver.rs
+++ b/bin_tests/src/bin/crashtracker_unix_socket_receiver.rs
@@ -1,0 +1,16 @@
+// Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+//! Sidecar-style crashtracker receiver that listens on a Unix socket.
+//! Used by integration tests to verify the socket-based receiver path
+
+#[cfg(not(unix))]
+fn main() {}
+
+#[cfg(unix)]
+fn main() -> anyhow::Result<()> {
+    let socket_path = std::env::args()
+        .nth(1)
+        .expect("usage: crashtracker_unix_socket_receiver <socket_path>");
+    libdd_crashtracker::receiver_entry_point_unix_socket(&socket_path)
+}

--- a/bin_tests/src/modes/behavior.rs
+++ b/bin_tests/src/modes/behavior.rs
@@ -140,6 +140,10 @@ pub fn get_behavior(mode_str: &str) -> Box<dyn Behavior> {
         "errno_preservation" => Box::new(test_016_errno_preservation::Test),
         "multi_thread_collection" => Box::new(test_017_multi_thread_collection::Test),
         "thread_limit" => Box::new(test_018_thread_limit::Test),
+        "sidecar_donothing" => Box::new(test_019_sidecar_donothing::Test),
+        "sidecar_multi_thread_collection" => {
+            Box::new(test_020_sidecar_multi_thread_collection::Test)
+        }
         "runtime_preload_logger" => Box::new(test_000_donothing::Test),
         _ => panic!("Unknown mode: {mode_str}"),
     }

--- a/bin_tests/src/modes/unix/mod.rs
+++ b/bin_tests/src/modes/unix/mod.rs
@@ -19,3 +19,5 @@ pub mod test_015_panic_hook_unknown_type;
 pub mod test_016_errno_preservation;
 pub mod test_017_multi_thread_collection;
 pub mod test_018_thread_limit;
+pub mod test_019_sidecar_donothing;
+pub mod test_020_sidecar_multi_thread_collection;

--- a/bin_tests/src/modes/unix/test_019_sidecar_donothing.rs
+++ b/bin_tests/src/modes/unix/test_019_sidecar_donothing.rs
@@ -1,0 +1,33 @@
+// Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+//! Baseline crash test using a sidecar (Unix socket) receiver instead of fork/exec.
+//! The socket path is passed using the DD_TEST_UNIX_SOCKET_PATH env var, which
+//! the integration test sets after spawning the receiver process.
+
+use crate::modes::behavior::Behavior;
+use libdd_crashtracker::CrashtrackerConfiguration;
+use std::path::Path;
+
+pub struct Test;
+
+impl Behavior for Test {
+    fn setup(
+        &self,
+        _output_dir: &Path,
+        config: &mut CrashtrackerConfiguration,
+    ) -> anyhow::Result<()> {
+        let socket_path = std::env::var("DD_TEST_UNIX_SOCKET_PATH")
+            .expect("DD_TEST_UNIX_SOCKET_PATH must be set for sidecar tests");
+        config.set_unix_socket_path(socket_path);
+        Ok(())
+    }
+
+    fn pre(&self, _output_dir: &Path) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn post(&self, _output_dir: &Path) -> anyhow::Result<()> {
+        Ok(())
+    }
+}

--- a/bin_tests/src/modes/unix/test_020_sidecar_multi_thread_collection.rs
+++ b/bin_tests/src/modes/unix/test_020_sidecar_multi_thread_collection.rs
@@ -1,0 +1,77 @@
+// Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+//! Multi-thread collection test using a sidecar (Unix socket) receiver.
+//! Combines the sidecar receiver path (SO_PEERCRED for PR_SET_PTRACER) with
+//! collect_all_threads to verify that ptrace works across non-descendant processes.
+
+use crate::modes::behavior::Behavior;
+use libdd_crashtracker::CrashtrackerConfiguration;
+use std::path::Path;
+use std::sync::{Arc, Barrier};
+use std::thread;
+use std::time::Duration;
+
+pub struct Test;
+
+#[inline(never)]
+fn worker_fn_0() {
+    loop {
+        std::hint::black_box(0x20_00u64);
+        std::hint::spin_loop();
+    }
+}
+
+#[inline(never)]
+fn worker_fn_1() {
+    loop {
+        std::hint::black_box(0x20_01u64);
+        std::hint::spin_loop();
+    }
+}
+
+impl Behavior for Test {
+    fn setup(
+        &self,
+        _output_dir: &Path,
+        config: &mut CrashtrackerConfiguration,
+    ) -> anyhow::Result<()> {
+        let socket_path = std::env::var("DD_TEST_UNIX_SOCKET_PATH")
+            .expect("DD_TEST_UNIX_SOCKET_PATH must be set for sidecar tests");
+        config.set_unix_socket_path(socket_path);
+        config.set_collect_all_threads(true);
+        config.set_max_threads(32);
+        Ok(())
+    }
+
+    fn pre(&self, _output_dir: &Path) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn post(&self, _output_dir: &Path) -> anyhow::Result<()> {
+        let barrier = Arc::new(Barrier::new(3));
+
+        let b0 = Arc::clone(&barrier);
+        let h0 = thread::Builder::new()
+            .name("ct_worker_0".to_string())
+            .spawn(move || {
+                b0.wait();
+                worker_fn_0();
+            })?;
+
+        let b1 = Arc::clone(&barrier);
+        let h1 = thread::Builder::new()
+            .name("ct_worker_1".to_string())
+            .spawn(move || {
+                b1.wait();
+                worker_fn_1();
+            })?;
+
+        barrier.wait();
+        thread::sleep(Duration::from_millis(20));
+
+        std::mem::forget(h0);
+        std::mem::forget(h1);
+        Ok(())
+    }
+}

--- a/bin_tests/src/test_types.rs
+++ b/bin_tests/src/test_types.rs
@@ -22,6 +22,8 @@ pub enum TestMode {
     ErrnoPreservation,
     MultiThreadCollection,
     ThreadLimit,
+    SidecarDoNothing,
+    SidecarMultiThreadCollection,
 }
 
 impl TestMode {
@@ -45,6 +47,8 @@ impl TestMode {
             Self::ErrnoPreservation => "errno_preservation",
             Self::MultiThreadCollection => "multi_thread_collection",
             Self::ThreadLimit => "thread_limit",
+            Self::SidecarDoNothing => "sidecar_donothing",
+            Self::SidecarMultiThreadCollection => "sidecar_multi_thread_collection",
         }
     }
 
@@ -68,6 +72,8 @@ impl TestMode {
             Self::ErrnoPreservation,
             Self::MultiThreadCollection,
             Self::ThreadLimit,
+            Self::SidecarDoNothing,
+            Self::SidecarMultiThreadCollection,
         ]
     }
 }
@@ -100,6 +106,8 @@ impl std::str::FromStr for TestMode {
             "errno_preservation" => Ok(Self::ErrnoPreservation),
             "multi_thread_collection" => Ok(Self::MultiThreadCollection),
             "thread_limit" => Ok(Self::ThreadLimit),
+            "sidecar_donothing" => Ok(Self::SidecarDoNothing),
+            "sidecar_multi_thread_collection" => Ok(Self::SidecarMultiThreadCollection),
             _ => Err(format!("Unknown test mode: {}", s)),
         }
     }

--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -342,6 +342,43 @@ fn test_crash_tracking_thread_limit() {
     run_crash_test_with_artifacts(&config, &artifacts_map, &artifacts, validator).unwrap();
 }
 
+/// Poll for a Unix socket file to appear on disk, indicating the receiver has bound it.
+/// Returns true if the socket appeared within the deadline, false on timeout.
+#[cfg(target_os = "linux")]
+fn wait_for_socket(path: &str, timeout: std::time::Duration) -> bool {
+    let deadline = std::time::Instant::now() + timeout;
+    while std::time::Instant::now() < deadline {
+        if Path::new(path).exists() {
+            return true;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+    false
+}
+
+/// Wait for a child process to exit within a timeout. If it doesn't exit in time,
+/// kill it and return the exit status.
+#[cfg(target_os = "linux")]
+fn wait_or_kill(child: &mut process::Child, timeout: std::time::Duration) -> process::ExitStatus {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return status,
+            Ok(None) => {
+                if std::time::Instant::now() >= deadline {
+                    let _ = child.kill();
+                    return child.wait().unwrap();
+                }
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            Err(_) => {
+                let _ = child.kill();
+                return child.wait().unwrap();
+            }
+        }
+    }
+}
+
 /// Tests that a basic crash report is generated correctly when using a sidecar-style
 /// Unix socket receiver. The receiver is a separate long-lived process that the
 /// crash handler connects to through a Unix socket.
@@ -350,6 +387,7 @@ fn test_crash_tracking_thread_limit() {
 #[cfg_attr(miri, ignore)]
 fn test_crash_tracking_sidecar_basic() {
     const RECEIVER_TIMEOUT_MS: &str = "15000";
+    const RECEIVER_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
     let profile = BuildProfile::Release;
     let socket_receiver = artifacts::crashtracker_unix_socket_receiver(profile);
@@ -372,8 +410,11 @@ fn test_crash_tracking_sidecar_basic() {
         .spawn()
         .unwrap();
 
-    // Give the receiver time to bind the socket
-    std::thread::sleep(std::time::Duration::from_millis(200));
+    // Wait for the receiver to bind the socket before launching the crash app
+    assert!(
+        wait_for_socket(socket_path_str, std::time::Duration::from_secs(5)),
+        "Sidecar receiver did not bind socket within timeout"
+    );
 
     let mut cmd = process::Command::new(&artifacts_map[&artifacts.crashtracker_bin]);
     cmd.arg(format!("file://{}", fixtures.crash_profile_path.display()))
@@ -392,8 +433,8 @@ fn test_crash_tracking_sidecar_basic() {
         "Expected crash test to exit with failure (signal), got: {exit_status:?}"
     );
 
-    // Wait for the receiver to finish processing
-    let receiver_status = receiver_proc.wait().unwrap();
+    // Wait for the receiver with a timeout to avoid hanging if it never got a connection
+    let receiver_status = wait_or_kill(&mut receiver_proc, RECEIVER_WAIT_TIMEOUT);
     assert!(
         receiver_status.success(),
         "Sidecar receiver exited with error: {receiver_status:?}"
@@ -421,6 +462,7 @@ fn test_crash_tracking_sidecar_basic() {
 #[cfg_attr(miri, ignore)]
 fn test_crash_tracking_sidecar_multi_thread_collection() {
     const RECEIVER_TIMEOUT_MS: &str = "15000";
+    const RECEIVER_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
     let profile = BuildProfile::Release;
     let socket_receiver = artifacts::crashtracker_unix_socket_receiver(profile);
@@ -443,8 +485,11 @@ fn test_crash_tracking_sidecar_multi_thread_collection() {
         .spawn()
         .unwrap();
 
-    // Give the receiver time to bind the socket
-    std::thread::sleep(std::time::Duration::from_millis(200));
+    // Wait for the receiver to bind the socket before launching the crash app
+    assert!(
+        wait_for_socket(socket_path_str, std::time::Duration::from_secs(5)),
+        "Sidecar receiver did not bind socket within timeout"
+    );
 
     let mut cmd = process::Command::new(&artifacts_map[&artifacts.crashtracker_bin]);
     cmd.arg(format!("file://{}", fixtures.crash_profile_path.display()))
@@ -463,8 +508,8 @@ fn test_crash_tracking_sidecar_multi_thread_collection() {
         "Expected crash test to exit with failure (signal), got: {exit_status:?}"
     );
 
-    // Wait for the receiver to finish processing
-    let receiver_status = receiver_proc.wait().unwrap();
+    // Wait for the receiver with a timeout to avoid hanging if it never got a connection
+    let receiver_status = wait_or_kill(&mut receiver_proc, RECEIVER_WAIT_TIMEOUT);
     assert!(
         receiver_status.success(),
         "Sidecar receiver exited with error: {receiver_status:?}"

--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -342,6 +342,208 @@ fn test_crash_tracking_thread_limit() {
     run_crash_test_with_artifacts(&config, &artifacts_map, &artifacts, validator).unwrap();
 }
 
+/// Tests that a basic crash report is generated correctly when using a sidecar-style
+/// Unix socket receiver. The receiver is a separate long-lived process that the
+/// crash handler connects to through a Unix socket.
+#[test]
+#[cfg(target_os = "linux")]
+#[cfg_attr(miri, ignore)]
+fn test_crash_tracking_sidecar_basic() {
+    const RECEIVER_TIMEOUT_MS: &str = "15000";
+
+    let profile = BuildProfile::Release;
+    let socket_receiver = artifacts::crashtracker_unix_socket_receiver(profile);
+    let artifacts = StandardArtifacts::new(profile);
+    let all_artifacts: Vec<&ArtifactsBuild> = vec![
+        &artifacts.crashtracker_bin,
+        &artifacts.crashtracker_receiver,
+        &socket_receiver,
+    ];
+    let artifacts_map = fetch_built_artifacts(&all_artifacts).unwrap();
+
+    let fixtures = bin_tests::test_runner::TestFixtures::new().unwrap();
+    let socket_path = fixtures.output_dir.join("crashtracker.sock");
+    let socket_path_str = socket_path.to_str().unwrap();
+
+    // Spawn the sidecar receiver listening on the Unix socket
+    let mut receiver_proc = process::Command::new(&artifacts_map[&socket_receiver])
+        .arg(socket_path_str)
+        .env("DD_CRASHTRACKER_RECEIVER_TIMEOUT_MS", RECEIVER_TIMEOUT_MS)
+        .spawn()
+        .unwrap();
+
+    // Give the receiver time to bind the socket
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    let mut cmd = process::Command::new(&artifacts_map[&artifacts.crashtracker_bin]);
+    cmd.arg(format!("file://{}", fixtures.crash_profile_path.display()))
+        .arg(&artifacts_map[&artifacts.crashtracker_receiver])
+        .arg(&fixtures.output_dir)
+        .arg(TestMode::SidecarDoNothing.as_str())
+        .arg(CrashType::NullDeref.as_str())
+        .env("DD_TEST_UNIX_SOCKET_PATH", socket_path_str)
+        .env("DD_CRASHTRACKER_RECEIVER_TIMEOUT_MS", RECEIVER_TIMEOUT_MS);
+
+    let mut child = cmd.spawn().unwrap();
+    let exit_status = child.wait().unwrap();
+
+    assert!(
+        !exit_status.success(),
+        "Expected crash test to exit with failure (signal), got: {exit_status:?}"
+    );
+
+    // Wait for the receiver to finish processing
+    let receiver_status = receiver_proc.wait().unwrap();
+    assert!(
+        receiver_status.success(),
+        "Sidecar receiver exited with error: {receiver_status:?}"
+    );
+
+    // Validate the crash report
+    let crash_payload =
+        bin_tests::validation::read_and_parse_crash_payload(&fixtures.crash_profile_path).unwrap();
+
+    PayloadValidator::new(&crash_payload)
+        .validate_counters()
+        .unwrap();
+
+    assert!(
+        crash_payload["error"]["message"].is_string(),
+        "error.message should be present in sidecar crash report"
+    );
+}
+
+/// Tests that collect_all_threads works with a sidecar (Unix socket) receiver.
+/// This exercises the SO_PEERCRED path in crash_handler.rs that resolves the
+/// receiver PID for PR_SET_PTRACER when receiver.handle.pid is None.
+#[test]
+#[cfg(target_os = "linux")]
+#[cfg_attr(miri, ignore)]
+fn test_crash_tracking_sidecar_multi_thread_collection() {
+    const RECEIVER_TIMEOUT_MS: &str = "15000";
+
+    let profile = BuildProfile::Release;
+    let socket_receiver = artifacts::crashtracker_unix_socket_receiver(profile);
+    let artifacts = StandardArtifacts::new(profile);
+    let all_artifacts: Vec<&ArtifactsBuild> = vec![
+        &artifacts.crashtracker_bin,
+        &artifacts.crashtracker_receiver,
+        &socket_receiver,
+    ];
+    let artifacts_map = fetch_built_artifacts(&all_artifacts).unwrap();
+
+    let fixtures = bin_tests::test_runner::TestFixtures::new().unwrap();
+    let socket_path = fixtures.output_dir.join("crashtracker.sock");
+    let socket_path_str = socket_path.to_str().unwrap();
+
+    // Spawn the sidecar receiver listening on the Unix socket
+    let mut receiver_proc = process::Command::new(&artifacts_map[&socket_receiver])
+        .arg(socket_path_str)
+        .env("DD_CRASHTRACKER_RECEIVER_TIMEOUT_MS", RECEIVER_TIMEOUT_MS)
+        .spawn()
+        .unwrap();
+
+    // Give the receiver time to bind the socket
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    let mut cmd = process::Command::new(&artifacts_map[&artifacts.crashtracker_bin]);
+    cmd.arg(format!("file://{}", fixtures.crash_profile_path.display()))
+        .arg(&artifacts_map[&artifacts.crashtracker_receiver])
+        .arg(&fixtures.output_dir)
+        .arg(TestMode::SidecarMultiThreadCollection.as_str())
+        .arg(CrashType::NullDeref.as_str())
+        .env("DD_TEST_UNIX_SOCKET_PATH", socket_path_str)
+        .env("DD_CRASHTRACKER_RECEIVER_TIMEOUT_MS", RECEIVER_TIMEOUT_MS);
+
+    let mut child = cmd.spawn().unwrap();
+    let exit_status = child.wait().unwrap();
+
+    assert!(
+        !exit_status.success(),
+        "Expected crash test to exit with failure (signal), got: {exit_status:?}"
+    );
+
+    // Wait for the receiver to finish processing
+    let receiver_status = receiver_proc.wait().unwrap();
+    assert!(
+        receiver_status.success(),
+        "Sidecar receiver exited with error: {receiver_status:?}"
+    );
+
+    // Validate the crash report
+    let crash_payload =
+        bin_tests::validation::read_and_parse_crash_payload(&fixtures.crash_profile_path).unwrap();
+
+    let all_threads = crash_payload["error"]["threads"].as_array();
+    assert!(
+        all_threads.is_some(),
+        "error.threads should be a JSON array; got: {:?}",
+        crash_payload["error"]["threads"]
+    );
+    let all_threads = all_threads.unwrap();
+
+    assert!(
+        all_threads.len() >= 2,
+        "error.threads should have at least 2 entries (sidecar multi-thread); got {}: {}",
+        all_threads.len(),
+        serde_json::to_string_pretty(&crash_payload).unwrap_or_default()
+    );
+
+    let thread_names: Vec<&str> = all_threads
+        .iter()
+        .map(|t| t["name"].as_str().unwrap_or("<none>"))
+        .collect();
+
+    for expected in ["ct_worker_0", "ct_worker_1"] {
+        assert!(
+            thread_names.contains(&expected),
+            "Expected worker thread '{expected}' in error.threads; got: {thread_names:?}"
+        );
+    }
+
+    // Verify worker threads have non-empty stacks (proving SO_PEERCRED + PR_SET_PTRACER works)
+    for expected in ["ct_worker_0", "ct_worker_1"] {
+        let worker = all_threads
+            .iter()
+            .find(|t| t["name"].as_str() == Some(expected));
+        assert!(
+            worker.is_some(),
+            "{expected} should be in error.threads; got: {thread_names:?}"
+        );
+        let worker = worker.unwrap();
+
+        let frames = worker["stack"]["frames"].as_array();
+        assert!(
+            frames.is_some(),
+            "{expected} stack.frames should be an array; got: {:?}",
+            worker["stack"]
+        );
+        let frames = frames.unwrap();
+
+        assert!(
+            !frames.is_empty(),
+            "{expected} should have non-empty stack frames (sidecar ptrace via SO_PEERCRED); \
+             got empty stack. This indicates PR_SET_PTRACER was not called correctly."
+        );
+
+        let worker_fn = if expected == "ct_worker_0" {
+            "worker_fn_0"
+        } else {
+            "worker_fn_1"
+        };
+        let has_worker_frame = frames.iter().any(|f| {
+            f["function"]
+                .as_str()
+                .map(|name| name.contains(worker_fn))
+                .unwrap_or(false)
+        });
+        assert!(
+            has_worker_frame,
+            "{expected} stack should contain '{worker_fn}' frame but got: {frames:?}"
+        );
+    }
+}
+
 #[test]
 #[cfg(target_os = "linux")]
 #[cfg_attr(miri, ignore)]

--- a/libdd-crashtracker/src/collector/crash_handler.rs
+++ b/libdd-crashtracker/src/collector/crash_handler.rs
@@ -312,6 +312,7 @@ fn handle_posix_signal_impl(
             None => {
                 let mut cred: libc::ucred = unsafe { std::mem::zeroed() };
                 let mut len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+                // SAFETY: getsockopt is async-signal-safe and we're just reading from the socket
                 let ret = unsafe {
                     libc::getsockopt(
                         receiver.handle.uds_fd,

--- a/libdd-crashtracker/src/collector/crash_handler.rs
+++ b/libdd-crashtracker/src/collector/crash_handler.rs
@@ -302,16 +302,36 @@ fn handle_posix_signal_impl(
 
     let receiver = Receiver::from_crashtracker_config(config)?;
 
-    // Enable ptrace permissions for receiver if multi-thread collection is enabled
+    // Enable ptrace permissions for receiver if multi-thread collection is enabled.
+    // For fork/exec receivers, we have the child PID directly. For socket-based
+    // receivers (PHP sidecar), resolve the peer PID using SO_PEERCRED.
     #[cfg(target_os = "linux")]
     if config.collect_all_threads() {
-        if let Some(receiver_pid) = receiver.handle.pid {
-            // Allow the receiver to ptrace this process for thread context collection.
-            // PR_SET_PTRACER only uses arg2 (the pid); the trailing zeros satisfy
-            // libc::prctl's fixed 5-argument FFI binding.
+        let ptracer_pid = match receiver.handle.pid {
+            Some(pid) => pid,
+            None => {
+                let mut cred: libc::ucred = unsafe { std::mem::zeroed() };
+                let mut len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+                let ret = unsafe {
+                    libc::getsockopt(
+                        receiver.handle.uds_fd,
+                        libc::SOL_SOCKET,
+                        libc::SO_PEERCRED,
+                        &mut cred as *mut _ as *mut libc::c_void,
+                        &mut len,
+                    )
+                };
+                if ret == 0 {
+                    cred.pid
+                } else {
+                    0
+                }
+            }
+        };
+        if ptracer_pid > 0 {
             // SAFETY: prctl is async-signal-safe and we're just setting ptrace permissions
             unsafe {
-                libc::prctl(libc::PR_SET_PTRACER, receiver_pid as libc::c_ulong);
+                libc::prctl(libc::PR_SET_PTRACER, ptracer_pid as libc::c_ulong);
             }
         }
     }

--- a/libdd-crashtracker/src/receiver/receive_report.rs
+++ b/libdd-crashtracker/src/receiver/receive_report.rs
@@ -585,7 +585,7 @@ fn collect_and_add_thread_contexts(
 
             let stack = match captured_context {
                 Some(ctx) => ctx.stack_trace.clone(),
-                None => StackTrace::empty(),
+                None => StackTrace::new_incomplete(),
             };
 
             collected_threads.push(ThreadData {

--- a/libdd-crashtracker/src/shared/configuration/mod.rs
+++ b/libdd-crashtracker/src/shared/configuration/mod.rs
@@ -157,6 +157,10 @@ impl CrashtrackerConfiguration {
         self.use_alt_stack = use_alt_stack;
         Ok(())
     }
+
+    pub fn set_unix_socket_path(&mut self, path: String) {
+        self.unix_socket_path = Some(path);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# What does this PR do?

In [crash_handler.rs](https://github.com/DataDog/libdatadog/blob/582bee193e6f4688fa546ca0b3e3b382de672538/libdd-crashtracker/src/collector/crash_handler.rs#L308-L315), PR_SET_PTRACER is only called when receiver.handle.pid is `Some`:

```
if let Some(receiver_pid) = receiver.handle.pid {
        unsafe {
            libc::prctl(libc::PR_SET_PTRACER, receiver_pid as libc::c_ulong);
        }
    }
```

PHP connects to a pre-existing sidecar process [using a Unix socket](https://github.com/DataDog/dd-trace-php/blob/991880e2016965f09bc0093e10537737d283f121/ext/signals.c#L281-L289) (`optional_unix_socket_filename`). 


[In receiver_manager.rs](https://github.com/DataDog/libdatadog/blob/582bee193e6f4688fa546ca0b3e3b382de672538/libdd-crashtracker/src/collector/receiver_manager.rs#L64-L66), the from_socket() path creates a ProcessHandle with pid: None:
```
Ok(Self {
    handle: ProcessHandle::new(uds_fd, None),
})
```

If `ptrace_scope=1`, since pid is `None`, `PR_SET_PTRACER` is never called. The sidecar then cannot ptrace the crashed process's threads.


The fix is to resolve the peer process's PID using `getsockopt(SO_PEERCRED)` on the Unix socket fd, then call `PR_SET_PTRACER` with that PID.


# Motivation

I noticed that all PHP crash reports (schema 1.7) have [error.threads with 0 frames per thread.](https://app.datadoghq.com/logs?query=source%3Aphp%20data_schema_version%3A1.7&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1780372800000&to_ts=1780545599999&live=false) Thread names are present (`ddprof_time`, `ddprof_upload`), but stacks are empty with incomplete: false. This affects 100% of PHP crashes. Ruby and Python are unaffected.


# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
