### PR TITLE
fix(remote-config): notification of multi-processing and runtime deduplication

### DIFF
--- a/datadog-remote-config/src/fetch/multitarget.rs
+++ b/datadog-remote-config/src/fetch/multitarget.rs
@@ -174,6 +174,7 @@ pub trait MultiTargetHandlers<
 
 struct RuntimeInfo<N: NotifyTarget> {
     notify_target: N,
+    session_id: String,
     targets: HashMap<Arc<Target>, u32>,
 }
 
@@ -212,7 +213,8 @@ where
 
     fn remove_target(
         self: &Arc<Self>,
-        runtime_id: &str,
+        instance_runtime_id: &str,
+        session_id: &str,
         target: &Arc<Target>,
         runtimes: MutexGuard<HashMap<String, RuntimeInfo<N>>>,
     ) {
@@ -229,13 +231,19 @@ where
                             match *status {
                                 KnownTargetStatus::Removing(ref future) => {
                                     let future = future.clone();
-                                    let runtime_id = runtime_id.to_string();
+                                    let instance_runtime_id = instance_runtime_id.to_string();
+                                    let session_id = session_id.to_string();
                                     let this = self.clone();
                                     let target = target.clone();
                                     tokio::spawn(async move {
                                         future.await;
                                         let runtimes = this.runtimes.lock_or_panic();
-                                        this.remove_target(runtime_id.as_str(), &target, runtimes);
+                                        this.remove_target(
+                                            instance_runtime_id.as_str(),
+                                            session_id.as_str(),
+                                            &target,
+                                            runtimes,
+                                        );
                                     });
                                     return;
                                 }
@@ -246,7 +254,7 @@ where
                             }
                         }
                         1 => {
-                            known_service.runtimes.remove(runtime_id);
+                            known_service.runtimes.remove(instance_runtime_id);
                             let mut status = known_service.status.lock_or_panic();
                             *status = match *status {
                                 KnownTargetStatus::Pending => KnownTargetStatus::Alive, /* not really */
@@ -265,7 +273,9 @@ where
                             0
                         }
                         _ => {
-                            if let Some(product_data) = known_service.runtimes.remove(runtime_id) {
+                            if let Some(product_data) =
+                                known_service.runtimes.remove(instance_runtime_id)
+                            {
                                 let mut update_product_data = false;
                                 for product in product_data.products {
                                     update_product_data =
@@ -285,15 +295,15 @@ where
                                 return;
                             }
                             if known_service.fetcher.runtime_id.lock_or_panic().as_str()
-                                == runtime_id
+                                == session_id
                             {
                                 'changed_rt_id: {
-                                    for (id, runtime) in runtimes.iter() {
+                                    for (_, runtime) in runtimes.iter() {
                                         if runtime.targets.len() == 1
                                             && runtime.targets.contains_key(target)
                                         {
                                             *known_service.fetcher.runtime_id.lock_or_panic() =
-                                                Arc::new(id.to_string());
+                                                Arc::new(runtime.session_id.clone());
                                             break 'changed_rt_id;
                                         }
                                     }
@@ -317,6 +327,7 @@ where
         self: &Arc<Self>,
         synthetic_id: bool,
         runtime_id: &str,
+        session_id: &str,
         target: Arc<Target>,
         product_capabilities: ProductCapabilities,
     ) {
@@ -351,12 +362,14 @@ where
                             // Avoid deadlocking between known_target.status and self.services
                             self.pending_async_insertions.fetch_add(1, Ordering::AcqRel);
                             let runtime_id = runtime_id.to_string();
+                            let session_id = session_id.to_string();
                             let this = self.clone();
                             tokio::spawn(async move {
                                 future.await;
                                 this.add_target(
                                     synthetic_id,
                                     runtime_id.as_str(),
+                                    session_id.as_str(),
                                     target,
                                     product_capabilities,
                                 );
@@ -398,7 +411,7 @@ where
                     .insert(runtime_id.to_string(), product_capabilities);
                 if !synthetic_id && known_target.synthetic_id {
                     known_target.synthetic_id = false;
-                    *known_target.fetcher.runtime_id.lock_or_panic() = Arc::new(runtime_id.into());
+                    *known_target.fetcher.runtime_id.lock_or_panic() = Arc::new(session_id.into());
                 }
             }
             Entry::Vacant(e) => {
@@ -433,7 +446,7 @@ where
                             if synthetic_id {
                                 Self::generate_synthetic_id()
                             } else {
-                                runtime_id.into()
+                                session_id.into()
                             },
                             ConfigProductCapabilities::new(
                                 product_capabilities.products,
@@ -448,6 +461,7 @@ where
 
     pub fn add_runtime(
         self: &Arc<Self>,
+        session_id: String,
         runtime_id: String,
         notify_target: N,
         target: &Arc<Target>,
@@ -480,6 +494,7 @@ where
                         self.add_target(
                             true,
                             runtime_entry.key(),
+                            session_id.as_str(),
                             target.clone(),
                             product_capabilities,
                         );
@@ -498,16 +513,28 @@ where
                 {
                     let info = RuntimeInfo {
                         notify_target,
+                        session_id: session_id.clone(),
                         targets: HashMap::from([(target.clone(), 1)]),
                     };
-                    self.add_target(false, e.key(), target.clone(), product_capabilities);
+                    self.add_target(
+                        false,
+                        e.key(),
+                        session_id.as_str(),
+                        target.clone(),
+                        product_capabilities,
+                    );
                     e.insert(info);
                 }
             }
         }
     }
 
-    pub fn delete_runtime(self: &Arc<Self>, runtime_id: &str, target: &Arc<Target>) {
+    pub fn delete_runtime(
+        self: &Arc<Self>,
+        runtime_id: &str,
+        session_id: &str,
+        target: &Arc<Target>,
+    ) {
         trace!("Removing remote config runtime: {target:?} with runtime id {runtime_id}");
         let mut runtimes = self.runtimes.lock_or_panic();
         let last_removed = {
@@ -531,7 +558,7 @@ where
         if last_removed {
             runtimes.remove(runtime_id);
         }
-        Self::remove_target(self, runtime_id, target, runtimes);
+        Self::remove_target(self, runtime_id, session_id, target, runtimes);
     }
 
     /// Sets the apply state on a stored file.
@@ -936,6 +963,7 @@ mod tests {
 
         fetcher.add_runtime(
             RT_ID_1.to_string(),
+            RT_ID_1.to_string(),
             Notifier {
                 id: 1,
                 state: state.clone(),
@@ -963,6 +991,7 @@ mod tests {
 
         fetcher.add_runtime(
             RT_ID_1.to_string(),
+            RT_ID_1.to_string(),
             Notifier {
                 id: 1,
                 state: state.clone(),
@@ -974,6 +1003,7 @@ mod tests {
             },
         );
         fetcher.add_runtime(
+            RT_ID_2.to_string(),
             RT_ID_2.to_string(),
             Notifier {
                 id: 2,
@@ -1019,6 +1049,7 @@ mod tests {
         assert_eq!(fetcher.services.lock().unwrap().len(), 2); // two fetchers
 
         fetcher.add_runtime(
+            RT_ID_3.to_string(),
             RT_ID_3.to_string(),
             Notifier {
                 id: 3,
@@ -1080,10 +1111,10 @@ mod tests {
             );
         }
 
-        fetcher.delete_runtime(RT_ID_1, &OTHER_TARGET);
-        fetcher.delete_runtime(RT_ID_1, &DUMMY_TARGET);
-        fetcher.delete_runtime(RT_ID_2, &DUMMY_TARGET);
-        fetcher.delete_runtime(RT_ID_3, &OTHER_TARGET);
+        fetcher.delete_runtime(RT_ID_1, RT_ID_1, &OTHER_TARGET);
+        fetcher.delete_runtime(RT_ID_1, RT_ID_1, &DUMMY_TARGET);
+        fetcher.delete_runtime(RT_ID_2, RT_ID_2, &DUMMY_TARGET);
+        fetcher.delete_runtime(RT_ID_3, RT_ID_3, &OTHER_TARGET);
 
         fetcher.shutdown();
         storage.expect_expiration(&DUMMY_TARGET);

--- a/datadog-sidecar-ffi/src/lib.rs
+++ b/datadog-sidecar-ffi/src/lib.rs
@@ -1350,6 +1350,7 @@ pub unsafe extern "C" fn ddog_sidecar_set_universal_service_tags(
     app_version: ffi::CharSlice,
     global_tags: &libdd_common_ffi::Vec<Tag>,
     dynamic_instrumentation_state: DynamicInstrumentationConfigState,
+    remote_config_generation: u64,
 ) -> MaybeError {
     try_c!(blocking::set_universal_service_tags(
         transport,
@@ -1360,6 +1361,7 @@ pub unsafe extern "C" fn ddog_sidecar_set_universal_service_tags(
         app_version.to_utf8_lossy().into(),
         global_tags.to_vec(),
         dynamic_instrumentation_state,
+        remote_config_generation,
     ));
 
     MaybeError::None

--- a/datadog-sidecar/src/one_way_shared_memory.rs
+++ b/datadog-sidecar/src/one_way_shared_memory.rs
@@ -82,6 +82,17 @@ impl<T: FileBackedHandle + From<MappedMem<T>>, D> OneWayShmReader<T, D> {
             extra,
         }
     }
+
+    /// Returns the generation of the last successfully read data, or 0 if nothing has been read.
+    pub fn last_read_generation(&self) -> u64 {
+        self.current_data
+            .as_ref()
+            .map(|d| {
+                let source_data: &RawData = d.as_slice().into();
+                source_data.meta.generation.load(Ordering::Acquire)
+            })
+            .unwrap_or(0)
+    }
 }
 
 impl<T: FileBackedHandle + From<MappedMem<T>>> OneWayShmWriter<T> {
@@ -224,5 +235,11 @@ impl<T: FileBackedHandle + From<MappedMem<T>>> OneWayShmWriter<T> {
 
     pub fn size(&self) -> usize {
         self.handle.lock_or_panic().as_slice().len()
+    }
+
+    pub fn current_generation(&self) -> u64 {
+        let mapped = self.handle.lock_or_panic();
+        let data = unsafe { &*(mapped.as_slice() as *const [u8] as *const RawData) };
+        data.meta.generation.load(Ordering::Acquire)
     }
 }

--- a/datadog-sidecar/src/service/blocking.rs
+++ b/datadog-sidecar/src/service/blocking.rs
@@ -375,6 +375,7 @@ pub fn set_universal_service_tags(
     app_version: String,
     global_tags: Vec<Tag>,
     dynamic_instrumentation_state: DynamicInstrumentationConfigState,
+    remote_config_generation: u64,
 ) -> io::Result<()> {
     lock_sender(transport)?.set_universal_service_tags(
         instance_id.clone(),
@@ -384,6 +385,7 @@ pub fn set_universal_service_tags(
         app_version,
         global_tags,
         dynamic_instrumentation_state,
+        remote_config_generation,
     );
     Ok(())
 }

--- a/datadog-sidecar/src/service/remote_configs.rs
+++ b/datadog-sidecar/src/service/remote_configs.rs
@@ -1,7 +1,7 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::service::DynamicInstrumentationConfigState;
+use crate::service::{DynamicInstrumentationConfigState, InstanceId};
 use crate::shm_remote_config::{ShmRemoteConfigs, ShmRemoteConfigsGuard};
 use datadog_remote_config::fetch::{
     ConfigInvariants, ConfigOptions, MultiTargetStats, NotifyTarget, ProductCapabilities,
@@ -103,7 +103,8 @@ impl RemoteConfigs {
         &self,
         options: ConfigOptions,
         poll_interval: Duration,
-        runtime_id: String,
+        instance_id: InstanceId,
+        remote_config_generation: u64,
         notify_target: RemoteConfigNotifyTarget,
         env: String,
         service: String,
@@ -138,7 +139,8 @@ impl RemoteConfigs {
             }
         }
         .add_runtime(
-            runtime_id,
+            instance_id,
+            remote_config_generation,
             notify_target,
             env,
             service,

--- a/datadog-sidecar/src/service/runtime_info.rs
+++ b/datadog-sidecar/src/service/runtime_info.rs
@@ -133,6 +133,8 @@ impl ActiveApplication {
         &mut self,
         remote_configs: &RemoteConfigs,
         session: &SessionInfo,
+        instance_id: InstanceId,
+        remote_config_generation: u64,
         notify_target: RemoteConfigNotifyTarget,
         dynamic_instrumentation_state: DynamicInstrumentationConfigState,
     ) {
@@ -149,7 +151,8 @@ impl ActiveApplication {
                 remote_configs.add_runtime(
                     options,
                     *session.remote_config_interval.lock_or_panic(),
-                    session.session_id.clone(),
+                    instance_id,
+                    remote_config_generation,
                     notify_target,
                     self.env.clone().expect("set_metadata was called before"),
                     self.service_name

--- a/datadog-sidecar/src/service/sender.rs
+++ b/datadog-sidecar/src/service/sender.rs
@@ -246,6 +246,7 @@ impl SidecarSender {
         app_version: String,
         global_tags: Vec<Tag>,
         dynamic_instrumentation_state: DynamicInstrumentationConfigState,
+        remote_config_generation: u64,
     ) {
         coalesce(
             &mut self.outbox,
@@ -257,6 +258,7 @@ impl SidecarSender {
                 app_version,
                 global_tags,
                 dynamic_instrumentation_state,
+                remote_config_generation,
             },
         );
         self.try_drain_outbox();

--- a/datadog-sidecar/src/service/sidecar_interface.rs
+++ b/datadog-sidecar/src/service/sidecar_interface.rs
@@ -177,6 +177,8 @@ pub trait SidecarInterface {
     /// * `global_tags` - Global tags which need to be propagated.
     /// * `dynamic_instrumentation_state` - Whether dynamic instrumentation is enabled, disabled or
     ///   not set.
+    /// * `remote_config_generation` - The SHM reader generation last read by the client (0 if
+    ///   unread).
     async fn set_universal_service_tags(
         instance_id: InstanceId,
         queue_id: QueueId,
@@ -185,6 +187,7 @@ pub trait SidecarInterface {
         app_version: String,
         global_tags: Vec<Tag>,
         dynamic_instrumentation_state: DynamicInstrumentationConfigState,
+        remote_config_generation: u64,
     );
 
     /// Sets request state which does not directly affect the RC connection.

--- a/datadog-sidecar/src/service/sidecar_server.rs
+++ b/datadog-sidecar/src/service/sidecar_server.rs
@@ -970,6 +970,7 @@ impl SidecarInterface for ConnectionSidecarHandler {
         app_version: String,
         global_tags: Vec<Tag>,
         dynamic_instrumentation_state: DynamicInstrumentationConfigState,
+        remote_config_generation: u64,
     ) {
         self.track_instance(&instance_id);
         debug!("Registered remote config metadata: instance {instance_id:?}, queue_id: {queue_id:?}, service: {service_name}, env: {env_name}, version: {app_version}");
@@ -985,6 +986,8 @@ impl SidecarInterface for ConnectionSidecarHandler {
         app.update_remote_config(
             &self.server.remote_configs,
             &session,
+            instance_id,
+            remote_config_generation,
             notify_target,
             dynamic_instrumentation_state,
         );
@@ -1008,6 +1011,8 @@ impl SidecarInterface for ConnectionSidecarHandler {
         app.update_remote_config(
             &self.server.remote_configs,
             &session,
+            instance_id,
+            0u64,
             notify_target,
             dynamic_instrumentation_state,
         );

--- a/datadog-sidecar/src/shm_remote_config.rs
+++ b/datadog-sidecar/src/shm_remote_config.rs
@@ -5,7 +5,7 @@ use crate::one_way_shared_memory::{
     open_named_shm, OneWayShmReader, OneWayShmWriter, ReaderOpener,
 };
 use crate::primary_sidecar_identifier;
-use crate::service::DynamicInstrumentationConfigState;
+use crate::service::{DynamicInstrumentationConfigState, InstanceId};
 use crate::tracer::SHM_LIMITER;
 use base64::prelude::BASE64_URL_SAFE_NO_PAD;
 use base64::Engine;
@@ -136,6 +136,10 @@ impl RemoteConfigWriter {
 
     pub fn write(&self, contents: &[u8]) {
         self.writer.write(contents)
+    }
+
+    pub fn current_generation(&self) -> u64 {
+        self.writer.current_generation()
     }
 }
 
@@ -364,6 +368,7 @@ impl<N: NotifyTarget + 'static> MultiTargetHandlers<N, Self> for ConfigFileStora
 pub struct ShmRemoteConfigsGuard<N: NotifyTarget + 'static> {
     target: Arc<Target>,
     runtime_id: String,
+    session_id: String,
     remote_configs: ShmRemoteConfigs<N>,
     dynamic_instrumentation_state: DynamicInstrumentationConfigState,
 }
@@ -371,7 +376,7 @@ pub struct ShmRemoteConfigsGuard<N: NotifyTarget + 'static> {
 impl<N: NotifyTarget + 'static> Drop for ShmRemoteConfigsGuard<N> {
     fn drop(&mut self) {
         let fetcher = &self.remote_configs.0;
-        fetcher.delete_runtime(&self.runtime_id, &self.target);
+        fetcher.delete_runtime(&self.runtime_id, &self.session_id, &self.target);
         if fetcher.invariants().endpoint.test_token.is_some() && fetcher.active_runtimes() == 0 {
             self.remote_configs.shutdown()
         }
@@ -460,7 +465,8 @@ impl<N: NotifyTarget + 'static> ShmRemoteConfigs<N> {
     #[allow(clippy::too_many_arguments)]
     pub fn add_runtime(
         &self,
-        runtime_id: String,
+        instance_id: InstanceId,
+        remote_config_generation: u64,
         notify_target: N,
         env: String,
         service: String,
@@ -478,13 +484,19 @@ impl<N: NotifyTarget + 'static> ShmRemoteConfigs<N> {
             process_tags,
         });
         self.0.add_runtime(
-            runtime_id.clone(),
-            notify_target,
+            instance_id.session_id.clone(),
+            instance_id.runtime_id.clone(),
+            notify_target.clone(),
             &target,
             product_capabilities,
         );
 
         let writers = self.0.storage.storage.writers.lock_or_panic();
+        if let Some(writer) = writers.get(&target) {
+            if writer.current_generation() > remote_config_generation {
+                notify_target.notify();
+            }
+        }
         if dynamic_instrumentation_state != DynamicInstrumentationConfigState::Disabled {
             let mut targets = self.0.storage.storage.targets.lock_or_panic();
             let info = targets
@@ -515,7 +527,8 @@ impl<N: NotifyTarget + 'static> ShmRemoteConfigs<N> {
 
         ShmRemoteConfigsGuard {
             target,
-            runtime_id,
+            runtime_id: instance_id.runtime_id,
+            session_id: instance_id.session_id,
             remote_configs: self.clone(),
             dynamic_instrumentation_state,
         }
@@ -604,6 +617,14 @@ impl RemoteConfigManager {
             check_configs: vec![],
             current_runtime_id: "".to_string(),
         }
+    }
+
+    /// Returns the generation last read by this client, or 0 if nothing has been read yet.
+    pub fn current_remote_config_generation(&self) -> u64 {
+        self.active_reader
+            .as_ref()
+            .map(|r| r.0.last_read_generation())
+            .unwrap_or(0)
     }
 
     /// Polls one configuration change.
@@ -874,7 +895,11 @@ mod tests {
         let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
 
         let shm_guard = shm.add_runtime(
-            "3b43524b-a70c-45dc-921d-34504e50c5eb".to_string(),
+            InstanceId {
+                session_id: "3b43524b-a70c-45dc-921d-34504e50c5eb".to_string(),
+                runtime_id: "3b43524b-a70c-45dc-921d-34504e50c5eb".to_string(),
+            },
+            0,
             NotifyDummy(Arc::new(sender)),
             DUMMY_TARGET.env.to_string(),
             DUMMY_TARGET.service.to_string(),
@@ -1059,7 +1084,11 @@ mod tests {
 
         let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
         let _shm_guard = shm.add_runtime(
-            "3b43524b-a70c-45dc-921d-34504e50c5eb".to_string(),
+            InstanceId {
+                session_id: "3b43524b-a70c-45dc-921d-34504e50c5eb".to_string(),
+                runtime_id: "3b43524b-a70c-45dc-921d-34504e50c5eb".to_string(),
+            },
+            0,
             NotifyDummy(Arc::new(sender)),
             DUMMY_TARGET.env.to_string(),
             DUMMY_TARGET.service.to_string(),


### PR DESCRIPTION
We want the session_id as runtime_id key, but still deduplicate *processes* according to their runtime_id, otherwise notifcation will not reach all targeted processes.

Additionally submit the remote_config_generation, so that processes which start up and have read the present configuration, get notified when a new configuration has intermittently been read. (race condition)