### PR TITLE
fix(sidecar): include `language:native` tag for sidecar crashtracker

### DIFF
--- a/datadog-sidecar/src/unix.rs
+++ b/datadog-sidecar/src/unix.rs
@@ -286,7 +286,7 @@ fn init_crashtracker(dependency_paths: Option<*const *const libc::c_char>) -> an
         "severity:crash".to_string(),
         format!("library_version:{}", crate::sidecar_version!()),
         "library:sidecar".to_string(),
-        "language:native".to_string(),
+        "language:php".to_string(),
     ];
 
     libdd_crashtracker::init(

--- a/datadog-sidecar/src/unix.rs
+++ b/datadog-sidecar/src/unix.rs
@@ -281,18 +281,13 @@ fn init_crashtracker(dependency_paths: Option<*const *const libc::c_char>) -> an
             config_builder = config_builder.endpoint_test_token(test_token);
         }
     }
-    let mut tags = vec![
+    let tags = vec![
         "is_crash:true".to_string(),
         "severity:crash".to_string(),
         format!("library_version:{}", crate::sidecar_version!()),
         "library:sidecar".to_string(),
         "language:native".to_string(),
     ];
-    if let Ok(env) = std::env::var("DD_ENV") {
-        if !env.is_empty() {
-            tags.push(format!("env:{env}"));
-        }
-    }
 
     libdd_crashtracker::init(
         config_builder.build()?,

--- a/datadog-sidecar/src/unix.rs
+++ b/datadog-sidecar/src/unix.rs
@@ -281,6 +281,19 @@ fn init_crashtracker(dependency_paths: Option<*const *const libc::c_char>) -> an
             config_builder = config_builder.endpoint_test_token(test_token);
         }
     }
+    let mut tags = vec![
+        "is_crash:true".to_string(),
+        "severity:crash".to_string(),
+        format!("library_version:{}", crate::sidecar_version!()),
+        "library:sidecar".to_string(),
+        "language:native".to_string(),
+    ];
+    if let Ok(env) = std::env::var("DD_ENV") {
+        if !env.is_empty() {
+            tags.push(format!("env:{env}"));
+        }
+    }
+
     libdd_crashtracker::init(
         config_builder.build()?,
         CrashtrackerReceiverConfig::new(
@@ -294,12 +307,7 @@ fn init_crashtracker(dependency_paths: Option<*const *const libc::c_char>) -> an
             "libdatadog".to_string(),
             crate::sidecar_version!().to_string(),
             "SIDECAR".to_string(),
-            vec![
-                "is_crash:true".to_string(),
-                "severity:crash".to_string(),
-                format!("library_version:{}", crate::sidecar_version!()),
-                "library:sidecar".to_string(),
-            ],
+            tags,
         ),
     )
 }


### PR DESCRIPTION
# What does this PR do?

Crashtracker crash logs can include the language tag. If included, [in the backend](https://github.com/DataDog/dd-go/blob/31428f1894713427d921abed736e6a0ce7f2fb94/trace/apps/tracer-telemetry-intake/logs_writer.go#L197), it will be used to set `Log.Ddsource`. It is also used to categorize `instrumentation-telemetry-data` crashes into `instrumentation-telemetry-data-{runtime}`. This PR sets it.


# Motivation
I noticed all crash logs from the sidecar are [missing source](https://app.datadoghq.com/logs?query=is_crash%3Atrue%20source%3Aunknown&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZ6UJqMO6s8cewAAABhBWjZVSnFNT0FBQUZvVlVKNFZqYlNBQUEAAAAkZDE5ZTk0MjYtYjBlOS00YmQyLTk3ZTgtZjVjNmMyYmU4YWVkAAADRg&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1778010046228&to_ts=1780602046228&live=true)


# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
