### PR TITLE
fix(crashtracker): increase test_waitall_nohang timeout to 500ms

### DIFF
--- a/libdd-crashtracker/src/collector/api.rs
+++ b/libdd-crashtracker/src/collector/api.rs
@@ -648,7 +648,7 @@ mod single_threaded_tests {
                 // should fail.
                 let mut children = vec![];
                 let sleep_duration = Duration::from_millis(100);
-                let timeout_duration = Duration::from_millis(150);
+                let timeout_duration = Duration::from_millis(500);
                 for _ in 0..10 {
                     match unsafe { libc::fork() } {
                         -1 => {


### PR DESCRIPTION
# What does this PR do?

Increases the `timeout_duration` in `test_waitall_nohang` from 150ms to 500ms.

# Motivation

The test is flaky under `cargo-llvm-cov` instrumentation. The grandchildren sleep 100ms, and the timeout was 150ms — only 50ms of headroom. On a [recent passing coverage run](https://github.com/DataDog/libdatadog/actions/runs/27149107391) the test completed in 138ms (12ms before the deadline). On [this run](https://github.com/DataDog/libdatadog/actions/runs/27198955847/job/80297741410) it timed out, exiting with code 250 (`-6 & 0xFF`), failing the coverage job for #2043.

The test validates correctness (no zombie children interfere with `waitpid(-1)`), not performance — the timeout is just a hang guard. 500ms gives comfortable headroom without meaningfully slowing CI.

# Additional Notes

N/A

# How to test the change?

`cargo nextest run -p libdd-crashtracker test_waitall_nohang`