### PR TITLE
fix(crashtracking): authenticate peer granted socket ptrace access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1562,6 +1562,7 @@ dependencies = [
  "libc",
  "libdd-common",
  "libdd-common-ffi",
+ "libdd-crashtracker",
  "libdd-crashtracker-ffi",
  "libdd-dogstatsd-client",
  "libdd-remote-config",

--- a/bin_tests/src/modes/unix/test_020_sidecar_multi_thread_collection.rs
+++ b/bin_tests/src/modes/unix/test_020_sidecar_multi_thread_collection.rs
@@ -46,6 +46,15 @@ impl Behavior for Test {
         config.set_unix_socket_path(socket_path);
         config.set_collect_all_threads(true);
         config.set_max_threads(32);
+
+        // Register the expected receiver PID so the crash handler authenticates
+        // the socket peer before granting ptrace permission.
+        if let Ok(pid_str) = std::env::var("DD_TEST_RECEIVER_PID") {
+            if let Ok(pid) = pid_str.parse::<i32>() {
+                libdd_crashtracker::set_expected_receiver_pid(pid);
+            }
+        }
+
         Ok(())
     }
 

--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -498,6 +498,7 @@ fn test_crash_tracking_sidecar_multi_thread_collection() {
         .arg(TestMode::SidecarMultiThreadCollection.as_str())
         .arg(CrashType::NullDeref.as_str())
         .env("DD_TEST_UNIX_SOCKET_PATH", socket_path_str)
+        .env("DD_TEST_RECEIVER_PID", receiver_proc.id().to_string())
         .env("DD_CRASHTRACKER_RECEIVER_TIMEOUT_MS", RECEIVER_TIMEOUT_MS);
 
     let mut child = cmd.spawn().unwrap();

--- a/datadog-sidecar-ffi/Cargo.toml
+++ b/datadog-sidecar-ffi/Cargo.toml
@@ -30,6 +30,9 @@ rmp-serde = "1.1.1"
 serde_json = "1.0"
 
 
+[target.'cfg(unix)'.dependencies]
+libdd-crashtracker = { path = "../libdd-crashtracker", default-features = false, features = ["collector"] }
+
 [target.'cfg(windows)'.dependencies]
 libdd-crashtracker-ffi = { path = "../libdd-crashtracker-ffi", features = ["collector", "collector_windows"] }
 

--- a/datadog-sidecar-ffi/src/lib.rs
+++ b/datadog-sidecar-ffi/src/lib.rs
@@ -323,6 +323,15 @@ pub extern "C" fn ddog_sidecar_connect(connection: &mut *mut SidecarTransport) -
     let cfg = datadog_sidecar::config::FromEnv::config();
 
     let stream = Box::new(try_c!(datadog_sidecar::start_or_connect_to_sidecar(cfg)));
+
+    // The daemon process hosts the crashtracker receiver socket. Register its
+    // PID so the crash handler can authenticate the socket peer before granting
+    // ptrace permission.
+    #[cfg(unix)]
+    if let Ok(pid) = stream.peer_pid() {
+        libdd_crashtracker::set_expected_receiver_pid(pid as i32);
+    }
+
     *connection = Box::into_raw(stream);
 
     MaybeError::None

--- a/datadog-sidecar/src/service/blocking.rs
+++ b/datadog-sidecar/src/service/blocking.rs
@@ -35,6 +35,19 @@ pub struct SidecarTransport {
 }
 
 impl SidecarTransport {
+    /// Returns the PID of the remote peer (the sidecar/daemon process).
+    ///
+    /// Uses the platform's peer credential mechanism (SO_PEERCRED on Linux,
+    /// LOCAL_PEERPID on macOS) on the underlying IPC socket.
+    pub fn peer_pid(&self) -> io::Result<u32> {
+        let sender = self
+            .inner
+            .lock()
+            .map_err(|e| io::Error::other(format!("Failed to lock transport: {e}")))?;
+        let creds = sender.channel.0.conn.peer_credentials()?;
+        Ok(creds.pid)
+    }
+
     pub fn reconnect<F>(&mut self, factory: F)
     where
         F: FnOnce() -> Option<Box<SidecarTransport>>,
@@ -506,5 +519,24 @@ mod tests {
         assert!(!transport.is_closed());
         drop(transport);
         drop(listener);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_peer_pid_returns_current_process() {
+        let tmpdir = tempdir().unwrap();
+        let socket_path = tmpdir.path().join("test_peer_pid.sock");
+
+        let listener = SeqpacketListener::bind(&socket_path).expect("Cannot bind");
+        let conn = SeqpacketConn::connect(&socket_path).unwrap();
+        let _server_conn = listener.try_accept().expect("try_accept");
+
+        let transport = SidecarTransport::from(conn);
+        let pid = transport.peer_pid().expect("peer_pid should succeed");
+        assert_eq!(
+            pid,
+            std::process::id(),
+            "peer_pid should be our own PID for a loopback connection"
+        );
     }
 }

--- a/libdd-crashtracker-ffi/src/collector/mod.rs
+++ b/libdd-crashtracker-ffi/src/collector/mod.rs
@@ -231,3 +231,24 @@ pub unsafe extern "C" fn ddog_crasht_report_unhandled_exception(
         )?;
     })
 }
+
+#[no_mangle]
+/// Register the expected PID of the socket-based crash receiver
+///
+/// When `collect_all_threads` is enabled and the receiver is reached via a Unix
+/// socket, the crash handler will only grant ptrace permission if the socket
+/// peer's PID matches this registered value.
+///
+/// Call this after establishing a trusted connection to the sidecar
+///
+/// # Safety
+///   This function is safe to call from any thread at any time.
+pub extern "C" fn ddog_crasht_set_expected_receiver_pid(pid: i32) {
+    libdd_crashtracker::set_expected_receiver_pid(pid);
+}
+
+#[no_mangle]
+/// Returns the currently registered expected receiver PID, or 0 if unset.
+pub extern "C" fn ddog_crasht_get_expected_receiver_pid() -> i32 {
+    libdd_crashtracker::get_expected_receiver_pid()
+}

--- a/libdd-crashtracker/src/collector/crash_handler.rs
+++ b/libdd-crashtracker/src/collector/crash_handler.rs
@@ -20,7 +20,7 @@ use std::panic;
 use std::panic::PanicHookInfo;
 use std::ptr;
 use std::sync::atomic::Ordering::SeqCst;
-use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicU64};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicPtr, AtomicU64};
 
 // Note that this file makes use the following async-signal safe functions in a signal handler.
 // <https://man7.org/linux/man-pages/man7/signal-safety.7.html>
@@ -47,6 +47,32 @@ static PANIC_MESSAGE: AtomicPtr<String> = AtomicPtr::new(ptr::null_mut());
 
 type PanicHook = Box<dyn Fn(&PanicHookInfo<'_>) + Send + Sync>;
 static PREVIOUS_PANIC_HOOK: AtomicPtr<PanicHook> = AtomicPtr::new(ptr::null_mut());
+
+/// Expected PID of the socket-based receiver (sidecar), set during trusted
+/// initialization. A value of 0 means "not set" and will cause the signal handler
+/// to skip granting ptrace permission
+static EXPECTED_RECEIVER_PID: AtomicI32 = AtomicI32::new(0);
+
+/// Register the expected receiver PID for socket-based crash receivers.
+///
+/// When `collect_all_threads` is enabled and the receiver is reached via a Unix
+/// socket (not a forked child), the signal handler will only grant ptrace
+/// permission (`PR_SET_PTRACER`) if the socket peer's PID (via `SO_PEERCRED`)
+/// matches this value.
+///
+/// Call this during trusted initialization (after connecting to or spawning
+/// the sidecar) with the sidecar's PID
+///
+/// SAFETY:
+///     This function is safe to call from any context, its a single atomic store.
+pub fn set_expected_receiver_pid(pid: i32) {
+    EXPECTED_RECEIVER_PID.store(pid, SeqCst);
+}
+
+/// Returns the currently registered expected receiver PID, or 0 if unset.
+pub fn get_expected_receiver_pid() -> i32 {
+    EXPECTED_RECEIVER_PID.load(SeqCst)
+}
 
 #[derive(Debug, thiserror::Error)]
 pub enum CrashHandlerError {
@@ -303,29 +329,37 @@ fn handle_posix_signal_impl(
     let receiver = Receiver::from_crashtracker_config(config)?;
 
     // Enable ptrace permissions for receiver if multi-thread collection is enabled.
-    // For fork/exec receivers, we have the child PID directly. For socket-based
-    // receivers (PHP sidecar), resolve the peer PID using SO_PEERCRED.
+    // For fork/exec receivers, we have the child PID directly (trusted: we spawned it).
+    // For socket-based receivers (PHP sidecar), verify the peer PID matches the
+    // expected receiver PID that was registered during trusted initialization
     #[cfg(target_os = "linux")]
     if config.collect_all_threads() {
         let ptracer_pid = match receiver.handle.pid {
             Some(pid) => pid,
             None => {
-                let mut cred: libc::ucred = unsafe { std::mem::zeroed() };
-                let mut len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
-                // SAFETY: getsockopt is async-signal-safe and we're just reading from the socket
-                let ret = unsafe {
-                    libc::getsockopt(
-                        receiver.handle.uds_fd,
-                        libc::SOL_SOCKET,
-                        libc::SO_PEERCRED,
-                        &mut cred as *mut _ as *mut libc::c_void,
-                        &mut len,
-                    )
-                };
-                if ret == 0 {
-                    cred.pid
-                } else {
+                let expected_pid = EXPECTED_RECEIVER_PID.load(SeqCst);
+                if expected_pid <= 0 {
+                    // No expected PID registered; fail closed.
                     0
+                } else {
+                    let mut cred: libc::ucred = unsafe { std::mem::zeroed() };
+                    let mut len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+                    // SAFETY: getsockopt is async-signal-safe
+                    let ret = unsafe {
+                        libc::getsockopt(
+                            receiver.handle.uds_fd,
+                            libc::SOL_SOCKET,
+                            libc::SO_PEERCRED,
+                            &mut cred as *mut _ as *mut libc::c_void,
+                            &mut len,
+                        )
+                    };
+                    if ret == 0 && cred.pid == expected_pid {
+                        cred.pid
+                    } else {
+                        // Peer PID doesn't match expected receiver; fail closed.
+                        0
+                    }
                 }
             }
         };

--- a/libdd-crashtracker/src/collector/crash_handler.rs
+++ b/libdd-crashtracker/src/collector/crash_handler.rs
@@ -11,7 +11,7 @@ use crate::crash_info::Metadata;
 use crate::shared::configuration::CrashtrackerConfiguration;
 use crate::StackTrace;
 use errno::{errno, set_errno};
-use libc::{c_void, siginfo_t, ucontext_t};
+use libc::{c_void, pid_t, siginfo_t, ucontext_t};
 use libdd_common::timeout::TimeoutManager;
 use std::os::fd::OwnedFd;
 use std::os::unix::io::{AsRawFd, FromRawFd};
@@ -19,7 +19,7 @@ use std::os::unix::net::UnixStream;
 use std::panic;
 use std::panic::PanicHookInfo;
 use std::ptr;
-use std::sync::atomic::Ordering::SeqCst;
+use std::sync::atomic::Ordering::{Relaxed, SeqCst};
 use std::sync::atomic::{AtomicBool, AtomicI32, AtomicPtr, AtomicU64};
 
 // Note that this file makes use the following async-signal safe functions in a signal handler.
@@ -65,13 +65,13 @@ static EXPECTED_RECEIVER_PID: AtomicI32 = AtomicI32::new(0);
 ///
 /// SAFETY:
 ///     This function is safe to call from any context, its a single atomic store.
-pub fn set_expected_receiver_pid(pid: i32) {
-    EXPECTED_RECEIVER_PID.store(pid, SeqCst);
+pub fn set_expected_receiver_pid(pid: pid_t) {
+    EXPECTED_RECEIVER_PID.store(pid, Relaxed);
 }
 
 /// Returns the currently registered expected receiver PID, or 0 if unset.
-pub fn get_expected_receiver_pid() -> i32 {
-    EXPECTED_RECEIVER_PID.load(SeqCst)
+pub fn get_expected_receiver_pid() -> pid_t {
+    EXPECTED_RECEIVER_PID.load(Relaxed)
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -337,7 +337,7 @@ fn handle_posix_signal_impl(
         let ptracer_pid = match receiver.handle.pid {
             Some(pid) => pid,
             None => {
-                let expected_pid = EXPECTED_RECEIVER_PID.load(SeqCst);
+                let expected_pid = get_expected_receiver_pid();
                 if expected_pid <= 0 {
                     // No expected PID registered; fail closed.
                     0

--- a/libdd-crashtracker/src/collector/mod.rs
+++ b/libdd-crashtracker/src/collector/mod.rs
@@ -21,6 +21,7 @@ pub use additional_tags::{
 pub use api::*;
 pub use counters::{begin_op, end_op, reset_counters, OpTypes};
 pub use crash_handler::{
-    disable, enable, report_unhandled_exception, update_config, update_metadata,
+    disable, enable, get_expected_receiver_pid, report_unhandled_exception,
+    set_expected_receiver_pid, update_config, update_metadata,
 };
 pub use spans::{clear_spans, clear_traces, insert_span, insert_trace, remove_span, remove_trace};

--- a/libdd-crashtracker/src/lib.rs
+++ b/libdd-crashtracker/src/lib.rs
@@ -74,10 +74,10 @@ pub mod shared;
 #[cfg(all(unix, feature = "collector"))]
 pub use collector::{
     begin_op, clear_additional_tags, clear_spans, clear_traces, consume_and_emit_additional_tags,
-    default_signals, disable, enable, end_op, init, insert_additional_tag, insert_span,
-    insert_trace, on_fork, reconfigure, remove_additional_tag, remove_span, remove_trace,
-    report_unhandled_exception, reset_counters, update_config, update_metadata, OpTypes,
-    DEFAULT_SYMBOLS,
+    default_signals, disable, enable, end_op, get_expected_receiver_pid, init,
+    insert_additional_tag, insert_span, insert_trace, on_fork, reconfigure, remove_additional_tag,
+    remove_span, remove_trace, report_unhandled_exception, reset_counters,
+    set_expected_receiver_pid, update_config, update_metadata, OpTypes, DEFAULT_SYMBOLS,
 };
 
 #[cfg(all(windows, feature = "collector_windows"))]


### PR DESCRIPTION
[PROF-15013](https://datadoghq.atlassian.net/jira/software/c/projects/PROF/boards/11?selectedIssue=PROF-15013)

# What does this PR do?

Issue was raised in [APMSP-3484](https://datadoghq.atlassian.net/browse/APMSP-3484)

This PR implements authenticatation for socket-based crash receiver before granting ptrace permission by `PR_SET_PTRACER`

We add `set_expected_receiver_pid()` API that must be called during trusted initialization to register the legitimate receiver's PID

Signal handler now verifies `SO_PEERCRED` peer PID matches the registered expected PID; fails closed (skips ptrace grant) on mismatch or if unset


# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.


[APMSP-3484]: https://datadoghq.atlassian.net/browse/APMSP-3484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PROF-15013]: https://datadoghq.atlassian.net/browse/PROF-15013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ