### PR TITLE
feat(crashtracking)!: add experimental frame count field

### DIFF
--- a/docs/RFCs/artifacts/crashtracker-unified-runtime-stack-schema-v1_8.json
+++ b/docs/RFCs/artifacts/crashtracker-unified-runtime-stack-schema-v1_8.json
@@ -185,6 +185,14 @@
             "type": "string"
           }
         },
+        "frame_count": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint",
+          "minimum": 0.0
+        },
         "runtime_stack": {
           "anyOf": [
             {

--- a/libdd-crashtracker/src/crash_info/builder.rs
+++ b/libdd-crashtracker/src/crash_info/builder.rs
@@ -242,6 +242,15 @@ impl CrashInfoBuilder {
         Ok(())
     }
 
+    pub fn with_experimental_frame_count(&mut self, frame_count: usize) -> anyhow::Result<()> {
+        if let Some(experimental) = &mut self.experimental {
+            experimental.frame_count = Some(frame_count);
+        } else {
+            self.experimental = Some(Experimental::new().with_frame_count(frame_count));
+        }
+        Ok(())
+    }
+
     pub fn with_kind(&mut self, kind: ErrorKind) -> anyhow::Result<()> {
         self.error.with_kind(kind)
     }
@@ -653,5 +662,46 @@ mod tests {
             crash_info.os_info.version, "Unknown",
             "version should not be 'Unknown'"
         );
+    }
+
+    #[test]
+    fn test_with_experimental_frame_count_sets_field() {
+        let mut builder = CrashInfoBuilder::new();
+        builder.with_kind(ErrorKind::UnixSignal).unwrap();
+
+        let frame1 = StackFrame::test_instance(1);
+        let frame2 = StackFrame::test_instance(2);
+        builder.error.with_stack_frame(frame1, true).unwrap();
+        builder.error.with_stack_frame(frame2, false).unwrap();
+
+        let count = builder
+            .error
+            .stack
+            .as_ref()
+            .map(|s| s.frames.len())
+            .unwrap_or(0);
+        builder.with_experimental_frame_count(count).unwrap();
+
+        let crash_info = builder.build().unwrap();
+        let experimental = crash_info.experimental.expect("experimental should be set");
+        assert_eq!(experimental.frame_count, Some(2));
+    }
+
+    #[test]
+    fn test_with_experimental_frame_count_zero_when_no_stack() {
+        let mut builder = CrashInfoBuilder::new();
+        builder.with_kind(ErrorKind::UnixSignal).unwrap();
+
+        let count = builder
+            .error
+            .stack
+            .as_ref()
+            .map(|s| s.frames.len())
+            .unwrap_or(0);
+        builder.with_experimental_frame_count(count).unwrap();
+
+        let crash_info = builder.build().unwrap();
+        let experimental = crash_info.experimental.expect("experimental should be set");
+        assert_eq!(experimental.frame_count, Some(0));
     }
 }

--- a/libdd-crashtracker/src/crash_info/experimental.rs
+++ b/libdd-crashtracker/src/crash_info/experimental.rs
@@ -12,6 +12,8 @@ pub struct Experimental {
     pub additional_tags: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_stack: Option<RuntimeStack>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub frame_count: Option<usize>,
 }
 
 impl Experimental {
@@ -28,12 +30,18 @@ impl Experimental {
         self.runtime_stack = Some(runtime_stack);
         self
     }
+
+    pub fn with_frame_count(mut self, frame_count: usize) -> Self {
+        self.frame_count = Some(frame_count);
+        self
+    }
 }
 
 impl UnknownValue for Experimental {
     fn unknown_value() -> Self {
         Self {
             additional_tags: vec![],
+            frame_count: None,
             runtime_stack: None,
         }
     }

--- a/libdd-crashtracker/src/receiver/receive_report.rs
+++ b/libdd-crashtracker/src/receiver/receive_report.rs
@@ -537,6 +537,15 @@ pub(crate) async fn receive_report_from_stream(
         }
     }
 
+    builder.with_experimental_frame_count(
+        builder
+            .error
+            .stack
+            .as_ref()
+            .map(|s| s.frames.len())
+            .unwrap_or(0),
+    )?;
+
     let crash_info = builder.build()?;
 
     if crash_info.incomplete {


### PR DESCRIPTION
[PROF-15014](https://datadoghq.atlassian.net/jira/software/c/projects/PROF/boards/11?selectedIssue=PROF-15014)

# What does this PR do?

It may be useful to filter crash reports on number of fields. Add an experimental field so that we can check this


# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.


[PROF-15014]: https://datadoghq.atlassian.net/browse/PROF-15014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ