### PR TITLE
fix(crashtracking): use `AtomicBool` readiness signal

### DIFF
--- a/bin_tests/src/modes/unix/test_017_multi_thread_collection.rs
+++ b/bin_tests/src/modes/unix/test_017_multi_thread_collection.rs
@@ -13,27 +13,6 @@ use std::time::{Duration, Instant};
 
 pub struct Test;
 
-static WORKER_0_READY: AtomicBool = AtomicBool::new(false);
-static WORKER_1_READY: AtomicBool = AtomicBool::new(false);
-
-#[inline(never)]
-fn worker_fn_0() {
-    WORKER_0_READY.store(true, Ordering::Release);
-    loop {
-        std::hint::black_box(0x17_00u64);
-        std::hint::spin_loop();
-    }
-}
-
-#[inline(never)]
-fn worker_fn_1() {
-    WORKER_1_READY.store(true, Ordering::Release);
-    loop {
-        std::hint::black_box(0x17_01u64);
-        std::hint::spin_loop();
-    }
-}
-
 impl Behavior for Test {
     fn setup(
         &self,
@@ -50,8 +29,36 @@ impl Behavior for Test {
     }
 
     fn post(&self, _output_dir: &Path) -> anyhow::Result<()> {
-        WORKER_0_READY.store(false, Ordering::Release);
-        WORKER_1_READY.store(false, Ordering::Release);
+        // We spawn two worker threads that spin in known, `#[inline(never)]`
+        // functions so the crash report can be validated to contain their
+        // distinct frames. The atomic flags + busy-wait ensure both threads
+        // are actually inside their spin loops before we return and trigger
+        // the crash. `mem::forget` on the JoinHandles keeps the threads alive
+        // (they would otherwise be detached on drop, which is fine, but
+        // forgetting makes the intent explicit)
+        static WORKER_0_READY: AtomicBool = AtomicBool::new(false);
+        static WORKER_1_READY: AtomicBool = AtomicBool::new(false);
+
+        #[inline(never)]
+        fn worker_fn_0() {
+            WORKER_0_READY.store(true, Ordering::Relaxed);
+            loop {
+                std::hint::black_box(0x17_00u64);
+                std::hint::spin_loop();
+            }
+        }
+
+        #[inline(never)]
+        fn worker_fn_1() {
+            WORKER_1_READY.store(true, Ordering::Relaxed);
+            loop {
+                std::hint::black_box(0x17_01u64);
+                std::hint::spin_loop();
+            }
+        }
+
+        WORKER_0_READY.store(false, Ordering::Relaxed);
+        WORKER_1_READY.store(false, Ordering::Relaxed);
 
         let h0 = thread::Builder::new()
             .name("ct_worker_0".to_string())

--- a/bin_tests/src/modes/unix/test_017_multi_thread_collection.rs
+++ b/bin_tests/src/modes/unix/test_017_multi_thread_collection.rs
@@ -7,15 +7,18 @@
 use crate::modes::behavior::Behavior;
 use libdd_crashtracker::CrashtrackerConfiguration;
 use std::path::Path;
-use std::sync::{Arc, Barrier};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 pub struct Test;
 
-// Black box to prevent compiler optimization
+static WORKER_0_READY: AtomicBool = AtomicBool::new(false);
+static WORKER_1_READY: AtomicBool = AtomicBool::new(false);
+
 #[inline(never)]
 fn worker_fn_0() {
+    WORKER_0_READY.store(true, Ordering::Release);
     loop {
         std::hint::black_box(0x17_00u64);
         std::hint::spin_loop();
@@ -24,6 +27,7 @@ fn worker_fn_0() {
 
 #[inline(never)]
 fn worker_fn_1() {
+    WORKER_1_READY.store(true, Ordering::Release);
     loop {
         std::hint::black_box(0x17_01u64);
         std::hint::spin_loop();
@@ -46,26 +50,24 @@ impl Behavior for Test {
     }
 
     fn post(&self, _output_dir: &Path) -> anyhow::Result<()> {
-        let barrier = Arc::new(Barrier::new(3));
+        WORKER_0_READY.store(false, Ordering::Release);
+        WORKER_1_READY.store(false, Ordering::Release);
 
-        let b0 = Arc::clone(&barrier);
         let h0 = thread::Builder::new()
             .name("ct_worker_0".to_string())
-            .spawn(move || {
-                b0.wait();
-                worker_fn_0();
-            })?;
+            .spawn(worker_fn_0)?;
 
-        let b1 = Arc::clone(&barrier);
         let h1 = thread::Builder::new()
             .name("ct_worker_1".to_string())
-            .spawn(move || {
-                b1.wait();
-                worker_fn_1();
-            })?;
+            .spawn(worker_fn_1)?;
 
-        barrier.wait();
-        thread::sleep(Duration::from_millis(20));
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !WORKER_0_READY.load(Ordering::Acquire) || !WORKER_1_READY.load(Ordering::Acquire) {
+            if Instant::now() >= deadline {
+                panic!("Workers did not reach spin loop within 5s");
+            }
+            thread::yield_now();
+        }
 
         std::mem::forget(h0);
         std::mem::forget(h1);

--- a/bin_tests/src/modes/unix/test_020_sidecar_multi_thread_collection.rs
+++ b/bin_tests/src/modes/unix/test_020_sidecar_multi_thread_collection.rs
@@ -8,14 +8,18 @@
 use crate::modes::behavior::Behavior;
 use libdd_crashtracker::CrashtrackerConfiguration;
 use std::path::Path;
-use std::sync::{Arc, Barrier};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 pub struct Test;
 
+static WORKER_0_READY: AtomicBool = AtomicBool::new(false);
+static WORKER_1_READY: AtomicBool = AtomicBool::new(false);
+
 #[inline(never)]
 fn worker_fn_0() {
+    WORKER_0_READY.store(true, Ordering::Release);
     loop {
         std::hint::black_box(0x20_00u64);
         std::hint::spin_loop();
@@ -24,6 +28,7 @@ fn worker_fn_0() {
 
 #[inline(never)]
 fn worker_fn_1() {
+    WORKER_1_READY.store(true, Ordering::Release);
     loop {
         std::hint::black_box(0x20_01u64);
         std::hint::spin_loop();
@@ -49,26 +54,28 @@ impl Behavior for Test {
     }
 
     fn post(&self, _output_dir: &Path) -> anyhow::Result<()> {
-        let barrier = Arc::new(Barrier::new(3));
+        WORKER_0_READY.store(false, Ordering::Release);
+        WORKER_1_READY.store(false, Ordering::Release);
 
-        let b0 = Arc::clone(&barrier);
         let h0 = thread::Builder::new()
             .name("ct_worker_0".to_string())
-            .spawn(move || {
-                b0.wait();
-                worker_fn_0();
-            })?;
+            .spawn(worker_fn_0)?;
 
-        let b1 = Arc::clone(&barrier);
         let h1 = thread::Builder::new()
             .name("ct_worker_1".to_string())
-            .spawn(move || {
-                b1.wait();
-                worker_fn_1();
-            })?;
+            .spawn(worker_fn_1)?;
 
-        barrier.wait();
-        thread::sleep(Duration::from_millis(20));
+        // Wait until both workers have entered their spin loop function.
+        // This eliminates the race where a worker is still in kernel/glibc
+        // code (e.g. futex/barrier) when ptrace captures it, which on
+        // CentOS 7's glibc 2.17 can produce zero unwind frames.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !WORKER_0_READY.load(Ordering::Acquire) || !WORKER_1_READY.load(Ordering::Acquire) {
+            if Instant::now() >= deadline {
+                panic!("Workers did not reach spin loop within 5s");
+            }
+            thread::yield_now();
+        }
 
         std::mem::forget(h0);
         std::mem::forget(h1);


### PR DESCRIPTION
# What does this PR do?

This PR replaces potentially flaky barrier + sleep synchronization in multi-thread collection tests where workers may have not entered user-space code before ptrace captures them


Agent input here:

```
When the crash triggers, the worker might still be:

In kernel space returning from the futex syscall (barrier implementation)
In glibc's pthread barrier code which on CentOS 7's glibc 2.17 may lack proper .eh_frame unwind info
```

# Motivation

Reports of the multi thread collection tests flaking on CentOS7.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
