### PR TITLE
feat(profiling): Add setting to omit `local root span id` from serialized pprof [PROF-15045]

### DIFF
--- a/examples/ffi/profiles.c
+++ b/examples/ffi/profiles.c
@@ -38,6 +38,15 @@ int main(void) {
     exit(EXIT_FAILURE);
   }
 
+  ddog_prof_Profile_Result omit_result =
+      ddog_prof_Profile_set_omit_local_root_span_id_when_serializing(&profile, true);
+  if (omit_result.tag != DDOG_PROF_PROFILE_RESULT_OK) {
+    ddog_CharSlice message = ddog_Error_message(&omit_result.err);
+    fprintf(stderr, "%.*s", (int)message.len, message.ptr);
+    ddog_Error_drop(&omit_result.err);
+    goto cleanup;
+  }
+
   // Original API sample
   ddog_prof_Location root_location = {
       // yes, a zero-initialized mapping is valid

--- a/libdd-profiling-ffi/src/profiles/datatypes.rs
+++ b/libdd-profiling-ffi/src/profiles/datatypes.rs
@@ -682,6 +682,33 @@ pub unsafe extern "C" fn ddog_prof_Profile_add_endpoint_count(
     .into()
 }
 
+/// Set whether "local root span id" labels should be omitted when serializing.
+///
+/// This is an experimental setting and defaults to false.
+///
+/// # Arguments
+/// * `profile` - a reference to the profile being configured.
+/// * `omit` - true to omit the label from serialized pprof samples.
+///
+/// # Safety
+/// The `profile` ptr must point to a valid Profile object created by this
+/// module.
+/// This call is _NOT_ thread-safe.
+#[no_mangle]
+#[must_use]
+pub unsafe extern "C" fn ddog_prof_Profile_set_omit_local_root_span_id_when_serializing(
+    profile: *mut Profile,
+    omit: bool,
+) -> ProfileResult {
+    (|| {
+        let profile = profile_ptr_to_inner(profile)?;
+        profile.set_omit_local_root_span_id_when_serializing(omit);
+        anyhow::Ok(())
+    })()
+    .context("ddog_prof_Profile_set_omit_local_root_span_id_when_serializing failed")
+    .into()
+}
+
 /// Add a poisson-based upscaling rule which will be use to adjust values and make them
 /// closer to reality.
 ///

--- a/libdd-profiling/src/internal/profile/mod.rs
+++ b/libdd-profiling/src/internal/profile/mod.rs
@@ -1504,11 +1504,12 @@ mod api_tests {
     }
 
     #[test]
-    fn omit_local_root_span_id_when_serializing() -> anyhow::Result<()> {
+    fn omit_local_root_span_id_when_serializing() {
         let sample_types = [api::SampleType::CpuSamples, api::SampleType::WallTime];
 
-        let mut profile: Profile = Profile::new(&sample_types, None);
-        profile.set_omit_local_root_span_id_when_serializing(true);
+        let mut regular_profile: Profile = Profile::new(&sample_types, None);
+        let mut omit_profile: Profile = Profile::new(&sample_types, None);
+        omit_profile.set_omit_local_root_span_id_when_serializing(true);
 
         let sample = api::Sample {
             locations: vec![],
@@ -1521,23 +1522,42 @@ mod api_tests {
             }],
         };
 
-        profile.try_add_sample(sample, None)?;
-        profile.add_endpoint(10, Cow::from("my endpoint"))?;
+        for profile in [&mut regular_profile, &mut omit_profile] {
+            profile.try_add_sample(sample.clone(), None).unwrap();
+            profile.add_endpoint(10, Cow::from("my endpoint")).unwrap();
+        }
 
-        let serialized_profile = roundtrip_to_pprof(profile)?;
-        let sample = serialized_profile.samples.first().expect("sample");
+        let regular_serialized = roundtrip_to_pprof(regular_profile).unwrap();
+        let regular_sample = regular_serialized.samples.first().expect("sample");
 
-        assert_eq!(sample.labels.len(), 1);
-        let endpoint_label = sample.labels.first().expect("label");
-        assert_eq!(
-            string_table_fetch(&serialized_profile, endpoint_label.key),
-            "trace endpoint"
-        );
-        assert_eq!(
-            string_table_fetch(&serialized_profile, endpoint_label.str),
-            "my endpoint"
-        );
-        Ok(())
+        let omit_serialized = roundtrip_to_pprof(omit_profile).unwrap();
+        let omit_sample = omit_serialized.samples.first().expect("sample");
+
+        for (serialized, sample) in [
+            (&regular_serialized, regular_sample),
+            (&omit_serialized, omit_sample),
+        ] {
+            let endpoint_label = sample
+                .labels
+                .iter()
+                .find(|label| string_table_fetch(serialized, label.key) == "trace endpoint")
+                .expect("trace endpoint label");
+            assert_eq!(
+                string_table_fetch(serialized, endpoint_label.str),
+                "my endpoint"
+            );
+        }
+
+        regular_sample
+            .labels
+            .iter()
+            .find(|label| {
+                string_table_fetch(&regular_serialized, label.key) == "local root span id"
+            })
+            .expect("local root span id label");
+
+        assert_eq!(regular_sample.labels.len(), 2);
+        assert_eq!(omit_sample.labels.len(), 1);
     }
 
     #[test]

--- a/libdd-profiling/src/internal/profile/mod.rs
+++ b/libdd-profiling/src/internal/profile/mod.rs
@@ -37,6 +37,7 @@ pub struct Profile {
     profiles_dictionary_translator: Option<ProfilesDictionaryTranslator>,
     active_samples: AtomicU64,
     endpoints: Endpoints,
+    experimental_omit_local_root_span_id_when_serializing: bool,
     functions: FxIndexSet<Function>,
     generation: interning_api::Generation,
     labels: FxIndexSet<Label>,
@@ -120,6 +121,10 @@ impl Profile {
             .stats
             .add_endpoint_count(endpoint.into_owned(), value);
         Ok(())
+    }
+
+    pub fn set_omit_local_root_span_id_when_serializing(&mut self, omit: bool) {
+        self.experimental_omit_local_root_span_id_when_serializing = omit;
     }
 
     pub fn try_add_sample(
@@ -543,6 +548,8 @@ impl Profile {
             extended_label_sets.push(self.expand_label_set(&label_set)?);
         }
 
+        let omit_local_root_span_id = self.experimental_omit_local_root_span_id_when_serializing;
+        let local_root_span_id_label = self.endpoints.local_root_span_id_label;
         let iter = std::mem::take(&mut self.observations).try_into_iter()?;
         for (sample, timestamp, mut values) in iter {
             let off = sample.labels.to_offset();
@@ -564,7 +571,16 @@ impl Profile {
                 // The memory was reserved by `expand_label_set`.
                 labels.push(Label::num(self.timestamp_key, ts.get(), StringId::ZERO))
             }
-            pprof_labels.extend(labels.iter().map(protobuf::Label::from));
+            if omit_local_root_span_id {
+                pprof_labels.extend(
+                    labels
+                        .iter()
+                        .filter(|label| label.get_key() != local_root_span_id_label)
+                        .map(protobuf::Label::from),
+                );
+            } else {
+                pprof_labels.extend(labels.iter().map(protobuf::Label::from));
+            }
             if timestamp.is_some() {
                 labels.pop();
             }
@@ -934,6 +950,7 @@ impl Profile {
             profiles_dictionary_translator,
             active_samples: Default::default(),
             endpoints: Default::default(),
+            experimental_omit_local_root_span_id_when_serializing: false,
             functions: Default::default(),
             generation: Generation::new(),
 
@@ -1483,6 +1500,43 @@ mod api_tests {
         // The trace endpoint label shouldn't be added to second sample because the span id doesn't
         // match
         assert_eq!(s2.labels.len(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn omit_local_root_span_id_when_serializing() -> anyhow::Result<()> {
+        let sample_types = [api::SampleType::CpuSamples, api::SampleType::WallTime];
+
+        let mut profile: Profile = Profile::new(&sample_types, None);
+        profile.set_omit_local_root_span_id_when_serializing(true);
+
+        let sample = api::Sample {
+            locations: vec![],
+            values: &[1, 10000],
+            labels: vec![api::Label {
+                key: "local root span id",
+                str: "",
+                num: 10,
+                num_unit: "",
+            }],
+        };
+
+        profile.try_add_sample(sample, None)?;
+        profile.add_endpoint(10, Cow::from("my endpoint"))?;
+
+        let serialized_profile = roundtrip_to_pprof(profile)?;
+        let sample = serialized_profile.samples.first().expect("sample");
+
+        assert_eq!(sample.labels.len(), 1);
+        let endpoint_label = sample.labels.first().expect("label");
+        assert_eq!(
+            string_table_fetch(&serialized_profile, endpoint_label.key),
+            "trace endpoint"
+        );
+        assert_eq!(
+            string_table_fetch(&serialized_profile, endpoint_label.str),
+            "my endpoint"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
# What does this PR do?

This PR adds a new API to profiles: `set_omit_local_root_span_id_when_serializing`. This API can be used to omit the `local root span id` from serialized pprof files.

**Note that nothing else changes**: The `local root span id` is still being tracked and used for everything in the profile, only never actually written in the pprof. Also, this is off by default and needs to be set on every profile before serialization (gets disabled again on profile reset).

# Motivation

In <https://datadoghq.atlassian.net/wiki/spaces/PROF/pages/6821413373/ADR+2026-06-04.1+Continue+using+span-child+filter+mode+remove+local-root-span+backend+support> we discussed experimenting with having libraries not emit local root span id. This is very relevant for implementing OTel thread context, since "local root span" is not a common otel concept and we need to do extra work in all libraries to try to keep it.

Having this in libdatadog and in an off-by-default opt-in-api will allow us to easily test this.

# Additional Notes

N/A

# How to test the change?

This change includes test coverage. I plan to wire this up to dd-trace-rb and add an end-to-end test there.
