### PR TITLE
fix(ffe): honor shared fixture result metadata

### DIFF
--- a/datadog-ffe-ffi/src/assignment.rs
+++ b/datadog-ffe-ffi/src/assignment.rs
@@ -380,6 +380,7 @@ impl From<AssignmentReason> for Reason {
         match value {
             AssignmentReason::TargetingMatch => Reason::TargetingMatch,
             AssignmentReason::Split => Reason::Split,
+            AssignmentReason::Default => Reason::Default,
             AssignmentReason::Static => Reason::Static,
         }
     }

--- a/datadog-ffe-ffi/src/assignment.rs
+++ b/datadog-ffe-ffi/src/assignment.rs
@@ -485,16 +485,3 @@ pub unsafe extern "C" fn ddog_ffe_assignment_drop(assignment: *mut Handle<Resolu
     // SAFETY: the caller must ensure that assignment is valid
     unsafe { Handle::free(assignment) }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn invalid_flag_configuration_maps_to_default_without_error_code() {
-        let details = ResolutionDetails::from(EvaluationError::FlagConfigurationInvalid);
-
-        assert!(matches!(Reason::from(&details), Reason::Default));
-        assert_eq!(ErrorCode::from(&details), ErrorCode::Ok);
-    }
-}

--- a/datadog-ffe-ffi/src/assignment.rs
+++ b/datadog-ffe-ffi/src/assignment.rs
@@ -370,6 +370,7 @@ impl From<&ResolutionDetails> for Reason {
             Ok(assignment) => assignment.reason.into(),
             Err(EvaluationError::FlagDisabled) => Reason::Disabled,
             Err(EvaluationError::DefaultAllocationNull) => Reason::Default,
+            Err(EvaluationError::FlagConfigurationInvalid) => Reason::Default,
             Err(_) => Reason::Error,
         }
     }
@@ -407,6 +408,7 @@ impl From<&EvaluationError> for ErrorCode {
             EvaluationError::TypeMismatch { .. } => ErrorCode::TypeMismatch,
             EvaluationError::TargetingKeyMissing => ErrorCode::TargetingKeyMissing,
             EvaluationError::ConfigurationParseError => ErrorCode::ParseError,
+            EvaluationError::FlagConfigurationInvalid => ErrorCode::Ok,
             EvaluationError::ConfigurationMissing => ErrorCode::ProviderNotReady,
             EvaluationError::FlagUnrecognizedOrDisabled => ErrorCode::FlagNotFound,
             EvaluationError::FlagDisabled => ErrorCode::Ok,
@@ -482,4 +484,17 @@ pub unsafe extern "C" fn ddog_ffe_assignnment_get_flag_metadata(
 pub unsafe extern "C" fn ddog_ffe_assignment_drop(assignment: *mut Handle<ResolutionDetails>) {
     // SAFETY: the caller must ensure that assignment is valid
     unsafe { Handle::free(assignment) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_flag_configuration_maps_to_default_without_error_code() {
+        let details = ResolutionDetails::from(EvaluationError::FlagConfigurationInvalid);
+
+        assert!(matches!(Reason::from(&details), Reason::Default));
+        assert_eq!(ErrorCode::from(&details), ErrorCode::Ok);
+    }
 }

--- a/datadog-ffe-test-suite/tests/canonical_fixtures.rs
+++ b/datadog-ffe-test-suite/tests/canonical_fixtures.rs
@@ -117,6 +117,7 @@ fn reason_from_assignment(reason: AssignmentReason) -> &'static str {
     match reason {
         AssignmentReason::TargetingMatch => "TARGETING_MATCH",
         AssignmentReason::Split => "SPLIT",
+        AssignmentReason::Default => "DEFAULT",
         AssignmentReason::Static => "STATIC",
     }
 }

--- a/datadog-ffe-test-suite/tests/canonical_fixtures.rs
+++ b/datadog-ffe-test-suite/tests/canonical_fixtures.rs
@@ -5,7 +5,8 @@ use std::{collections::HashMap, fs, path::PathBuf, sync::Arc};
 
 use chrono::Utc;
 use datadog_ffe::rules_based::{
-    get_assignment, Attribute, Configuration, EvaluationContext, FlagType, Str, UniversalFlagConfig,
+    get_assignment, AssignmentReason, Attribute, Configuration, EvaluationContext, EvaluationError,
+    FlagType, Str, UniversalFlagConfig,
 };
 use serde::Deserialize;
 
@@ -21,8 +22,11 @@ struct TestCase {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct TestResult {
     value: serde_json::Value,
+    reason: Option<String>,
+    error_code: Option<String>,
 }
 
 fn fixture_root() -> PathBuf {
@@ -63,9 +67,18 @@ fn evaluates_canonical_json_fixtures() {
                 now,
             );
 
-            let actual = result
-                .map(|assignment| assignment.value.variation_value())
-                .unwrap_or(test_case.default_value);
+            let (actual, actual_reason, actual_error_code) = match result {
+                Ok(assignment) => (
+                    assignment.value.variation_value(),
+                    reason_from_assignment(assignment.reason),
+                    None,
+                ),
+                Err(err) => (
+                    test_case.default_value.clone(),
+                    reason_from_error(&err),
+                    error_code_from_error(&err),
+                ),
+            };
 
             assert_eq!(
                 actual,
@@ -74,8 +87,61 @@ fn evaluates_canonical_json_fixtures() {
                 test_case.flag,
                 path.display()
             );
+
+            if let Some(expected_reason) = test_case.result.reason.as_deref() {
+                assert_eq!(
+                    actual_reason,
+                    expected_reason,
+                    "unexpected reason for flag {} in {}",
+                    test_case.flag,
+                    path.display()
+                );
+            }
+
+            if let Some(expected_error_code) = test_case.result.error_code.as_deref() {
+                assert_eq!(
+                    actual_error_code,
+                    Some(expected_error_code),
+                    "unexpected error code for flag {} in {}",
+                    test_case.flag,
+                    path.display()
+                );
+            }
         }
     }
 
     assert!(fixture_count > 0, "no canonical FFE fixtures loaded");
+}
+
+fn reason_from_assignment(reason: AssignmentReason) -> &'static str {
+    match reason {
+        AssignmentReason::TargetingMatch => "TARGETING_MATCH",
+        AssignmentReason::Split => "SPLIT",
+        AssignmentReason::Static => "STATIC",
+    }
+}
+
+fn reason_from_error(err: &EvaluationError) -> &'static str {
+    match err {
+        EvaluationError::FlagDisabled => "DISABLED",
+        EvaluationError::DefaultAllocationNull | EvaluationError::FlagConfigurationInvalid => {
+            "DEFAULT"
+        }
+        _ => "ERROR",
+    }
+}
+
+fn error_code_from_error(err: &EvaluationError) -> Option<&'static str> {
+    match err {
+        EvaluationError::FlagDisabled
+        | EvaluationError::DefaultAllocationNull
+        | EvaluationError::FlagConfigurationInvalid => None,
+        EvaluationError::TypeMismatch { .. } => Some("TYPE_MISMATCH"),
+        EvaluationError::TargetingKeyMissing => Some("TARGETING_KEY_MISSING"),
+        EvaluationError::ConfigurationParseError => Some("PARSE_ERROR"),
+        EvaluationError::ConfigurationMissing => Some("PROVIDER_NOT_READY"),
+        EvaluationError::FlagUnrecognizedOrDisabled => Some("FLAG_NOT_FOUND"),
+        EvaluationError::Internal(_) => Some("GENERAL"),
+        _ => Some("GENERAL"),
+    }
 }

--- a/datadog-ffe/src/rules_based/error.rs
+++ b/datadog-ffe/src/rules_based/error.rs
@@ -32,6 +32,11 @@ pub enum EvaluationError {
     #[error("failed to parse configuration")]
     ConfigurationParseError,
 
+    /// A requested flag exists in the configuration payload, but its per-flag configuration is
+    /// invalid or unsupported by this SDK. The SDK should return the caller default for that flag.
+    #[error("flag configuration is invalid or unsupported")]
+    FlagConfigurationInvalid,
+
     /// Configuration has not been fetched yet.
     #[error("flags configuration is missing")]
     ConfigurationMissing,

--- a/datadog-ffe/src/rules_based/eval/eval_assignment.rs
+++ b/datadog-ffe/src/rules_based/eval/eval_assignment.rs
@@ -149,9 +149,9 @@ impl Allocation {
         };
 
         // Determine the reason for assignment
-        let reason = if !self.rules.is_empty() || self.start_at.is_some() || self.end_at.is_some() {
+        let reason = if !self.rules.is_empty() {
             AssignmentReason::TargetingMatch
-        } else if self.splits.len() == 1 && self.splits[0].shards.is_empty() {
+        } else if self.splits.len() == 1 && !self.splits[0].has_shards {
             AssignmentReason::Static
         } else {
             AssignmentReason::Split

--- a/datadog-ffe/src/rules_based/eval/eval_assignment.rs
+++ b/datadog-ffe/src/rules_based/eval/eval_assignment.rs
@@ -149,8 +149,11 @@ impl Allocation {
         };
 
         // Determine the reason for assignment
+        let has_time_bounds = self.start_at.is_some() || self.end_at.is_some();
         let reason = if !self.rules.is_empty() {
             AssignmentReason::TargetingMatch
+        } else if has_time_bounds && self.splits.len() == 1 && split.shards.is_empty() {
+            AssignmentReason::Default
         } else if self.splits.len() == 1 && !self.splits[0].has_shards {
             AssignmentReason::Static
         } else {

--- a/datadog-ffe/src/rules_based/ufc/assignment.rs
+++ b/datadog-ffe/src/rules_based/ufc/assignment.rs
@@ -11,10 +11,12 @@ use crate::rules_based::{ufc::VariationType, FlagType, Str};
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum AssignmentReason {
-    /// Assignment was made based on targeting rules or time bounds.
+    /// Assignment was made based on targeting rules.
     TargetingMatch,
     /// Assignment was made based on traffic split allocation.
     Split,
+    /// Assignment was made from a platform/default allocation value.
+    Default,
     /// Assignment was made as a static/default value.
     Static,
 }

--- a/datadog-ffe/src/rules_based/ufc/compiled_flag_config.rs
+++ b/datadog-ffe/src/rules_based/ufc/compiled_flag_config.rs
@@ -51,6 +51,7 @@ pub(crate) struct Allocation {
 #[derive(Debug)]
 pub(crate) struct Split {
     pub shards: Vec<Shard>,
+    pub has_shards: bool,
     pub variation_key: Str,
     pub value: AssignmentValue,
     pub serial_id: Option<i32>,
@@ -85,8 +86,9 @@ impl From<UniversalFlagConfigWire> for CompiledFlagsConfig {
                 (
                     key,
                     Option::from(flag)
-                        .ok_or(EvaluationError::ConfigurationParseError)
-                        .and_then(compile_flag),
+                        .ok_or(EvaluationError::FlagConfigurationInvalid)
+                        .and_then(compile_flag)
+                        .map_err(per_flag_config_error),
                 )
             })
             .collect();
@@ -96,6 +98,13 @@ impl From<UniversalFlagConfigWire> for CompiledFlagsConfig {
             environment: config.environment,
             flags,
         }
+    }
+}
+
+fn per_flag_config_error(err: EvaluationError) -> EvaluationError {
+    match err {
+        EvaluationError::ConfigurationParseError => EvaluationError::FlagConfigurationInvalid,
+        err => err,
     }
 }
 
@@ -150,6 +159,7 @@ fn compile_split(
     split: SplitWire,
     variation_values: &HashMap<Str, AssignmentValue>,
 ) -> Result<Split, EvaluationError> {
+    let has_shards = !split.shards.is_empty();
     let shards = split
         .shards
         .into_iter()
@@ -167,6 +177,7 @@ fn compile_split(
 
     Ok(Split {
         shards,
+        has_shards,
         variation_key: split.variation_key,
         value: result,
         serial_id: split.serial_id,


### PR DESCRIPTION
## Motivation

The shared FFE fixtures now assert result metadata beyond returned values, including `reason` and `errorCode`. libdatadog was only checking fixture values, so it could accept shared fixture bumps while still drifting on public assignment metadata.

The latest `ffe-system-test-data` main also corrects temporal allocation fixtures to expect `DEFAULT` for active date-window-only allocations. Those allocations return a configured platform/default value, but no targeting rule matched and no non-vacuous split selected the subject.

## Changes

This updates the `ffe-system-test-data` submodule through `d9d8020`, including the merged temporal reason correction from DataDog/ffe-system-test-data#15.

The canonical fixture harness now asserts fixture-provided `reason` and `errorCode` fields in addition to values. Invalid or unsupported per-flag config is represented as a distinct evaluation error that maps to caller-default behavior while preserving isolation for valid flags in the same payload.

The evaluator now has an explicit `AssignmentReason::Default` for successful default/platform assignments. Active temporal allocations with no rules and no effective split now report `DEFAULT`, and the FFI mapping exposes that as `ddog_ffe_Reason::Default`.

## Decisions

Top-level configuration parse behavior is unchanged: a malformed full payload still fails configuration creation, while malformed individual flags are isolated and evaluate to caller defaults. Missing flags continue to report `FLAG_NOT_FOUND`. Optional `errorCode` fixture assertions remain optional because some existing shared cases omit that field even when the reason is `ERROR`.

Validation:
- `cargo +nightly-2026-02-08 fmt --all -- --check`
- `cargo check -p datadog-ffe -p datadog-ffe-ffi -p datadog-ffe-test-suite`
- `cargo nextest run -p datadog-ffe -p datadog-ffe-ffi -p datadog-ffe-test-suite --no-fail-fast`
- `cargo test --doc -p datadog-ffe -p datadog-ffe-ffi -p datadog-ffe-test-suite`
- `cargo +stable clippy -p datadog-ffe -p datadog-ffe-ffi -p datadog-ffe-test-suite --all-targets --all-features -- -D warnings`
- Earlier on this branch: `cargo +stable clippy --workspace --all-targets --all-features -- -D warnings`
- Earlier on this branch: `cargo ffi-test` built the FFI artifacts and the `ffe` example passed; the overall command failed in the unrelated `crashtracking` example with signal 5.