### PR TITLE
fix(trace-utils): mark decoded span maps as deduped

### DIFF
--- a/libdd-trace-utils/src/msgpack_decoder/v04/mod.rs
+++ b/libdd-trace-utils/src/msgpack_decoder/v04/mod.rs
@@ -409,6 +409,32 @@ mod tests {
     }
 
     #[test]
+    fn test_decoded_span_maps_are_marked_deduped() {
+        // A decoded span's meta/metrics/meta_struct come from msgpack maps (unique keys) or are
+        // left empty: they must be flagged deduped so the msgpack encoder doesn't have to perform
+        // (and warn about) a defensive on-the-fly dedup when re-encoding (e.g. in the sidecar).
+        let mut span = create_test_json_span(1, 2, 0, 0, false);
+        span["meta"] = json!({ "key": "value" });
+        span["metrics"] = json!({ "metric": 1.0 });
+        // No meta_struct on the wire: it stays at its empty `Span::default()` value.
+
+        let encoded_data = rmp_serde::to_vec_named(&vec![vec![span]]).unwrap();
+        let (decoded_traces, _) =
+            from_bytes(libdd_tinybytes::Bytes::from(encoded_data)).expect("Decoding failed");
+
+        let decoded_span = &decoded_traces[0][0];
+        assert!(decoded_span.meta.is_deduped(), "meta should be deduped");
+        assert!(
+            decoded_span.metrics.is_deduped(),
+            "metrics should be deduped"
+        );
+        assert!(
+            decoded_span.meta_struct.is_deduped(),
+            "empty meta_struct should be deduped"
+        );
+    }
+
+    #[test]
     fn test_decoder_span_link_success() {
         let expected_span_link = json!({
             "trace_id": 1,

--- a/libdd-trace-utils/src/msgpack_decoder/v04/mod.rs
+++ b/libdd-trace-utils/src/msgpack_decoder/v04/mod.rs
@@ -410,9 +410,8 @@ mod tests {
 
     #[test]
     fn test_decoded_span_maps_are_marked_deduped() {
-        // A decoded span's meta/metrics/meta_struct come from msgpack maps (unique keys) or are
-        // left empty: they must be flagged deduped so the msgpack encoder doesn't have to perform
-        // (and warn about) a defensive on-the-fly dedup when re-encoding (e.g. in the sidecar).
+        // A decoded span's maps must be flagged deduped so the encoder skips the defensive dedup
+        // (and its warning) when re-encoding (e.g. in the sidecar).
         let mut span = create_test_json_span(1, 2, 0, 0, false);
         span["meta"] = json!({ "key": "value" });
         span["metrics"] = json!({ "metric": 1.0 });

--- a/libdd-trace-utils/src/msgpack_decoder/v04/span.rs
+++ b/libdd-trace-utils/src/msgpack_decoder/v04/span.rs
@@ -42,11 +42,8 @@ pub fn decode_span<T: DeserializableTraceData>(
         fill_span(&mut span, buffer)?;
     }
 
-    // Each of these maps is decoded from a msgpack map (so keys are unique by construction) or left
-    // empty at its `Span::default()` value. Either way it holds no duplicate keys, so mark it
-    // deduped to skip the redundant defensive dedup (and its one-time warning) at encoding time. A
-    // later mutation re-dirties the flag, so this stays correct if the span is edited before
-    // re-encoding.
+    // Decoded from msgpack maps (unique keys) or empty defaults: no duplicates, so mark deduped to
+    // skip the defensive dedup (and its warning) at encoding time. A later mutation re-dirties it.
     span.meta.mark_deduped();
     span.metrics.mark_deduped();
     span.meta_struct.mark_deduped();

--- a/libdd-trace-utils/src/msgpack_decoder/v04/span.rs
+++ b/libdd-trace-utils/src/msgpack_decoder/v04/span.rs
@@ -42,6 +42,15 @@ pub fn decode_span<T: DeserializableTraceData>(
         fill_span(&mut span, buffer)?;
     }
 
+    // Each of these maps is decoded from a msgpack map (so keys are unique by construction) or left
+    // empty at its `Span::default()` value. Either way it holds no duplicate keys, so mark it
+    // deduped to skip the redundant defensive dedup (and its one-time warning) at encoding time. A
+    // later mutation re-dirties the flag, so this stays correct if the span is edited before
+    // re-encoding.
+    span.meta.mark_deduped();
+    span.metrics.mark_deduped();
+    span.meta_struct.mark_deduped();
+
     Ok(span)
 }
 

--- a/libdd-trace-utils/src/msgpack_decoder/v05/mod.rs
+++ b/libdd-trace-utils/src/msgpack_decoder/v05/mod.rs
@@ -212,9 +212,8 @@ where
     span.metrics = read_metrics(data, dict)?;
     span.r#type = get_from_dict(data, dict)?;
 
-    // Decoded from msgpack maps (unique keys) or left empty at their `Span::default()` value, so
-    // these hold no duplicate keys. Mark them deduped to skip the redundant defensive dedup (and
-    // its one-time warning) at encoding time. A later mutation re-dirties the flag.
+    // Decoded from msgpack maps (unique keys) or empty defaults: no duplicates, so mark deduped to
+    // skip the defensive dedup (and its warning) at encoding time. A later mutation re-dirties it.
     span.meta.mark_deduped();
     span.metrics.mark_deduped();
     span.meta_struct.mark_deduped();

--- a/libdd-trace-utils/src/msgpack_decoder/v05/mod.rs
+++ b/libdd-trace-utils/src/msgpack_decoder/v05/mod.rs
@@ -212,6 +212,13 @@ where
     span.metrics = read_metrics(data, dict)?;
     span.r#type = get_from_dict(data, dict)?;
 
+    // Decoded from msgpack maps (unique keys) or left empty at their `Span::default()` value, so
+    // these hold no duplicate keys. Mark them deduped to skip the redundant defensive dedup (and
+    // its one-time warning) at encoding time. A later mutation re-dirties the flag.
+    span.meta.mark_deduped();
+    span.metrics.mark_deduped();
+    span.meta_struct.mark_deduped();
+
     Ok(span)
 }
 

--- a/libdd-trace-utils/src/span/vec_map.rs
+++ b/libdd-trace-utils/src/span/vec_map.rs
@@ -184,9 +184,16 @@ impl<K, V> VecMap<K, V> {
         self.deduped
     }
 
+    /// Assert, without scanning, that this map holds no duplicate keys, setting the `deduped` flag.
+    ///
+    /// For builders whose source guarantees key uniqueness (e.g. msgpack decoding, where the wire
+    /// format is a map), to skip the [Self::dedup] pass. A later mutation re-dirties the flag.
+    ///
+    /// **Caution**: if the source can actually contain duplicate keys, prefer [Self::dedup].
     #[inline]
     pub fn mark_deduped(&mut self) {
         self.deduped = true;
+    }
 
     #[inline]
     pub fn clear(&mut self) {

--- a/libdd-trace-utils/src/span/vec_map.rs
+++ b/libdd-trace-utils/src/span/vec_map.rs
@@ -183,6 +183,26 @@ impl<K, V> VecMap<K, V> {
     pub fn is_deduped(&self) -> bool {
         self.deduped
     }
+
+    /// Assert, without scanning, that this map currently holds no duplicate keys, setting the
+    /// `deduped` flag accordingly.
+    ///
+    /// This is meant for builders that produce a map from a source where key uniqueness is
+    /// guaranteed by construction — for example msgpack decoding of a trace payload, where the
+    /// wire format is a map. It avoids the linear [Self::dedup] pass (and the defensive dedup at
+    /// encoding time) in that case.
+    ///
+    /// The assertion only covers the map's current state: any subsequent mutation that could
+    /// introduce duplicates ([Self::insert], [Self::extend], [Self::iter_mut], ...) re-dirties the
+    /// flag, so a later [Self::dedup] will run as usual.
+    ///
+    /// **Caution**: if the source can actually contain duplicate keys, prefer [Self::dedup], which
+    /// removes them. Marking a map with duplicates as deduped lets them flow through to encoding
+    /// unchanged.
+    #[inline]
+    pub fn mark_deduped(&mut self) {
+        self.deduped = true;
+    }
 }
 
 impl<K: Eq + Hash, V> VecMap<K, V> {


### PR DESCRIPTION
## What

A span's `meta`, `metrics` and `meta_struct` are decoded from msgpack maps (keys unique by construction) or are left empty at their `Span::default()` value. In both cases they hold no duplicate keys, but the generic `VecMap` builders leave the `deduped` flag unset.

As a result, **re-encoding a decoded span** — e.g. when the sidecar forwards traces to the agent via `SendData::send_with_msgpack` → `msgpack_encoder::v04::to_vec` — hits `VecMap::defensive_dedup()`, which performs a redundant on-the-fly dedup and logs a one-time warning:

```
VecMap not deduped before encoding. Performing defensive on-the-fly dedup
```

## Fix

- Add `VecMap::mark_deduped()` to assert (without scanning) that a map currently holds no duplicate keys.
- Call it on `meta`/`metrics`/`meta_struct` right after decoding a span in both the **v04** (`decode_span`) and **v05** (`deserialize_span`) decoders.

Marking at the span-decode level (rather than in the low-level map builders) covers three cases in one place:
1. populated maps decoded from the wire,
2. empty-but-present wire maps,
3. absent-key maps left at `Span::default()` — which matters because the **v1 encoder** calls `defensive_dedup()` *unguarded* by `is_empty()`.

Any later mutation (`insert`/`extend`/`iter_mut`) re-dirties the flag, so this stays correct if a span is edited before re-encoding.

## Why it matters

The warning is benign (decoded maps never actually contain duplicate keys for tracer traffic), but it fires once per sidecar process for essentially every consumer using the sidecar trace sender, and it broke dd-trace-php integration tests: the warning lands in the web server error log, which the PHP test harness treats as a failure.

## Testing

- New regression test `test_decoded_span_maps_are_marked_deduped`.
- `cargo nextest`/`cargo test -p libdd-trace-utils` (decoder + vec_map suites) green.
- `cargo +nightly fmt --all` + `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.

Paired with the dd-trace-php submodule bump PR.