### PR TITLE
fix(crashtracking): multi thread collection centos flakes harden

### DIFF
--- a/libdd-crashtracker/src/receiver/ptrace_collector.rs
+++ b/libdd-crashtracker/src/receiver/ptrace_collector.rs
@@ -129,6 +129,12 @@ fn wait_for_stop(tid: libc::pid_t, deadline: Instant) -> Result<(), PtraceError>
 /// to enter ptrace-stop state before returning.
 ///
 /// `stop_deadline` bounds how long we poll for the stop event.
+///
+/// After the thread enters ptrace-stop, this function also polls until the
+/// instruction pointer is non-zero. On older kernels there may be a race where
+/// `waitpid` returns WIFSTOPPED but the thread's register state hasn't been fully
+/// flushed to the ptrace-accessible area yet. Reading registers in that window
+/// yields zeros, which causes libunwind to produce an empty stack trace.
 fn attach_thread(tid: libc::pid_t, stop_deadline: Instant) -> Result<(), PtraceError> {
     // PTRACE_SEIZE attaches without stopping the thread
     let result = unsafe {
@@ -163,7 +169,39 @@ fn attach_thread(tid: libc::pid_t, stop_deadline: Instant) -> Result<(), PtraceE
         let _ = detach_thread(tid);
         return Err(e);
     }
+
+    // On older kernels, the register state may not be
+    // immediately readable after waitpid reports the stop. Spin briefly
+    // until PEEKUSER returns a non-zero IP, proving registers are committed.
+    wait_for_registers(tid, stop_deadline);
+
     Ok(())
+}
+
+/// Poll the thread's instruction pointer using PTRACE_PEEKUSER until it is
+/// non-zero or the deadline expires. On modern kernels this should return on the
+/// first iteration; on older ones, it may take a few microseconds.
+fn wait_for_registers(tid: libc::pid_t, deadline: Instant) {
+    #[cfg(target_arch = "x86_64")]
+    const IP_OFFSET: libc::c_long = 16 * std::mem::size_of::<libc::c_long>() as libc::c_long; // RIP
+
+    #[cfg(target_arch = "aarch64")]
+    const IP_OFFSET: libc::c_long = 32 * std::mem::size_of::<libc::c_long>() as libc::c_long; // PC
+
+    const SPIN_SLEEP: Duration = Duration::from_micros(100);
+
+    loop {
+        unsafe { *libc::__errno_location() = 0 };
+        let ip = unsafe { libc::ptrace(libc::PTRACE_PEEKUSER, tid as libc::c_long, IP_OFFSET, 0) };
+        // PEEKUSER returns the register value; errno==0 means success.
+        if ip != 0 && unsafe { *libc::__errno_location() } == 0 {
+            return;
+        }
+        if Instant::now() >= deadline {
+            return;
+        }
+        std::thread::sleep(SPIN_SLEEP);
+    }
 }
 
 fn detach_thread(tid: libc::pid_t) -> Result<(), PtraceError> {


### PR DESCRIPTION
[PROF-15089](https://datadoghq.atlassian.net/jira/software/c/projects/PROF/boards/11?selectedIssue=PROF-15089)

# What does this PR do?

On older kernels, there may be a race where `waitpid` reports a thread as stopped but the register state hasn't been flushed to the ptrace-accessible area yet. Reading registers in that window gives zeros, causing libunwind to produce empty stack traces.

Adds a `wait_for_registers` polling loop after `attach_thread` that spins on `PTRACE_PEEKUSER` until the instruction pointer is non-zero or the existing deadline expires. On modern kernels this should return immediately on the first iteration.


# Motivation

More [flakes](https://app.datadoghq.com/ci/pipeline-executions?query=ci_level%3Apipeline%20%40git.repository.name%3ADataDog%2A%2Flibdatadog%20%28%40git.is_default_branch%3Atrue%20OR%20%40git.branch%3Amq%2A%29%20%40ci.status%3Aerror%20%21%40ci.pipeline.name%3ADDCI%2A%20%21%40ci.pipeline.name%3A%22Release%20-%20Open%20a%20release%20proposal%20PR%22&agg_m=count&agg_m_source=base&agg_t=count&fromUser=false&index=cipipeline&refresh_mode=sliding&tab=logs&start=1780928483247&end=1781533283247&paused=false) on multi thread collection tests


# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

I ran all thread collection tests on cent os 10x and observed no failures

[PROF-15089]: https://datadoghq.atlassian.net/browse/PROF-15089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ