### PR TITLE
refactor(clippy): prefer core and alloc imports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,8 @@ todo = "warn"
 unimplemented = "warn"
 unreachable = "warn"
 panic_in_result_fn = "warn"
+std_instead_of_alloc = "warn"
+std_instead_of_core = "warn"
 # TODO: Re-enable once every crate defines package keywords and categories.
 cargo_common_metadata = "allow"
 # TODO: Re-enable once the workspace dependency graph is deduplicated.

--- a/libdd-common-ffi/Cargo.toml
+++ b/libdd-common-ffi/Cargo.toml
@@ -32,3 +32,7 @@ serde = "1.0"
 bolero = "0.13"
 assert_no_alloc = "1.1.2"
 function_name = "0.3.0"
+
+[lints.clippy]
+std_instead_of_alloc = "warn"
+std_instead_of_core = "warn"

--- a/libdd-common-ffi/src/array_queue.rs
+++ b/libdd-common-ffi/src/array_queue.rs
@@ -3,7 +3,7 @@
 
 use crate::Error;
 use anyhow::Context;
-use std::{ffi::c_void, ptr::NonNull};
+use core::{ffi::c_void, ptr::NonNull};
 
 #[derive(Debug)]
 #[repr(C)]
@@ -300,11 +300,11 @@ pub unsafe extern "C" fn ddog_ArrayQueue_capacity(queue_ptr: &ArrayQueue) -> Arr
 mod tests {
     use super::*;
     use bolero::TypeGenerator;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use core::sync::atomic::{AtomicUsize, Ordering};
 
     unsafe extern "C" fn drop_item(item: *mut c_void) -> c_void {
         _ = Box::from_raw(item as *mut i32);
-        std::mem::zeroed()
+        core::mem::zeroed()
     }
 
     #[test]
@@ -313,7 +313,7 @@ mod tests {
         assert!(matches!(queue_new_result, ArrayQueueNewResult::Ok(_)));
         let queue_ptr = match queue_new_result {
             ArrayQueueNewResult::Ok(ptr) => ptr.as_ptr(),
-            _ => std::ptr::null_mut(),
+            _ => core::ptr::null_mut(),
         };
         let item = Box::new(1i32);
         let item_ptr = Box::into_raw(item);
@@ -335,7 +335,7 @@ mod tests {
             );
             let item_ptr = match result {
                 ArrayQueuePopResult::Ok(ptr) => ptr,
-                _ => std::ptr::null_mut(),
+                _ => core::ptr::null_mut(),
             };
             drop(Box::from_raw(item_ptr as *mut i32));
             let result = ddog_ArrayQueue_push(queue, item3_ptr as *mut c_void);
@@ -438,7 +438,7 @@ mod tests {
                 assert!(matches!(queue_new_result, ArrayQueueNewResult::Ok(_)));
                 let queue_ptr = match queue_new_result {
                     ArrayQueueNewResult::Ok(ptr) => ptr.as_ptr(),
-                    _ => std::ptr::null_mut(),
+                    _ => core::ptr::null_mut(),
                 };
                 let queue = unsafe { &*queue_ptr };
 

--- a/libdd-common-ffi/src/cstr.rs
+++ b/libdd-common-ffi/src/cstr.rs
@@ -1,8 +1,11 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+use alloc::ffi::{CString as AllocCString, NulError};
+use alloc::vec::Vec;
+use core::ffi::CStr as CoreCStr;
 use core::fmt;
-use std::{
+use core::{
     ffi::c_char,
     marker::PhantomData,
     mem::{self, ManuallyDrop},
@@ -17,21 +20,21 @@ pub struct CStr<'a> {
     ptr: ptr::NonNull<c_char>,
     /// Length of the array, not counting the null-terminator
     length: usize,
-    _lifetime_marker: std::marker::PhantomData<&'a c_char>,
+    _lifetime_marker: core::marker::PhantomData<&'a c_char>,
 }
 
 impl<'a> CStr<'a> {
-    pub fn from_std(s: &'a std::ffi::CStr) -> Self {
+    pub fn from_std(s: &'a CoreCStr) -> Self {
         Self {
             ptr: unsafe { ptr::NonNull::new_unchecked(s.as_ptr().cast_mut()) },
             length: s.to_bytes().len(),
-            _lifetime_marker: std::marker::PhantomData,
+            _lifetime_marker: core::marker::PhantomData,
         }
     }
 
-    pub fn into_std(&self) -> &'a std::ffi::CStr {
+    pub fn into_std(&self) -> &'a CoreCStr {
         unsafe {
-            std::ffi::CStr::from_bytes_with_nul_unchecked(std::slice::from_raw_parts(
+            CoreCStr::from_bytes_with_nul_unchecked(core::slice::from_raw_parts(
                 self.ptr.as_ptr().cast_const().cast(),
                 self.length + 1,
             ))
@@ -56,8 +59,8 @@ impl fmt::Debug for CString {
 }
 
 impl CString {
-    pub fn new<T: Into<Vec<u8>>>(t: T) -> Result<Self, std::ffi::NulError> {
-        Ok(Self::from_std(std::ffi::CString::new(t)?))
+    pub fn new<T: Into<Vec<u8>>>(t: T) -> Result<Self, NulError> {
+        Ok(Self::from_std(AllocCString::new(t)?))
     }
 
     /// Creates a new `CString` from the given input, or returns an empty `CString`
@@ -99,7 +102,7 @@ impl CString {
         }
     }
 
-    pub fn from_std(s: std::ffi::CString) -> Self {
+    pub fn from_std(s: AllocCString) -> Self {
         let length = s.to_bytes().len();
         Self {
             ptr: unsafe { ptr::NonNull::new_unchecked(s.into_raw()) },
@@ -107,10 +110,10 @@ impl CString {
         }
     }
 
-    pub fn into_std(self) -> std::ffi::CString {
+    pub fn into_std(self) -> AllocCString {
         let s = ManuallyDrop::new(self);
         unsafe {
-            std::ffi::CString::from_vec_with_nul_unchecked(Vec::from_raw_parts(
+            AllocCString::from_vec_with_nul_unchecked(Vec::from_raw_parts(
                 s.ptr.as_ptr().cast(),
                 s.length + 1, // +1 for the null terminator
                 s.length + 1, // +1 for the null terminator
@@ -123,7 +126,7 @@ impl Drop for CString {
     fn drop(&mut self) {
         let ptr = mem::replace(&mut self.ptr, NonNull::dangling());
         drop(unsafe {
-            std::ffi::CString::from_vec_with_nul_unchecked(Vec::from_raw_parts(
+            AllocCString::from_vec_with_nul_unchecked(Vec::from_raw_parts(
                 ptr.as_ptr().cast(),
                 self.length + 1,
                 self.length + 1,
@@ -138,7 +141,7 @@ mod tests {
 
     #[test]
     fn test_cstr() {
-        let s = std::ffi::CString::new("hello").unwrap();
+        let s = AllocCString::new("hello").unwrap();
         let cstr = CStr::from_std(&s);
         assert_eq!(cstr.into_std().to_str().unwrap(), "hello");
     }

--- a/libdd-common-ffi/src/endpoint.rs
+++ b/libdd-common-ffi/src/endpoint.rs
@@ -3,10 +3,10 @@
 
 use crate::slice::AsBytes;
 use crate::Error;
+use alloc::borrow::Cow;
+use core::str::FromStr;
 use hyper::http::uri::{Authority, Parts};
 use libdd_common::{parse_uri, Endpoint};
-use std::borrow::Cow;
-use std::str::FromStr;
 
 #[no_mangle]
 #[must_use]

--- a/libdd-common-ffi/src/error.rs
+++ b/libdd-common-ffi/src/error.rs
@@ -3,7 +3,7 @@
 
 use crate::slice::{AsBytes, CharSlice};
 use crate::vec::Vec;
-use std::fmt::{Debug, Display, Formatter};
+use core::fmt::{Debug, Display, Formatter};
 
 /// You probably don't want to use this directly. This constant is used by `handle_panic_error` to
 /// signal that something went wrong, but avoid needing any allocations to represent it.
@@ -15,7 +15,7 @@ pub(crate) const CANNOT_ALLOCATE_ERROR: Error = Error {
 
 // This error message is used as a placeholder for errors without message -- corresponding to an
 // error where we couldn't even _allocate_ the message (or some other even weirder error).
-const CANNOT_ALLOCATE: &std::ffi::CStr =
+const CANNOT_ALLOCATE: &core::ffi::CStr =
     c"libdatadog failed: (panic) Cannot allocate error message";
 const CANNOT_ALLOCATE_CHAR_SLICE: CharSlice = unsafe {
     crate::Slice::from_raw_parts(CANNOT_ALLOCATE.as_ptr(), CANNOT_ALLOCATE.to_bytes().len())
@@ -40,18 +40,18 @@ impl AsRef<str> for Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.write_str(self.as_ref())
     }
 }
 
 impl Debug for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.write_fmt(format_args!("Error(\"{}\")", self.as_ref()))
     }
 }
 
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 impl From<String> for Error {
     fn from(value: String) -> Self {
@@ -63,7 +63,7 @@ impl From<String> for Error {
 impl From<Error> for String {
     fn from(mut value: Error) -> String {
         let mut vec = Vec::default();
-        std::mem::swap(&mut vec, &mut value.message);
+        core::mem::swap(&mut vec, &mut value.message);
         // Safety: .message is a String (just FFI safe).
         unsafe { String::from_utf8_unchecked(vec.into()) }
     }
@@ -83,8 +83,8 @@ impl From<anyhow::Error> for Error {
     }
 }
 
-impl From<Box<&dyn std::error::Error>> for Error {
-    fn from(value: Box<&dyn std::error::Error>) -> Self {
+impl From<Box<&dyn core::error::Error>> for Error {
+    fn from(value: Box<&dyn core::error::Error>) -> Self {
         Self::from(value.to_string())
     }
 }

--- a/libdd-common-ffi/src/handle.rs
+++ b/libdd-common-ffi/src/handle.rs
@@ -1,7 +1,7 @@
 // Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use std::ptr::null_mut;
+use core::ptr::null_mut;
 
 use anyhow::Context;
 
@@ -48,7 +48,7 @@ impl<T> ToInner<T> for Handle<T> {
     unsafe fn take(&mut self) -> anyhow::Result<Box<T>> {
         // Leaving a null will help with double-free issues that can arise in C.
         // Of course, it's best to never get there in the first place!
-        let raw = std::mem::replace(&mut self.inner, std::ptr::null_mut());
+        let raw = core::mem::replace(&mut self.inner, core::ptr::null_mut());
         anyhow::ensure!(
             !raw.is_null(),
             "inner pointer was null, indicates use after free"

--- a/libdd-common-ffi/src/lib.rs
+++ b/libdd-common-ffi/src/lib.rs
@@ -6,6 +6,8 @@
 #![cfg_attr(not(test), deny(clippy::todo))]
 #![cfg_attr(not(test), deny(clippy::unimplemented))]
 
+extern crate alloc;
+
 mod error;
 
 pub mod array_queue;

--- a/libdd-common-ffi/src/option.rs
+++ b/libdd-common-ffi/src/option.rs
@@ -1,7 +1,7 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 #[repr(C)]
 #[derive(Debug, PartialEq, Eq)]
@@ -12,11 +12,11 @@ pub enum Option<T> {
 }
 
 impl<T> Option<T> {
-    pub fn to_std(self) -> std::option::Option<T> {
+    pub fn to_std(self) -> core::option::Option<T> {
         self.into()
     }
 
-    pub fn to_std_ref(&self) -> std::option::Option<&T> {
+    pub fn to_std_ref(&self) -> core::option::Option<&T> {
         match self {
             Option::Some(ref s) => Some(s),
             Option::None => None,
@@ -43,7 +43,7 @@ impl<T> Option<T> {
     }
 }
 
-impl<T> From<Option<T>> for std::option::Option<T> {
+impl<T> From<Option<T>> for core::option::Option<T> {
     fn from(o: Option<T>) -> Self {
         match o {
             Option::Some(s) => Some(s),
@@ -52,8 +52,8 @@ impl<T> From<Option<T>> for std::option::Option<T> {
     }
 }
 
-impl<T> From<std::option::Option<T>> for Option<T> {
-    fn from(o: std::option::Option<T>) -> Self {
+impl<T> From<core::option::Option<T>> for Option<T> {
+    fn from(o: core::option::Option<T>) -> Self {
         match o {
             Some(s) => Option::Some(s),
             None => Option::None,
@@ -61,7 +61,7 @@ impl<T> From<std::option::Option<T>> for Option<T> {
     }
 }
 
-impl<T: Copy> From<&Option<T>> for std::option::Option<T> {
+impl<T: Copy> From<&Option<T>> for core::option::Option<T> {
     fn from(o: &Option<T>) -> Self {
         match o {
             Option::Some(s) => Some(*s),

--- a/libdd-common-ffi/src/slice.rs
+++ b/libdd-common-ffi/src/slice.rs
@@ -1,16 +1,16 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+use alloc::borrow::Cow;
+use core::ffi::c_char;
+use core::fmt::{Debug, Display, Formatter};
+use core::hash::{Hash, Hasher};
+use core::marker::PhantomData;
 use core::slice;
+use core::str::Utf8Error;
 use libdd_common::error::FfiSafeErrorMessage;
 use serde::ser::Error;
 use serde::Serializer;
-use std::borrow::Cow;
-use std::fmt::{Debug, Display, Formatter};
-use std::hash::{Hash, Hasher};
-use std::marker::PhantomData;
-use std::os::raw::c_char;
-use std::str::Utf8Error;
 
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
@@ -37,7 +37,7 @@ pub struct Slice<'a, T: 'a> {
 /// # Safety
 /// All strings are valid UTF-8 (enforced by using c-str literals in Rust).
 unsafe impl FfiSafeErrorMessage for SliceConversionError {
-    fn as_ffi_str(&self) -> &'static std::ffi::CStr {
+    fn as_ffi_str(&self) -> &'static core::ffi::CStr {
         match self {
             SliceConversionError::LargeLength => c"length was too large",
             SliceConversionError::NullPointer => c"null pointer with non-zero length",
@@ -46,7 +46,7 @@ unsafe impl FfiSafeErrorMessage for SliceConversionError {
     }
 }
 impl Display for SliceConversionError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         Display::fmt(self.as_rust_str(), f)
     }
 }
@@ -62,7 +62,7 @@ impl<'a, T: 'a> core::ops::Deref for Slice<'a, T> {
 }
 
 impl<T: Debug> Debug for Slice<'_, T> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         self.as_slice().fmt(f)
     }
 }
@@ -106,7 +106,7 @@ pub trait AsBytes<'a> {
 
     #[inline]
     fn try_to_utf8(&self) -> Result<&'a str, Utf8Error> {
-        std::str::from_utf8(self.as_bytes())
+        core::str::from_utf8(self.as_bytes())
     }
 
     fn try_to_string(&self) -> Result<String, Utf8Error> {
@@ -127,7 +127,7 @@ pub trait AsBytes<'a> {
     /// # Safety
     /// Must only be used when the underlying data was already confirmed to be utf8.
     unsafe fn assume_utf8(&self) -> &'a str {
-        std::str::from_utf8_unchecked(self.as_bytes())
+        core::str::from_utf8_unchecked(self.as_bytes())
     }
 }
 
@@ -276,8 +276,8 @@ impl<'a, T> Display for Slice<'a, T>
 where
     Slice<'a, T>: AsBytes<'a>,
 {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.try_to_utf8().map_err(|_| std::fmt::Error)?)
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.try_to_utf8().map_err(|_| core::fmt::Error)?)
     }
 }
 
@@ -322,8 +322,8 @@ impl<'a> CharSlice<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::ptr;
     use std::os::raw::c_char;
-    use std::ptr;
 
     #[test]
     fn slice_from_into_slice() {

--- a/libdd-common-ffi/src/slice_mut.rs
+++ b/libdd-common-ffi/src/slice_mut.rs
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::slice::{AsBytes, SliceConversionError};
+use core::fmt::{Debug, Display, Formatter};
+use core::hash::{Hash, Hasher};
+use core::marker::PhantomData;
+use core::ptr::NonNull;
 use core::slice;
 use serde::ser::Error;
 use serde::Serializer;
-use std::fmt::{Debug, Display, Formatter};
-use std::hash::{Hash, Hasher};
-use std::marker::PhantomData;
 use std::os::raw::c_char;
-use std::ptr::NonNull;
 
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -34,7 +34,7 @@ impl<'a, T: 'a> core::ops::Deref for MutSlice<'a, T> {
 }
 
 impl<T: Debug> Debug for MutSlice<'_, T> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         self.as_slice().fmt(f)
     }
 }
@@ -175,8 +175,8 @@ impl<'a, T> Display for MutSlice<'a, T>
 where
     MutSlice<'a, T>: AsBytes<'a>,
 {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.try_to_utf8().map_err(|_| std::fmt::Error)?)
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.try_to_utf8().map_err(|_| core::fmt::Error)?)
     }
 }
 
@@ -202,7 +202,7 @@ impl<'a> From<&'a mut str> for MutSlice<'a, c_char> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::ptr;
+    use core::ptr;
 
     #[derive(Debug, Eq, PartialEq)]
     struct Foo(i64);

--- a/libdd-common-ffi/src/string.rs
+++ b/libdd-common-ffi/src/string.rs
@@ -29,7 +29,7 @@ impl From<String> for StringWrapper {
 
 impl From<StringWrapper> for String {
     fn from(mut value: StringWrapper) -> Self {
-        let msg = std::mem::take(&mut value.message);
+        let msg = core::mem::take(&mut value.message);
         #[allow(clippy::unwrap_used)]
         String::from_utf8(msg.into()).unwrap()
     }

--- a/libdd-common-ffi/src/timespec.rs
+++ b/libdd-common-ffi/src/timespec.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use chrono::{DateTime, TimeZone, Utc};
-use std::fmt::Debug;
+use core::fmt::Debug;
 use std::time::SystemTime;
 
 /// Represents time since the Unix Epoch in seconds plus nanoseconds.

--- a/libdd-common-ffi/src/utils.rs
+++ b/libdd-common-ffi/src/utils.rs
@@ -1,7 +1,8 @@
 // Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use std::panic::{catch_unwind, AssertUnwindSafe};
+use core::panic::AssertUnwindSafe;
+use std::panic::catch_unwind;
 
 /// Wraps a C-FFI function in standard form
 /// Expects the function to return a result type that implements into and to be decorated with
@@ -9,7 +10,8 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 #[macro_export]
 macro_rules! wrap_with_ffi_result {
     ($body:block) => {{
-        use std::panic::{catch_unwind, AssertUnwindSafe};
+        use core::panic::AssertUnwindSafe;
+        use std::panic::catch_unwind;
 
         catch_unwind(AssertUnwindSafe(|| {
             $crate::wrap_with_ffi_result_no_catch!({ $body })
@@ -38,7 +40,8 @@ macro_rules! wrap_with_ffi_result_no_catch {
 #[macro_export]
 macro_rules! wrap_with_void_ffi_result {
     ($body:block) => {{
-        use std::panic::{catch_unwind, AssertUnwindSafe};
+        use core::panic::AssertUnwindSafe;
+        use std::panic::catch_unwind;
 
         catch_unwind(AssertUnwindSafe(|| {
             $crate::wrap_with_void_ffi_result_no_catch!({ $body })
@@ -80,7 +83,7 @@ impl ToHexStr for usize {
 /// being unable to allocate, this helper handles failures to allocate as well, turning them into a
 /// fallback error.
 pub fn handle_panic_error(
-    error: Box<dyn std::any::Any + Send + 'static>,
+    error: Box<dyn core::any::Any + Send + 'static>,
     function_name: &str,
 ) -> crate::Error {
     catch_unwind(AssertUnwindSafe(|| {
@@ -112,7 +115,7 @@ mod tests {
 
     #[test]
     fn test_handle_panic_error_fallback_does_not_allocate() {
-        let mut error_result_buffer: [std::os::raw::c_char; 100] = [0; 100];
+        let mut error_result_buffer: [core::ffi::c_char; 100] = [0; 100];
 
         assert_no_alloc(|| {
             // Simulate fallback code path of handle_panic_error + ddog_Error_message
@@ -125,7 +128,7 @@ mod tests {
         });
 
         unsafe {
-            let c_str = std::ffi::CStr::from_ptr(error_result_buffer.as_ptr());
+            let c_str = core::ffi::CStr::from_ptr(error_result_buffer.as_ptr());
             assert_eq!(
                 c_str.to_str().unwrap(),
                 "libdatadog failed: (panic) Cannot allocate error message"

--- a/libdd-common-ffi/src/vec.rs
+++ b/libdd-common-ffi/src/vec.rs
@@ -4,10 +4,10 @@
 extern crate alloc;
 
 use crate::slice::Slice;
+use core::marker::PhantomData;
+use core::mem::ManuallyDrop;
 use core::ops::Deref;
-use std::marker::PhantomData;
-use std::mem::ManuallyDrop;
-use std::ptr::NonNull;
+use core::ptr::NonNull;
 
 /// Holds the raw parts of a Rust Vec; it should only be created from Rust,
 /// never from C.
@@ -97,7 +97,7 @@ impl<'a, T> IntoIterator for &'a Vec<T> {
 }
 
 impl<T> Vec<T> {
-    fn replace(&mut self, mut vec: ManuallyDrop<std::vec::Vec<T>>) {
+    fn replace(&mut self, mut vec: ManuallyDrop<alloc::vec::Vec<T>>) {
         self.ptr = vec.as_mut_ptr();
         self.len = vec.len();
         self.capacity = vec.capacity();

--- a/libdd-common/Cargo.toml
+++ b/libdd-common/Cargo.toml
@@ -123,3 +123,7 @@ bench-utils = ["dep:criterion"]
 # normal environments, so we need to let the rust linter know that it is in
 # fact a real thing, though one that shows up only in some situations.
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)'] }
+
+[lints.clippy]
+std_instead_of_alloc = "warn"
+std_instead_of_core = "warn"

--- a/libdd-common/src/azure_app_services.rs
+++ b/libdd-common/src/azure_app_services.rs
@@ -84,7 +84,7 @@ fn read_proc_self_environ() -> HashMap<String, String> {
         if entry.is_empty() {
             continue;
         }
-        let s = match std::str::from_utf8(entry) {
+        let s = match core::str::from_utf8(entry) {
             Ok(s) => s,
             Err(_) => continue,
         };

--- a/libdd-common/src/bench_utils.rs
+++ b/libdd-common/src/bench_utils.rs
@@ -7,11 +7,8 @@
 
 #![allow(missing_docs)]
 
-use std::{
-    alloc::{GlobalAlloc, System},
-    cell::Cell,
-    time::Duration,
-};
+use core::{alloc::GlobalAlloc, cell::Cell, time::Duration};
+use std::alloc::System;
 
 use criterion::{Criterion, Throughput};
 
@@ -46,16 +43,16 @@ struct AllocStats {
 
 pub struct ReportingAllocator<T: GlobalAlloc> {
     alloc: T,
-    allocated_bytes: std::sync::atomic::AtomicUsize,
-    allocations: std::sync::atomic::AtomicUsize,
+    allocated_bytes: core::sync::atomic::AtomicUsize,
+    allocations: core::sync::atomic::AtomicUsize,
 }
 
 impl<T: GlobalAlloc> ReportingAllocator<T> {
     pub const fn new(alloc: T) -> Self {
         Self {
             alloc,
-            allocated_bytes: std::sync::atomic::AtomicUsize::new(0),
-            allocations: std::sync::atomic::AtomicUsize::new(0),
+            allocated_bytes: core::sync::atomic::AtomicUsize::new(0),
+            allocations: core::sync::atomic::AtomicUsize::new(0),
         }
     }
 
@@ -63,22 +60,22 @@ impl<T: GlobalAlloc> ReportingAllocator<T> {
         AllocStats {
             allocated_bytes: self
                 .allocated_bytes
-                .load(std::sync::atomic::Ordering::Relaxed),
-            allocations: self.allocations.load(std::sync::atomic::Ordering::Relaxed),
+                .load(core::sync::atomic::Ordering::Relaxed),
+            allocations: self.allocations.load(core::sync::atomic::Ordering::Relaxed),
         }
     }
 }
 
 unsafe impl<T: GlobalAlloc> GlobalAlloc for ReportingAllocator<T> {
-    unsafe fn alloc(&self, layout: std::alloc::Layout) -> *mut u8 {
+    unsafe fn alloc(&self, layout: core::alloc::Layout) -> *mut u8 {
         self.allocated_bytes
-            .fetch_add(layout.size(), std::sync::atomic::Ordering::Relaxed);
+            .fetch_add(layout.size(), core::sync::atomic::Ordering::Relaxed);
         self.allocations
-            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            .fetch_add(1, core::sync::atomic::Ordering::Relaxed);
         self.alloc.alloc(layout)
     }
 
-    unsafe fn dealloc(&self, ptr: *mut u8, layout: std::alloc::Layout) {
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: core::alloc::Layout) {
         self.alloc.dealloc(ptr, layout);
     }
 }
@@ -169,8 +166,9 @@ impl criterion::measurement::ValueFormatter for AllocationFormatter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::alloc::{GlobalAlloc, Layout};
     use criterion::measurement::{Measurement, ValueFormatter};
-    use std::alloc::{GlobalAlloc, Layout, System};
+    use std::alloc::System;
 
     static SHARED: ReportingAllocator<System> = ReportingAllocator::new(System);
 

--- a/libdd-common/src/config.rs
+++ b/libdd-common/src/config.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod parse_env {
+    use core::{str::FromStr, time::Duration};
     use http::Uri;
-    use std::{env, str::FromStr, time::Duration};
+    use std::env;
 
     use crate::parse_uri;
 

--- a/libdd-common/src/connector/conn_stream.rs
+++ b/libdd-common/src/connector/conn_stream.rs
@@ -1,7 +1,7 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{
+use core::{
     pin::Pin,
     task::{Context, Poll},
 };
@@ -35,7 +35,7 @@ pub enum ConnStream {
     },
 }
 
-pub type ConnStreamError = Box<dyn std::error::Error + Send + Sync>;
+pub type ConnStreamError = Box<dyn core::error::Error + Send + Sync>;
 
 use hyper_util::client::legacy::connect::{self, HttpConnector};
 use hyper_util::rt::TokioIo;

--- a/libdd-common/src/connector/errors.rs
+++ b/libdd-common/src/connector/errors.rs
@@ -1,8 +1,8 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+use alloc::fmt;
 use std::error;
-use std::fmt;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Error {

--- a/libdd-common/src/connector/mod.rs
+++ b/libdd-common/src/connector/mod.rs
@@ -5,10 +5,10 @@ use futures::future::BoxFuture;
 use futures::{future, FutureExt};
 use hyper_util::client::legacy::connect;
 
-use std::future::Future;
-use std::pin::Pin;
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll};
 use std::sync::LazyLock;
-use std::task::{Context, Poll};
 
 #[cfg(unix)]
 pub mod uds;

--- a/libdd-common/src/cstr.rs
+++ b/libdd-common/src/cstr.rs
@@ -31,7 +31,7 @@ macro_rules! cstr {
         }
 
         $crate::cstr::validate_cstr_contents(bytes);
-        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(bytes) }
+        unsafe { core::ffi::CStr::from_bytes_with_nul_unchecked(bytes) }
     }};
 }
 
@@ -39,7 +39,7 @@ macro_rules! cstr {
 macro_rules! cstr_u8 {
     ($s:literal) => {{
         $crate::cstr::validate_cstr_contents($s);
-        unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked($s as &[u8]) }
+        unsafe { core::ffi::CStr::from_bytes_with_nul_unchecked($s as &[u8]) }
     }};
 }
 

--- a/libdd-common/src/dump_server.rs
+++ b/libdd-common/src/dump_server.rs
@@ -178,7 +178,7 @@ fn is_chunked_encoding(headers: &[httparse::Header]) -> bool {
     headers.iter().any(|h| {
         h.name
             .eq_ignore_ascii_case(http::header::TRANSFER_ENCODING.as_str())
-            && std::str::from_utf8(h.value).is_ok_and(|v| v.to_lowercase().contains("chunked"))
+            && core::str::from_utf8(h.value).is_ok_and(|v| v.to_lowercase().contains("chunked"))
     })
 }
 
@@ -190,7 +190,7 @@ fn get_content_length(headers: &[httparse::Header]) -> Option<usize> {
             h.name
                 .eq_ignore_ascii_case(http::header::CONTENT_LENGTH.as_str())
         })
-        .and_then(|h| std::str::from_utf8(h.value).ok())
+        .and_then(|h| core::str::from_utf8(h.value).ok())
         .and_then(|v| v.trim().parse().ok())
 }
 
@@ -294,7 +294,7 @@ fn decode_chunked_body(chunked_data: &[u8]) -> anyhow::Result<Vec<u8>> {
             .with_context(|| format!("Missing CRLF after chunk size at position {}", pos))?;
 
         // Parse the chunk size (hex)
-        let size_str = std::str::from_utf8(&chunked_data[pos..pos + line_end])
+        let size_str = core::str::from_utf8(&chunked_data[pos..pos + line_end])
             .context("Invalid UTF-8 in chunk size")?;
 
         let chunk_size = usize::from_str_radix(size_str.trim(), 16)

--- a/libdd-common/src/entity_id/unix/mod.rs
+++ b/libdd-common/src/entity_id/unix/mod.rs
@@ -1,8 +1,8 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+use alloc::fmt;
 use std::error;
-use std::fmt;
 use std::path::Path;
 use std::sync::LazyLock;
 
@@ -66,7 +66,7 @@ fn get_cgroup_path() -> &'static str {
     #[cfg(feature = "cgroup_testing")]
     return TESTING_CGROUP_PATH
         .get()
-        .map(std::ops::Deref::deref)
+        .map(core::ops::Deref::deref)
         .unwrap_or(DEFAULT_CGROUP_PATH);
     #[cfg(not(feature = "cgroup_testing"))]
     return DEFAULT_CGROUP_PATH;

--- a/libdd-common/src/error.rs
+++ b/libdd-common/src/error.rs
@@ -20,7 +20,7 @@
 pub unsafe trait FfiSafeErrorMessage {
     /// Returns the error message as a static CStr. It must also be a valid
     /// Rust string, including being UTF-8.
-    fn as_ffi_str(&self) -> &'static std::ffi::CStr;
+    fn as_ffi_str(&self) -> &'static core::ffi::CStr;
 
     /// Returns the error message as a static Rust str, excluding the null
     /// terminator. If you need it, use [`FfiSafeErrorMessage::as_ffi_str`].
@@ -29,6 +29,6 @@ pub unsafe trait FfiSafeErrorMessage {
     fn as_rust_str(&self) -> &'static str {
         // Bytes will not contain the null terminator.
         let bytes = self.as_ffi_str().to_bytes();
-        unsafe { std::str::from_utf8_unchecked(bytes) }
+        unsafe { core::str::from_utf8_unchecked(bytes) }
     }
 }

--- a/libdd-common/src/http_common.rs
+++ b/libdd-common/src/http_common.rs
@@ -1,8 +1,8 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+use core::convert::Infallible;
 use core::fmt;
-use std::convert::Infallible;
 
 use thiserror::Error;
 
@@ -26,8 +26,8 @@ pub struct ClientError {
     kind: ErrorKind,
 }
 
-impl std::fmt::Display for ClientError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for ClientError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         self.source.fmt(f)
     }
 }
@@ -46,7 +46,7 @@ pub enum Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Error::Client(e) => write!(f, "client error: {e}"),
             Error::Infallible(e) => match *e {},
@@ -67,15 +67,15 @@ impl From<http::Error> for Error {
     }
 }
 
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 // --- Native-only code (hyper, Body, client builders, etc.) ---
 
 #[cfg(not(target_arch = "wasm32"))]
 mod native {
     use super::*;
-    use std::error::Error as _;
-    use std::task::Poll;
+    use core::error::Error as _;
+    use core::task::Poll;
 
     use crate::connector::Connector;
     use http_body_util::BodyExt;
@@ -205,7 +205,7 @@ mod native {
         }
 
         pub fn boxed<
-            E: std::error::Error + Sync + Send + 'static,
+            E: core::error::Error + Sync + Send + 'static,
             T: hyper::body::Body<Data = hyper::body::Bytes, Error = E> + Sync + Send + 'static,
         >(
             body: T,
@@ -253,9 +253,9 @@ mod native {
         type Error = Error;
 
         fn poll_frame(
-            self: std::pin::Pin<&mut Self>,
-            cx: &mut std::task::Context<'_>,
-        ) -> std::task::Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
+            self: core::pin::Pin<&mut Self>,
+            cx: &mut core::task::Context<'_>,
+        ) -> core::task::Poll<Option<Result<http_body::Frame<Self::Data>, Self::Error>>> {
             match self.project() {
                 BodyProj::Single(pin) => pin.poll_frame(cx).map_err(Error::Infallible),
                 BodyProj::Empty(pin) => pin.poll_frame(cx).map_err(Error::Infallible),

--- a/libdd-common/src/lib.rs
+++ b/libdd-common/src/lib.rs
@@ -6,12 +6,16 @@
 #![cfg_attr(not(test), deny(clippy::todo))]
 #![cfg_attr(not(test), deny(clippy::unimplemented))]
 
+extern crate alloc;
+
+use alloc::borrow::Cow;
 use anyhow::Context;
+use core::{ops::Deref, str::FromStr};
 use http::uri;
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::path::PathBuf;
 use std::sync::{Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard};
-use std::{borrow::Cow, ops::Deref, path::PathBuf, str::FromStr};
 
 pub mod azure_app_services;
 #[cfg(not(target_arch = "wasm32"))]
@@ -460,7 +464,7 @@ impl Endpoint {
         // configuration will mutate the system environment (it doesn't pass
         // it as part of the SAPI env, it changes the actual system env).
         let mut builder = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_millis(self.timeout_ms))
+            .timeout(core::time::Duration::from_millis(self.timeout_ms))
             .hickory_dns(!self.use_system_resolver)
             .no_proxy();
 

--- a/libdd-common/src/rate_limiter.rs
+++ b/libdd-common/src/rate_limiter.rs
@@ -1,7 +1,7 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::atomic::{AtomicI64, AtomicU32, AtomicU64, Ordering};
+use core::sync::atomic::{AtomicI64, AtomicU32, AtomicU64, Ordering};
 
 pub trait Limiter {
     /// Takes the limit per interval.
@@ -158,7 +158,7 @@ impl Limiter for LocalLimiter {
 #[cfg(test)]
 mod tests {
     use crate::rate_limiter::{now, Limiter, LocalLimiter, MOCK_NOW, TIME_PER_SECOND};
-    use std::sync::atomic::Ordering;
+    use core::sync::atomic::Ordering;
 
     fn set_mock_time(nanos: u64) {
         MOCK_NOW.store(nanos, Ordering::Relaxed);

--- a/libdd-common/src/tag.rs
+++ b/libdd-common/src/tag.rs
@@ -1,9 +1,9 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+use alloc::borrow::Cow;
+use core::fmt::{Debug, Display, Formatter};
 use serde::{Deserialize, Serialize};
-use std::borrow::Cow;
-use std::fmt::{Debug, Display, Formatter};
 
 pub use static_assertions::{const_assert, const_assert_ne};
 
@@ -71,7 +71,7 @@ macro_rules! tag {
 }
 
 impl Debug for Tag {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Tag").field("value", &self.value).finish()
     }
 }
@@ -84,7 +84,7 @@ impl AsRef<str> for Tag {
 
 // Any type which implements Display automatically has to_string.
 impl Display for Tag {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.value)
     }
 }

--- a/libdd-common/src/test_utils.rs
+++ b/libdd-common/src/test_utils.rs
@@ -36,7 +36,7 @@ impl Drop for TempFileGuard {
     }
 }
 
-impl std::ops::Deref for TempFileGuard {
+impl core::ops::Deref for TempFileGuard {
     type Target = PathBuf;
 
     fn deref(&self) -> &Self::Target {
@@ -158,7 +158,7 @@ pub fn count_active_threads() -> anyhow::Result<usize> {
 
     #[cfg(windows)]
     {
-        use std::mem::{size_of, zeroed};
+        use core::mem::{size_of, zeroed};
         use windows_sys::Win32::Foundation::CloseHandle;
         use windows_sys::Win32::System::Diagnostics::ToolHelp::{
             CreateToolhelp32Snapshot, Thread32First, Thread32Next, TH32CS_SNAPTHREAD, THREADENTRY32,
@@ -529,7 +529,8 @@ mod tests {
         );
 
         // Spawn some threads and verify the count increases
-        use std::sync::{Arc, Barrier};
+        use alloc::sync::Arc;
+        use std::sync::Barrier;
         let barrier = Arc::new(Barrier::new(6)); // 5 spawned threads + main thread
 
         let handles: Vec<_> = (0..5)
@@ -537,7 +538,7 @@ mod tests {
                 let barrier = Arc::clone(&barrier);
                 std::thread::spawn(move || {
                     barrier.wait();
-                    std::thread::sleep(std::time::Duration::from_millis(50));
+                    std::thread::sleep(core::time::Duration::from_millis(50));
                 })
             })
             .collect();

--- a/libdd-common/src/timeout.rs
+++ b/libdd-common/src/timeout.rs
@@ -1,7 +1,8 @@
 // Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::{Duration, Instant};
+use core::time::Duration;
+use std::time::Instant;
 
 pub struct TimeoutManager {
     start_time: Instant,
@@ -38,8 +39,8 @@ impl TimeoutManager {
     }
 }
 
-impl std::fmt::Debug for TimeoutManager {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for TimeoutManager {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("TimeoutManager")
             .field("start_time", &self.start_time)
             .field("elapsed", &self.elapsed())

--- a/libdd-common/src/unix_utils/execve.rs
+++ b/libdd-common/src/unix_utils/execve.rs
@@ -1,9 +1,9 @@
 // Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+use alloc::ffi::{CString, NulError};
 use libc::execve;
 use nix::errno::Errno;
-use std::ffi::CString;
 
 // The args_cstrings and env_vars_strings fields are just storage.  Even though they're
 // unreferenced, they're a necessary part of the struct.
@@ -20,15 +20,15 @@ pub struct PreparedExecve {
 #[derive(Debug, thiserror::Error)]
 pub enum PreparedExecveError {
     #[error("Failed to convert binary path to CString: {0}")]
-    BinaryPathError(std::ffi::NulError),
+    BinaryPathError(NulError),
     #[error("Failed to convert argument to CString: {0}")]
-    ArgumentError(std::ffi::NulError),
+    ArgumentError(NulError),
     #[error("Failed to convert environment variable to CString: {0}")]
-    EnvironmentError(std::ffi::NulError),
+    EnvironmentError(NulError),
 }
 
-impl From<std::ffi::NulError> for PreparedExecveError {
-    fn from(err: std::ffi::NulError) -> Self {
+impl From<NulError> for PreparedExecveError {
+    fn from(err: NulError) -> Self {
         PreparedExecveError::BinaryPathError(err)
     }
 }
@@ -47,12 +47,12 @@ impl PreparedExecve {
         let args_cstrings: Vec<CString> = args
             .iter()
             .map(|s| CString::new(s.as_str()))
-            .collect::<Result<Vec<CString>, std::ffi::NulError>>()
+            .collect::<Result<Vec<CString>, NulError>>()
             .map_err(PreparedExecveError::ArgumentError)?;
         let args_ptrs: Vec<*const libc::c_char> = args_cstrings
             .iter()
             .map(|arg| arg.as_ptr())
-            .chain(std::iter::once(std::ptr::null())) // Adds a null pointer to the end of the list
+            .chain(core::iter::once(core::ptr::null())) // Adds a null pointer to the end of the list
             .collect();
 
         // Allocate and store environment variables
@@ -62,12 +62,12 @@ impl PreparedExecve {
                 let env_str = format!("{key}={value}");
                 CString::new(env_str)
             })
-            .collect::<Result<Vec<CString>, std::ffi::NulError>>()
+            .collect::<Result<Vec<CString>, NulError>>()
             .map_err(PreparedExecveError::EnvironmentError)?;
         let env_vars_ptrs: Vec<*const libc::c_char> = env_vars_cstrings
             .iter()
             .map(|env| env.as_ptr())
-            .chain(std::iter::once(std::ptr::null())) // Adds a null pointer to the end of the list
+            .chain(core::iter::once(core::ptr::null())) // Adds a null pointer to the end of the list
             .collect();
 
         Ok(Self {
@@ -119,7 +119,7 @@ mod tests {
 
         // Verify the struct was created successfully
         // We can't directly access private fields, but we can verify the struct exists
-        assert!(std::mem::size_of_val(&prepared) > 0);
+        assert!(core::mem::size_of_val(&prepared) > 0);
     }
 
     #[test]
@@ -131,7 +131,7 @@ mod tests {
         let prepared = PreparedExecve::new(binary_path, &args, &env).unwrap();
 
         // Should still create successfully with empty args and env
-        assert!(std::mem::size_of_val(&prepared) > 0);
+        assert!(core::mem::size_of_val(&prepared) > 0);
     }
 
     #[test]
@@ -152,7 +152,7 @@ mod tests {
         let prepared = PreparedExecve::new(binary_path, &args, &env).unwrap();
 
         // Should handle complex arguments and environment variables
-        assert!(std::mem::size_of_val(&prepared) > 0);
+        assert!(core::mem::size_of_val(&prepared) > 0);
     }
 
     #[test]
@@ -228,7 +228,7 @@ mod tests {
         let prepared = PreparedExecve::new(binary_path, &args, &env).unwrap();
 
         // Should handle Unicode characters
-        assert!(std::mem::size_of_val(&prepared) > 0);
+        assert!(core::mem::size_of_val(&prepared) > 0);
     }
 
     #[test]
@@ -240,7 +240,7 @@ mod tests {
         let prepared = PreparedExecve::new(binary_path, &args, &env).unwrap();
 
         // Should handle large numbers of arguments
-        assert!(std::mem::size_of_val(&prepared) > 0);
+        assert!(core::mem::size_of_val(&prepared) > 0);
     }
 
     #[test]
@@ -254,7 +254,7 @@ mod tests {
         let prepared = PreparedExecve::new(binary_path, &args, &env).unwrap();
 
         // Should handle large numbers of environment variables
-        assert!(std::mem::size_of_val(&prepared) > 0);
+        assert!(core::mem::size_of_val(&prepared) > 0);
     }
 
     #[test]
@@ -266,7 +266,7 @@ mod tests {
         let prepared = PreparedExecve::new(binary_path, &args, &env).unwrap();
 
         // Should handle empty binary path (though this might not be valid for execve)
-        assert!(std::mem::size_of_val(&prepared) > 0);
+        assert!(core::mem::size_of_val(&prepared) > 0);
     }
 
     #[test]
@@ -281,7 +281,7 @@ mod tests {
         let prepared = PreparedExecve::new(binary_path, &args, &env).unwrap();
 
         // Should handle empty keys and values
-        assert!(std::mem::size_of_val(&prepared) > 0);
+        assert!(core::mem::size_of_val(&prepared) > 0);
     }
 
     #[test]

--- a/libdd-common/src/unix_utils/fork.rs
+++ b/libdd-common/src/unix_utils/fork.rs
@@ -84,7 +84,7 @@ fn is_being_traced_internal(mut file: File) -> io::Result<bool> {
 #[cfg(target_os = "linux")]
 fn check_tracer_pid_line(line: &[u8], marker: &[u8]) -> io::Result<Option<bool>> {
     if line.starts_with(marker) && line.len() > marker.len() {
-        if let Ok(line_str) = std::str::from_utf8(line) {
+        if let Ok(line_str) = core::str::from_utf8(line) {
             let tracer_pid = line_str.split_whitespace().nth(1).unwrap_or("0");
             return Ok(Some(tracer_pid != "0"));
         }
@@ -114,7 +114,7 @@ pub fn alt_fork() -> libc::pid_t {
         syscall(
             SYS_clone,
             (CLONE_CHILD_CLEARTID | CLONE_CHILD_SETTID | SIGCHLD | extra_flags) as c_ulong,
-            std::ptr::null_mut::<c_void>(),
+            core::ptr::null_mut::<c_void>(),
             &mut _ptid as *mut pid_t,
             &mut _ctid as *mut pid_t,
             0 as c_ulong,

--- a/libdd-common/src/unix_utils/process.rs
+++ b/libdd-common/src/unix_utils/process.rs
@@ -103,7 +103,7 @@ pub fn wait_for_pollhup(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::time::Duration;
+    use core::time::Duration;
 
     #[cfg_attr(miri, ignore)] // miri doesn't support waitpid
     #[test]

--- a/libdd-library-config-ffi/Cargo.toml
+++ b/libdd-library-config-ffi/Cargo.toml
@@ -29,3 +29,7 @@ build_common = { path = "../build-common" }
 
 [dev-dependencies]
 tempfile = { version = "3.3" }
+
+[lints.clippy]
+std_instead_of_alloc = "warn"
+std_instead_of_core = "warn"

--- a/libdd-library-config-ffi/src/lib.rs
+++ b/libdd-library-config-ffi/src/lib.rs
@@ -1,13 +1,17 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+extern crate alloc;
+
 pub mod tracer_metadata;
 
 use libdd_common_ffi::{self as ffi, slice::AsBytes, CString, CharSlice, Error};
 use libdd_library_config::{self as lib_config, LibraryConfigSource};
 
 #[cfg(all(feature = "catch_panic", panic = "unwind"))]
-use std::panic::{catch_unwind, AssertUnwindSafe};
+use core::panic::AssertUnwindSafe;
+#[cfg(all(feature = "catch_panic", panic = "unwind"))]
+use std::panic::catch_unwind;
 
 #[cfg(all(feature = "catch_panic", panic = "unwind"))]
 macro_rules! catch_panic {
@@ -87,15 +91,15 @@ impl LibraryConfig {
             .into_iter()
             .map(|c| {
                 Ok(LibraryConfig {
-                    name: ffi::CString::from_std(std::ffi::CString::new(c.name)?),
-                    value: ffi::CString::from_std(std::ffi::CString::new(c.value)?),
+                    name: ffi::CString::from_std(alloc::ffi::CString::new(c.name)?),
+                    value: ffi::CString::from_std(alloc::ffi::CString::new(c.value)?),
                     source: c.source,
-                    config_id: ffi::CString::from_std(std::ffi::CString::new(
+                    config_id: ffi::CString::from_std(alloc::ffi::CString::new(
                         c.config_id.unwrap_or_default(),
                     )?),
                 })
             })
-            .collect::<Result<Vec<_>, std::ffi::NulError>>()?;
+            .collect::<Result<Vec<_>, alloc::ffi::NulError>>()?;
         Ok(ffi::Vec::from_std(cfg))
     }
 
@@ -238,7 +242,7 @@ pub extern "C" fn ddog_library_config_fleet_stable_config_path() -> ffi::CStr<'s
             lib_config::Configurator::FLEET_STABLE_CONFIGURATION_PATH,
             "\0"
         );
-        std::ffi::CStr::from_bytes_with_nul_unchecked(path.as_bytes())
+        core::ffi::CStr::from_bytes_with_nul_unchecked(path.as_bytes())
     })
 }
 
@@ -251,7 +255,7 @@ pub extern "C" fn ddog_library_config_local_stable_config_path() -> ffi::CStr<'s
             lib_config::Configurator::LOCAL_STABLE_CONFIGURATION_PATH,
             "\0"
         );
-        std::ffi::CStr::from_bytes_with_nul_unchecked(path.as_bytes())
+        core::ffi::CStr::from_bytes_with_nul_unchecked(path.as_bytes())
     })
 }
 

--- a/libdd-library-config-ffi/src/tracer_metadata.rs
+++ b/libdd-library-config-ffi/src/tracer_metadata.rs
@@ -1,11 +1,11 @@
 // Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+use core::ffi::CStr;
 use libdd_common_ffi::Result;
 #[cfg(target_os = "linux")]
 use libdd_library_config::tracer_metadata::AnonymousFileHandle;
 use libdd_library_config::tracer_metadata::{self, TracerMetadata};
-use std::ffi::CStr;
 use std::os::raw::{c_char, c_int};
 
 /// C-compatible representation of an anonymous file handle

--- a/libdd-library-config/Cargo.toml
+++ b/libdd-library-config/Cargo.toml
@@ -36,3 +36,7 @@ serial_test = "3.2"
 [target.'cfg(unix)'.dependencies]
 memfd = { version = "0.6" }
 libc = "0.2"
+
+[lints.clippy]
+std_instead_of_alloc = "warn"
+std_instead_of_core = "warn"

--- a/libdd-library-config/src/lib.rs
+++ b/libdd-library-config/src/lib.rs
@@ -1,14 +1,15 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
+extern crate alloc;
+
 pub mod otel_process_ctx;
 pub mod tracer_metadata;
 
-use std::borrow::Cow;
-use std::cell::OnceCell;
+use alloc::borrow::Cow;
+use core::{cell::OnceCell, mem, ops::Deref};
 use std::collections::HashMap;
-use std::ops::Deref;
 use std::path::Path;
-use std::{env, fs, io, mem};
+use std::{env, fs, io};
 
 /// This struct holds maps used to match and template configurations.
 ///
@@ -30,7 +31,7 @@ impl<'a> MatchMaps<'a> {
         self.env_map.get_or_init(|| {
             let mut map = HashMap::new();
             for e in &process_info.envp {
-                let Ok(s) = std::str::from_utf8(e.deref()) else {
+                let Ok(s) = core::str::from_utf8(e.deref()) else {
                     continue;
                 };
                 let (k, v) = match s.split_once('=') {
@@ -47,7 +48,7 @@ impl<'a> MatchMaps<'a> {
         self.args_map.get_or_init(|| {
             let mut map = HashMap::new();
             for arg in &process_info.args {
-                let Ok(arg) = std::str::from_utf8(arg.deref()) else {
+                let Ok(arg) = core::str::from_utf8(arg.deref()) else {
                     continue;
                 };
                 // Split args between key and value on '='
@@ -145,7 +146,7 @@ impl<'a> Matcher<'a> {
                     template_map_key(index, self.match_maps.args(self.process_info))
                 }
                 "tags" => template_map_key(index, self.match_maps.tags),
-                _ => std::borrow::Cow::Borrowed("UNDEFINED"),
+                _ => alloc::borrow::Cow::Borrowed("UNDEFINED"),
             };
             templated.push_str(&val);
             rest = tail;
@@ -257,7 +258,7 @@ impl<'de> serde::Deserialize<'de> for ConfigMap {
         impl<'de> serde::de::Visitor<'de> for ConfigMapVisitor {
             type Value = ConfigMap;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
                 formatter.write_str("struct ConfigMap(HashMap<String, String>)")
             }
 

--- a/libdd-library-config/src/otel_process_ctx.rs
+++ b/libdd-library-config/src/otel_process_ctx.rs
@@ -14,16 +14,16 @@
 #[cfg(target_os = "linux")]
 #[cfg(target_has_atomic = "64")]
 pub mod linux {
-    use std::{
+    use core::{
         ffi::{c_void, CStr},
-        mem::ManuallyDrop,
-        os::fd::{AsRawFd, FromRawFd, OwnedFd},
+        mem::{swap, ManuallyDrop},
         ptr::{self, addr_of_mut},
-        sync::{
-            atomic::{fence, AtomicU64, Ordering},
-            Mutex, MutexGuard,
-        },
+        sync::atomic::{fence, AtomicU64, Ordering},
         time::Duration,
+    };
+    use std::{
+        os::fd::{AsRawFd, FromRawFd, OwnedFd},
+        sync::{Mutex, MutexGuard},
     };
 
     use anyhow::Context;
@@ -435,7 +435,7 @@ pub mod linux {
                 //
                 // To do so, we get the old handler back in `local_handler` and prevent `mapping`
                 // from being dropped specifically.
-                std::mem::swap(&mut local_handler, handler);
+                swap(&mut local_handler, handler);
                 let _: ManuallyDrop<MemMapping> = ManuallyDrop::new(local_handler.mapping);
 
                 Ok(())
@@ -466,11 +466,14 @@ pub mod linux {
     mod tests {
         use super::MappingHeader;
         use anyhow::ensure;
+        use core::{
+            ptr::{self, addr_of_mut},
+            sync::atomic::{fence, AtomicU64, Ordering},
+            time::Duration,
+        };
         use std::{
             fs::File,
             io::{BufRead, BufReader},
-            ptr::{self, addr_of_mut},
-            sync::atomic::{fence, AtomicU64, Ordering},
         };
 
         /// Parses the start address from a /proc/self/maps line
@@ -553,7 +556,7 @@ pub mod linux {
             let mapping_addr = find_otel_mapping()?;
             let header_ptr = verify_mapping_at(mapping_addr)?;
             // Safety: the pointer returned by `verify_mapping_at` points to an initialized header
-            Ok(unsafe { std::ptr::read(header_ptr) })
+            Ok(unsafe { ptr::read(header_ptr) })
         }
 
         #[test]
@@ -569,7 +572,7 @@ pub mod linux {
             // Safety: the published context must have put valid bytes of size payload_size in the
             // context if the signature check succeded.
             let read_payload = unsafe {
-                std::slice::from_raw_parts(header.payload_ptr, header.payload_size as usize)
+                core::slice::from_raw_parts(header.payload_ptr, header.payload_size as usize)
             };
 
             assert!(header.signature == *super::SIGNATURE, "wrong signature");
@@ -589,7 +592,7 @@ pub mod linux {
 
             let published_at_ns_v1 = header.monotonic_published_at_ns;
             // Ensure the clock advances so the updated timestamp is strictly greater
-            std::thread::sleep(std::time::Duration::from_nanos(10));
+            std::thread::sleep(Duration::from_nanos(10));
 
             super::publish_raw_payload(payload_v2.as_bytes().to_vec())
                 .expect("couldn't update the process context");
@@ -598,7 +601,7 @@ pub mod linux {
             // Safety: the published context must have put valid bytes of size payload_size in the
             // context if the signature check succeded.
             let read_payload = unsafe {
-                std::slice::from_raw_parts(header.payload_ptr, header.payload_size as usize)
+                core::slice::from_raw_parts(header.payload_ptr, header.payload_size as usize)
             };
 
             assert!(header.signature == *super::SIGNATURE, "wrong signature");

--- a/libdd-library-config/src/tracer_metadata.rs
+++ b/libdd-library-config/src/tracer_metadata.rs
@@ -1,7 +1,7 @@
 // Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
+use core::default::Default;
 use libdd_trace_protobuf::opentelemetry::proto as otel_proto;
-use std::default::Default;
 
 /// This struct MUST be backward compatible.
 #[derive(serde::Serialize, Debug, PartialEq, Eq, Hash)]
@@ -139,7 +139,7 @@ impl TracerMetadata {
                 key: "threadlocal.attribute_key_map".to_owned(),
                 value: Some(AnyValue {
                     value: Some(any_value::Value::ArrayValue(ArrayValue {
-                        values: std::iter::once(AnyValue {
+                        values: core::iter::once(AnyValue {
                             value: Some(any_value::Value::StringValue(
                                 "datadog.local_root_span_id".to_owned(),
                             )),

--- a/libdd-trace-obfuscation/benches/benchmarks/credit_cards_bench.rs
+++ b/libdd-trace-obfuscation/benches/benchmarks/credit_cards_bench.rs
@@ -1,8 +1,8 @@
 // Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use std::hint::black_box;
-use std::time::Duration;
+use core::hint::black_box;
+use core::time::Duration;
 
 use criterion::Throughput::Elements;
 use criterion::{criterion_group, BatchSize, BenchmarkId, Criterion};

--- a/libdd-trace-obfuscation/benches/benchmarks/ip_address_bench.rs
+++ b/libdd-trace-obfuscation/benches/benchmarks/ip_address_bench.rs
@@ -1,9 +1,9 @@
 // Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+use alloc::borrow::Cow;
 use criterion::{black_box, criterion_group, Criterion};
 use libdd_trace_obfuscation::ip_address;
-use std::borrow::Cow;
 
 fn quantize_peer_ip_address_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("ip_address");

--- a/libdd-trace-obfuscation/benches/trace_obfuscation.rs
+++ b/libdd-trace-obfuscation/benches/trace_obfuscation.rs
@@ -1,6 +1,8 @@
 // Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+extern crate alloc;
+
 use criterion::criterion_main;
 
 mod benchmarks;

--- a/libdd-trace-obfuscation/src/http.rs
+++ b/libdd-trace-obfuscation/src/http.rs
@@ -5,9 +5,9 @@
 // restrictive on the accepted forms of urls so that this module can be greatly simplified.
 // One idea for now is to match the url to a regex on both side to validate it
 
+use core::fmt::Write;
 use fluent_uri::UriRef;
 use percent_encoding::percent_decode_str;
-use std::fmt::Write;
 
 /// Returns true for Go net/url's "category 1" characters:
 /// ASCII bytes that always trigger escaping in URLs (plus space and quote).

--- a/libdd-trace-obfuscation/src/ip_address.rs
+++ b/libdd-trace-obfuscation/src/ip_address.rs
@@ -1,8 +1,10 @@
 // Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+use alloc::borrow::Cow;
+use core::net::Ipv6Addr;
 use libdd_common::regex_engine::Regex;
-use std::{borrow::Cow, collections::HashSet, net::Ipv6Addr, sync::LazyLock};
+use std::{collections::HashSet, sync::LazyLock};
 
 const ALLOWED_IP_ADDRESSES: [&str; 5] = [
     // localhost

--- a/libdd-trace-obfuscation/src/json/mod.rs
+++ b/libdd-trace-obfuscation/src/json/mod.rs
@@ -181,7 +181,7 @@ mod tests {
             enabled: true,
             keep_keys: keep_keys
                 .iter()
-                .map(std::string::ToString::to_string)
+                .map(alloc::string::ToString::to_string)
                 .collect(),
             ..Default::default()
         })
@@ -192,11 +192,11 @@ mod tests {
             enabled: true,
             keep_keys: keep_keys
                 .iter()
-                .map(std::string::ToString::to_string)
+                .map(alloc::string::ToString::to_string)
                 .collect(),
             transform_keys: transform_keys
                 .iter()
-                .map(std::string::ToString::to_string)
+                .map(alloc::string::ToString::to_string)
                 .collect(),
             transformer: Some(obfuscate_sql_string),
         })

--- a/libdd-trace-obfuscation/src/lib.rs
+++ b/libdd-trace-obfuscation/src/lib.rs
@@ -1,5 +1,7 @@
 // Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
+extern crate alloc;
+
 pub mod credit_cards;
 pub mod http;
 pub mod ip_address;

--- a/libdd-trace-obfuscation/src/obfuscation_config.rs
+++ b/libdd-trace-obfuscation/src/obfuscation_config.rs
@@ -106,7 +106,7 @@ impl ObfuscationConfig {
     /// # Errors
     ///
     /// Returns an error if one of the regular expressions used by the config cannot be compiled.
-    pub fn new() -> Result<Self, Box<dyn std::error::Error>> {
+    pub fn new() -> Result<Self, Box<dyn core::error::Error>> {
         let tag_replace_rules: Option<Vec<ReplaceRule>> = match env::var("DD_APM_REPLACE_TAGS") {
             Ok(replace_rules_str) => match replacer::parse_rules_from_string(&replace_rules_str) {
                 Ok(res) => {

--- a/libdd-trace-obfuscation/src/replacer.rs
+++ b/libdd-trace-obfuscation/src/replacer.rs
@@ -192,7 +192,7 @@ fn replace_all(
         }
         scratch_space.push_str(&haystack[last_match..]);
     }
-    std::mem::swap(scratch_space, haystack);
+    core::mem::swap(scratch_space, haystack);
     scratch_space.truncate(0);
 }
 

--- a/libdd-trace-obfuscation/src/sql.rs
+++ b/libdd-trace-obfuscation/src/sql.rs
@@ -2276,7 +2276,7 @@ fn normalize_plan_sql(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{DbmsKind, SqlObfuscateConfig, SqlObfuscationMode};
-    use std::fmt::Write;
+    use core::fmt::Write;
 
     #[test]
     fn test_sql_obfuscation() {

--- a/libdd-trace-obfuscation/tests/test_span_obfuscation.rs
+++ b/libdd-trace-obfuscation/tests/test_span_obfuscation.rs
@@ -9,10 +9,11 @@
     clippy::format_push_string
 )]
 
-use std::{
-    collections::{BTreeSet, HashSet},
-    fmt::{self, Display},
-};
+extern crate alloc;
+
+use alloc::{collections::BTreeSet, fmt};
+use core::fmt::Display;
+use std::collections::HashSet;
 
 use libdd_trace_obfuscation::{obfuscate::obfuscate_span, obfuscation_config::ObfuscationConfig};
 use libdd_trace_protobuf::pb::{
@@ -152,7 +153,7 @@ impl<'a> SpanComparison<'a> {
     }
 }
 impl Display for SpanComparison<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         fn cmp_field<T: PartialEq + fmt::Debug>(left: &T, right: &T) -> String {
             if left == right {
                 format!("{left:?}")


### PR DESCRIPTION
## What changed

Enabled `clippy::std_instead_of_alloc` and `clippy::std_instead_of_core` for the targeted crates and the workspace-inheriting `libdd-trace-obfuscation` crate.

Applied the resulting mechanical imports and path rewrites from `std` to `core` or `alloc` where available.

## Why

This narrows standard-library dependencies where the APIs are available from `core` or `alloc`, supporting the repository's ongoing no-std compatibility work.

## Validation

- `cargo +nightly-2026-02-08 fmt --all -- --check`
- `cargo +stable clippy -p libdd-library-config -p libdd-common -p libdd-common-ffi -p libdd-library-config-ffi -p libdd-trace-obfuscation --all-targets --all-features -- -D warnings`
- `git diff --check`

Also ran `cargo ffi-test`. The FFI libraries and examples built, but the example run reported 2 failures that appear unrelated to this change:

- `crashtracking`: expected crash signal, got signal 5
- `ffe`: missing `./datadog-ffe-test-suite/ffe-system-test-data/ufc-config.json` from the temp run directory
