### PR TITLE
doc(crashtracking): update errors intake payload documentation

### DIFF
--- a/docs/RFCs/0013-crashtracker-errors-intake-payload.md
+++ b/docs/RFCs/0013-crashtracker-errors-intake-payload.md
@@ -7,12 +7,11 @@ document are to be interpreted as described in
 
 ## Summary
 
-This RFC specifies the payloads produced by the crashtracker
-`ErrorsIntakePayload` (`libdd-crashtracker/src/crash_info/errors_intake.rs`)
-and uploaded to the `/api/v2/errorsintake` API (direct) or the
-`/evp_proxy/v4/api/v2/errorsintake` agent proxy. It formalizes the
-shape, required fields, extensibility expectations, and how crash
-metadata is translated into `ddtags`.
+This RFC specifies the JSON payloads that the crashtracker sends to the
+`/api/v2/errorsintake` endpoint. It describes the wire format—field
+names, types, presence rules, and value semantics—so that intake
+consumers, backend teams, and language integrations have a single
+reference for what arrives on the wire.
 
 ## Motivation
 
@@ -29,148 +28,347 @@ single reference schema:
 
 ## Scope
 
-This RFC covers:
+This RFC covers the JSON body sent to Errors Intake for:
 
-- The JSON payload emitted by `ErrorsIntakePayload::from_crash_info`
-  and `ErrorsIntakePayload::from_crash_ping`.
-- The mapping from `CrashInfo` to `error`, `ddtags`, and other
-  top-level fields.
-- Expectations for optional / future fields and forward compatibility.
+1. **Crash reports** — full crash payloads with stack traces, thread
+   state, and signal details.
+2. **Crash pings** — lightweight notifications sent at the start of
+   crash processing.
 
-This RFC does **not** redefine the crash info schema itself—see RFC 0011
-for the authoritative crash report format.
+It does **not** redefine the crash info file format (see RFC 0011).
 
-## Transport Overview
+## Transport
 
-The payload described here is identical regardless of delivery path:
+| Path | Auth | Notes |
+|---|---|---|
+| Direct: `https://error-tracking-intake.<site>/api/v2/errorsintake` | `DD-API-KEY` header | Used when direct submission is enabled. |
+| Agent proxy: `http(s)://<agent>/evp_proxy/v4/api/v2/errorsintake` | `X-Datadog-EVP-Subdomain: error-tracking-intake` | Default path through the local agent. |
+| File: `file://<path>` | — | Test/debug only; writes pretty-printed JSON with `.errors` extension. |
 
-- **Direct submission:** HTTPS requests to
-  `https://error-tracking-intake.<site>/api/v2/errorsintake` with
-  `DD-API-KEY`.
-- **Agent proxy:** HTTP POST to
-  `http(s)://<agent>/evp_proxy/v4/api/v2/errorsintake` with the
-  `X-Datadog-EVP-Subdomain: error-tracking-intake` header.
+All HTTP requests carry `Content-Type: application/json`.
 
-Producers MAY also write payloads to a `file://` endpoint (primarily for
-tests) using the same schema.
+### Configuration
 
-## Payload Structure
+| Variable | Default | Purpose |
+|---|---|---|
+| `DD_CRASHTRACKING_ERRORS_INTAKE_ENABLED` | `true` | Set `false` to disable errors intake entirely. |
+| `_DD_DIRECT_SUBMISSION_ENABLED` | `false` | When `true` and `DD_API_KEY` is set, bypass the agent and submit directly. |
+| `DD_API_KEY` | — | Required for direct submission. |
+| `DD_SITE` | `datadoghq.com` | Datadog site; used to build the direct URL. |
+| `DD_ERRORS_INTAKE_DD_URL` | — | Overrides the direct-submission base URL (takes priority over `DD_SITE`). |
+| `DD_TRACE_AGENT_URL` | — | Highest-priority agent URL. Supports `http://`, `https://`, `unix://`. |
+| `DD_AGENT_HOST` | `localhost` | Agent host (used if `DD_TRACE_AGENT_URL` is unset). |
+| `DD_TRACE_AGENT_PORT` | `8126` | Agent port. |
+| `DD_TRACE_PIPE_NAME` | — | Windows named pipe. |
+
+**Agent endpoint priority:** `DD_TRACE_AGENT_URL` > named pipe
+(Windows) > UDS at `/var/run/datadog/apm.socket` (Unix) >
+`DD_AGENT_HOST:DD_TRACE_AGENT_PORT` > `localhost:8126`.
+
+---
+
+## Crash Report Payload
 
 ### Top-Level Fields
 
-- `timestamp`: **[required]** UNIX epoch in milliseconds. Derived from
-  `CrashInfo.timestamp`
-- `ddsource`: **[required]** Always the string `"crashtracker"` to allow
-  downstream filtering.
-- `ddtags`: **[required]** A comma-separated `key:value` string that
-  encodes service metadata, runtime metadata, crash info, counters, and
-  signal details (see [Tag Encoding](#tag-encoding)).
-- `error`: **[required]** An `ErrorObject` describing the crash details
-  (see [Error Object](#error-object)).
-- `trace_id`: **[optional]** String trace identifier. Reserved for
-  future correlation; currently unset by crashtracker.
-- `os_info`: **[required]** Same structure as defined in RFC 0011:
-  - `architecture`: **[required]** (e.g. `"arm64"`)
-  - `bitness`: **[required]** (e.g. `"64-bit"`)
-  - `os_type`: **[required]** (e.g. `"Linux"`)
-  - `version`: **[required]** (e.g. `"6.8.0"`)
-- `sig_info`: **[optional]** Present for Unix signal-based crashes.
-  Reuses the fields from RFC 0011 (`si_addr`, `si_code`, `si_code_human_readable`,
-  `si_signo`, `si_signo_human_readable`).
+| Field | Type | Presence | Description |
+|---|---|---|---|
+| `timestamp` | integer | always | UNIX epoch **milliseconds**. Parsed from the crash timestamp (RFC 3339 string); falls back to current time on parse failure. |
+| `ddsource` | string | always | `"crashtracker"` |
+| `ddtags` | string | always | Comma-separated `key:value` pairs. See [Tag Encoding](#tag-encoding). |
+| `error` | object | always | See [error object](#error-object). |
+| `os_info` | object | always | See [os_info object](#os_info-object). |
+| `sig_info` | object | when signal-based | See [sig_info object](#sig_info-object). |
+| `proc_info` | object | when available | See [proc_info object](#proc_info-object). |
+| `ucontext` | object | when available | See [ucontext object](#ucontext-object). |
+| `files` | object | when non-empty | See [files object](#files-object). |
+| `trace_id` | string \| null | always | Reserved for APM correlation. Currently `null`. |
 
-### Error Object
+### `error` object
 
-The nested `error` object is serialized from `ErrorObject`:
+| Field | Type | Presence | Description |
+|---|---|---|---|
+| `type` | string | always | Error classification. For signal crashes: the signal name (e.g. `"SIGSEGV"`). Otherwise: the error kind (e.g. `"Panic"`, `"UnixSignal"`). |
+| `message` | string | optional | Human-readable summary. Resolution order: (1) an explicit message set by the caller, (2) if `sig_info` is present, auto-generated as `"Process terminated with <si_code_human_readable> (<si_signo_human_readable>)"` (e.g. `"Process terminated with SEGV_MAPERR (SIGSEGV)"`), (3) otherwise absent. |
+| `stack` | object | optional | Crashing thread stacktrace. Omitted when no frames were captured. See [stack object](#stack-object). |
+| `threads` | array | optional | State of all threads at crash time. See [thread entry](#thread-entry). |
+| `thread_name` | string | optional | Name of the crashing thread. |
+| `is_crash` | boolean | always | `true` for crash reports. |
+| `source_type` | string | always | `"Crashtracking"` |
+| `experimental` | object | optional | Experimental / unstable data. See [experimental object](#experimental-object). |
 
-- `type`: A human-readable error kind. For signal-based
-  crashes, this is the signal human-readable name (e.g. `"SIGSEGV"`).
-  Otherwise `"Unknown"` unless upstream sets `CrashInfo.error.kind`.
-- `message`: **[optional]** Human readable summary. For signals the
-  default is `"Process terminated with <SIG>"`.
-- `stack`: **[optional]** When the crashing thread stack contains at
-  least one frame, this field embeds the crash stacktrace as defined in
-  RFC 0011 (format `"Datadog Crashtracker 1.0"` plus frames).
-- `is_crash`: Boolean. `true` for crash payloads and `false` for crash pings.
-- `fingerprint`: **[optional]** Correlates to `CrashInfo.fingerprint`
-  for deduplication.
-- `source_type`: Always `"Crashtracking"` so downstream
-  consumers can distinguish crashtracker-originated data from other
-  producers.
-- `experimental`: **[optional]** Pass-through copy of
-  `CrashInfo.experimental`. MUST contain valid JSON when present to
-  allow experimentation without schema churn.
+> **Note:** The official intake schema defines an `error.fingerprint`
+> field for Custom Grouping. Crashtracker currently encodes this value
+> in `ddtags` (`fingerprint:<value>`) rather than as a field on the
+> error object.
 
-### Tag Encoding
+### `stack` object
 
-`ddtags` is constructed by concatenating comma-delimited `key:value`
-pairs. Consumers SHOULD tolerate new tags and
-order changes.
+| Field | Type | Description |
+|---|---|---|
+| `format` | string | Always `"Datadog Crashtracker 1.0"`. |
+| `frames` | array | Ordered stack frames (top of stack first). See [frame fields](#frame-fields). |
+| `incomplete` | boolean | `true` if the stack could not be fully captured. |
 
-1. **Service tags** (always present):
-   - `service:<name>` (defaults to `"unknown"` if missing)
-   - `env:<env>` **[optional]**
-   - `version:<service_version>` **[optional]**
-2. **Runtime tags**:
-   - `language_name:<language>` This should always be present, as the Errortracking product uses this tag to identify the runtime of the crashing service. We should use the same naming convention defined in [here](https://github.com/DataDog/logs-backend/blob/122abe4e9cef1b76cffccb2eb6fa10607fcc4c87/domains/event-platform/libs/processing/processing-common/src/main/java/com/dd/logs/processing/processors/errortracking/LanguageDetection.java#L95-L113).
-   - `language_version:<version>` *(optional)*
-   - `tracer_version:<version>` *(optional)*
-3. **Crash info tags** (always present):
-   - `data_schema_version:<value>`
-   - `fingerprint:<value>` **[optional]**
-   - `incomplete:<true|false>`
-   - `is_crash:<true|false>`
-   - `uuid:<CrashInfo.uuid>`
-   - `<counter_name>:<counter_value>` for each entry in `CrashInfo.counters`
-4. **Signal tags** *(conditional on `sig_info`)*:
-   - `si_addr:<hex>` **[optional]**
-   - `si_code:<int>`
-   - `si_code_human_readable:<string>`
-   - `si_signo:<int>`
-   - `si_signo_human_readable:<string>`
+#### Frame fields
 
-Tags are appended as literal strings; no escaping is performed beyond
-the standard JSON encoding of the `ddtags` field itself. The receiver
-MUST accept unknown tags and preserve existing ones.
+All frame fields are optional; a frame includes whichever were resolved.
+
+| Field | Type | Description |
+|---|---|---|
+| `ip` | string | Instruction pointer (hex). |
+| `sp` | string | Stack pointer (hex). |
+| `module_base_address` | string | Base address of the containing module (hex). |
+| `symbol_address` | string | Start address of the symbol (hex). |
+| `relative_address` | string | Offset within the binary (hex). |
+| `path` | string | File path of the binary/shared object. |
+| `build_id` | string | Build ID of the binary. |
+| `build_id_type` | string | Build ID type (e.g. `"Gnu"`, `"Go"`). |
+| `file_type` | string | Binary file type (e.g. `"Elf"`, `"MachO"`). |
+| `function` | string | Demangled function/symbol name. |
+| `mangled_name` | string | Raw mangled symbol name. |
+| `type_name` | string | Enclosing type/class name. |
+| `file` | string | Source file path. |
+| `line` | integer | Source line number. |
+| `column` | integer | Source column number. |
+| `comments` | array[string] | Diagnostic annotations from enrichment. |
+
+#### Thread entry
+
+| Field | Type | Description |
+|---|---|---|
+| `crashed` | boolean | Whether this is the crashing thread. |
+| `name` | string | Thread name. |
+| `stack` | object | Same schema as the [stack object](#stack-object). |
+| `state` | string (optional) | Thread state (e.g. `"S"` for sleeping). |
+
+### `os_info` object
+
+| Field | Type | Presence | Description |
+|---|---|---|---|
+| `architecture` | string | required | CPU architecture (e.g. `"x86_64"`, `"arm64"`). Required by the intake for callstack resolution. |
+| `bitness` | string | optional | e.g. `"64-bit"` |
+| `os_type` | string | optional | e.g. `"Linux"`, `"Mac OS"` |
+| `version` | string | optional | OS version/kernel release (e.g. `"6.8.0"`, `"14.7.0"`) |
+
+### `sig_info` object
+
+Present only for Unix signal-based crashes.
+
+| Field | Type | Presence | Description |
+|---|---|---|---|
+| `si_signo` | integer | required | Signal number (e.g. `11`). |
+| `si_signo_human_readable` | string | required | Signal name (e.g. `"SIGSEGV"`). |
+| `si_code` | integer | required | Signal code (e.g. `1`). |
+| `si_code_human_readable` | string | required | Code name (e.g. `"SEGV_MAPERR"`). |
+| `si_addr` | string | optional | Faulting address (hex, e.g. `"0x0000000000001234"`). |
+
+### `proc_info` object
+
+| Field | Type | Presence | Description |
+|---|---|---|---|
+| `pid` | integer | required | Process ID. |
+| `tid` | integer | optional | Thread ID of the crashing thread. |
+
+### `ucontext` object
+
+CPU register state captured from the signal handler.
+
+| Field | Type | Presence | Description |
+|---|---|---|---|
+| `arch` | string | required | Architecture (e.g. `"x86_64"`, `"aarch64"`). |
+| `registers` | object | required | Map of register name → hex value (e.g. `{"rip": "0x00007f..."}`). |
+| `raw` | string | optional | Full debug-formatted ucontext preserving FPU/signal-mask state. |
+
+### `files` object
+
+A map of `filename → array[string]` attaching auxiliary file contents
+captured at crash time (e.g. `/proc/self/maps`). Omitted when empty.
+
+### `experimental` object
+
+| Field | Type | Description |
+|---|---|---|
+| `additional_tags` | array[string] | Extra `key:value` tag strings. |
+| `runtime_stack` | object (optional) | Language-runtime-level stack. Contains `format` (string), `frames` (array), and/or `stacktrace_string` (string). |
+
+---
+
+## Tag Encoding
+
+The `ddtags` string is a comma-separated list of `key:value` pairs
+assembled in the following order. Consumers MUST tolerate new tags and
+ordering changes.
+
+### 1. Service tags (always present)
+
+| Tag | Presence | Description |
+|---|---|---|
+| `service:<name>` | always | Defaults to `"unknown"` if not configured. |
+| `env:<env>` | optional | |
+| `version:<version>` | optional | Service version. |
+
+### 2. Runtime tags
+
+| Tag | Presence | Description |
+|---|---|---|
+| `language_name:<lang>` | should be present | Identifies the runtime for Error Tracking grouping. Values SHOULD follow the [LanguageDetection naming convention](https://github.com/DataDog/logs-backend/blob/122abe4e9cef1b76cffccb2eb6fa10607fcc4c87/domains/event-platform/libs/processing/processing-common/src/main/java/com/dd/logs/processing/processors/errortracking/LanguageDetection.java#L95-L113). |
+| `language_version:<version>` | optional | |
+| `tracer_version:<version>` | optional | |
+
+### 3. Crash info tags
+
+| Tag | Presence | Description |
+|---|---|---|
+| `data_schema_version:<semver>` | always | Schema version of the crash data (e.g. `"1.8"`). |
+| `fingerprint:<value>` | optional | Custom grouping fingerprint. |
+| `incomplete:<bool>` | always | Whether the crash info is incomplete. |
+| `is_crash:<bool>` | always | `true` for crashes, `false` for pings. |
+| `uuid:<uuid>` | always | Unique crash identifier. |
+| `<counter>:<int>` | per counter | One tag per counter entry (e.g. `collecting_sample:1`). |
+
+### 4. Signal tags (when `sig_info` is present)
+
+| Tag | Presence | Description |
+|---|---|---|
+| `si_addr:<hex>` | optional | Faulting address. |
+| `si_code:<int>` | always | |
+| `si_code_human_readable:<name>` | always | |
+| `si_signo:<int>` | always | |
+| `si_signo_human_readable:<name>` | always | |
+
+### 5. Platform tag (always present)
+
+| Tag | Description |
+|---|---|
+| `runtime_platform:<target_triple>` | Compilation target (e.g. `x86_64-unknown-linux-gnu`). |
+
+No escaping is performed on tag values beyond standard JSON string
+encoding of the `ddtags` field itself. Receivers MUST accept unknown
+tags.
+
+---
+
+## Crash Ping Payload
+
+A crash ping is a lightweight notification sent at the start of crash
+processing, before the full report is ready.
+
+### Differences from crash reports
+
+| Field | Crash Report | Crash Ping |
+|---|---|---|
+| `timestamp` | From crash event | Current time at send |
+| `error.is_crash` | `true` | `false` |
+| `error.stack` | Present (if frames exist) | Absent |
+| `error.threads` | Present (if captured) | Absent |
+| `error.thread_name` | Present (if known) | Absent |
+| `error.experimental` | Present (if set) | Absent |
+| `error.message` | Crash-derived | See [message format](#crash-ping-message-format) |
+| `proc_info` | Present (if available) | Absent |
+| `ucontext` | Present (if captured) | Absent |
+| `files` | Present (if non-empty) | Absent |
+| `os_info` | From crash data | Detected at ping send time |
+
+### Crash ping message format
+
+The `error.message` for a crash ping follows one of:
+
+- `"Crashtracker crash ping: crash processing started - Process terminated with <si_code_human_readable> (<si_signo_human_readable>)"`
+- `"Crashtracker crash ping: crash processing started - <custom_message>"`
+- `"Crashtracker crash ping: crash processing started - Process terminated due to <error_kind>"`
+
+### Crash ping `ddtags`
+
+Crash pings use a reduced tag set:
+
+| Tag | Presence |
+|---|---|
+| `uuid:<crash_uuid>` | always |
+| `is_crash_ping:true` | always |
+| `service:<name>` | always |
+| `language_name:<lang>` | when available |
+| `language_version:<version>` | optional |
+| `tracer_version:<version>` | optional |
+| `env:<env>` | optional |
+| `version:<version>` | optional |
+| `si_code_human_readable:<name>` | when signal-based |
+| `si_signo:<int>` | when signal-based |
+| `si_signo_human_readable:<name>` | when signal-based |
+| `runtime_platform:<target_triple>` | always |
+
+Crash pings do **not** include `data_schema_version`, `incomplete`,
+`is_crash`, `fingerprint`, or counter tags.
+
+---
+
+## Intake Schema Alignment
+
+The official Errors Intake schema defines fields that crashtracker does
+not currently populate:
+
+| Intake Field | Status | Notes |
+|---|---|---|
+| `error.fingerprint` | Sent via `ddtags` | Not set as a dedicated field on the error object. May be promoted in a future version. |
+| `trace_id` | Placeholder | Always `null`. Will be set when crashes are correlated with APM traces. |
+| `_dd.error_tracking_standalone.error` | Not sent | Reserved for APM Error Tracking Standalone mode. |
+
+---
 
 ## Extensibility & Compatibility
 
-- The schema follows the crash info semver. Because the payload embeds
-  `CrashInfo`, additions to crash info fields may appear inside the
-  `stack` or `experimental` objects without changing Errors Intake
-  expectations.
-- Producers MAY add additional top-level fields provided they do not
-  conflict with existing keys. Consumers MUST ignore unknown fields.
-- Additional tags MAY be appended to `ddtags`. Downstream systems MUST
-  be resilient to new `key:value` pairs.
-- Future work MAY populate `trace_id` when a crash occurs within a
-  traced span; consumers MUST handle both presence and absence.
+- Consumers MUST ignore unknown top-level fields and unknown tags.
+- Producers MAY append new tags to `ddtags` and new fields to the
+  payload without a schema version bump.
+- The `experimental` object allows adding unstable data without
+  affecting the stable schema contract.
+- Future versions MAY populate `trace_id` and
+  `_dd.error_tracking_standalone.error` when applicable.
 
-## Example Payload
+---
 
-```
+## Example Crash Report
+
+```json
 {
   "timestamp": 1733420830123,
   "ddsource": "crashtracker",
-  "ddtags": "service:checkout,env:prod,version:1.4.2,language_name:native,data_schema_version:1.4,incomplete:false,is_crash:true,uuid:f7e2...,collecting_sample:1",
+  "ddtags": "service:checkout,env:prod,version:1.4.2,language_name:native,data_schema_version:1.8,incomplete:false,is_crash:true,uuid:f7e2a1b3-4c5d-6e7f-8a9b-0c1d2e3f4a5b,collecting_sample:1,not_profiling:0,si_addr:0x0000000000001234,si_code:1,si_code_human_readable:SEGV_MAPERR,si_signo:11,si_signo_human_readable:SIGSEGV,runtime_platform:x86_64-unknown-linux-gnu",
   "error": {
     "type": "SIGSEGV",
-    "message": "Process terminated by signal {sig_co} ({sig_num})",
+    "message": "Process terminated with SEGV_MAPERR (SIGSEGV)",
+    "thread_name": "main",
     "stack": {
       "format": "Datadog Crashtracker 1.0",
       "frames": [
         {
+          "ip": "0x00007f7e11d3a2b0",
           "function": "main",
           "file": "app.rs",
-          "line": 42
+          "line": 42,
+          "path": "/usr/bin/myapp",
+          "relative_address": "0x1a2b0",
+          "build_id": "abcdef1234567890",
+          "build_id_type": "Gnu"
         }
-        // more frames ...
-      ]
+      ],
+      "incomplete": false
     },
+    "threads": [
+      {
+        "crashed": false,
+        "name": "worker-1",
+        "stack": {
+          "format": "Datadog Crashtracker 1.0",
+          "frames": [],
+          "incomplete": true
+        },
+        "state": "S"
+      }
+    ],
     "is_crash": true,
-    "fingerprint": "sigsegv-main",
     "source_type": "Crashtracking"
   },
-  "trace_id": null,
   "os_info": {
     "architecture": "x86_64",
     "bitness": "64-bit",
@@ -178,16 +376,56 @@ MUST accept unknown tags and preserve existing ones.
     "version": "6.8.0"
   },
   "sig_info": {
+    "si_addr": "0x0000000000001234",
     "si_code": 1,
     "si_code_human_readable": "SEGV_MAPERR",
     "si_signo": 11,
-    "si_signo_human_readable": "SIGSEGV",
-    "si_addr": "0x0000000000001234"
+    "si_signo_human_readable": "SIGSEGV"
+  },
+  "proc_info": {
+    "pid": 12345
+  },
+  "ucontext": {
+    "arch": "x86_64",
+    "registers": {
+      "rip": "0x00007f7e11d3a2b0",
+      "rsp": "0x00007ffee3b4c8a0",
+      "rbp": "0x00007ffee3b4c910"
+    }
+  },
+  "files": {
+    "/proc/self/maps": [
+      "55a1b2c3d000-55a1b2c4e000 r-xp 00000000 08:01 12345 /usr/bin/myapp"
+    ]
   }
 }
 ```
 
-This example omits optional fields such as `experimental`, `span_ids`,
-and additional stack metadata for brevity. Refer to RFC 0011 for the
-full stack trace schema.
+## Example Crash Ping
 
+```json
+{
+  "timestamp": 1733420829500,
+  "ddsource": "crashtracker",
+  "ddtags": "uuid:f7e2a1b3-4c5d-6e7f-8a9b-0c1d2e3f4a5b,is_crash_ping:true,service:checkout,language_name:native,env:prod,version:1.4.2,si_code_human_readable:SEGV_MAPERR,si_signo:11,si_signo_human_readable:SIGSEGV,runtime_platform:x86_64-unknown-linux-gnu",
+  "error": {
+    "type": "SIGSEGV",
+    "message": "Crashtracker crash ping: crash processing started - Process terminated with SEGV_MAPERR (SIGSEGV)",
+    "is_crash": false,
+    "source_type": "Crashtracking"
+  },
+  "os_info": {
+    "architecture": "x86_64",
+    "bitness": "64-bit",
+    "os_type": "Linux",
+    "version": "6.8.0"
+  },
+  "sig_info": {
+    "si_addr": "0x0000000000001234",
+    "si_code": 1,
+    "si_code_human_readable": "SEGV_MAPERR",
+    "si_signo": 11,
+    "si_signo_human_readable": "SIGSEGV"
+  }
+}
+```


### PR DESCRIPTION
# What does this PR do?

With increased adoption of errors intake usage, we should clarify and sharpen up the documentation of what we send to errors intake


# Motivation

I took a look at this doc page when thinking over eBPF crashtracker and found it lacking

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
