### PR TITLE
fix: Fix http PathAndQuery Uri Parsing

### DIFF
--- a/libdd-common/src/connector/named_pipe.rs
+++ b/libdd-common/src/connector/named_pipe.rs
@@ -19,7 +19,7 @@ pub fn named_pipe_path_to_uri(path: &Path) -> Result<hyper::Uri, hyper::http::Er
     hyper::Uri::builder()
         .scheme("windows")
         .authority(path)
-        .path_and_query("")
+        .path_and_query("/")
         .build()
 }
 

--- a/libdd-common/src/connector/uds.rs
+++ b/libdd-common/src/connector/uds.rs
@@ -12,7 +12,7 @@ pub fn socket_path_to_uri(path: &Path) -> Result<hyper::Uri, hyper::http::Error>
     hyper::Uri::builder()
         .scheme("unix")
         .authority(path)
-        .path_and_query("")
+        .path_and_query("/")
         .build()
 }
 

--- a/libdd-common/src/lib.rs
+++ b/libdd-common/src/lib.rs
@@ -308,7 +308,7 @@ fn encode_uri_path_in_authority(scheme: &str, path: &str) -> anyhow::Result<http
     let path = hex::encode(path);
 
     parts.authority = uri::Authority::from_str(path.as_str()).ok();
-    parts.path_and_query = Some(uri::PathAndQuery::from_static(""));
+    parts.path_and_query = Some(uri::PathAndQuery::from_static("/"));
     Ok(http::Uri::from_parts(parts)?)
 }
 
@@ -511,5 +511,24 @@ impl Endpoint {
         };
 
         Ok((builder, request_url))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_uri;
+
+    /// A scheme prefix with an empty path produces an empty (and therefore
+    /// dropped) authority. parsing must reject these as malformed rather
+    /// than accept them.
+    #[test]
+    fn empty_authority_uris_are_rejected() {
+        for input in ["unix://", "windows:", "file://"] {
+            let result = parse_uri(input);
+            assert!(
+                result.is_err(),
+                "expected {input:?} to be rejected, got {result:?}"
+            );
+        }
     }
 }


### PR DESCRIPTION
# What does this PR do?

`http` version 1.4.1 became stricter in `PathAndQuery` input parsing to reject all inputs that do not start with `/`, including empty inputs. Previously, this library passed in an empty input in multiple places when constructing a `PathAndQuery`. Users are not able to upgrade `http` past 1.4.0 without this library breaking. This commit fixes the issue by replacing the empty inputs with `"/"`.

# Motivation

Fix this library for `http` versions >= 1.4.1.

# Additional Notes

See https://dd.slack.com/archives/C05M4JAM5BJ/p1781552060779329?thread_ts=1781534034.370109&cid=C05M4JAM5BJ

# How to test the change?

Existing unit tests should be sufficient, assuming the modified functions have coverage.
