### PR TITLE
chore(nix): add development shell and CI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -111,3 +111,4 @@ libdd-data-pipeline/tests/test_trace_exporter_otlp_export.rs @DataDog/apm-sdk-ca
 libdd-trace-utils/src/otlp_encoder/                     @DataDog/apm-sdk-capabilities-rust
 datadog-sidecar/src/service/ffe_exposures_flusher.rs    @DataDog/libdatadog-php @DataDog/libdatadog-apm @DataDog/feature-flagging-and-experimentation-sdk
 datadog-sidecar/src/service/ffe_metrics_flusher.rs      @DataDog/libdatadog-php @DataDog/libdatadog-apm @DataDog/feature-flagging-and-experimentation-sdk
+.github/workflows/nix.yml                               @DataDog/nix-guild @DataDog/apm-common-components-core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -97,6 +97,10 @@ tools/                               @DataDog/apm-common-components-core
 windows/                             @DataDog/libdatadog-core
 fuzz/                                @DataDog/chaos-platform
 
+# Nix
+*.nix                                @DataDog/nix-guild @DataDog/apm-common-components-core
+flake.*                              @DataDog/nix-guild @DataDog/apm-common-components-core
+
 # Specific overrides (must come after their general patterns above)
 bin_tests/tests/test_the_tests.rs    @DataDog/libdatadog-core
 bin_tests/src/bin/test_the_tests.rs  @DataDog/libdatadog-core

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -15,6 +15,11 @@ on: # yamllint disable-line rule:truthy
       - "rust-toolchain.toml"
       - "nightly-toolchain.toml"
       - ".github/workflows/nix.yml"
+  # Nightly safeguard: catches devshell drift from changes that don't match the
+  # paths above (e.g. a dependency or build-script change that needs new native
+  # tooling). Scheduled runs only fire from the default branch, against its HEAD.
+  schedule:
+    - cron: "0 4 * * *" # daily at 04:00 UTC
 
 # Default permissions for all jobs
 permissions: {}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -42,7 +42,6 @@ jobs:
 
     permissions:
       contents: read
-      id-token: write
 
     steps:
       - name: Check CPU arch

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -6,13 +6,14 @@ on: # yamllint disable-line rule:truthy
       - main
       - mq-working-branch-*
   # Also run on PRs that touch the devshell or what it reads. Paths mirror the
-  # Nix CODEOWNERS entries, plus rust-toolchain.toml (read by the flake) and
+  # Nix CODEOWNERS entries, plus the toolchain files (read by the flake) and
   # this workflow itself.
   pull_request:
     paths:
       - "*.nix"
       - "flake.*"
       - "rust-toolchain.toml"
+      - "nightly-toolchain.toml"
       - ".github/workflows/nix.yml"
 
 # Default permissions for all jobs
@@ -71,6 +72,8 @@ jobs:
           nix develop --command rustc --version
           nix develop --command cargo --version
           nix develop --command cbindgen --version
+      - name: Check nightly formatter toolchain
+        run: nix develop .#nightly --command cargo fmt --version
       - name: Build workspace
         run: nix develop --command cargo build --workspace --exclude builder
 

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -51,6 +51,17 @@ jobs:
       - name: Check CPU arch
         run: |
           test "$(uname -m)" = "${{ matrix.platform.cpu }}"
+      - name: Free Disk Space (Linux only)
+        if: runner.os == 'Linux'
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # 1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: false
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,7 +1,6 @@
 name: Test Nix
 
 on: # yamllint disable-line rule:truthy
-  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,61 @@
+name: Test Nix
+
+on: # yamllint disable-line rule:truthy
+  pull_request:
+  push:
+    branches:
+      - main
+      - mq-working-branch-*
+
+# Default permissions for all jobs
+permissions: {}
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - os: darwin
+            cpu: arm64
+            base: macos-15 # always arm64-darwin
+          - os: linux
+            cpu: x86_64
+            base: ubuntu-24.04 # always x86_64-linux-gnu
+          - os: linux
+            cpu: aarch64
+            base: ubuntu-24.04-arm # always aarch64-linux-gnu
+
+    name: Test Nix (${{ matrix.platform.cpu }}-${{ matrix.platform.os }})
+    runs-on: ${{ matrix.platform.base }}
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Check CPU arch
+        run: |
+          test "$(uname -m)" = "${{ matrix.platform.cpu }}"
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f # v31.10.5
+      - name: Print toolchain versions
+        run: |
+          nix develop --command rustc --version
+          nix develop --command cargo --version
+          nix develop --command cbindgen --version
+      - name: Build workspace
+        run: nix develop --command cargo build --workspace --exclude builder
+
+  complete:
+    name: Nix (complete)
+    runs-on: ubuntu-24.04
+    needs:
+      - test
+    steps:
+      - run: echo "DONE!"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -18,6 +18,10 @@ on: # yamllint disable-line rule:truthy
 # Default permissions for all jobs
 permissions: {}
 
+concurrency:
+  group: ci-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}-nix
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -5,6 +5,15 @@ on: # yamllint disable-line rule:truthy
     branches:
       - main
       - mq-working-branch-*
+  # Also run on PRs that touch the devshell or what it reads. Paths mirror the
+  # Nix CODEOWNERS entries, plus rust-toolchain.toml (read by the flake) and
+  # this workflow itself.
+  pull_request:
+    paths:
+      - "*.nix"
+      - "flake.*"
+      - "rust-toolchain.toml"
+      - ".github/workflows/nix.yml"
 
 # Default permissions for all jobs
 permissions: {}

--- a/README.md
+++ b/README.md
@@ -93,6 +93,52 @@ We provide two Dev Container configurations:
 
 The container includes all necessary dependencies for building and testing `libdatadog`.
 
+#### Nix development shell
+
+The Nix flake provides a reproducible, pinned shell with Rust, `cbindgen`, and native build tools.
+
+This works natively under both Linux and Darwin.
+
+##### Prerequisite: install Nix
+
+This one-liner installs Nix isolated in `/nix`:
+
+```bash
+curl --proto '=https' --tlsv1.2 --location https://nixos.org/nix/install | sh -s -- --daemon
+```
+
+Enable the modern CLI and flakes in `/etc/nix/nix.conf`:
+
+```bash
+echo "experimental-features = nix-command flakes" | sudo tee -a /etc/nix/nix.conf
+```
+
+See the [Nix manual](https://nix.dev/manual/nix/2.28/installation/index.html) for more information.
+
+##### Spawn an interactive shell
+
+Spawn a shell with an environment set up to expose the tooling:
+
+```bash
+nix develop
+```
+
+Note: legacy `nix-shell` and `nix-build` are also available via the `flake-compat` shims.
+
+##### Run commands
+
+Alternatively, run individual commands:
+
+```bash
+nix develop --command cargo build --workspace --exclude builder
+nix develop .#nightly --command cargo fmt --all -- --check
+```
+
+##### Debugging CI failures
+
+- Reproduce the Nix CI build with `nix develop --command cargo build --workspace --exclude builder`.
+- After an MSRV or nightly bump, update `rust-toolchain.toml` or `nightly-toolchain.toml`, then refresh `flake.lock` with `nix flake update`.
+
 #### Docker container
 A dockerfile is provided to run tests in a Ubuntu linux environment. This is particularly useful for running and debugging linux-only tests on macOS.
 

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,14 @@
+# Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+
+# flake-compat shim for usage without flakes
+(import
+  (
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
+    fetchTarball {
+      url = lock.nodes.flake-compat.locked.url or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,97 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1733328505,
+        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "revCount": 69,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.1.0/01948eb7-9cba-704f-bbf3-3fa956735b52/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778075060,
+        "narHash": "sha256-92Rkn1l444SJcZ/W34ZimhmzA38wUoW4UOehHHjxTCI=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "d8176a9b6c86c609774bc698d9c5ee8649089c98",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "release-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781580018,
+        "narHash": "sha256-BlTedbM77FmesD2ZqR73vhFy+y77UrhefV7IYw1pDsk=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "8bceba21a1ebea535c27c4dc723a0d5a4db9e386",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -34,16 +34,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778075060,
-        "narHash": "sha256-92Rkn1l444SJcZ/W34ZimhmzA38wUoW4UOehHHjxTCI=",
+        "lastModified": 1782132410,
+        "narHash": "sha256-R0zNDRb/ic5M3BMDFN+h6oBX/ft4OGACDojddDc5K/g=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d8176a9b6c86c609774bc698d9c5ee8649089c98",
+        "rev": "16157b94dc2865a74f968c367ed315151aa609f9",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "release-25.11",
+        "ref": "release-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -40,7 +40,7 @@
           # hardening in the shell so those builds succeed.
           hardeningDisable = [ "fortify" "fortify3" ];
 
-          buildInputs = [
+          nativeBuildInputs = [
             rust            # rustc + cargo + rustfmt + clippy, pinned via toolchain file
             pkgs.rust-cbindgen
             pkgs.cmake

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,46 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/release-25.11";
+
+    # cross-platform convenience
+    flake-utils.url = "github:numtide/flake-utils";
+
+    # backwards compatibility with nix-build and nix-shell
+    flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
+
+    # pinned, exact upstream Rust toolchains
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, flake-compat, rust-overlay }:
+    # resolve for all platforms in turn
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        # packages for this system platform, with the rust-overlay applied
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ (import rust-overlay) ];
+        };
+
+        # pinned Rust toolchain; single source of truth is ./rust-toolchain.toml
+        # (channel + components + profile), so the devshell matches CI and rustup.
+        rust = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+      in {
+        devShells.default = pkgs.stdenv.mkDerivation {
+          name = "libdatadog-devshell";
+
+          buildInputs = [
+            rust            # rustc + cargo + rustfmt + clippy, pinned via toolchain file
+            pkgs.rust-cbindgen
+            pkgs.cmake
+            pkgs.autoconf
+            pkgs.automake
+            pkgs.libtool
+          ];
+        };
+      }
+    );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
 {
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/release-25.11";
+    nixpkgs.url = "github:nixos/nixpkgs/release-26.05";
 
     # cross-platform convenience
     flake-utils.url = "github:numtide/flake-utils";

--- a/flake.nix
+++ b/flake.nix
@@ -25,11 +25,9 @@
           overlays = [ (import rust-overlay) ];
         };
 
-        # pinned Rust toolchain; single source of truth is ./rust-toolchain.toml
-        # (channel + components + profile), so the devshell matches CI and rustup.
-        rust = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
-      in {
-        devShells.default = pkgs.stdenv.mkDerivation {
+        # A devshell for a given Rust toolchain (read from a toolchain file via
+        # rust-overlay), with the rest of the build dependencies.
+        mkDevShell = rust: pkgs.stdenv.mkDerivation {
           name = "libdatadog-devshell";
 
           # The stdenv cc-wrapper injects -D_FORTIFY_SOURCE, which glibc rejects
@@ -48,6 +46,14 @@
             pkgs.libtool
           ];
         };
+      in {
+        # Default: the pinned stable toolchain (single source of truth is
+        # ./rust-toolchain.toml), matching CI and rustup.
+        devShells.default = mkDevShell (pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml);
+
+        # Nightly toolchain (./nightly-toolchain.toml) for the jobs that
+        # genuinely need a nightly compiler. Use with `nix develop .#nightly`.
+        devShells.nightly = mkDevShell (pkgs.rust-bin.fromRustupToolchainFile ./nightly-toolchain.toml);
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,3 +1,6 @@
+# Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/release-25.11";

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,13 @@
         devShells.default = pkgs.stdenv.mkDerivation {
           name = "libdatadog-devshell";
 
+          # The stdenv cc-wrapper injects -D_FORTIFY_SOURCE, which glibc rejects
+          # when compiling without optimization. Some build scripts (e.g.
+          # spawn_worker's trampoline.c) compile C at -O0 with -Werror, so the
+          # resulting fortify #warning becomes a hard error. Disable fortify
+          # hardening in the shell so those builds succeed.
+          hardeningDisable = [ "fortify" "fortify3" ];
+
           buildInputs = [
             rust            # rustc + cargo + rustfmt + clippy, pinned via toolchain file
             pkgs.rust-cbindgen

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
 
         # A devshell for a given Rust toolchain (read from a toolchain file via
         # rust-overlay), with the rest of the build dependencies.
-        mkDevShell = rust: pkgs.stdenv.mkDerivation {
+        mkDevShell = rust: pkgs.mkShell {
           name = "libdatadog-devshell";
 
           # The stdenv cc-wrapper injects -D_FORTIFY_SOURCE, which glibc rejects

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,14 @@
+# Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+
+# flake-compat shim for usage without flakes
+(import
+  (
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
+    fetchTarball {
+      url = lock.nodes.flake-compat.locked.url or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).shellNix


### PR DESCRIPTION
# What does this PR do?

Adds a Nix flake development shell to the repository, with a CI workflow that exercises it.

- `flake.nix` / `flake.lock`: a devshell providing the Rust toolchain (rustc, cargo, rustfmt, clippy), cbindgen, cmake and autotools. The Rust toolchain is pinned via the `oxalica/rust-overlay` input reading the existing `rust-toolchain.toml`, so the devshell tracks the same channel as CI and rustup.
- `.github/workflows/nix.yml`: enters the devshell and builds the workspace on Linux (x86_64, aarch64) and macOS (arm64), mirroring the Nix CI already present in dd-trace-rb and libdatadog-rb.
- `CODEOWNERS`: co-owns the Nix files and workflow with the Nix guild.

# Motivation

Contributors using Nix previously kept these files locally and unshared, with the Rust version floating with the nixpkgs channel (currently 1.91.1) rather than matching the toolchain libdatadog is built with. Committing a pinned devshell gives a reproducible, low-setup environment, and the CI guard keeps it from bit-rotting.

# Additional Notes

The pin derives from `rust-toolchain.toml` (single source of truth), so a future MSRV bump updates the devshell automatically.

AI was used to accelerate implementation; all code was reviewed and understood.

# How to test the change?

`nix develop --command cargo build --workspace --exclude builder`, and confirm `nix develop --command rustc --version` reports the channel from `rust-toolchain.toml`. CI runs the same build across the three platforms.