### PR TITLE
ci: allow dd-trace-*/libdatadog to write pr comments on libdatadog

### DIFF
--- a/.github/chainguard/gitlab.write.benchmarking-pr-comments.sts.yaml
+++ b/.github/chainguard/gitlab.write.benchmarking-pr-comments.sts.yaml
@@ -1,0 +1,6 @@
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/apm-reliability/(dd-trace-.*|libdatadog):.*"
+
+permissions:
+  pull_requests: write


### PR DESCRIPTION
# What does this PR do?

Allows dd-trace-* and libdatadog to write PR comments on libdatadog.

# Motivation

libdatadog will run benchmarks by triggering downstream dd-trace-* pipelines. Those pipelines need to report results back to libdatadog. One way to report results back is through PR comments.

# Additional Notes

This policy can be tightened to make it absolutely secure, but the risks it incurs (an attacker might create PR comments on branches on dd-trace-* repos' CIs) are too low compared to the complexity of setting up and testing a more fleshed-out policy. 

I'd be happy to update the policy if these risks are something we should address :)

# How to test the change?

Should be verified ad-hoc with prototype PR comments, due to how dd-octo-sts works. Changes need to be on `main` to be effective.