### PR TITLE
chore(profiling): Use SECURITY_ANONYMOUS when connecting to named pipe server

### DIFF
--- a/libdd-common/src/connector/conn_stream.rs
+++ b/libdd-common/src/connector/conn_stream.rs
@@ -63,7 +63,9 @@ impl ConnStream {
             let path = super::named_pipe::named_pipe_path_from_uri(&uri)?;
             Ok(ConnStream::NamedPipe {
                 transport: TokioIo::new(
-                    tokio::net::windows::named_pipe::ClientOptions::new().open(path)?,
+                    tokio::net::windows::named_pipe::ClientOptions::new()
+                        .security_qos_flags(super::named_pipe::ANONYMOUS_IMPERSONATION_QOS)
+                        .open(path)?,
                 ),
             })
         }
@@ -188,5 +190,45 @@ impl hyper::rt::Write for ConnStream {
             #[cfg(windows)]
             ConnStreamProj::NamedPipe { transport } => transport.poll_flush(cx),
         }
+    }
+}
+
+#[cfg(all(test, windows))]
+mod windows_named_pipe_tests {
+    use super::ConnStream;
+    use crate::connector::named_pipe::named_pipe_path_to_uri;
+    use std::path::Path;
+    use tokio::net::windows::named_pipe::ServerOptions;
+
+    /// Verifies that `from_named_pipe_uri` opens a client connection successfully
+    /// when impersonation is disabled (Anonymous QoS). The server accepting the
+    /// connection confirms the `SECURITY_SQOS_PRESENT | SECURITY_ANONYMOUS` flags
+    /// produce a usable transport.
+    #[tokio::test]
+    async fn from_named_pipe_uri_connects_with_anonymous_qos() {
+        let pipe_name = format!(
+            r"\\.\pipe\libdd_common_conn_stream_test_{}_{}",
+            std::process::id(),
+            rand::random::<u64>()
+        );
+
+        let server = ServerOptions::new()
+            .first_pipe_instance(true)
+            .create(&pipe_name)
+            .expect("failed to create named pipe server");
+
+        let server_task = tokio::spawn(async move {
+            server.connect().await.expect("server failed to accept");
+        });
+
+        let uri = named_pipe_path_to_uri(Path::new(&pipe_name)).expect("failed to build uri");
+        let conn = ConnStream::from_named_pipe_uri(uri).await;
+        assert!(
+            conn.is_ok(),
+            "expected named pipe client to connect with Anonymous QoS: {:?}",
+            conn.err()
+        );
+
+        server_task.await.expect("server task panicked");
     }
 }

--- a/libdd-common/src/connector/named_pipe.rs
+++ b/libdd-common/src/connector/named_pipe.rs
@@ -3,6 +3,20 @@
 
 use std::path::{Path, PathBuf};
 
+/// Security Quality of Service flags used when opening a Windows named pipe client.
+///
+/// We disable impersonation by requesting `SECURITY_ANONYMOUS`, mirroring the
+/// dd-trace-dotnet change that sets `TokenImpersonationLevel.Anonymous`. The pipe is
+/// only used as a byte transport to the agent, so the server end never needs to
+/// identify or impersonate the (potentially privileged) connecting client. Denying
+/// impersonation enforces least privilege and prevents a malicious/squatting pipe
+/// server from reading the client's identity or acting on its behalf.
+///
+/// `SECURITY_ANONYMOUS` has the value `0`; tokio's `ClientOptions::security_qos_flags`
+/// automatically ORs in `SECURITY_SQOS_PRESENT`.
+#[cfg(windows)]
+pub const ANONYMOUS_IMPERSONATION_QOS: u32 = 0; // SECURITY_ANONYMOUS
+
 /// Windows Named Pipe
 /// https://docs.microsoft.com/en-us/windows/win32/ipc/named-pipes
 ///


### PR DESCRIPTION
# What does this PR do?

Disables named-pipe client impersonation in libdatadog's Windows named-pipe transport by opening the pipe with `SECURITY_ANONYMOUS` (the Rust/tokio equivalent of .NET's `TokenImpersonationLevel.Anonymous`).

Concretely, `libdd-common`'s hyper-based connector now sets `ClientOptions::security_qos_flags(SECURITY_ANONYMOUS)` when opening a named pipe in `ConnStream::from_named_pipe_uri`, instead of relying on tokio's default of `SECURITY_IDENTIFICATION`.

# Motivation

This mirrors the dd-trace-dotnet change [Set `TokenImpersonationLevel.Anonymous` in `NamedPipeClient` (#8676)] https://github.com/DataDog/dd-trace-dotnet/pull/8676).

A Windows named pipe exposes the connecting client's security token to the server end, which can use it to identify or even impersonate the client. In our usage the pipe is just a dumb byte transport to the Datadog Agent, so the server end never needs any information about, or the ability to act as, the connecting (potentially privileged) process. Opening with `Anonymous` enforces least privilege and removes that capability, hardening against a malicious or pipe-squatting server reading the client's identity/privileges.

# Additional Notes

- libdatadog opens named-pipe clients through two transport stacks:
  - **hyper connector** (`libdd-common`) — fixed in this PR. Used by the     `libdd-http-client` hyper backend.
  - **reqwest** — the path used by the profiling exporter, `libdd-agent-client`,     and the default `libdd-http-client` backend. reqwest currently hardcodes     `ClientOptions::new().open(pipe)` and exposes no API to set the QoS flags, so     that path is **not** addressed here. A follow-up will upstream a     security-flags option to reqwest and then consume it at those call sites.
- Severity note: tokio's default is already `Identification` (not `Impersonation`),   so the server cannot *act* as the client today; it can only read the client's  identity/privileges. This change is therefore a defense-in-depth / least-privilege  hardening that aligns the Rust posture with the .NET fix, not a fix for an  exploitable privilege escalation on the Rust side.
- A shared `ANONYMOUS_IMPERSONATION_QOS` constant was added in  `libdd-common/src/connector/named_pipe.rs` so the same value can be reused by  the future reqwest call sites.

# How to test the change?

The change is Windows-only (`#[cfg(windows)]`).

- Automated: a round-trip test `from_named_pipe_uri_connects_with_anonymous_qos` was added in `libdd-common/src/connector/conn_stream.rs`. It stands up a tokio `ServerOptions` named-pipe server and asserts the client connects successfully with the Anonymous QoS flags. On a Windows host: