### PR TITLE
feat(profiling)!: add OffCpuTime and OffCpuSamples sample types

### DIFF
--- a/libdd-profiling/src/api/sample_type.rs
+++ b/libdd-profiling/src/api/sample_type.rs
@@ -75,6 +75,9 @@ pub enum SampleType {
     /// Legacy: Use `WallTime` instead for consistency with naming scheme
     WallLegacy,
 
+    OffCpuSamples,
+    OffCpuTime,
+
     // Experimental sample types for testing and development.
     ExperimentalCount,
     ExperimentalNanoseconds,
@@ -160,6 +163,8 @@ impl From<SampleType> for ValueType<'static> {
             SampleType::WallSamples => ValueType::new("wall-samples", "count"),
             SampleType::WallTime => ValueType::new("wall-time", "nanoseconds"),
             SampleType::WallLegacy => ValueType::new("wall", "nanoseconds"),
+            SampleType::OffCpuSamples => ValueType::new("off-cpu-samples", "count"),
+            SampleType::OffCpuTime => ValueType::new("off-cpu-time", "nanoseconds"),
             SampleType::ExperimentalCount => ValueType::new("experimental-count", "count"),
             SampleType::ExperimentalNanoseconds => {
                 ValueType::new("experimental-nanoseconds", "nanoseconds")
@@ -226,6 +231,8 @@ impl<'a> TryFrom<ValueType<'a>> for SampleType {
             ("wall-samples", "count") => SampleType::WallSamples,
             ("wall-time", "nanoseconds") => SampleType::WallTime,
             ("wall", "nanoseconds") => SampleType::WallLegacy,
+            ("off-cpu-samples", "count") => SampleType::OffCpuSamples,
+            ("off-cpu-time", "nanoseconds") => SampleType::OffCpuTime,
             ("experimental-count", "count") => SampleType::ExperimentalCount,
             ("experimental-nanoseconds", "nanoseconds") => SampleType::ExperimentalNanoseconds,
             ("experimental-bytes", "bytes") => SampleType::ExperimentalBytes,

--- a/libdd-profiling/src/cxx.rs
+++ b/libdd-profiling/src/cxx.rs
@@ -89,6 +89,8 @@ pub mod ffi {
         WallSamples,
         WallTime,
         WallLegacy, // LEGACY: Use WallTime instead
+        OffCpuSamples,
+        OffCpuTime,
         ExperimentalCount,
         ExperimentalNanoseconds,
         ExperimentalBytes,
@@ -391,6 +393,8 @@ impl TryFrom<ffi::SampleType> for api::SampleType {
             ffi::SampleType::WallSamples => api::SampleType::WallSamples,
             ffi::SampleType::WallTime => api::SampleType::WallTime,
             ffi::SampleType::WallLegacy => api::SampleType::WallLegacy,
+            ffi::SampleType::OffCpuSamples => api::SampleType::OffCpuSamples,
+            ffi::SampleType::OffCpuTime => api::SampleType::OffCpuTime,
             ffi::SampleType::ExperimentalCount => api::SampleType::ExperimentalCount,
             ffi::SampleType::ExperimentalNanoseconds => api::SampleType::ExperimentalNanoseconds,
             ffi::SampleType::ExperimentalBytes => api::SampleType::ExperimentalBytes,


### PR DESCRIPTION
# What does this PR do?

Adds `OffCpuSamples` and `OffCpuTime` as first-class sample types in the profiling API. Both the Rust API (`sample_type.rs`) and the C FFI layer (`cxx.rs`) are updated:

- `OffCpuTime` → pprof string `("off-cpu-time", "nanoseconds")`
- `OffCpuSamples` → pprof string `("off-cpu-samples", "count")`
- Bidirectional mapping: `SampleType → ValueType` and `ValueType → SampleType` (`TryFrom`) are both implemented.

# Motivation

Needed for PR: https://github.com/DataDog/dd-trace-py/pull/18623, which adds support for an "approximate" OffCpu profiling. Currently we're using `ExperimentalNanoseconds` as a placeholder because the new types don't exist yet (this PR).

# Additional Notes

* after codegen runs in CI, we should see `common.h` auto-generated from `cxx.rs`, and will include the new types.

# How to test the change?

```
$ cargo test -p libdd-profiling
running 136 tests
...
test api::sample_type::tests::sample_type_round_trip_conversion ... ok
test api::sample_type::tests::value_type_to_sample_type_unknown_type ... ok
...
```