### PR TITLE
chore: remove redundant version from libdd-agent-client

### DIFF
--- a/libdd-agent-client/Cargo.toml
+++ b/libdd-agent-client/Cargo.toml
@@ -11,6 +11,7 @@ authors.workspace = true
 description = "A Datadog-agent-specialized HTTP client library"
 homepage = "https://github.com/DataDog/libdatadog/tree/main/libdd-agent-client"
 repository = "https://github.com/DataDog/libdatadog/tree/main/libdd-agent-client"
+publish = false
 
 [lib]
 bench = false
@@ -28,7 +29,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2"
 tokio = { version = "1.23", features = ["rt"] }
-libdd-http-client = { version = "35.0", path = "../libdd-http-client", default-features = false }
+libdd-http-client = { path = "../libdd-http-client", default-features = false }
 libdd-common = { version = "4.0", path = "../libdd-common", default-features = false }
 tracing = { version = "0.1", default-features = false }
 

--- a/libdd-http-client/Cargo.toml
+++ b/libdd-http-client/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 description = "HTTP client library intended for use by other languages via FFI"
 homepage = "https://github.com/DataDog/libdatadog/tree/main/libdd-http-client"
 repository = "https://github.com/DataDog/libdatadog/tree/main/libdd-http-client"
+publish = false
 
 [lib]
 bench = false


### PR DESCRIPTION
# What does this PR do?

Remove pinned version on libdd-agent-client. Since the version for libdd-http-client is tied to the workspace just setting the path will follow the workspace version

# Motivation
Preventing updating the versions on too many places when the workspace version is bumped.