### PR TITLE
ci: proposal wf fixes and cleanup

### DIFF
--- a/.github/chainguard/gitlab.github-access.write-contents.sts.yaml
+++ b/.github/chainguard/gitlab.github-access.write-contents.sts.yaml
@@ -4,8 +4,8 @@ subject_pattern: "project_path:DataDog/.*"
 
 claim_pattern:
   project_id: "2260"
-  ref: "(main|release|igor/versioning/.*)" # TODO: remove testing branch and uncomment ref_protected
-  # ref_protected: "true"
+  ref: "(main|release)"
+  ref_protected: "true"
 
 permissions:
   contents: write

--- a/.github/workflows/release-proposal-dispatch.yml
+++ b/.github/workflows/release-proposal-dispatch.yml
@@ -903,9 +903,13 @@ jobs:
           echo "PR body written to /tmp/pr-body.md (length: $(wc -c < /tmp/pr-body.md) bytes)"
 
           # NOTE: the PR title must start with 'chore(release): proposal for'. Downstream tooling matches on that prefix.
+          PR_TITLE="chore(release): proposal for ${{ needs.validate-inputs.outputs.crates_display }}"
+          if [ "${#PR_TITLE}" -gt 100 ]; then
+            PR_TITLE="${PR_TITLE:0:97}..."
+          fi
           gh pr create \
             --head "$BRANCH_NAME" \
-            --title "chore(release): proposal for ${{ needs.validate-inputs.outputs.crates_display }}" \
+            --title "$PR_TITLE" \
             --body-file /tmp/pr-body.md \
             --label "release-proposal" \
             --label "skip-metadata-check" \

--- a/.github/workflows/release-proposal-test.yml
+++ b/.github/workflows/release-proposal-test.yml
@@ -88,7 +88,7 @@ jobs:
     if: needs.package-and-upload-crates.outputs.upload_artifact == 'true'
     strategy:
       matrix:
-        version: ["datadog-opentelemetry-v0.3.3", "datadog-opentelemetry-v0.3.2", "datadog-opentelemetry-v0.3.1"]
+        version: ["datadog-opentelemetry-v0.4.0", "datadog-opentelemetry-v0.3.3", "datadog-opentelemetry-v0.3.2"]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
         with:


### PR DESCRIPTION
# What does this PR do?

- Clean up STS policy
- Limit PR title
- Add latest tracer version to proposal test wf