### PR TITLE
chore: bump version v36.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,7 +695,7 @@ checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "build_common"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "cbindgen",
  "serde",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "builder"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1386,7 +1386,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-ffe-test-suite"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -1479,7 +1479,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-replayer"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2813,7 +2813,7 @@ checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libdd-agent-client"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "bytes",
  "flate2",
@@ -2907,7 +2907,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-common-ffi"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "assert_no_alloc",
@@ -2960,7 +2960,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-crashtracker-ffi"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -3022,7 +3022,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-data-pipeline-ffi"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "build_common",
  "httpmock",
@@ -3051,7 +3051,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-ddsketch-ffi"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "build_common",
  "libdd-common-ffi",
@@ -3073,7 +3073,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-http-client"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "bytes",
  "fastrand",
@@ -3144,7 +3144,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-log-ffi"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "build_common",
  "libdd-common-ffi",
@@ -3313,7 +3313,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-shared-runtime-ffi"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "build_common",
  "libdd-shared-runtime",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-telemetry-ffi"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "build_common",
  "function_name",
@@ -5615,7 +5615,7 @@ dependencies = [
 
 [[package]]
 name = "symbolizer-ffi"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "blazesym-c",
  "build_common",
@@ -6063,7 +6063,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "35.0.0"
+version = "36.0.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.87.0"
 edition = "2021"
-version = "35.0.0"
+version = "36.0.0"
 license = "Apache-2.0"
 authors = ["Datadog Inc. <info@datadoghq.com>"]
 

--- a/libdd-agent-client/Cargo.toml
+++ b/libdd-agent-client/Cargo.toml
@@ -11,6 +11,7 @@ authors.workspace = true
 description = "A Datadog-agent-specialized HTTP client library"
 homepage = "https://github.com/DataDog/libdatadog/tree/main/libdd-agent-client"
 repository = "https://github.com/DataDog/libdatadog/tree/main/libdd-agent-client"
+publish = false
 
 [lib]
 bench = false
@@ -28,7 +29,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2"
 tokio = { version = "1.23", features = ["rt"] }
-libdd-http-client = { version = "35.0", path = "../libdd-http-client", default-features = false }
+libdd-http-client = { path = "../libdd-http-client", default-features = false }
 libdd-common = { version = "4.0", path = "../libdd-common", default-features = false }
 tracing = { version = "0.1", default-features = false }
 

--- a/libdd-http-client/Cargo.toml
+++ b/libdd-http-client/Cargo.toml
@@ -8,6 +8,7 @@ authors.workspace = true
 description = "HTTP client library intended for use by other languages via FFI"
 homepage = "https://github.com/DataDog/libdatadog/tree/main/libdd-http-client"
 repository = "https://github.com/DataDog/libdatadog/tree/main/libdd-http-client"
+publish = false
 
 [lib]
 bench = false


### PR DESCRIPTION
# Release v36.0.0 
This release bumps the workspace version `35.0.0 → 36.0.0`. Below are the commits in `v35.0.0..HEAD` that directly modify the C ABI surface consumed by downstream SDKs.

## Major

| Commit | FFI crate(s) affected |
|---|---|
| `refactor(shm)!: Extract one_way_shared_memory to IPC and prepare libdd-remote-config for python` (#2121) | `datadog-sidecar-ffi` |
| `refactor(span)!: use VecMap for meta, metrics and meta_struct for v04 spans` (#2043) | `datadog-sidecar-ffi`, `libdd-data-pipeline-ffi` |
| `feat(data-pipeline)!: add fork safety hooks and cancellation token for trace exporter FFI` (#2051) | `libdd-data-pipeline-ffi`, `libdd-profiling-ffi` |

## Minor

| Commit | FFI crate(s) affected |
|---|---|
| `feat(sidecar): add retry interval configuration` (#2106) | `datadog-sidecar-ffi` |
| `feat(profiling): Add setting to omit local root span id from serialized pprof` (#2104) | `libdd-profiling-ffi` |
| `feat(live-debugger): agentless intake forwarding` (#2075) | `datadog-live-debugger-ffi` |
| `feat(sidecar): forward FFE exposures to EVP proxy` (#2026) | `datadog-sidecar-ffi` |
| `feat(sidecar): forward FFE evaluation metrics to OTLP intake` (#2052) | `datadog-sidecar-ffi` |
| `feat: cross-language LTO to inline C TLS shim into Rust FFI` (#1982) | `libdd-otel-thread-ctx-ffi` (build-only: build.rs / scripts / README) |

## Patch

| Commit | FFI crate(s) affected |
|---|---|
| `fix(ffe): honor shared fixture result metadata` (#2109) | `datadog-ffe-ffi` |
| `fix(sidecar): Dedup VecMap spans before serialization` (#2107) | `datadog-sidecar-ffi` |
| `fix(crashtracking): authenticate peer granted socket ptrace access` (#2098) | `libdd-crashtracker-ffi`, `datadog-sidecar-ffi` |
| `fix(remote-config): notification of multi-processing and runtime deduplication` (#2082) | `datadog-sidecar-ffi` |
| `fix(sidecar): configure OTLP endpoint for FFE metrics` (#2076) | `datadog-sidecar-ffi` |
| `refactor(datadog-remote-config): rename as libdd-remote-config` (#2085) | `datadog-sidecar-ffi` (incl. `cbindgen.toml`) |

