### PR TITLE
refactor(sidecar): Use oneshot flusher instead of async manual future

### DIFF
--- a/datadog-sidecar/src/service/sidecar_server.rs
+++ b/datadog-sidecar/src/service/sidecar_server.rs
@@ -1066,6 +1066,7 @@ impl SidecarInterface for ConnectionSidecarHandler {
                 error!("Failed flushing traces: {e:?}");
             }
             flush_all_stats_now(&self.server.span_concentrators).await;
+            debug!("Finished executing flush() for traces and stats")
         }
         if options.telemetry {
             let workers: Vec<_> = {

--- a/datadog-sidecar/src/service/stats_flusher.rs
+++ b/datadog-sidecar/src/service/stats_flusher.rs
@@ -14,6 +14,7 @@ use base64::Engine;
 use datadog_ipc::shm_stats::{
     ShmSpanConcentrator, DEFAULT_SLOT_COUNT, DEFAULT_STRING_POOL_BYTES, RELOAD_FILL_RATIO,
 };
+use futures::{future::join_all, TryFutureExt};
 use http::uri::PathAndQuery;
 use libdd_capabilities_impl::{HttpClientCapability, NativeCapabilities};
 use libdd_common::{Endpoint, MutexExt};
@@ -23,7 +24,7 @@ use std::ffi::CString;
 use std::hash::{Hash, Hasher};
 use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 use zwohash::ZwoHasher;
 
 /// Build the stats endpoint by appending `/v0.6/stats` to the agent base URL.
@@ -283,14 +284,29 @@ pub(crate) fn get_or_create_concentrator(
 pub async fn flush_all_stats_now(
     state: &Arc<Mutex<HashMap<ConcentratorKey, Arc<SpanConcentratorState>>>>,
 ) {
-    let states: Vec<Arc<SpanConcentratorState>> = {
+    let states: Vec<_> = {
         let guard = state.lock_or_panic();
-        guard.values().cloned().collect()
+        guard
+            .values()
+            .map(|s| {
+                (
+                    make_exporter(s, s.endpoint.clone(), Duration::from_secs(10)),
+                    s.endpoint.clone(),
+                )
+            })
+            .collect()
     };
-    for s in states {
-        let exporter = make_exporter(&s, s.endpoint.clone(), Duration::from_secs(10));
-        if let Err(e) = exporter.send(false).await {
-            warn!("flush_all_stats_now: failed to send stats: {e}");
-        }
-    }
+    debug!(
+        "Flushing all stats now: {} different exporters",
+        states.len()
+    );
+    join_all(states.iter().map(|(exporter, endpoint)| {
+        exporter.send(false).inspect_err(move |e| {
+            warn!(
+                "flush_all_stats_now: failed to send stats to {:?}: {}",
+                endpoint, e
+            );
+        })
+    }))
+    .await;
 }

--- a/datadog-sidecar/src/service/tracing/trace_flusher.rs
+++ b/datadog-sidecar/src/service/tracing/trace_flusher.rs
@@ -10,7 +10,6 @@ use libdd_common::{Endpoint, MutexExt};
 use libdd_trace_utils::trace_utils;
 use libdd_trace_utils::trace_utils::SendData;
 use libdd_trace_utils::trace_utils::SendDataResult;
-use manual_future::{ManualFuture, ManualFutureCompleter};
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeMap, HashMap};
@@ -20,6 +19,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use tokio::select;
 use tokio::sync::mpsc;
+use tokio::sync::oneshot;
 use tokio::task::{JoinError, JoinHandle};
 use tracing::{debug, error, info};
 
@@ -134,9 +134,9 @@ impl TraceFlusher {
         flush_data.traces.send_data.push(data);
 
         if flush_data.flusher.is_none() {
-            let (force_flush, completer) = ManualFuture::new();
-            flush_data.flusher = Some(self.clone().start_trace_flusher(force_flush));
-            flush_data.traces.force_flush = Some(completer);
+            let (force_flush_tx, force_flush_rx) = oneshot::channel();
+            flush_data.flusher = Some(self.clone().start_trace_flusher(force_flush_rx));
+            flush_data.traces.force_flush = Some(force_flush_tx);
         }
 
         if flush_data.traces.send_data_size
@@ -230,14 +230,14 @@ impl TraceFlusher {
 
     fn replace_trace_send_data(
         &self,
-        completer: ManualFutureCompleter<Option<mpsc::Sender<()>>>,
+        force_flush_tx: oneshot::Sender<Option<mpsc::Sender<()>>>,
     ) -> Vec<SendData> {
         let trace_buffer = std::mem::replace(
             &mut self.inner.lock_or_panic().traces,
             TraceSendData {
                 send_data: vec![],
                 send_data_size: 0,
-                force_flush: Some(completer),
+                force_flush: Some(force_flush_tx),
             },
         )
         .send_data;
@@ -266,7 +266,7 @@ impl TraceFlusher {
 
     fn start_trace_flusher(
         self: Arc<Self>,
-        mut force_flush: ManualFuture<Option<mpsc::Sender<()>>>,
+        mut force_flush_rx: oneshot::Receiver<Option<mpsc::Sender<()>>>,
     ) -> JoinHandle<()> {
         tokio::spawn(async move {
             loop {
@@ -275,7 +275,11 @@ impl TraceFlusher {
                     _ = tokio::time::sleep(Duration::from_millis(
                         self.interval_ms.load(Ordering::Relaxed),
                     )) => {},
-                    sender = force_flush => { flush_done_sender = sender; },
+                    result = &mut force_flush_rx => {
+                        if let Ok(sender) = result {
+                            flush_done_sender = sender;
+                        }
+                    },
                 }
 
                 debug!(
@@ -283,10 +287,10 @@ impl TraceFlusher {
                     self.inner.lock_or_panic().traces.send_data_size
                 );
 
-                let (new_force_flush, completer) = ManualFuture::new();
-                force_flush = new_force_flush;
+                let (new_force_flush_tx, new_force_flush_rx) = oneshot::channel();
+                force_flush_rx = new_force_flush_rx;
 
-                let send_data = self.replace_trace_send_data(completer);
+                let send_data = self.replace_trace_send_data(new_force_flush_tx);
                 join_all(send_data.into_iter().map(|d| self.send_and_handle_trace(d))).await;
 
                 drop(flush_done_sender);

--- a/datadog-sidecar/src/service/tracing/trace_send_data.rs
+++ b/datadog-sidecar/src/service/tracing/trace_send_data.rs
@@ -4,8 +4,8 @@
 use futures::future::Map;
 use futures::FutureExt;
 use libdd_trace_utils::trace_utils::SendData;
-use manual_future::ManualFutureCompleter;
 use tokio::sync::mpsc::Sender;
+use tokio::sync::oneshot;
 use tokio::task::{JoinError, JoinHandle};
 use tracing::debug;
 
@@ -13,7 +13,7 @@ use tracing::debug;
 pub(crate) struct TraceSendData {
     pub send_data: Vec<SendData>,
     pub send_data_size: usize,
-    pub force_flush: Option<ManualFutureCompleter<Option<Sender<()>>>>,
+    pub force_flush: Option<oneshot::Sender<Option<Sender<()>>>>,
 }
 
 impl TraceSendData {
@@ -41,7 +41,7 @@ impl TraceSendData {
                 "Emitted flush for traces with {} bytes in send_data buffer",
                 self.send_data_size
             );
-            tokio::spawn(force_flush.complete(sender));
+            let _ = force_flush.send(sender);
         }
     }
 }


### PR DESCRIPTION
Scheduling of oneshot tasks is more deterministic - we're trying to track spurious timeouts...