### PR TITLE
fix(sidecar): Avoid notifying in set_request_config

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -12,7 +12,7 @@ benchmarks:
     - if: $CI_COMMIT_BRANCH == "main"
       interruptible: false
     - interruptible: true
-  timeout: 1h
+  timeout: 80m
   script:
     - export ARTIFACTS_DIR="$(pwd)/reports" && (mkdir "${ARTIFACTS_DIR}" || :)
     - git clone --branch libdatadog/benchmarks https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform /platform && cd /platform

--- a/datadog-sidecar/src/service/sidecar_server.rs
+++ b/datadog-sidecar/src/service/sidecar_server.rs
@@ -1013,7 +1013,7 @@ impl SidecarInterface for ConnectionSidecarHandler {
             &self.server.remote_configs,
             &session,
             instance_id,
-            0u64,
+            !0u64, // no need for a notification here, just a config update
             notify_target,
             dynamic_instrumentation_state,
         );

--- a/datadog-sidecar/src/shm_remote_config.rs
+++ b/datadog-sidecar/src/shm_remote_config.rs
@@ -491,6 +491,10 @@ impl<N: NotifyTarget + 'static> ShmRemoteConfigs<N> {
         let writers = self.0.storage.storage.writers.lock_or_panic();
         if let Some(writer) = writers.get(&target) {
             if writer.current_generation() > remote_config_generation {
+                debug!(
+                    "Notify {:?} about newer remote config changes existing",
+                    notify_target
+                );
                 notify_target.notify();
             }
         }


### PR DESCRIPTION
Doesn't actually do harm, but one of our dd-trace-php tests is sensitive to extra notifications...