### PR TITLE
refactor(rc): reexport Endpoint and Tag common types

### DIFF
--- a/libdd-remote-config/src/lib.rs
+++ b/libdd-remote-config/src/lib.rs
@@ -22,10 +22,9 @@ mod targets;
 pub use parse::*;
 pub use path::*;
 
-use {
-    libdd_common::tag::Tag,
-    serde::{Deserialize, Serialize},
-};
+pub use libdd_common::{tag::Tag, Endpoint};
+
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
 pub struct Target {


### PR DESCRIPTION
# What does this PR do?

Reexport `Endpoint` and `Tag` common types

# Motivation

Re-exporting types allows the crate to coexist with other crates that use a different libdd-common version