### PR TITLE
fix(crashtracking): sanitize type and message for unhandled exceptions

### DIFF
--- a/libdd-crashtracker/src/collector/crash_handler.rs
+++ b/libdd-crashtracker/src/collector/crash_handler.rs
@@ -488,12 +488,16 @@ pub fn report_unhandled_exception(
     let pid = unsafe { libc::getpid() };
     let tid = libdd_common::threading::get_current_thread_id() as libc::pid_t;
 
-    let error_type_str = exception_type.unwrap_or("<unknown>");
-
-    // This allocates but this is okay because we are not in a signal handler.
-    // This is necessary, because user defined exception messages can have newlines
-    // and the receiver state machine parsing depends on newlines for different sections
-    // of the crash report.
+    // This allocates but that is okay because we are not in the signal handling path
+    // Both error type and error message are user-controlled and may contain newlines or protocol
+    // sentinel strings (DD_CRASHTRACK_*). We need to escape newlines here, as the receiver treats new lines
+    // as separate sections in the crash report, and this allows consumers to potentially inject artitrary
+    // configuration and other sections into the crash report. emit_message adds a second sanitization pass
+    // as defense-in-depth at the protocol boundary.
+    let error_type_str = exception_type
+        .unwrap_or("<unknown>")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r");
     let error_message_str = exception_message
         .unwrap_or("<no message>")
         .replace('\n', "\\n")

--- a/libdd-crashtracker/src/collector/crash_handler.rs
+++ b/libdd-crashtracker/src/collector/crash_handler.rs
@@ -490,10 +490,11 @@ pub fn report_unhandled_exception(
 
     // This allocates but that is okay because we are not in the signal handling path
     // Both error type and error message are user-controlled and may contain newlines or protocol
-    // sentinel strings (DD_CRASHTRACK_*). We need to escape newlines here, as the receiver treats new lines
-    // as separate sections in the crash report, and this allows consumers to potentially inject artitrary
-    // configuration and other sections into the crash report. emit_message adds a second sanitization pass
-    // as defense-in-depth at the protocol boundary.
+    // sentinel strings (DD_CRASHTRACK_*). We need to escape newlines here, as the receiver treats
+    // new lines as separate sections in the crash report, and this allows consumers to
+    // potentially inject artitrary configuration and other sections into the crash report.
+    // emit_message adds a second sanitization pass as defense-in-depth at the protocol
+    // boundary.
     let error_type_str = exception_type
         .unwrap_or("<unknown>")
         .replace('\n', "\\n")

--- a/libdd-crashtracker/src/collector/emitters.rs
+++ b/libdd-crashtracker/src/collector/emitters.rs
@@ -795,7 +795,6 @@ mod tests {
     use std::str;
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn test_emit_complete_stacktrace() {
         // new_incomplete() starts with incomplete: true, which push_frame requires
         let mut stacktrace = StackTrace::new_incomplete();
@@ -827,7 +826,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn test_emit_message_nullptr() {
         let mut buf = Vec::new();
         emit_message(&mut buf, std::ptr::null_mut()).expect("to work ;-)");
@@ -835,7 +833,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn test_emit_message() {
         let message = "test message";
         let message_ptr = Box::into_raw(Box::new(message.to_string()));
@@ -850,7 +847,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn test_emit_message_empty_string() {
         let empty_message = String::new();
         let message_ptr = Box::into_raw(Box::new(empty_message));
@@ -865,7 +861,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn test_emit_message_whitespace_only() {
         // Whitespace-only messages should not be emitted
         let whitespace_message = "   \n\t  ".to_string();
@@ -881,7 +876,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn test_emit_message_with_leading_trailing_whitespace() {
         // Messages with content and whitespace should be emitted (with the whitespace)
         let message_with_whitespace = "  error message  ".to_string();
@@ -900,7 +894,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn test_emit_message_with_newlines() {
         let message_with_newlines = "line1\nline2\nline3".to_string();
         let message_ptr = Box::into_raw(Box::new(message_with_newlines));
@@ -923,7 +916,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn test_emit_message_unicode() {
         let unicode_message = "Hello 世界 🦀 Rust!".to_string();
         let message_ptr = Box::into_raw(Box::new(unicode_message.clone()));
@@ -939,7 +931,7 @@ mod tests {
 
     #[test]
     #[cfg(target_os = "linux")]
-    #[cfg_attr(miri, ignore)]
+    // #[cfg_attr(miri, ignore)]
     fn test_emit_procinfo() {
         let pid = unsafe { libc::getpid() };
         let tid = unsafe { libc::syscall(libc::SYS_gettid) as libc::pid_t };
@@ -955,7 +947,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn test_emit_message_sentinel_injection_via_newline() {
         // An attacker-controlled error_type/message containing newlines and sentinel
         // strings could break out of the MESSAGE block and inject a CONFIG section
@@ -997,7 +988,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn test_emit_message_content_starting_with_sentinel_prefix() {
         let sentinel_message = format!("{} extra data", DD_CRASHTRACK_END_MESSAGE);
         let message_ptr = Box::into_raw(Box::new(sentinel_message));
@@ -1019,7 +1009,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn test_write_sanitized_message_line_basic() {
         let mut buf = Vec::new();
         write_sanitized_message_line(&mut buf, "hello").unwrap();
@@ -1035,7 +1024,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn test_write_sanitized_message_line_sentinel_prefix() {
         let input = format!("{} injected", DD_CRASHTRACK_END_MESSAGE);
         let mut buf = Vec::new();
@@ -1046,7 +1034,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn test_emit_message_very_long() {
         let long_message = "x".repeat(100000); // 100KB
         let message_ptr = Box::into_raw(Box::new(long_message.clone()));
@@ -1064,7 +1051,6 @@ mod tests {
     // The core unwinding logic is tested in the libunwind crate.
     #[test]
     #[cfg(target_os = "linux")]
-    #[cfg_attr(miri, ignore)]
     fn test_emit_backtrace_via_libunwind_null_ucontext() {
         let mut buf = Vec::new();
         unsafe {
@@ -1102,7 +1088,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(miri, ignore)]
     fn test_emit_ucontext_null_pointer() {
         let mut buf = Vec::new();
         let result = emit_ucontext(&mut buf, std::ptr::null());
@@ -1114,7 +1099,6 @@ mod tests {
 
     #[test]
     #[cfg(target_os = "linux")]
-    #[cfg_attr(miri, ignore)]
     fn test_emit_ucontext_linux_valid() {
         // Create a minimal valid ucontext_t with zeroed register values
         let mut context: libc::ucontext_t = unsafe { std::mem::zeroed() };

--- a/libdd-crashtracker/src/collector/emitters.rs
+++ b/libdd-crashtracker/src/collector/emitters.rs
@@ -445,12 +445,56 @@ fn emit_metadata(w: &mut impl Write, metadata_str: &str) -> Result<(), EmitterEr
     Ok(())
 }
 
+/// Write message content to the wire, escaping newlines and neutralizing sentinel
+/// prefixes with no allocation, as this is called in the signal handler path.
+///
+/// The receiver's state machine splits input on newlines and treats any line
+/// starting with `DD_CRASHTRACK_` as a protocol sentinel. If unsanitized
+/// user-controlled content (an exception message passed through the FFI)
+/// contains embedded newlines or sentinel-like text, it can break out of the
+/// message block and inject arbitrary protocol sections, including a config
+/// section that controls which endpoint receives the crash upload and arbitrary files
+/// to include in the crash report.
+///
+/// This function streams directly to `w`:
+/// 1. Escapes real `\n`/`\r` to `\\n`/`\\r` so the content stays on one wire line (the receiver
+///    reverses this by replacing `\\n`/`\\r` with `\n`/`\r`)
+/// 2. Prefixes with a space if the content starts with `DD_CRASHTRACK_` to prevent the receiver
+///    from matching it as a sentinel
+/// 3. Terminates with a newline
+fn write_sanitized_message_line(w: &mut impl Write, message: &str) -> Result<(), EmitterError> {
+    if message.starts_with("DD_CRASHTRACK_") {
+        w.write_all(b" ")?;
+    }
+    let bytes = message.as_bytes();
+    let mut start = 0;
+    for (i, &byte) in bytes.iter().enumerate() {
+        let escape: Option<&[u8]> = match byte {
+            b'\n' => Some(b"\\n"),
+            b'\r' => Some(b"\\r"),
+            _ => None,
+        };
+        if let Some(replacement) = escape {
+            if start < i {
+                w.write_all(&bytes[start..i])?;
+            }
+            w.write_all(replacement)?;
+            start = i + 1;
+        }
+    }
+    if start < bytes.len() {
+        w.write_all(&bytes[start..])?;
+    }
+    w.write_all(b"\n")?;
+    Ok(())
+}
+
 fn emit_message(w: &mut impl Write, message_ptr: *mut String) -> Result<(), EmitterError> {
     if !message_ptr.is_null() {
         let message = unsafe { &*message_ptr };
         if !message.trim().is_empty() {
             writeln!(w, "{DD_CRASHTRACK_BEGIN_MESSAGE}")?;
-            writeln!(w, "{message}")?;
+            write_sanitized_message_line(w, message)?;
             writeln!(w, "{DD_CRASHTRACK_END_MESSAGE}")?;
             w.flush()?;
         }
@@ -869,6 +913,12 @@ mod tests {
         assert!(out.contains("line2"));
         assert!(out.contains("line3"));
 
+        // Newlines must be escaped on the wire so the message stays on one
+        // protocol line and cannot inject sentinel-delimited sections.
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 3, "BEGIN_MESSAGE, content, END_MESSAGE");
+        assert!(lines[1].contains("line1\\nline2\\nline3"));
+
         unsafe { drop(Box::from_raw(message_ptr)) };
     }
 
@@ -902,6 +952,97 @@ mod tests {
 
         assert!(proc_info_block.contains(&format!("\"pid\": {pid}")));
         assert!(proc_info_block.contains(&format!("\"tid\": {tid}")));
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_emit_message_sentinel_injection_via_newline() {
+        // An attacker-controlled error_type/message containing newlines and sentinel
+        // strings could break out of the MESSAGE block and inject a CONFIG section
+        // that controls the crash upload endpoint.
+        let malicious = format!(
+            "innocent prefix\n{}\n{}\n{{\"endpoint\":\"https://evil.example\"}}\n{}\n{}",
+            DD_CRASHTRACK_END_MESSAGE,
+            DD_CRASHTRACK_BEGIN_CONFIG,
+            DD_CRASHTRACK_END_CONFIG,
+            DD_CRASHTRACK_DONE,
+        );
+        let message_ptr = Box::into_raw(Box::new(malicious));
+        let mut buf = Vec::new();
+
+        emit_message(&mut buf, message_ptr).expect("to work");
+        let out = str::from_utf8(&buf).expect("to be valid UTF8");
+
+        let lines: Vec<&str> = out.lines().collect();
+        // Must be exactly 3 wire lines: BEGIN, content, END
+        assert_eq!(
+            lines.len(),
+            3,
+            "sentinel injection must not create extra lines"
+        );
+        assert_eq!(lines[0], DD_CRASHTRACK_BEGIN_MESSAGE);
+        assert_eq!(lines[2], DD_CRASHTRACK_END_MESSAGE);
+
+        // The injected sentinels must NOT appear as separate lines
+        assert!(
+            !lines.contains(&DD_CRASHTRACK_BEGIN_CONFIG),
+            "injected BEGIN_CONFIG must not appear as a wire line"
+        );
+        assert!(
+            !lines.contains(&DD_CRASHTRACK_DONE),
+            "injected DONE must not appear as a wire line"
+        );
+
+        unsafe { drop(Box::from_raw(message_ptr)) };
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_emit_message_content_starting_with_sentinel_prefix() {
+        let sentinel_message = format!("{} extra data", DD_CRASHTRACK_END_MESSAGE);
+        let message_ptr = Box::into_raw(Box::new(sentinel_message));
+        let mut buf = Vec::new();
+
+        emit_message(&mut buf, message_ptr).expect("to work");
+        let out = str::from_utf8(&buf).expect("to be valid UTF8");
+
+        let lines: Vec<&str> = out.lines().collect();
+        assert_eq!(lines.len(), 3);
+        // The content line shouldn't start with the sentinel prefix
+        assert!(
+            !lines[1].starts_with("DD_CRASHTRACK_"),
+            "content line must not start with sentinel prefix, got: {}",
+            lines[1]
+        );
+
+        unsafe { drop(Box::from_raw(message_ptr)) };
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_write_sanitized_message_line_basic() {
+        let mut buf = Vec::new();
+        write_sanitized_message_line(&mut buf, "hello").unwrap();
+        assert_eq!(buf, b"hello\n");
+
+        buf.clear();
+        write_sanitized_message_line(&mut buf, "line1\nline2").unwrap();
+        assert_eq!(buf, b"line1\\nline2\n");
+
+        buf.clear();
+        write_sanitized_message_line(&mut buf, "a\r\nb").unwrap();
+        assert_eq!(buf, b"a\\r\\nb\n");
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_write_sanitized_message_line_sentinel_prefix() {
+        let input = format!("{} injected", DD_CRASHTRACK_END_MESSAGE);
+        let mut buf = Vec::new();
+        write_sanitized_message_line(&mut buf, &input).unwrap();
+        let out = str::from_utf8(&buf).unwrap();
+        assert!(!out.starts_with("DD_CRASHTRACK_"));
+        assert!(out.starts_with(' '));
     }
 
     #[test]

--- a/libdd-crashtracker/src/collector/emitters.rs
+++ b/libdd-crashtracker/src/collector/emitters.rs
@@ -998,10 +998,10 @@ mod tests {
 
         let lines: Vec<&str> = out.lines().collect();
         assert_eq!(lines.len(), 3);
-        // The content line shouldn't start with the sentinel prefix
+        // The content line shouldn't start with the sentinel
         assert!(
-            !lines[1].starts_with("DD_CRASHTRACK_"),
-            "content line must not start with sentinel prefix, got: {}",
+            !lines[1].starts_with(DD_CRASHTRACK_END_MESSAGE),
+            "content line must not start with DD_CRASHTRACK_END_MESSAGE, got: {}",
             lines[1]
         );
 
@@ -1029,7 +1029,7 @@ mod tests {
         let mut buf = Vec::new();
         write_sanitized_message_line(&mut buf, &input).unwrap();
         let out = str::from_utf8(&buf).unwrap();
-        assert!(!out.starts_with("DD_CRASHTRACK_"));
+        assert!(!out.starts_with(DD_CRASHTRACK_END_MESSAGE));
         assert!(out.starts_with(' '));
     }
 

--- a/libdd-crashtracker/src/receiver/receive_report.rs
+++ b/libdd-crashtracker/src/receiver/receive_report.rs
@@ -882,4 +882,54 @@ mod tests {
         assert!(!stack.incomplete, "Stack should be marked complete");
         assert_eq!(stack.frames[0].ip, Some("0x1234".to_string()));
     }
+
+    #[test]
+    fn test_message_with_escaped_sentinel_does_not_inject() {
+        // Simulates what emit_message produces after sanitize_message_for_wire:
+        // the sentinel strings are on a single escaped line, not separate lines.
+        let mut builder = CrashInfoBuilder::new();
+        let mut config = None;
+        let mut state = StdinState::Waiting;
+
+        // Enter message state
+        state = process_line(
+            &mut builder,
+            &mut config,
+            DD_CRASHTRACK_BEGIN_MESSAGE,
+            state,
+            &None,
+        )
+        .unwrap();
+        assert!(matches!(state, StdinState::Message));
+
+        // Feed the sanitized content (newlines escaped, so it's one line)
+        let sanitized_line = format!(
+            "Exception 'Evil'\\n{}\\n{}\\n{{}}\\n{}",
+            DD_CRASHTRACK_END_MESSAGE, DD_CRASHTRACK_BEGIN_CONFIG, DD_CRASHTRACK_END_CONFIG,
+        );
+        state = process_line(&mut builder, &mut config, &sanitized_line, state, &None).unwrap();
+        // Must still be in Message state. the escaped sentinels are just text
+        assert!(
+            matches!(state, StdinState::Message),
+            "escaped sentinels must not trigger state transitions"
+        );
+
+        // Now the real end sentinel
+        state = process_line(
+            &mut builder,
+            &mut config,
+            DD_CRASHTRACK_END_MESSAGE,
+            state,
+            &None,
+        )
+        .unwrap();
+        assert!(matches!(state, StdinState::Waiting));
+
+        // No config should have been injected
+        assert!(
+            config.is_none(),
+            "no config section should have been parsed"
+        );
+        assert!(builder.has_message());
+    }
 }


### PR DESCRIPTION
# What does this PR do?

Security issue raised in [PROF-15169](https://datadoghq.atlassian.net/jira/software/c/projects/PROF/boards/11?selectedIssue=PROF-15169)


This is, in my opinion, not that severe of an issue, as this requires attackers to have access to spawning the receiver  and have access to calling this FFI at crash time. 

However, it is good to be safe than sorry


# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.


[PROF-15169]: https://datadoghq.atlassian.net/browse/PROF-15169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ