### PR TITLE
feat(crashtracking): collect all native stacks for unhandled exception and also crashing thread

### DIFF
--- a/bin_tests/src/bin/crashtracker_bin_test.rs
+++ b/bin_tests/src/bin/crashtracker_bin_test.rs
@@ -161,12 +161,10 @@ mod unix {
             "unhandled_exception" => {
                 let mut stacktrace = StackTrace::new_incomplete();
                 let mut stackframe1 = StackFrame::new();
-                stackframe1.with_ip(1234);
                 stackframe1.with_function("test_function1".to_string());
                 stackframe1.with_file("test_file1".to_string());
 
                 let mut stackframe2 = StackFrame::new();
-                stackframe2.with_ip(5678);
                 stackframe2.with_function("test_function2".to_string());
                 stackframe2.with_file("test_file2".to_string());
 

--- a/bin_tests/src/modes/behavior.rs
+++ b/bin_tests/src/modes/behavior.rs
@@ -144,6 +144,9 @@ pub fn get_behavior(mode_str: &str) -> Box<dyn Behavior> {
         "sidecar_multi_thread_collection" => {
             Box::new(test_020_sidecar_multi_thread_collection::Test)
         }
+        "unhandled_exception_multi_thread" => {
+            Box::new(test_021_unhandled_exception_multi_thread::Test)
+        }
         "runtime_preload_logger" => Box::new(test_000_donothing::Test),
         _ => panic!("Unknown mode: {mode_str}"),
     }

--- a/bin_tests/src/modes/unix/mod.rs
+++ b/bin_tests/src/modes/unix/mod.rs
@@ -21,3 +21,4 @@ pub mod test_017_multi_thread_collection;
 pub mod test_018_thread_limit;
 pub mod test_019_sidecar_donothing;
 pub mod test_020_sidecar_multi_thread_collection;
+pub mod test_021_unhandled_exception_multi_thread;

--- a/bin_tests/src/modes/unix/test_018_thread_limit.rs
+++ b/bin_tests/src/modes/unix/test_018_thread_limit.rs
@@ -36,7 +36,8 @@ impl Behavior for Test {
     fn post(&self, _output_dir: &Path) -> anyhow::Result<()> {
         let barrier = Arc::new(Barrier::new(THREAD_COUNT + 1));
 
-        for i in 0..THREAD_COUNT {
+        // Make space for the crashing thread
+        for i in 0..(THREAD_COUNT - 1) {
             let barrier = Arc::clone(&barrier);
             std::thread::Builder::new()
                 .name(format!("worker-{i}"))

--- a/bin_tests/src/modes/unix/test_018_thread_limit.rs
+++ b/bin_tests/src/modes/unix/test_018_thread_limit.rs
@@ -34,7 +34,7 @@ impl Behavior for Test {
     }
 
     fn post(&self, _output_dir: &Path) -> anyhow::Result<()> {
-        let barrier = Arc::new(Barrier::new(THREAD_COUNT + 1));
+        let barrier = Arc::new(Barrier::new(THREAD_COUNT));
 
         // Make space for the crashing thread
         for i in 0..(THREAD_COUNT - 1) {

--- a/bin_tests/src/modes/unix/test_021_unhandled_exception_multi_thread.rs
+++ b/bin_tests/src/modes/unix/test_021_unhandled_exception_multi_thread.rs
@@ -1,0 +1,76 @@
+// Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tests that the crashtracker collects stack information for all threads when
+//! reporting an unhandled exception (not just signal-based crashes).
+
+use crate::modes::behavior::Behavior;
+use libdd_crashtracker::CrashtrackerConfiguration;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+pub struct Test;
+
+impl Behavior for Test {
+    fn setup(
+        &self,
+        _output_dir: &Path,
+        config: &mut CrashtrackerConfiguration,
+    ) -> anyhow::Result<()> {
+        config.set_collect_all_threads(true);
+        config.set_max_threads(32);
+        Ok(())
+    }
+
+    fn pre(&self, _output_dir: &Path) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn post(&self, _output_dir: &Path) -> anyhow::Result<()> {
+        static WORKER_0_READY: AtomicBool = AtomicBool::new(false);
+        static WORKER_1_READY: AtomicBool = AtomicBool::new(false);
+
+        #[inline(never)]
+        fn worker_fn_0() {
+            WORKER_0_READY.store(true, Ordering::Relaxed);
+            loop {
+                std::hint::black_box(0x21_00u64);
+                std::hint::spin_loop();
+            }
+        }
+
+        #[inline(never)]
+        fn worker_fn_1() {
+            WORKER_1_READY.store(true, Ordering::Relaxed);
+            loop {
+                std::hint::black_box(0x21_01u64);
+                std::hint::spin_loop();
+            }
+        }
+
+        WORKER_0_READY.store(false, Ordering::Relaxed);
+        WORKER_1_READY.store(false, Ordering::Relaxed);
+
+        let h0 = thread::Builder::new()
+            .name("ct_worker_0".to_string())
+            .spawn(worker_fn_0)?;
+
+        let h1 = thread::Builder::new()
+            .name("ct_worker_1".to_string())
+            .spawn(worker_fn_1)?;
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !WORKER_0_READY.load(Ordering::Acquire) || !WORKER_1_READY.load(Ordering::Acquire) {
+            if Instant::now() >= deadline {
+                panic!("Workers did not reach spin loop within 5s");
+            }
+            thread::yield_now();
+        }
+
+        std::mem::forget(h0);
+        std::mem::forget(h1);
+        Ok(())
+    }
+}

--- a/bin_tests/src/test_types.rs
+++ b/bin_tests/src/test_types.rs
@@ -24,6 +24,7 @@ pub enum TestMode {
     ThreadLimit,
     SidecarDoNothing,
     SidecarMultiThreadCollection,
+    UnhandledExceptionMultiThread,
 }
 
 impl TestMode {
@@ -49,6 +50,7 @@ impl TestMode {
             Self::ThreadLimit => "thread_limit",
             Self::SidecarDoNothing => "sidecar_donothing",
             Self::SidecarMultiThreadCollection => "sidecar_multi_thread_collection",
+            Self::UnhandledExceptionMultiThread => "unhandled_exception_multi_thread",
         }
     }
 
@@ -74,6 +76,7 @@ impl TestMode {
             Self::ThreadLimit,
             Self::SidecarDoNothing,
             Self::SidecarMultiThreadCollection,
+            Self::UnhandledExceptionMultiThread,
         ]
     }
 }
@@ -108,6 +111,7 @@ impl std::str::FromStr for TestMode {
             "thread_limit" => Ok(Self::ThreadLimit),
             "sidecar_donothing" => Ok(Self::SidecarDoNothing),
             "sidecar_multi_thread_collection" => Ok(Self::SidecarMultiThreadCollection),
+            "unhandled_exception_multi_thread" => Ok(Self::UnhandledExceptionMultiThread),
             _ => Err(format!("Unknown test mode: {}", s)),
         }
     }

--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -426,9 +426,9 @@ fn test_crash_tracking_thread_limit() {
             .expect("error.threads should be a JSON array of thread objects");
 
         assert!(
-            thread_array.len() > THREAD_COUNT,
-            "expected at least {} thread entries (1 crashed + {THREAD_COUNT} workers), got {}",
-            THREAD_COUNT + 1,
+            thread_array.len() == THREAD_COUNT,
+            "expected {} thread entries ({THREAD_COUNT} workers), got {}",
+            THREAD_COUNT,
             thread_array.len(),
         );
 

--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -159,6 +159,115 @@ fn test_crash_tracking_bin_unhandled_exception() {
     run_crash_test_with_artifacts(&config, &artifacts_map, &artifacts, validator).unwrap();
 }
 
+/// Tests that when `collect_all_threads` is enabled and the crash is reported via
+/// `report_unhandled_exception`, the crash report contains entries in `error.threads`
+/// for background threads with valid stack traces.
+///
+/// This verifies that `PR_SET_PTRACER` is correctly called in the unhandled exception
+/// path so the receiver can ptrace the still-alive parent process.
+#[test]
+#[cfg(target_os = "linux")]
+#[cfg_attr(miri, ignore)]
+fn test_crash_tracking_bin_unhandled_exception_multi_thread() {
+    let config = CrashTestConfig::new(
+        BuildProfile::Release,
+        TestMode::UnhandledExceptionMultiThread,
+        CrashType::UnhandledException,
+    );
+    let artifacts = StandardArtifacts::new(config.profile);
+    let artifacts_map = fetch_built_artifacts(&artifacts.as_slice()).unwrap();
+
+    let validator: ValidatorFn = Box::new(|payload, _fixtures| {
+        PayloadValidator::new(payload)
+            .validate_error_kind("UnhandledException")?
+            .validate_error_message_contains(
+                "Process was terminated due to an unhandled exception of type 'RuntimeException'",
+            )?;
+
+        let all_threads = payload["error"]["threads"]
+            .as_array()
+            .expect("error.threads should be a JSON array of thread objects");
+
+        assert!(
+            all_threads.len() >= 3,
+            "error.threads should contain at least 3 threads (1 crashed + 2 workers); got {} in payload: {}",
+            all_threads.len(),
+            serde_json::to_string_pretty(payload).unwrap_or_default()
+        );
+
+        let thread_names: Vec<&str> = all_threads
+            .iter()
+            .map(|t| t["name"].as_str().unwrap_or("<none>"))
+            .collect();
+
+        let crashed_threads: Vec<_> = all_threads
+            .iter()
+            .filter(|t| t["crashed"].as_bool() == Some(true))
+            .collect();
+        assert_eq!(
+            crashed_threads.len(),
+            1,
+            "exactly one thread should have crashed=true; got: {crashed_threads:?}"
+        );
+
+        for thread in all_threads {
+            assert!(
+                thread["name"].is_string(),
+                "thread entry missing 'name': {thread:?}"
+            );
+            assert!(
+                thread["crashed"].is_boolean(),
+                "thread entry missing 'crashed': {thread:?}"
+            );
+            assert!(
+                thread["stack"].is_object(),
+                "thread entry missing 'stack': {thread:?}"
+            );
+        }
+
+        for expected in ["ct_worker_0", "ct_worker_1"] {
+            assert!(
+                thread_names.contains(&expected),
+                "Expected worker thread '{expected}' in error.threads; got: {thread_names:?}"
+            );
+
+            let worker = all_threads
+                .iter()
+                .find(|t| t["name"].as_str() == Some(expected))
+                .unwrap_or_else(|| panic!("{expected} should be in threads"));
+
+            let frames = worker["stack"]["frames"]
+                .as_array()
+                .unwrap_or_else(|| panic!("{expected} stack.frames should be an array"));
+
+            assert!(
+                !frames.is_empty(),
+                "{expected} should have non-empty stack frames (ptrace should succeed with PR_SET_PTRACER)"
+            );
+
+            let worker_fn = if expected == "ct_worker_0" {
+                "worker_fn_0"
+            } else {
+                "worker_fn_1"
+            };
+            let has_worker_frame = frames.iter().any(|f| {
+                f["function"]
+                    .as_str()
+                    .map(|name| name.contains(worker_fn))
+                    .unwrap_or(false)
+            });
+            assert!(
+                has_worker_frame,
+                "{expected} stack should contain a frame for '{worker_fn}' but got: {frames:?}"
+            );
+        }
+
+        Ok(())
+    });
+
+    run_crash_test_with_artifacts(&config, &artifacts_map, &artifacts, validator).unwrap();
+}
+
 #[test]
 #[cfg_attr(miri, ignore)]
 fn test_crash_tracking_bin_runtime_callback_frame() {
@@ -189,7 +298,7 @@ fn test_crash_tracking_bin_runtime_callback_frame() {
 }
 
 /// Tests that when `collect_all_threads` is enabled, the crash report contains
-/// entries in `error.threads` for background threads beyond the crashing thread.
+/// entries in `error.threads` for all threads including the crashing thread.
 ///
 /// The behavior (test_017_multi_thread_collection.rs) enables `collect_all_threads`,
 /// spawns two named sleeping worker threads in `post()`, and then crashes the main thread.
@@ -200,8 +309,8 @@ fn test_crash_tracking_bin_runtime_callback_frame() {
 ///
 /// We verify:
 ///   - `error.threads` is a non-empty array of thread objects.
-///   - Each thread entry is well-formed: `crashed=false`, `name`, and `stack` present.
-///   - The crashing thread stack is in `error.stack`, not `error.threads`.
+///   - Each thread entry is well-formed: `crashed`, `name`, and `stack` present.
+///   - Exactly one thread has `crashed=true` (the crashing thread).
 ///   - Both worker threads are present by name (ct_worker_0, ct_worker_1).
 ///   - Each worker has their work frame in the stack trace.
 #[test]
@@ -220,10 +329,9 @@ fn test_crash_tracking_multi_thread_collection() {
         let all_threads = payload["error"]["threads"]
             .as_array()
             .expect("error.threads should be a JSON array of thread objects");
-
         assert!(
-            all_threads.len() >= 2,
-            "error.threads should be non-empty when collect_all_threads is enabled; got payload: {}",
+            all_threads.len() >= 3,
+            "error.threads should contain at least 3 threads (1 crashed + 2 workers); got payload: {}",
             serde_json::to_string_pretty(payload).unwrap_or_default()
         );
 
@@ -231,6 +339,16 @@ fn test_crash_tracking_multi_thread_collection() {
             .iter()
             .map(|t| t["name"].as_str().unwrap_or("<none>"))
             .collect();
+
+        let crashed_threads: Vec<_> = all_threads
+            .iter()
+            .filter(|t| t["crashed"].as_bool() == Some(true))
+            .collect();
+        assert_eq!(
+            crashed_threads.len(),
+            1,
+            "exactly one thread should have crashed=true; got: {crashed_threads:?}"
+        );
 
         for thread in all_threads {
             assert!(
@@ -244,10 +362,6 @@ fn test_crash_tracking_multi_thread_collection() {
             assert!(
                 thread["stack"].is_object(),
                 "thread entry missing 'stack': {thread:?}"
-            );
-            assert!(
-                !thread["crashed"].as_bool().unwrap_or(true),
-                "threads in error.threads must have crashed=false: {thread:?}"
             );
         }
 
@@ -312,9 +426,20 @@ fn test_crash_tracking_thread_limit() {
             .expect("error.threads should be a JSON array of thread objects");
 
         assert!(
-            thread_array.len() >= THREAD_COUNT,
-            "expected at least {THREAD_COUNT} thread entries, got {}",
+            thread_array.len() > THREAD_COUNT,
+            "expected at least {} thread entries (1 crashed + {THREAD_COUNT} workers), got {}",
+            THREAD_COUNT + 1,
             thread_array.len(),
+        );
+
+        let crashed_threads: Vec<_> = thread_array
+            .iter()
+            .filter(|t| t["crashed"].as_bool() == Some(true))
+            .collect();
+        assert_eq!(
+            crashed_threads.len(),
+            1,
+            "exactly one thread should have crashed=true; got: {crashed_threads:?}"
         );
 
         for thread in thread_array {
@@ -329,10 +454,6 @@ fn test_crash_tracking_thread_limit() {
             assert!(
                 thread["stack"].is_object(),
                 "thread entry missing 'stack': {thread:?}"
-            );
-            assert!(
-                !thread["crashed"].as_bool().unwrap_or(true),
-                "threads in error.threads must have crashed=false: {thread:?}"
             );
         }
 
@@ -529,8 +650,8 @@ fn test_crash_tracking_sidecar_multi_thread_collection() {
     let all_threads = all_threads.unwrap();
 
     assert!(
-        all_threads.len() >= 2,
-        "error.threads should have at least 2 entries (sidecar multi-thread); got {}: {}",
+        all_threads.len() >= 3,
+        "error.threads should have at least 3 entries (1 crashed + 2 workers, sidecar multi-thread); got {}: {}",
         all_threads.len(),
         serde_json::to_string_pretty(&crash_payload).unwrap_or_default()
     );

--- a/libdd-crashtracker/src/collector/crash_handler.rs
+++ b/libdd-crashtracker/src/collector/crash_handler.rs
@@ -334,41 +334,7 @@ fn handle_posix_signal_impl(
     // expected receiver PID that was registered during trusted initialization
     #[cfg(target_os = "linux")]
     if config.collect_all_threads() {
-        let ptracer_pid = match receiver.handle.pid {
-            Some(pid) => pid,
-            None => {
-                let expected_pid = get_expected_receiver_pid();
-                if expected_pid <= 0 {
-                    // No expected PID registered; fail closed.
-                    0
-                } else {
-                    let mut cred: libc::ucred = unsafe { std::mem::zeroed() };
-                    let mut len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
-                    // SAFETY: getsockopt is async-signal-safe
-                    let ret = unsafe {
-                        libc::getsockopt(
-                            receiver.handle.uds_fd,
-                            libc::SOL_SOCKET,
-                            libc::SO_PEERCRED,
-                            &mut cred as *mut _ as *mut libc::c_void,
-                            &mut len,
-                        )
-                    };
-                    if ret == 0 && cred.pid == expected_pid {
-                        cred.pid
-                    } else {
-                        // Peer PID doesn't match expected receiver; fail closed.
-                        0
-                    }
-                }
-            }
-        };
-        if ptracer_pid > 0 {
-            // SAFETY: prctl is async-signal-safe and we're just setting ptrace permissions
-            unsafe {
-                libc::prctl(libc::PR_SET_PTRACER, ptracer_pid as libc::c_ulong);
-            }
-        }
+        grant_ptracer_permission(&receiver);
     }
 
     let collector = Collector::spawn(
@@ -438,6 +404,50 @@ fn take_config() -> Option<(
     }
 }
 
+/// Grant the receiver process permission to ptrace this process via `PR_SET_PTRACER`.
+///
+/// For fork/exec receivers we have the child PID directly (trusted: we spawned it).
+/// For socket-based receivers (e.g. PHP sidecar), we verify the peer PID via
+/// `SO_PEERCRED` matches the expected receiver PID registered during initialization.
+///
+/// This is async-signal-safe: only calls `getsockopt` and `prctl`.
+#[cfg(target_os = "linux")]
+fn grant_ptracer_permission(receiver: &Receiver) {
+    let ptracer_pid = match receiver.handle.pid {
+        Some(pid) => pid,
+        None => {
+            let expected_pid = get_expected_receiver_pid();
+            if expected_pid <= 0 {
+                0
+            } else {
+                let mut cred: libc::ucred = unsafe { std::mem::zeroed() };
+                let mut len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+                // SAFETY: getsockopt is async-signal-safe
+                let ret = unsafe {
+                    libc::getsockopt(
+                        receiver.handle.uds_fd,
+                        libc::SOL_SOCKET,
+                        libc::SO_PEERCRED,
+                        &mut cred as *mut _ as *mut libc::c_void,
+                        &mut len,
+                    )
+                };
+                if ret == 0 && cred.pid == expected_pid {
+                    cred.pid
+                } else {
+                    0
+                }
+            }
+        }
+    };
+    if ptracer_pid > 0 {
+        // SAFETY: prctl is async-signal-safe
+        unsafe {
+            libc::prctl(libc::PR_SET_PTRACER, ptracer_pid as libc::c_ulong);
+        }
+    }
+}
+
 /// This function is designed to be when a program is at a terminal state
 /// and the application wants to report an unhandled exception to the crashtracker
 /// If this crashes, then the application will also crash. Ensure that this API is
@@ -482,6 +492,11 @@ pub fn report_unhandled_exception(
     let (_metadata, metadata_str) = take_metadata().ok_or(CrashHandlerError::NoMetadata)?;
 
     let receiver = Receiver::from_crashtracker_config(&config)?;
+
+    #[cfg(target_os = "linux")]
+    if config.collect_all_threads() {
+        grant_ptracer_permission(&receiver);
+    }
 
     let timeout_manager = TimeoutManager::new(config.timeout());
 

--- a/libdd-crashtracker/src/crash_info/builder.rs
+++ b/libdd-crashtracker/src/crash_info/builder.rs
@@ -103,9 +103,6 @@ impl ErrorDataBuilder {
     }
 
     pub fn with_thread(&mut self, thread: ThreadData) -> anyhow::Result<()> {
-        if thread.crashed {
-            return Ok(());
-        }
         self.threads.get_or_insert_with(Vec::new).push(thread);
         Ok(())
     }

--- a/libdd-crashtracker/src/receiver/ptrace_collector.rs
+++ b/libdd-crashtracker/src/receiver/ptrace_collector.rs
@@ -374,6 +374,10 @@ const STOP_TIMEOUT_PER_THREAD: Duration = Duration::from_millis(50);
 /// For each thread in the process the callback receives the TID and an optional
 /// `CapturedThreadContext` (None if attachment or unwinding failed).
 ///
+/// The `crashing_tid` is always processed first (regardless of `/proc` iteration
+/// order) to guarantee it appears in the output even when the `max_threads` cap
+/// truncates collection.
+///
 /// Two deadlines bound collection:
 /// - An *overall* deadline derived from `timeout`, shared across all threads.
 /// - A *per-thread stop* deadline of at most `STOP_TIMEOUT_PER_THREAD` (capped at the overall
@@ -384,6 +388,7 @@ const STOP_TIMEOUT_PER_THREAD: Duration = Duration::from_millis(50);
 /// threads that were not visited.
 pub fn stream_thread_contexts<F>(
     parent_pid: libc::pid_t,
+    crashing_tid: libc::pid_t,
     max_threads: usize,
     timeout: Duration,
     resolve_frames: crate::StacktraceCollection,
@@ -405,7 +410,19 @@ where
         return Ok(true); // treat as incomplete; nothing was collected
     };
 
+    // Process the crashing thread first so it is never dropped by the cap.
+    if crashing_tid != 0 && tids.contains(&crashing_tid) {
+        let stop_deadline = (Instant::now() + STOP_TIMEOUT_PER_THREAD).min(overall_deadline);
+        let context =
+            capture_thread_context(crashing_tid, resolve_frames, addr_space, stop_deadline).ok();
+        callback(crashing_tid, context.as_ref());
+        processed += 1;
+    }
+
     for tid in tids {
+        if tid == crashing_tid {
+            continue;
+        }
         let now = Instant::now();
         if now >= overall_deadline || processed >= max_threads {
             break;
@@ -532,13 +549,15 @@ mod tests {
         let mut collected = 0usize;
         let _ = stream_thread_contexts(
             std::process::id() as libc::pid_t,
+            current_tid(),
             2,
             Duration::from_secs(5),
             crate::StacktraceCollection::Disabled,
             |_tid, _ctx| collected += 1,
         );
 
-        assert!(collected <= 2, "collected {collected}, expected <= 2");
+        // max_threads=2 but crashing_tid is always included, so up to 3
+        assert!(collected <= 3, "collected {collected}, expected <= 3");
         for h in handles {
             h.join().unwrap();
         }
@@ -563,6 +582,7 @@ mod tests {
         let self_tid = current_tid();
         let _ = stream_thread_contexts(
             std::process::id() as libc::pid_t,
+            self_tid,
             64,
             Duration::from_secs(5),
             crate::StacktraceCollection::Disabled,

--- a/libdd-crashtracker/src/receiver/ptrace_collector.rs
+++ b/libdd-crashtracker/src/receiver/ptrace_collector.rs
@@ -371,7 +371,7 @@ const STOP_TIMEOUT_PER_THREAD: Duration = Duration::from_millis(50);
 
 /// Stream thread contexts to a callback one at a time.
 ///
-/// For each non-crashing thread the callback receives the TID and an optional
+/// For each thread in the process the callback receives the TID and an optional
 /// `CapturedThreadContext` (None if attachment or unwinding failed).
 ///
 /// Two deadlines bound collection:
@@ -384,7 +384,6 @@ const STOP_TIMEOUT_PER_THREAD: Duration = Duration::from_millis(50);
 /// threads that were not visited.
 pub fn stream_thread_contexts<F>(
     parent_pid: libc::pid_t,
-    crashing_tid: libc::pid_t,
     max_threads: usize,
     timeout: Duration,
     resolve_frames: crate::StacktraceCollection,
@@ -395,12 +394,7 @@ where
 {
     let overall_deadline = Instant::now() + timeout;
     let tids = enumerate_threads(parent_pid)?;
-    // Exclude the crashing thread from the eligible set before checking the cap.
-    let eligible: Vec<_> = tids
-        .into_iter()
-        .filter(|&tid| tid != crashing_tid)
-        .collect();
-    let total_eligible = eligible.len();
+    let total_eligible = tids.len();
     let mut processed = 0;
 
     // Create a single address space shared across all threads.  All threads in the
@@ -411,7 +405,7 @@ where
         return Ok(true); // treat as incomplete; nothing was collected
     };
 
-    for tid in eligible {
+    for tid in tids {
         let now = Instant::now();
         if now >= overall_deadline || processed >= max_threads {
             break;
@@ -538,7 +532,6 @@ mod tests {
         let mut collected = 0usize;
         let _ = stream_thread_contexts(
             std::process::id() as libc::pid_t,
-            current_tid(),
             2,
             Duration::from_secs(5),
             crate::StacktraceCollection::Disabled,
@@ -553,7 +546,7 @@ mod tests {
 
     #[test]
     #[cfg_attr(miri, ignore)]
-    fn stream_excludes_crashing_tid() {
+    fn stream_includes_all_threads() {
         let barrier = Arc::new(Barrier::new(2));
         let b: Arc<Barrier> = Arc::clone(&barrier);
         let (tx, rx) = std::sync::mpsc::channel();
@@ -565,11 +558,11 @@ mod tests {
 
         let worker_tid = rx.recv().unwrap();
 
-        // Declare the worker as the crashing TID; it must be skipped.
         let mut seen_worker = false;
+        let mut seen_self = false;
+        let self_tid = current_tid();
         let _ = stream_thread_contexts(
             std::process::id() as libc::pid_t,
-            worker_tid,
             64,
             Duration::from_secs(5),
             crate::StacktraceCollection::Disabled,
@@ -577,10 +570,14 @@ mod tests {
                 if tid == worker_tid {
                     seen_worker = true;
                 }
+                if tid == self_tid {
+                    seen_self = true;
+                }
             },
         );
 
-        assert!(!seen_worker, "crashing_tid should not appear in callbacks");
+        assert!(seen_worker, "worker thread should appear in callbacks");
+        assert!(seen_self, "current thread should appear in callbacks");
 
         barrier.wait();
         handle.join().unwrap();

--- a/libdd-crashtracker/src/receiver/receive_report.rs
+++ b/libdd-crashtracker/src/receiver/receive_report.rs
@@ -570,6 +570,7 @@ fn collect_and_add_thread_contexts(
 
     let incomplete = stream_thread_contexts(
         parent_pid,
+        crashing_tid,
         config.max_threads(),
         budget,
         config.resolve_frames(),

--- a/libdd-crashtracker/src/receiver/receive_report.rs
+++ b/libdd-crashtracker/src/receiver/receive_report.rs
@@ -566,18 +566,12 @@ fn collect_and_add_thread_contexts(
     let crashing_tid = crashing_tid.unwrap_or(0) as i32;
     let parent_pid = parent_pid as i32;
 
-    // Use the remaining receiver budget
-    // When this expires, stream_thread_contexts stops and returns the threads
-    // collected so far, which are still emitted in the report.
-    let context_timeout = budget;
-
     let mut collected_threads = Vec::new();
 
     let incomplete = stream_thread_contexts(
         parent_pid,
-        crashing_tid,
         config.max_threads(),
-        context_timeout,
+        budget,
         config.resolve_frames(),
         |tid, captured_context| {
             let (name, state) = read_thread_stat(parent_pid, tid);
@@ -589,7 +583,7 @@ fn collect_and_add_thread_contexts(
             };
 
             collected_threads.push(ThreadData {
-                crashed: false,
+                crashed: tid == crashing_tid,
                 name,
                 stack,
                 state,


### PR DESCRIPTION
# What does this PR do?

Previously, when a runtime reported an unhandled exception, only the runtime-provided stack trace was captured; no native stacks were collected for any thread because `PR_SET_PTRACER` was not set for unhandled exceptions. Additionally, when all-thread collection was enabled for signal-based crashes, the crashing thread was excluded from the threads array.

This change:
1. Enables native stack collection for all threads (including the crashing thread) when reporting unhandled exceptions with `collect_all_threads` enabled. The receiver now has the necessary ptrace permissions to unwind every thread in the process.
2. Includes the crashing thread in the `error.threads` array (marked with `crashed: true`) for both signal-based crashes and unhandled exceptions. Its native stack is collected by the receiver using ptrace, same as every other thread.

The runtime-provided stack remains in `error.stack` as the canonical crash context, while `error.threads` provides a uniform native view of all threads at the time of the crash.

This gives us two immediate benefits:
1. Unhandled exception crash reports now include native stacks for all threads, providing visibility into what the process was doing at the OS level; not just the managed runtime view.
2. The crashing thread's native stack is now collected in the receiver alongside all other threads, establishing a path toward consolidating all stack collection in the receiver process in the future.

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
