### PR TITLE
fix(otel-thread-ctx): put the threadlocal attributes at the right place in the context

### DIFF
--- a/libdd-library-config/src/tracer_metadata.rs
+++ b/libdd-library-config/src/tracer_metadata.rs
@@ -115,8 +115,7 @@ impl TracerMetadata {
             threadlocal_attribute_keys,
         } = self;
 
-        #[cfg_attr(not(feature = "otel-thread-ctx"), allow(unused_mut))]
-        let mut attributes = vec![
+        let attributes = vec![
             key_value_opt("service.name", service_name),
             key_value_opt("service.instance.id", runtime_id),
             key_value_opt("service.version", service_version),
@@ -128,14 +127,16 @@ impl TracerMetadata {
             key_value_opt("container.id", container_id),
         ];
 
+        let mut extra_attributes = vec![key_value_opt("datadog.process_tags", process_tags)];
+
         #[cfg(feature = "otel-thread-ctx")]
         if let Some(threadlocal_attribute_keys) = threadlocal_attribute_keys.as_ref() {
-            attributes.push(key_value(
+            extra_attributes.push(key_value(
                 "threadlocal.schema_version",
                 "tlsdesc_v1_dev".to_owned(),
             ));
 
-            attributes.push(KeyValue {
+            extra_attributes.push(KeyValue {
                 key: "threadlocal.attribute_key_map".to_owned(),
                 value: Some(AnyValue {
                     value: Some(any_value::Value::ArrayValue(ArrayValue {
@@ -160,7 +161,7 @@ impl TracerMetadata {
                 dropped_attributes_count: 0,
                 entity_refs: vec![],
             }),
-            extra_attributes: vec![key_value_opt("datadog.process_tags", process_tags)],
+            extra_attributes,
         }
     }
 }

--- a/libdd-library-config/src/tracer_metadata.rs
+++ b/libdd-library-config/src/tracer_metadata.rs
@@ -115,7 +115,7 @@ impl TracerMetadata {
             threadlocal_attribute_keys,
         } = self;
 
-        let attributes = vec![
+        let resource_attrs = vec![
             key_value_opt("service.name", service_name),
             key_value_opt("service.instance.id", runtime_id),
             key_value_opt("service.version", service_version),
@@ -127,6 +127,8 @@ impl TracerMetadata {
             key_value_opt("container.id", container_id),
         ];
 
+        // `mut` is only needed when `otel-thread-ctx` is enabled.
+        #[allow(unused_mut)]
         let mut extra_attributes = vec![key_value_opt("datadog.process_tags", process_tags)];
 
         #[cfg(feature = "otel-thread-ctx")]
@@ -157,7 +159,7 @@ impl TracerMetadata {
 
         ProcessContext {
             resource: Some(Resource {
-                attributes,
+                attributes: resource_attrs,
                 dropped_attributes_count: 0,
                 entity_refs: vec![],
             }),

--- a/libdd-library-config/src/tracer_metadata.rs
+++ b/libdd-library-config/src/tracer_metadata.rs
@@ -240,10 +240,8 @@ mod tests {
     use libdd_trace_protobuf::opentelemetry::proto::common::v1::any_value;
     use libdd_trace_protobuf::opentelemetry::proto::common::v1::{AnyValue, ProcessContext};
 
-    fn find_attr<'a>(ctx: &'a ProcessContext, key: &str) -> Option<&'a AnyValue> {
-        ctx.resource
-            .as_ref()?
-            .attributes
+    fn find_extra_attr<'a>(ctx: &'a ProcessContext, key: &str) -> Option<&'a AnyValue> {
+        ctx.extra_attributes
             .iter()
             .find(|kv| kv.key == key)?
             .value
@@ -273,8 +271,8 @@ mod tests {
     fn threadlocal_attrs_absent_when_keys_empty() {
         let ctx = TracerMetadata::default().to_otel_process_ctx();
 
-        assert!(find_attr(&ctx, "threadlocal.schema_version").is_none());
-        assert!(find_attr(&ctx, "threadlocal.attribute_key_map").is_none());
+        assert!(find_extra_attr(&ctx, "threadlocal.schema_version").is_none());
+        assert!(find_extra_attr(&ctx, "threadlocal.attribute_key_map").is_none());
     }
 
     #[cfg(feature = "otel-thread-ctx")]
@@ -291,7 +289,7 @@ mod tests {
         .to_otel_process_ctx();
 
         // Schema version attribute
-        let schema_version = find_attr(&ctx, "threadlocal.schema_version")
+        let schema_version = find_extra_attr(&ctx, "threadlocal.schema_version")
             .expect("threadlocal.schema_version should be present");
         assert_eq!(
             schema_version.value,
@@ -299,7 +297,7 @@ mod tests {
         );
 
         // Key map attribute: ordered array of key name strings
-        let key_map = find_attr(&ctx, "threadlocal.attribute_key_map")
+        let key_map = find_extra_attr(&ctx, "threadlocal.attribute_key_map")
             .expect("threadlocal.attribute_key_map should be present");
         let array = match &key_map.value {
             Some(any_value::Value::ArrayValue(a)) => a,


### PR DESCRIPTION
# What does this PR do?

This PR stores the `threadlocal*` attributes in the `attributes` field of the process context, instead of the `resource` field.
Additionally, fix an unrelated issue (remove undue `#[cfg(..)]` gate) that was introduced in the [otel thread feature-gating](https://github.com/DataDog/libdatadog/pull/1843), preventing normal tracer metadata from being published in the context when the `otel-thread-ctx` feature is active.

# Motivation

After experimenting more with OTel thread context sharing, I found out the way we set up the process context is incorrect. The `threadlocal*` attributes should go in the `attributes`/`extra_attributes` part of the process context, not the `resource` part. Tested that it now works with the context reader locally.

# Additional Notes

N/A

# How to test the change?

I'm using this version in a prototype integration in dd-trace-rs, using the [context reader](https://github.com/scottgerring/ctx-sharing-demo/tree/main/context-reader). This is how I uncovered the issue initially. Now I'm seeing context properly read with this fix.