### PR TITLE
chore: bump workspace version to 37.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,7 +695,7 @@ checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "build_common"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "cbindgen",
  "serde",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "builder"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1386,7 +1386,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-ffe-test-suite"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -1479,7 +1479,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-replayer"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2819,7 +2819,7 @@ checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libdd-agent-client"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "bytes",
  "flate2",
@@ -2913,7 +2913,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-common-ffi"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "assert_no_alloc",
@@ -2966,7 +2966,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-crashtracker-ffi"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -3029,7 +3029,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-data-pipeline-ffi"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "build_common",
  "httpmock",
@@ -3058,7 +3058,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-ddsketch-ffi"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "build_common",
  "libdd-common-ffi",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-http-client"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "bytes",
  "fastrand",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-log-ffi"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "build_common",
  "libdd-common-ffi",
@@ -3322,7 +3322,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-shared-runtime-ffi"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "build_common",
  "libdd-shared-runtime",
@@ -3359,7 +3359,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-telemetry-ffi"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "build_common",
  "function_name",
@@ -5625,7 +5625,7 @@ dependencies = [
 
 [[package]]
 name = "symbolizer-ffi"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "blazesym-c",
  "build_common",
@@ -6073,7 +6073,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "36.0.0"
+version = "37.0.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.87.0"
 edition = "2021"
-version = "36.0.0"
+version = "37.0.0"
 license = "Apache-2.0"
 authors = ["Datadog Inc. <info@datadoghq.com>"]
 


### PR DESCRIPTION
## chore: release v37.0.0

Bumps the workspace version from `36.0.0` to `37.0.0` in `Cargo.toml` and regenerates `Cargo.lock`.

## Post-merge steps

1. Trigger the `create_release` job on GitLab — builds artifacts and creates a draft GitHub release.
2. Ask someone from `libdatadog-core` or `libdatadog-release` to publish the draft release.
3. Trigger the `release-proposal-dispatch` GitHub Actions workflow for per-crate crates.io publishing:
   crates: libdd-data-pipeline,libdd-trace-stats,libdd-trace-utils,libdd-ddsketch

## Notable changes since v36.0.0

- `feat(data-pipeline)`: export client-computed span stats as OTLP trace metrics (#2067)
- `feat(otel-thread-ctx)`: add self check capability (#2095)
- `fix(trace-stats)`: add `grpc_method` to aggregation key (#2151)
- `feat(data-pipeline)`: add stdout log trace exporter (#2074)
- `feat(remote-config)`: use the proto file from the agent (#2165)
- `feat(sidecar)`: expose `default_service_name` for `svc.*` process tags (#2053)
- feat(otlp)!: Export OTLP spans with attribute-level OTel compatibility (#2091)