### PR TITLE
refactor(libdd-remote-config)!: hide Target inner properties so they are not leaked

### DIFF
--- a/datadog-sidecar-ffi/src/lib.rs
+++ b/datadog-sidecar-ffi/src/lib.rs
@@ -264,9 +264,9 @@ pub unsafe extern "C" fn ddog_remote_config_reader_for_endpoint<'a>(
             endpoint: endpoint.clone(),
         },
         &Arc::new(Target::new(
-            &service_name.to_utf8_lossy(),
-            &env_name.to_utf8_lossy(),
-            &app_version.to_utf8_lossy(),
+            service_name.to_utf8_lossy().to_string(),
+            env_name.to_utf8_lossy().to_string(),
+            app_version.to_utf8_lossy().to_string(),
             tags.as_slice().iter().map(|t| t.to_string()).collect(),
             vec![],
         )),

--- a/datadog-sidecar-ffi/src/lib.rs
+++ b/datadog-sidecar-ffi/src/lib.rs
@@ -263,13 +263,13 @@ pub unsafe extern "C" fn ddog_remote_config_reader_for_endpoint<'a>(
             tracer_version: tracer_version.to_utf8_lossy().into(),
             endpoint: endpoint.clone(),
         },
-        &Arc::new(Target {
-            service: service_name.to_utf8_lossy().into(),
-            env: env_name.to_utf8_lossy().into(),
-            app_version: app_version.to_utf8_lossy().into(),
-            tags: tags.as_slice().to_vec(),
-            process_tags: vec![],
-        }),
+        &Arc::new(Target::new(
+            &service_name.to_utf8_lossy(),
+            &env_name.to_utf8_lossy(),
+            &app_version.to_utf8_lossy(),
+            tags.as_slice().iter().map(|t| t.to_string()).collect(),
+            vec![],
+        )),
     ))
 }
 

--- a/datadog-sidecar/src/shm_remote_config.rs
+++ b/datadog-sidecar/src/shm_remote_config.rs
@@ -473,13 +473,13 @@ impl<N: NotifyTarget + 'static> ShmRemoteConfigs<N> {
         dynamic_instrumentation_state: DynamicInstrumentationConfigState,
         process_tags: Vec<Tag>,
     ) -> ShmRemoteConfigsGuard<N> {
-        let target = Arc::new(Target {
-            service,
-            env,
-            app_version,
-            tags,
-            process_tags,
-        });
+        let target = Arc::new(Target::new(
+            &service,
+            &env,
+            &app_version,
+            tags.iter().map(|t| t.to_string()).collect(),
+            process_tags.iter().map(|t| t.to_string()).collect(),
+        ));
         self.0.add_runtime(
             instance_id.session_id.clone(),
             instance_id.runtime_id.clone(),
@@ -824,15 +824,8 @@ mod tests {
         name: "config".to_string(),
     });
 
-    static DUMMY_TARGET: LazyLock<Arc<Target>> = LazyLock::new(|| {
-        Arc::new(Target {
-            service: "service".to_string(),
-            env: "env".to_string(),
-            app_version: "1.3.5".to_string(),
-            tags: vec![],
-            process_tags: vec![],
-        })
-    });
+    static DUMMY_TARGET: LazyLock<Arc<Target>> =
+        LazyLock::new(|| Arc::new(Target::new("service", "env", "1.3.5", vec![], vec![])));
 
     #[derive(Debug, Clone)]
     struct NotifyDummy(Arc<tokio::sync::mpsc::Sender<()>>);
@@ -902,16 +895,16 @@ mod tests {
             },
             0,
             NotifyDummy(Arc::new(sender)),
-            DUMMY_TARGET.env.to_string(),
-            DUMMY_TARGET.service.to_string(),
-            DUMMY_TARGET.app_version.to_string(),
-            DUMMY_TARGET.tags.clone(),
+            "env".to_string(),
+            "service".to_string(),
+            "1.3.5".to_string(),
+            vec![],
             ProductCapabilities {
                 products: server.dummy_options().products,
                 capabilities: server.dummy_options().capabilities,
             },
             DynamicInstrumentationConfigState::Disabled,
-            DUMMY_TARGET.process_tags.clone(),
+            vec![],
         );
 
         receiver.recv().await;
@@ -1091,16 +1084,16 @@ mod tests {
             },
             0,
             NotifyDummy(Arc::new(sender)),
-            DUMMY_TARGET.env.to_string(),
-            DUMMY_TARGET.service.to_string(),
-            DUMMY_TARGET.app_version.to_string(),
-            DUMMY_TARGET.tags.clone(),
+            "env".to_string(),
+            "service".to_string(),
+            "1.3.5".to_string(),
+            vec![],
             ProductCapabilities {
                 products: server.dummy_options().products,
                 capabilities: server.dummy_options().capabilities,
             },
             DynamicInstrumentationConfigState::Enabled,
-            DUMMY_TARGET.process_tags.clone(),
+            vec![],
         );
 
         receiver.recv().await;

--- a/datadog-sidecar/src/shm_remote_config.rs
+++ b/datadog-sidecar/src/shm_remote_config.rs
@@ -474,9 +474,9 @@ impl<N: NotifyTarget + 'static> ShmRemoteConfigs<N> {
         process_tags: Vec<Tag>,
     ) -> ShmRemoteConfigsGuard<N> {
         let target = Arc::new(Target::new(
-            &service,
-            &env,
-            &app_version,
+            service,
+            env,
+            app_version,
             tags.iter().map(|t| t.to_string()).collect(),
             process_tags.iter().map(|t| t.to_string()).collect(),
         ));
@@ -824,8 +824,15 @@ mod tests {
         name: "config".to_string(),
     });
 
-    static DUMMY_TARGET: LazyLock<Arc<Target>> =
-        LazyLock::new(|| Arc::new(Target::new("service", "env", "1.3.5", vec![], vec![])));
+    static DUMMY_TARGET: LazyLock<Arc<Target>> = LazyLock::new(|| {
+        Arc::new(Target::new(
+            "service".to_string(),
+            "env".to_string(),
+            "1.3.5".to_string(),
+            vec![],
+            vec![],
+        ))
+    });
 
     #[derive(Debug, Clone)]
     struct NotifyDummy(Arc<tokio::sync::mpsc::Sender<()>>);

--- a/libdd-remote-config/examples/remote_config_fetch.rs
+++ b/libdd-remote-config/examples/remote_config_fetch.rs
@@ -28,9 +28,9 @@ async fn main() {
         // FileStorage implementation is recommended
         ParsedFileStorage::default(),
         Target::new(
-            SERVICE,
-            ENV,
-            VERSION,
+            SERVICE.to_string(),
+            ENV.to_string(),
+            VERSION.to_string(),
             vec!["test:value".to_string()],
             vec![],
         ),

--- a/libdd-remote-config/examples/remote_config_fetch.rs
+++ b/libdd-remote-config/examples/remote_config_fetch.rs
@@ -1,7 +1,6 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use libdd_common::tag::Tag;
 use libdd_common::Endpoint;
 use libdd_remote_config::fetch::{ConfigInvariants, ConfigOptions, SingleChangesFetcher};
 use libdd_remote_config::file_change_tracker::{Change, FilePath};
@@ -28,13 +27,13 @@ async fn main() {
         // For more complicated use cases, like needing to store data in shared memory, a custom
         // FileStorage implementation is recommended
         ParsedFileStorage::default(),
-        Target {
-            service: SERVICE.to_string(),
-            env: ENV.to_string(),
-            app_version: VERSION.to_string(),
-            tags: vec![Tag::new("test", "value").unwrap()],
-            process_tags: vec![],
-        },
+        Target::new(
+            SERVICE,
+            ENV,
+            VERSION,
+            vec!["test:value".to_string()],
+            vec![],
+        ),
         RUNTIME_ID.to_string(),
         ConfigOptions {
             invariants: ConfigInvariants {

--- a/libdd-remote-config/src/fetch/fetcher.rs
+++ b/libdd-remote-config/src/fetch/fetcher.rs
@@ -309,8 +309,8 @@ impl<S: FileStorage> ConfigFetcher<S> {
                     extra_services,
                     env,
                     app_version,
-                    tags: tags.iter().map(|t| t.to_string()).collect(),
-                    process_tags: process_tags.iter().map(|t| t.to_string()).collect(),
+                    tags,
+                    process_tags,
                     container_tags: vec![],
                 }),
                 is_agent: false,
@@ -596,26 +596,19 @@ pub mod tests {
             name: "config".to_string(),
         });
 
-    pub(crate) static DUMMY_TARGET: LazyLock<Arc<Target>> = LazyLock::new(|| {
-        Arc::new(Target {
-            service: "service".to_string(),
-            env: "env".to_string(),
-            app_version: "1.3.5".to_string(),
-            tags: vec![],
-            process_tags: vec![],
-        })
-    });
+    pub(crate) static DUMMY_TARGET: LazyLock<Arc<Target>> =
+        LazyLock::new(|| Arc::new(Target::new("service", "env", "1.3.5", vec![], vec![])));
     pub(crate) static DUMMY_TARGET_WITH_PROCESS_TAGS: LazyLock<Arc<Target>> = LazyLock::new(|| {
-        Arc::new(Target {
-            service: "service".to_string(),
-            env: "env".to_string(),
-            app_version: "1.3.5".to_string(),
-            tags: vec![],
-            process_tags: vec![
-                libdd_common::tag!("entrypoint.workdir", "libdd-remote-config"),
-                libdd_common::tag!("entrypoint.type", "script"),
+        Arc::new(Target::new(
+            "service",
+            "env",
+            "1.3.5",
+            vec![],
+            vec![
+                "entrypoint.workdir:libdd-remote-config".to_string(),
+                "entrypoint.type:script".to_string(),
             ],
-        })
+        ))
     });
 
     static DUMMY_RUNTIME_ID: &str = "3b43524b-a70c-45dc-921d-34504e50c5eb";

--- a/libdd-remote-config/src/fetch/fetcher.rs
+++ b/libdd-remote-config/src/fetch/fetcher.rs
@@ -596,13 +596,20 @@ pub mod tests {
             name: "config".to_string(),
         });
 
-    pub(crate) static DUMMY_TARGET: LazyLock<Arc<Target>> =
-        LazyLock::new(|| Arc::new(Target::new("service", "env", "1.3.5", vec![], vec![])));
+    pub(crate) static DUMMY_TARGET: LazyLock<Arc<Target>> = LazyLock::new(|| {
+        Arc::new(Target::new(
+            "service".to_string(),
+            "env".to_string(),
+            "1.3.5".to_string(),
+            vec![],
+            vec![],
+        ))
+    });
     pub(crate) static DUMMY_TARGET_WITH_PROCESS_TAGS: LazyLock<Arc<Target>> = LazyLock::new(|| {
         Arc::new(Target::new(
-            "service",
-            "env",
-            "1.3.5",
+            "service".to_string(),
+            "env".to_string(),
+            "1.3.5".to_string(),
             vec![],
             vec![
                 "entrypoint.workdir:libdd-remote-config".to_string(),

--- a/libdd-remote-config/src/fetch/shared.rs
+++ b/libdd-remote-config/src/fetch/shared.rs
@@ -379,15 +379,8 @@ pub mod tests {
     use futures::future::join_all;
     use std::sync::{Arc, LazyLock};
 
-    pub(crate) static OTHER_TARGET: LazyLock<Arc<Target>> = LazyLock::new(|| {
-        Arc::new(Target {
-            service: "other".to_string(),
-            env: "env".to_string(),
-            app_version: "7.8.9".to_string(),
-            tags: vec![],
-            process_tags: vec![],
-        })
-    });
+    pub(crate) static OTHER_TARGET: LazyLock<Arc<Target>> =
+        LazyLock::new(|| Arc::new(Target::new("other", "env", "7.8.9", vec![], vec![])));
 
     pub struct RcPathStore {
         pub store: Arc<PathStore>,

--- a/libdd-remote-config/src/fetch/shared.rs
+++ b/libdd-remote-config/src/fetch/shared.rs
@@ -379,8 +379,15 @@ pub mod tests {
     use futures::future::join_all;
     use std::sync::{Arc, LazyLock};
 
-    pub(crate) static OTHER_TARGET: LazyLock<Arc<Target>> =
-        LazyLock::new(|| Arc::new(Target::new("other", "env", "7.8.9", vec![], vec![])));
+    pub(crate) static OTHER_TARGET: LazyLock<Arc<Target>> = LazyLock::new(|| {
+        Arc::new(Target::new(
+            "other".to_string(),
+            "env".to_string(),
+            "7.8.9".to_string(),
+            vec![],
+            vec![],
+        ))
+    });
 
     pub struct RcPathStore {
         pub store: Arc<PathStore>,

--- a/libdd-remote-config/src/lib.rs
+++ b/libdd-remote-config/src/lib.rs
@@ -37,9 +37,9 @@ impl Target {
     /// Creates a new `Target`. `tags` and `process_tags` are expected as
     /// already-formatted `"key:value"` strings.
     pub fn new(
-        service: &str,
-        env: &str,
-        app_version: &str,
+        service: String,
+        env: String,
+        app_version: String,
         tags: Vec<String>,
         process_tags: Vec<String>,
     ) -> Target {

--- a/libdd-remote-config/src/lib.rs
+++ b/libdd-remote-config/src/lib.rs
@@ -22,17 +22,35 @@ mod targets;
 pub use parse::*;
 pub use path::*;
 
-pub use libdd_common::{tag::Tag, Endpoint};
-
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
 pub struct Target {
-    pub service: String,
-    pub env: String,
-    pub app_version: String,
-    pub tags: Vec<Tag>,
-    pub process_tags: Vec<Tag>,
+    service: String,
+    env: String,
+    app_version: String,
+    tags: Vec<String>,
+    process_tags: Vec<String>,
+}
+
+impl Target {
+    /// Creates a new `Target`. `tags` and `process_tags` are expected as
+    /// already-formatted `"key:value"` strings.
+    pub fn new(
+        service: &str,
+        env: &str,
+        app_version: &str,
+        tags: Vec<String>,
+        process_tags: Vec<String>,
+    ) -> Target {
+        Target {
+            service: service.to_string(),
+            env: env.to_string(),
+            app_version: app_version.to_string(),
+            tags,
+            process_tags,
+        }
+    }
 }
 
 #[repr(C)]

--- a/libdd-tracer-flare/src/lib.rs
+++ b/libdd-tracer-flare/src/lib.rs
@@ -191,13 +191,7 @@ impl TracerFlareManager {
 
         tracer_flare.listener = Some(SingleChangesFetcher::new(
             ParsedFileStorage::default(),
-            Target {
-                service,
-                env,
-                app_version,
-                tags: vec![],
-                process_tags: vec![],
-            },
+            Target::new(&service, &env, &app_version, vec![], vec![]),
             runtime_id,
             config_to_fetch,
         ));

--- a/libdd-tracer-flare/src/lib.rs
+++ b/libdd-tracer-flare/src/lib.rs
@@ -191,7 +191,7 @@ impl TracerFlareManager {
 
         tracer_flare.listener = Some(SingleChangesFetcher::new(
             ParsedFileStorage::default(),
-            Target::new(&service, &env, &app_version, vec![], vec![]),
+            Target::new(service, env, app_version, vec![], vec![]),
             runtime_id,
             config_to_fetch,
         ));


### PR DESCRIPTION
# What does this PR do?

Hide internal implementation so types are not leaked to the consumers

# Motivation

Avoid symol/crate duplication on downstream projects.
