### PR TITLE
ci(fuzz): fix gitlab fuzz job that has started to fail on main due to pulling in packages above MSRV

### DIFF
--- a/.gitlab/fuzz.yml
+++ b/.gitlab/fuzz.yml
@@ -24,7 +24,7 @@ fuzz:
     - VAULT_VERSION=1.15.4 && curl -fsSL "https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip" -o vault.zip && unzip vault.zip && mv vault /usr/local/bin/vault && rm vault.zip && chmod +x /usr/local/bin/vault
     - NIGHTLY_VERSION=$(awk -F'"' '/^channel[[:space:]]*=/ {print $2}' nightly-toolchain.toml)
     - rustup default "$NIGHTLY_VERSION"
-    - cargo install cargo-fuzz
+    - cargo +"$NIGHTLY_VERSION" install cargo-fuzz --locked
     - pip3 install requests toml
     - python3 fuzz/fuzz_infra.py
   allow_failure: true


### PR DESCRIPTION
# What does this PR do?
The fuzz job on gitlab has started to [fail on main](https://gitlab.ddbuild.io/DataDog/apm-reliability/libdatadog/-/jobs/1820649675
).

The job does rustup default nightly-2026-02-08 (rustc 1.95) at line 26, but cargo install then runs inside the repo directory, where rust-toolchain.toml pins channel = "1.87.0". A rust-toolchain.toml directory override beats the rustup default, so      cargo-fuzz gets compiled with 1.87.0.

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

[Ran the fuzz job manually on my PR](https://gitlab.ddbuild.io/DataDog/apm-reliability/libdatadog/-/jobs/1820747534) 