### PR TITLE
fix: update anyhow for unsoundness

### DIFF
--- a/.github/actions/Cargo.lock
+++ b/.github/actions/Cargo.lock
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arc-swap"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"

--- a/datadog-ffe-ffi/Cargo.toml
+++ b/datadog-ffe-ffi/Cargo.toml
@@ -21,7 +21,7 @@ cbindgen = ["build_common/cbindgen", "libdd-common-ffi/cbindgen"]
 build_common = { path = "../build-common" }
 
 [dependencies]
-anyhow = "1.0.93"
+anyhow = "1.0.103"
 datadog-ffe = { path = "../datadog-ffe", version = "=1.0.0" }
 libdd-common-ffi = { path = "../libdd-common-ffi", default-features = false }
 function_name = "0.3.0"

--- a/libdd-common/Cargo.toml
+++ b/libdd-common/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["lib"]
 bench = false
 
 [dependencies]
-anyhow = "1.0"
+anyhow = "1.0.103"
 futures = "0.3"
 futures-core = { version = "0.3.0", default-features = false }
 futures-util = { version = "0.3.0", default-features = false }

--- a/libdd-trace-obfuscation/src/replacer.rs
+++ b/libdd-trace-obfuscation/src/replacer.rs
@@ -126,7 +126,7 @@ pub fn parse_rules_from_string(
         let compiled_regex = match Regex::new(&raw_rule.pattern) {
             Ok(res) => res,
             Err(err) => {
-                anyhow::bail!("Obfuscator Error: Error while parsing rule: {}", err)
+                anyhow::bail!("Obfuscator Error: Error while parsing rule: {err}")
             }
         };
         let no_expansion = Replacer::no_expansion(&mut &raw_rule.repl).is_some();


### PR DESCRIPTION
# What does this PR do?

This updates anyhow from 1.0.93 to 1.0.103.

# Motivation

This update fixes an unsoundness issue, see [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190).

# Additional Notes

We do not use `Error::downcast_mut()`, so this does not directly affect us. Just being prudent.

# How to test the change?

Test as usual, this is a `Cargo.lock` change with one `clippy::uninlined-format-args` fix.
