### PR TITLE
ci(miri): skip slow miri tests

### DIFF
--- a/datadog-sidecar/src/service/ffe_exposures_flusher.rs
+++ b/datadog-sidecar/src/service/ffe_exposures_flusher.rs
@@ -216,6 +216,7 @@ mod tests {
         .await;
     }
 
+    #[cfg_attr(miri, ignore)] // tokio executor park/wake overhead is prohibitively slow under Miri
     #[tokio::test]
     async fn timeout_returns_without_waiting_for_http_response() {
         let ep = Endpoint {

--- a/datadog-sidecar/src/service/ffe_metrics_flusher.rs
+++ b/datadog-sidecar/src/service/ffe_metrics_flusher.rs
@@ -169,6 +169,7 @@ mod tests {
         .await;
     }
 
+    #[cfg_attr(miri, ignore)] // tokio executor park/wake overhead is prohibitively slow under Miri
     #[tokio::test]
     async fn timeout_returns_without_waiting_for_http_response() {
         let ep = Endpoint {

--- a/libdd-agent-client/src/builder.rs
+++ b/libdd-agent-client/src/builder.rs
@@ -310,6 +310,7 @@ mod tests {
         assert!(matches!(result, Err(BuildError::MissingLanguageMetadata)));
     }
 
+    #[cfg_attr(miri, ignore)] // real TLS/HTTP client construction is prohibitively slow under Miri
     #[test]
     fn build_succeeds_with_required_fields() {
         let _ = rustls::crypto::ring::default_provider().install_default();

--- a/libdd-agent-client/src/client.rs
+++ b/libdd-agent-client/src/client.rs
@@ -296,12 +296,14 @@ mod tests {
             .unwrap()
     }
 
+    #[cfg_attr(miri, ignore)] // real TLS/HTTP client construction is prohibitively slow under Miri
     #[test]
     fn builder_roundtrip() {
         let client = test_client(8126);
         assert!(client.base_url.contains("localhost"));
     }
 
+    #[cfg_attr(miri, ignore)] // real TLS/HTTP client construction is prohibitively slow under Miri
     #[test]
     fn static_headers_contain_language_metadata() {
         let client = test_client(8126);
@@ -315,6 +317,7 @@ mod tests {
         assert!(keys.contains(&"User-Agent"));
     }
 
+    #[cfg_attr(miri, ignore)] // real TLS/HTTP client construction is prohibitively slow under Miri
     #[test]
     fn extra_headers_propagated() {
         ensure_crypto_provider();

--- a/libdd-http-client/src/client.rs
+++ b/libdd-http-client/src/client.rs
@@ -110,6 +110,7 @@ mod tests {
         let _ = rustls::crypto::ring::default_provider().install_default();
     }
 
+    #[cfg_attr(miri, ignore)] // real TLS/HTTP client construction is prohibitively slow under Miri
     #[test]
     fn new_creates_client() {
         ensure_crypto_provider();
@@ -120,6 +121,7 @@ mod tests {
         assert_eq!(client.config().timeout(), Duration::from_secs(3));
     }
 
+    #[cfg_attr(miri, ignore)] // real TLS/HTTP client construction is prohibitively slow under Miri
     #[test]
     fn builder_creates_client() {
         ensure_crypto_provider();

--- a/libdd-http-client/src/config.rs
+++ b/libdd-http-client/src/config.rs
@@ -230,6 +230,7 @@ mod tests {
             .contains("timeout is required"));
     }
 
+    #[cfg_attr(miri, ignore)] // real TLS/HTTP client construction is prohibitively slow under Miri
     #[test]
     fn builder_success() {
         ensure_crypto_provider();
@@ -240,6 +241,7 @@ mod tests {
         assert!(client.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)] // real TLS/HTTP client construction is prohibitively slow under Miri
     #[test]
     fn builder_treat_http_errors_defaults_true() {
         ensure_crypto_provider();
@@ -251,6 +253,7 @@ mod tests {
         assert!(client.config().treat_http_errors_as_errors());
     }
 
+    #[cfg_attr(miri, ignore)] // real TLS/HTTP client construction is prohibitively slow under Miri
     #[test]
     fn builder_treat_http_errors_set_false() {
         ensure_crypto_provider();
@@ -263,6 +266,7 @@ mod tests {
         assert!(!client.config().treat_http_errors_as_errors());
     }
 
+    #[cfg_attr(miri, ignore)] // real TLS/HTTP client construction is prohibitively slow under Miri
     #[test]
     fn builder_allow_connection_pooling_defaults_true() {
         ensure_crypto_provider();
@@ -274,6 +278,7 @@ mod tests {
         assert!(client.config().allow_connection_pooling());
     }
 
+    #[cfg_attr(miri, ignore)] // real TLS/HTTP client construction is prohibitively slow under Miri
     #[test]
     fn builder_allow_connection_pooling_set_false() {
         ensure_crypto_provider();

--- a/libdd-telemetry/src/worker/mod.rs
+++ b/libdd-telemetry/src/worker/mod.rs
@@ -1344,6 +1344,7 @@ mod tests {
         b.build_worker(Some(rt.handle().clone())).1
     }
 
+    #[cfg_attr(miri, ignore)] // reqwest in build_worker
     #[test]
     fn telemetry_http_includes_dd_session_id() {
         let req = test_worker(Some("sess".into()), None, None)
@@ -1357,6 +1358,7 @@ mod tests {
         assert!(req.headers().get(DD_PARENT_SESSION_ID).is_none());
     }
 
+    #[cfg_attr(miri, ignore)] // reqwest in build_worker
     #[test]
     fn telemetry_http_omits_root_session_id_when_same_as_session_id() {
         let req = test_worker(
@@ -1381,6 +1383,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)] // reqwest in build_worker
     #[test]
     fn telemetry_http_omits_parent_session_id_when_same_as_session_id() {
         let req = test_worker(
@@ -1405,6 +1408,7 @@ mod tests {
         assert!(req.headers().get(DD_PARENT_SESSION_ID).is_none());
     }
 
+    #[cfg_attr(miri, ignore)] // reqwest in build_worker
     #[test]
     fn telemetry_http_omits_session_family_without_valid_session_id() {
         let assert_no_session_headers = |req: &http_common::HttpRequest| {
@@ -1428,6 +1432,7 @@ mod tests {
         assert_no_session_headers(&req);
     }
 
+    #[cfg_attr(miri, ignore)] // reqwest in build_worker
     #[test]
     fn telemetry_http_includes_dd_session_root_and_parent_session_ids() {
         let req = test_worker(
@@ -1600,6 +1605,7 @@ mod tests {
         }
 
         /// After reset(), pending buffered telemetry and dedupe history is cleared.
+        #[cfg_attr(miri, ignore)] // reqwest in build_worker
         #[tokio::test]
         async fn test_reset_clears_buffered_data() {
             let (handle, mut worker) = build_test_worker();
@@ -1685,6 +1691,7 @@ mod tests {
         }
 
         /// After reset(), actions queued in the mailbox before the fork are discarded.
+        #[cfg_attr(miri, ignore)] // reqwest in build_worker
         #[tokio::test]
         async fn test_reset_drains_mailbox() {
             let (handle, mut worker) = build_test_worker();
@@ -1726,6 +1733,7 @@ mod tests {
         }
 
         /// After reset(), the worker accepts new telemetry and processes it normally.
+        #[cfg_attr(miri, ignore)] // reqwest in build_worker
         #[tokio::test]
         async fn test_worker_accepts_new_data_after_reset() {
             let (handle, mut worker) = build_test_worker();
@@ -1753,6 +1761,7 @@ mod tests {
         }
 
         /// After reset(), lifecycle state needed to keep periodic flushing alive is preserved.
+        #[cfg_attr(miri, ignore)] // reqwest in build_worker
         #[tokio::test]
         async fn test_reset_preserves_started_and_deadlines() {
             let (_handle, mut worker) = build_test_worker();

--- a/libdd-trace-obfuscation/src/sql.rs
+++ b/libdd-trace-obfuscation/src/sql.rs
@@ -3302,6 +3302,7 @@ mod tests {
         ("-012345678", "?"),
     ];
 
+    #[cfg_attr(miri, ignore)] // large fixture suite, prohibitively slow under Miri
     #[test]
     fn test_sql_obfuscation_suite() {
         let mut errors = String::new();

--- a/libdd-trace-obfuscation/tests/test_span_obfuscation.rs
+++ b/libdd-trace-obfuscation/tests/test_span_obfuscation.rs
@@ -30,6 +30,7 @@ struct Testcase {
     expected: libdd_trace_protobuf::pb::Span,
 }
 
+#[cfg_attr(miri, ignore)] // large fixture suite, prohibitively slow under Miri
 #[test]
 fn test_obfuscate_span() {
     let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))

--- a/libdd-trace-utils/src/agentless_encoder/tests.rs
+++ b/libdd-trace-utils/src/agentless_encoder/tests.rs
@@ -30,6 +30,7 @@ fn json_from_bytes(b: &[u8]) -> Value {
     serde_json::from_slice(b).expect("payload must be valid JSON")
 }
 
+#[cfg_attr(miri, ignore)] // serde_json/rmp_serde overhead is prohibitively slow under Miri
 #[test]
 fn top_level_payload_shape_and_metadata() {
     let span: Span<BytesData> = Span {
@@ -81,6 +82,7 @@ fn top_level_payload_shape_and_metadata() {
     assert_eq!(meta["_dd.compute_stats"], "1");
 }
 
+#[cfg_attr(miri, ignore)] // serde_json/rmp_serde overhead is prohibitively slow under Miri
 #[test]
 fn resource_defaults_to_name_when_empty() {
     let span: Span<BytesData> = Span {
@@ -100,6 +102,7 @@ fn resource_defaults_to_name_when_empty() {
     assert_eq!(s["resource"], "op");
 }
 
+#[cfg_attr(miri, ignore)] // serde_json/rmp_serde overhead is prohibitively slow under Miri
 #[test]
 fn keeps_existing_dd_p_tid_in_meta() {
     // When the tracer already supplies `_dd.p.tid`, the encoder must pass it
@@ -128,6 +131,7 @@ fn keeps_existing_dd_p_tid_in_meta() {
     assert_eq!(meta["some.tag"], "kept");
 }
 
+#[cfg_attr(miri, ignore)] // serde_json/rmp_serde overhead is prohibitively slow under Miri
 #[test]
 fn span_links_serialised_into_meta_as_json_string() {
     // Span links are JSON-stringified and stored in meta["_dd.span_links"];
@@ -174,6 +178,7 @@ fn span_links_serialised_into_meta_as_json_string() {
     assert_eq!(link_obj["tracestate"], "dd=s:1");
 }
 
+#[cfg_attr(miri, ignore)] // serde_json/rmp_serde overhead is prohibitively slow under Miri
 #[test]
 fn span_events_serialised_into_meta_as_json_string() {
     // Span events are JSON-stringified and stored in meta["events"];
@@ -212,6 +217,7 @@ fn span_events_serialised_into_meta_as_json_string() {
     assert_eq!(evt["attributes"]["exception.message"], "timeout");
 }
 
+#[cfg_attr(miri, ignore)] // serde_json/rmp_serde overhead is prohibitively slow under Miri
 #[test]
 fn top_level_only_for_first_span_when_parent_in_other_service() {
     // Trace with two spans, parent in different service.
@@ -270,6 +276,7 @@ fn top_level_only_for_first_span_when_parent_in_other_service() {
     assert!(spans[2]["meta"].get("_dd.compute_stats").is_none());
 }
 
+#[cfg_attr(miri, ignore)] // serde_json/rmp_serde overhead is prohibitively slow under Miri
 #[test]
 fn meta_struct_msgpack_values_are_inlined_as_json_objects() {
     // `meta_struct` values are msgpack-encoded objects in memory. On the
@@ -327,6 +334,7 @@ fn meta_struct_msgpack_values_are_inlined_as_json_objects() {
     assert_eq!(inlined["list"], serde_json::json!([1, 2, 3]));
 }
 
+#[cfg_attr(miri, ignore)] // serde_json/rmp_serde overhead is prohibitively slow under Miri
 #[test]
 fn meta_struct_field_omitted_when_empty() {
     // No meta_struct entries -> the field is not emitted at all.

--- a/libdd-trace-utils/src/trace_filter.rs
+++ b/libdd-trace-utils/src/trace_filter.rs
@@ -403,6 +403,7 @@ mod tests {
         assert!(traces.is_empty());
     }
 
+    #[cfg_attr(miri, ignore)] // regex compilation is prohibitively slow under Miri
     #[test]
     fn reject_regex_value_no_match_keeps() {
         let mut traces = one_trace(span_with("r", &[("env", "staging")]));
@@ -646,6 +647,7 @@ mod tests {
         assert!(traces.is_empty());
     }
 
+    #[cfg_attr(miri, ignore)] // regex compilation is prohibitively slow under Miri
     #[test]
     fn regex_require_spaces_around_colon_keeps() {
         let mut traces = one_trace(span_with("r", &[("env", "production")]));


### PR DESCRIPTION
# What does this PR do?

Adds `#[cfg_attr(miri, ignore)]` to 34 SLOW tests.

# Motivation

The run-miri job partitions were taking 20-24 minutes each, dominated by 34 tests nextest flagged as SLOW (many 400-520s). None of these hang or exercise unsafe code Miri exists to check - they're slow because Miri must bytecode-interpret real TLS/HTTP client construction (rustls/ring crypto init, cert-store loading), tokio's executor park/wake machinery, large fixture-driven test loops, or regex-crate compilation/serde overhead on otherwise-trivial inputs.

# Additional Notes

I had claude sonnet 5 do all the analysis and judge the appropriate fixes, and had it leave justifications for why so we can audit that ourselves. They look reasonable to me.

# How to test the change?

Same as usual, should just be faster under miri.
