### PR TITLE
ci(benchmarks): skip perf benchmarks on merge-queue

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -9,6 +9,9 @@ benchmarks:
   image:
     name: $BASE_CI_IMAGE
   rules:
+    # Don't run on merge-queue working branches
+    - if: '$CI_COMMIT_BRANCH =~ /^mq-working-branch-/'
+      when: never
     - if: $CI_COMMIT_BRANCH == "main"
       interruptible: false
     - interruptible: true


### PR DESCRIPTION
# What does this PR do?

There is no point in running perf benchmarks on the MQ right now.

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
