### PR TITLE
fix(shared-runtime): wrap run() in select! so cancellation interrupts in-flight operations

### DIFF
--- a/libdd-shared-runtime/src/shared_runtime/pausable_worker.rs
+++ b/libdd-shared-runtime/src/shared_runtime/pausable_worker.rs
@@ -122,9 +122,16 @@ impl<T: Worker + MaybeSend + Sync + 'static> PausableWorker<T> {
                         _ = cloned_token.cancelled() => {
                             return worker;
                         }
-                        _ = worker.initial_trigger() => {
-                            worker.run().await;
-                        }
+                        _ = worker.initial_trigger() => {}
+                    }
+
+                    // First run — also cancellable so that a fork signal received
+                    // while run() is executing (e.g. mid-HTTP-request) exits
+                    // immediately rather than waiting for the request to complete.
+                    select! {
+                        biased;
+                        _ = cloned_token.cancelled() => { return worker; }
+                        _ = worker.run() => {}
                     }
 
                     // Regular iterations
@@ -134,9 +141,17 @@ impl<T: Worker + MaybeSend + Sync + 'static> PausableWorker<T> {
                             _ = cloned_token.cancelled() => {
                                 break;
                             }
-                            _ = worker.trigger() => {
-                                worker.run().await;
-                            }
+                            _ = worker.trigger() => {}
+                        }
+
+                        // run() is also wrapped in select! so that a cancellation
+                        // signal (e.g. from before_fork) interrupts an in-flight
+                        // operation at the next tokio yield point instead of
+                        // blocking until the operation completes.
+                        select! {
+                            biased;
+                            _ = cloned_token.cancelled() => { break; }
+                            _ = worker.run() => {}
                         }
                     }
                     worker
@@ -250,5 +265,59 @@ mod tests {
         }
         pausable_worker.start(tokio_spawn_fn(&handle)).unwrap();
         assert_eq!(receiver.recv().unwrap(), next_message);
+    }
+
+    /// Regression test: pause() must return promptly even when run() is executing
+    /// a long-running operation (e.g. an HTTP request to a slow agent).
+    ///
+    /// Before the fix, the task loop did not wrap `worker.run()` in a select!
+    /// against the cancellation token, so pause() had to wait for run() to
+    /// complete regardless of how long it took.
+    ///
+    /// After the fix, run() is also wrapped in select!, so cancelling the token
+    /// interrupts run() at its next tokio yield point, and pause() returns in
+    /// microseconds.
+    #[test]
+    fn test_pause_interrupts_long_running_run() {
+        /// Worker whose run() blocks for 10 seconds — simulates a slow agent.
+        #[derive(Debug)]
+        struct SlowWorker;
+
+        #[async_trait]
+        impl Worker for SlowWorker {
+            async fn run(&mut self) {
+                // Simulate a slow HTTP request (e.g. GET /info on an overloaded agent).
+                // Without the fix this holds up pause() for the full 10s.
+                sleep(Duration::from_secs(10)).await;
+            }
+
+            async fn trigger(&mut self) {
+                // Fire immediately so run() is called right away.
+            }
+        }
+
+        let runtime = Builder::new_multi_thread()
+            .enable_time()
+            .build()
+            .unwrap();
+        let handle = runtime.handle().clone();
+        let mut worker: PausableWorker<Box<dyn Worker + Sync>> =
+            PausableWorker::new(Box::new(SlowWorker));
+
+        worker.start(tokio_spawn_fn(&handle)).unwrap();
+
+        // Give the task time to enter run() and start the 10s sleep.
+        std::thread::sleep(Duration::from_millis(50));
+
+        // pause() must complete well within 1 second, not after the 10s run().
+        let start = std::time::Instant::now();
+        runtime.block_on(async { worker.pause().await.unwrap() });
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "pause() took {elapsed:?} — run() was not interrupted by cancellation token. \
+             Before the fix, this would have blocked for ~10s waiting for the slow HTTP request."
+        );
     }
 }


### PR DESCRIPTION
## What

`PausableWorker` wraps each `Worker` in a task loop. When `pause()` is called (e.g. from `before_fork()`), it cancels the stop token and awaits the task handle.

Before this change, the task loop checked the token **between** `trigger()` and `run()`, but not **during** `run()`:

```rust
loop {
    select! {
        biased;
        _ = cloned_token.cancelled() => { break; }  // ✓ checked here
        _ = worker.trigger() => {
            worker.run().await;  // ✗ token ignored here — run() blocks until done
        }
    }
}
```

If `run()` was executing when the token was cancelled, `pause()` had to wait for `run()` to return on its own.

## Contract

The `Worker` trait documents the expectation:

```rust
/// Code in this function must always use timeout on long-running await calls to avoid
/// blocking forks if an await call takes too long to complete.
async fn run(&mut self);
```

This put the burden on each implementation. This PR enforces it at the framework level instead: `run()` is now also wrapped in `select!` against the cancellation token. Implementations no longer need internal timeouts for fork safety — cancellation already happens at the right time and now propagates into `run()`.

## Concrete example

`AgentInfoFetcher::run()` makes an HTTP GET to `/info`. Without the fix, if a fork fires while the request is in flight:

```
before_fork()
  → pause() → stop_token.cancel()
  → handle.await
      task loop: select! → token cancelled? yes, but we're inside run().await
      AgentInfoFetcher::run() → HTTP GET /info → agent slow → blocks 2s
  → pause() returns after 2s
os.fork() returns after 2s
```

With the fix:

```
before_fork()
  → pause() → stop_token.cancel()
  → handle.await
      task loop: select! on run() → token already cancelled
      → exits at next .await inside HTTP client (~microseconds)
  → pause() returns in <1ms
os.fork() returns in <1ms
```

## Change

Two `select!` blocks added to the task loop in `PausableWorker::start()`, one for the initial run and one in the regular loop. No API changes.

## Testing

New test `test_pause_interrupts_long_running_run`: worker whose `run()` sleeps 10s. `pause()` must return in < 1s. Fails without the fix.

End-to-end in dd-trace-py against a fake agent that delays `/info` by 2s:

```
before_fork() without fix:   3005ms
before_fork() with fix:         1ms
```