### PR TITLE
fix(release): detect in-proposal dependency major bumps

### DIFF
--- a/.github/workflows/release-proposal-dispatch.yml
+++ b/.github/workflows/release-proposal-dispatch.yml
@@ -645,14 +645,17 @@ jobs:
           jq . /tmp/major-bumps-input.json
 
           # Run the audit in a throwaway worktree so extra worktrees / cargo metadata do not touch
-          # the job checkout. Check it out at the ref actually being released (the ephemeral release
-          # branch tip captured before version bumps), NOT github.sha: for a hotfix or older-ref
-          # release those differ, and auditing against current main could major-bump a crate for a
-          # dependency requirement change that is not present in the branch being released.
+          # the job checkout. Check it out at the proposal branch tip (HEAD) — the released ref plus
+          # this run's version bumps from the previous step. This is deliberate on both ends:
+          #   - It includes the dependency-requirement rewrites cargo-release made in the previous
+          #     step, so a dependency bumped to a new major IN THIS proposal propagates a major bump
+          #     to its dependents (e.g. protobuf 3->4 forces its dependents major).
+          #   - It is built from the released ref, NOT github.sha, so changes present only on current
+          #     main (and absent from a hotfix/older-ref release) never trigger a spurious bump.
           MAJOR_BUMPS_WT=$(mktemp -d "${RUNNER_TEMP:-/tmp}/major-bumps-wt.XXXXXX")
-          RELEASE_SHA=$(cat /tmp/release_head_sha)
+          PROPOSAL_SHA=$(git rev-parse HEAD)
 
-          git worktree add --detach "$MAJOR_BUMPS_WT" "$RELEASE_SHA"
+          git worktree add --detach "$MAJOR_BUMPS_WT" "$PROPOSAL_SHA"
           set +e
           ( cd "$MAJOR_BUMPS_WT" && "${WORKFLOW_SCRIPTS_ROOT}/major-bumps-level.sh" /tmp/major-bumps-input.json ) \
             > /tmp/api-changes-with-major-bumps-pre-commit.json


### PR DESCRIPTION
## What

The release-proposal major-bump audit now runs against the **proposal branch HEAD** (the released ref plus this run's version bumps) instead of the pre-bump release ref, so a crate whose direct `libdd-*` dependency is bumped to a new major **within the same proposal** is correctly escalated to a major bump.

## Why

In run [28800859299](https://github.com/DataDog/libdatadog/actions/runs/28800859299/job/85403702020) (PR #2199), `libdd-trace-protobuf` was bumped `3.0.2 → 4.0.0` and step 1 rewrote `libdd-trace-normalization`'s dependency requirement to `4.0.0` on the proposal branch — but `libdd-trace-normalization` only got a **minor** bump.

The audit worktree was checked out at `release_head_sha` (the released ref *before* step-1 bumps), where `libdd-trace-normalization` still required protobuf `^3` — same as its prev_tag — so no major diff was detected. Already-merged majors (e.g. `libdd-common ^4 → ^5`) worked because that change was already present at the released ref; only **in-proposal** majors were missed.

## How

Check the audit worktree out at `git rev-parse HEAD` (proposal branch tip) rather than `release_head_sha`.

| Reference | In-proposal dep majors | Already-merged majors | Main-only changes (hotfix risk) |
|---|---|---|---|
| `github.sha` | ❌ | ✅ | ❌ spurious |
| `release_head_sha` (pre-bump) | ❌ ← this bug | ✅ | ✅ excluded |
| **proposal HEAD** | ✅ | ✅ | ✅ excluded |

Proposal HEAD includes cargo-release's dependency-requirement rewrites from the previous step (so in-proposal majors propagate) while still being built from the released ref (so main-only changes absent from a hotfix/older-ref release don't trigger spurious bumps — preserving the guarantee from the earlier review of #2195). Pending no-commit crates now also propagate in-proposal dependency majors, not just already-merged ones.

## Testing

YAML validated. Behavior verified by tracing the failing run's logs against the new reference; the full workflow requires the CI runner + org tokens and was not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
