### PR TITLE
test(data-pipeline): gate telemetry-only tests behind the telemetry feature

### DIFF
--- a/libdd-data-pipeline/examples/send-traces-with-stats.rs
+++ b/libdd-data-pipeline/examples/send-traces-with-stats.rs
@@ -1,100 +1,119 @@
 // Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use clap::Parser;
-use libdd_capabilities_impl::NativeCapabilities;
-use libdd_data_pipeline::trace_exporter::{
-    TelemetryConfig, TraceExporter, TraceExporterInputFormat, TraceExporterOutputFormat,
-};
-use libdd_log::logger::{
-    logger_configure_std, logger_set_log_level, LogEventLevel, StdConfig, StdTarget,
-};
-use libdd_shared_runtime::{ForkSafeRuntime, SharedRuntime};
-use libdd_trace_protobuf::pb;
-use std::{
-    collections::HashMap,
-    sync::Arc,
-    time::{Duration, UNIX_EPOCH},
-};
+// This example exercises `enable_telemetry`, which is only available with the
+// `telemetry` feature. Gate the whole body on it so the example still compiles
+// (as a no-op) when the crate is built without default features.
+#[cfg(feature = "telemetry")]
+mod example {
+    use clap::Parser;
+    use libdd_capabilities_impl::NativeCapabilities;
+    use libdd_data_pipeline::trace_exporter::{
+        TelemetryConfig, TraceExporter, TraceExporterInputFormat, TraceExporterOutputFormat,
+    };
+    use libdd_log::logger::{
+        logger_configure_std, logger_set_log_level, LogEventLevel, StdConfig, StdTarget,
+    };
+    use libdd_shared_runtime::{ForkSafeRuntime, SharedRuntime};
+    use libdd_trace_protobuf::pb;
+    use std::{
+        collections::HashMap,
+        sync::Arc,
+        time::{Duration, UNIX_EPOCH},
+    };
 
-fn get_span(now: i64, trace_id: u64, span_id: u64) -> pb::Span {
-    pb::Span {
-        trace_id,
-        span_id,
-        parent_id: span_id - 1,
-        duration: trace_id as i64 % 3 * 10_000_000 + span_id as i64 * 1_000_000,
-        start: now + trace_id as i64 * 1_000_000_000 + span_id as i64 * 1_000_000,
-        service: "data-pipeline-test".to_string(),
-        name: format!("test-name-{}", span_id % 2),
-        resource: format!("test-resource-{}", (span_id + trace_id) % 3),
-        error: if trace_id.is_multiple_of(10) { 1 } else { 0 },
-        metrics: HashMap::from([
-            ("_sampling_priority_v1".to_string(), 1.0),
-            ("_dd.measured".to_string(), 1.0),
-        ]),
-        ..Default::default()
-    }
-}
-
-#[derive(Parser)]
-#[command(name = "send-traces-with-stats")]
-#[command(about = "A data pipeline example for sending traces with statistics")]
-struct Args {
-    #[arg(
-        short = 'u',
-        long = "url",
-        default_value = "http://localhost:8126",
-        help = "Set the trace agent URL\n\nExamples:\n  http://localhost:8126 (default)\n  windows://./pipe/dd-apm-test-agent (Windows named pipe)\n  https://trace.agent.datadoghq.com:443 (custom endpoint)"
-    )]
-    url: String,
-}
-
-fn main() {
-    logger_configure_std(StdConfig {
-        target: StdTarget::Out,
-    })
-    .expect("Failed to configure logger");
-    logger_set_log_level(LogEventLevel::Debug).expect("Failed to set log level");
-
-    let shared_runtime = Arc::new(ForkSafeRuntime::new().expect("Failed to create runtime"));
-
-    let args = Args::parse();
-    let telemetry_cfg = TelemetryConfig::default();
-    let mut builder = TraceExporter::<NativeCapabilities, ForkSafeRuntime>::builder();
-    builder
-        .set_url(&args.url)
-        .set_hostname("test")
-        .set_env("testing")
-        .set_app_version(env!("CARGO_PKG_VERSION"))
-        .set_service("data-pipeline-test")
-        .set_tracer_version(env!("CARGO_PKG_VERSION"))
-        .set_language("rust")
-        .set_language_version(env!("CARGO_PKG_RUST_VERSION"))
-        .set_input_format(TraceExporterInputFormat::V04)
-        .set_output_format(TraceExporterOutputFormat::V04)
-        .set_shared_runtime(shared_runtime.clone())
-        .enable_telemetry(telemetry_cfg)
-        .enable_stats(Duration::from_secs(10));
-    let exporter = builder
-        .build::<NativeCapabilities>()
-        .expect("Failed to build TraceExporter");
-    let now = UNIX_EPOCH
-        .elapsed()
-        .expect("Failed to get time since UNIX_EPOCH")
-        .as_nanos() as i64;
-
-    let mut traces = Vec::new();
-    for trace_id in 1..=2 {
-        let mut trace = Vec::new();
-        for span_id in 1..=2 {
-            trace.push(get_span(now, trace_id, span_id));
+    fn get_span(now: i64, trace_id: u64, span_id: u64) -> pb::Span {
+        pb::Span {
+            trace_id,
+            span_id,
+            parent_id: span_id - 1,
+            duration: trace_id as i64 % 3 * 10_000_000 + span_id as i64 * 1_000_000,
+            start: now + trace_id as i64 * 1_000_000_000 + span_id as i64 * 1_000_000,
+            service: "data-pipeline-test".to_string(),
+            name: format!("test-name-{}", span_id % 2),
+            resource: format!("test-resource-{}", (span_id + trace_id) % 3),
+            error: if trace_id.is_multiple_of(10) { 1 } else { 0 },
+            metrics: HashMap::from([
+                ("_sampling_priority_v1".to_string(), 1.0),
+                ("_dd.measured".to_string(), 1.0),
+            ]),
+            ..Default::default()
         }
-        traces.push(trace);
     }
-    let data = rmp_serde::to_vec_named(&traces).expect("Failed to serialize traces");
 
-    exporter.send(data.as_ref()).expect("Failed to send traces");
-    shared_runtime
-        .shutdown(None)
-        .expect("Failed to shutdown runtime");
+    #[derive(Parser)]
+    #[command(name = "send-traces-with-stats")]
+    #[command(about = "A data pipeline example for sending traces with statistics")]
+    struct Args {
+        #[arg(
+            short = 'u',
+            long = "url",
+            default_value = "http://localhost:8126",
+            help = "Set the trace agent URL\n\nExamples:\n  http://localhost:8126 (default)\n  windows://./pipe/dd-apm-test-agent (Windows named pipe)\n  https://trace.agent.datadoghq.com:443 (custom endpoint)"
+        )]
+        url: String,
+    }
+
+    pub fn run() {
+        logger_configure_std(StdConfig {
+            target: StdTarget::Out,
+        })
+        .expect("Failed to configure logger");
+        logger_set_log_level(LogEventLevel::Debug).expect("Failed to set log level");
+
+        let shared_runtime = Arc::new(ForkSafeRuntime::new().expect("Failed to create runtime"));
+
+        let args = Args::parse();
+        let telemetry_cfg = TelemetryConfig::default();
+        let mut builder = TraceExporter::<NativeCapabilities, ForkSafeRuntime>::builder();
+        builder
+            .set_url(&args.url)
+            .set_hostname("test")
+            .set_env("testing")
+            .set_app_version(env!("CARGO_PKG_VERSION"))
+            .set_service("data-pipeline-test")
+            .set_tracer_version(env!("CARGO_PKG_VERSION"))
+            .set_language("rust")
+            .set_language_version(env!("CARGO_PKG_RUST_VERSION"))
+            .set_input_format(TraceExporterInputFormat::V04)
+            .set_output_format(TraceExporterOutputFormat::V04)
+            .set_shared_runtime(shared_runtime.clone())
+            .enable_telemetry(telemetry_cfg)
+            .enable_stats(Duration::from_secs(10));
+        let exporter = builder
+            .build::<NativeCapabilities>()
+            .expect("Failed to build TraceExporter");
+        let now = UNIX_EPOCH
+            .elapsed()
+            .expect("Failed to get time since UNIX_EPOCH")
+            .as_nanos() as i64;
+
+        let mut traces = Vec::new();
+        for trace_id in 1..=2 {
+            let mut trace = Vec::new();
+            for span_id in 1..=2 {
+                trace.push(get_span(now, trace_id, span_id));
+            }
+            traces.push(trace);
+        }
+        let data = rmp_serde::to_vec_named(&traces).expect("Failed to serialize traces");
+
+        exporter.send(data.as_ref()).expect("Failed to send traces");
+        shared_runtime
+            .shutdown(None)
+            .expect("Failed to shutdown runtime");
+    }
+}
+
+#[cfg(feature = "telemetry")]
+fn main() {
+    example::run();
+}
+
+#[cfg(not(feature = "telemetry"))]
+fn main() {
+    eprintln!(
+        "This example requires the `telemetry` feature. Rebuild with \
+         `--features telemetry` (enabled by default)."
+    );
 }

--- a/libdd-data-pipeline/src/trace_exporter/builder.rs
+++ b/libdd-data-pipeline/src/trace_exporter/builder.rs
@@ -986,12 +986,13 @@ mod tests {
             .set_git_commit_sha("797e9ea")
             .set_input_format(TraceExporterInputFormat::V04)
             .set_output_format(TraceExporterOutputFormat::V04)
-            .set_client_computed_stats()
-            .enable_telemetry(TelemetryConfig {
-                heartbeat: 1000,
-                runtime_id: None,
-                debug_enabled: false,
-            });
+            .set_client_computed_stats();
+        #[cfg(feature = "telemetry")]
+        builder.enable_telemetry(TelemetryConfig {
+            heartbeat: 1000,
+            runtime_id: None,
+            debug_enabled: false,
+        });
         let exporter = builder.build::<NativeCapabilities>().unwrap();
 
         assert_eq!(
@@ -1009,6 +1010,7 @@ mod tests {
         assert_eq!(exporter.metadata.language_interpreter_vendor, "node");
         assert_eq!(exporter.metadata.git_commit_sha, "797e9ea");
         assert!(exporter.metadata.client_computed_stats);
+        #[cfg(feature = "telemetry")]
         assert!(exporter.telemetry.is_some());
     }
 
@@ -1031,6 +1033,7 @@ mod tests {
         assert_eq!(exporter.metadata.language_version, "");
         assert_eq!(exporter.metadata.language_interpreter, "");
         assert!(!exporter.metadata.client_computed_stats);
+        #[cfg(feature = "telemetry")]
         assert!(exporter.telemetry.is_none());
     }
 
@@ -1155,6 +1158,7 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "telemetry")]
     #[cfg_attr(miri, ignore)]
     #[test]
     fn test_agentless_skips_info_fetcher_and_telemetry() {

--- a/libdd-data-pipeline/src/trace_exporter/mod.rs
+++ b/libdd-data-pipeline/src/trace_exporter/mod.rs
@@ -1118,11 +1118,7 @@ mod tests {
     use libdd_tinybytes::BytesString;
     use libdd_trace_utils::msgpack_encoder;
     use libdd_trace_utils::span::v04::SpanBytes;
-    use libdd_trace_utils::span::v05;
     use std::net;
-
-    // v05 messagepack empty payload -> [[""], []]
-    const V5_EMPTY: [u8; 4] = [0x92, 0x91, 0xA0, 0x90];
 
     #[test]
     fn test_from_tracer_tags_to_tracer_header_tags() {
@@ -1322,7 +1318,7 @@ mod tests {
         datagram.trim_matches(char::from(0)).to_string()
     }
 
-    fn build_test_exporter(
+    pub(crate) fn build_test_exporter(
         url: String,
         dogstatsd_url: Option<String>,
         input: TraceExporterInputFormat,
@@ -1351,6 +1347,7 @@ mod tests {
         };
 
         if enable_telemetry {
+            #[cfg(feature = "telemetry")]
             builder.enable_telemetry(TelemetryConfig {
                 heartbeat: 100,
                 ..Default::default()
@@ -1971,172 +1968,6 @@ mod tests {
 
     #[test]
     #[cfg_attr(miri, ignore)]
-    fn test_exporter_metrics_v4() {
-        let server = MockServer::start();
-        let response_body = r#"{
-                        "rate_by_service": {
-                            "service:foo,env:staging": 1.0,
-                            "service:,env:": 0.8
-                        }
-                    }"#;
-        let traces_endpoint = server.mock(|when, then| {
-            when.method(POST).path(V04_TRACES_ENDPOINT);
-            then.status(200)
-                .header("content-type", "application/json")
-                .body(response_body);
-        });
-
-        let metrics_endpoint = server.mock(|when, then| {
-            when.method(POST)
-                .body_includes("\"metric\":\"trace_api.bytes\"")
-                .path("/telemetry/proxy/api/v2/apmtelemetry");
-            then.status(200)
-                .header("content-type", "application/json")
-                .body("");
-        });
-
-        let mut builder = TraceExporter::<NativeCapabilities, ForkSafeRuntime>::builder();
-        builder
-            .set_url(&server.url("/"))
-            .set_service("foo")
-            .set_env("foo-env")
-            .set_tracer_version("v0.1")
-            .set_language("nodejs")
-            .set_language_version("1.0")
-            .set_language_interpreter("v8")
-            .enable_telemetry(TelemetryConfig {
-                heartbeat: 100,
-                ..Default::default()
-            });
-        let exporter = builder.build::<NativeCapabilities>().unwrap();
-
-        let traces = vec![0x90];
-        let result = exporter.send(traces.as_ref()).unwrap();
-        let AgentResponse::Changed { body } = result else {
-            panic!("Expected Changed response");
-        };
-        assert_eq!(body, response_body);
-
-        traces_endpoint.assert_calls(1);
-        while metrics_endpoint.calls() == 0 {
-            std::thread::sleep(Duration::from_millis(100));
-        }
-        metrics_endpoint.assert_calls(1);
-    }
-
-    #[test]
-    #[cfg_attr(miri, ignore)]
-    fn test_exporter_metrics_v5() {
-        let server = MockServer::start();
-        let response_body = r#"{
-                        "rate_by_service": {
-                            "service:foo,env:staging": 1.0,
-                            "service:,env:": 0.8
-                        }
-                    }"#;
-        let traces_endpoint = server.mock(|when, then| {
-            when.method(POST).path(V05_TRACES_ENDPOINT);
-            then.status(200)
-                .header("content-type", "application/json")
-                .body(response_body);
-        });
-
-        let metrics_endpoint = server.mock(|when, then| {
-            when.method(POST)
-                .body_includes("\"metric\":\"trace_api.bytes\"")
-                .path("/telemetry/proxy/api/v2/apmtelemetry");
-            then.status(200)
-                .header("content-type", "application/json")
-                .body("");
-        });
-
-        let exporter = build_test_exporter(
-            server.url("/"),
-            None,
-            TraceExporterInputFormat::V05,
-            TraceExporterOutputFormat::V05,
-            true,
-            true,
-        );
-
-        let v5: (Vec<BytesString>, Vec<Vec<v05::Span>>) = (vec![], vec![]);
-        let traces = rmp_serde::to_vec(&v5).unwrap();
-        let result = exporter.send(traces.as_ref()).unwrap();
-        let AgentResponse::Changed { body } = result else {
-            panic!("Expected Changed response");
-        };
-        assert_eq!(body, response_body);
-
-        traces_endpoint.assert_calls(1);
-        while metrics_endpoint.calls() == 0 {
-            std::thread::sleep(Duration::from_millis(100));
-        }
-        metrics_endpoint.assert_calls(1);
-    }
-
-    #[test]
-    #[cfg_attr(miri, ignore)]
-    fn test_exporter_metrics_v4_to_v5() {
-        let server = MockServer::start();
-        let response_body = r#"{
-                        "rate_by_service": {
-                            "service:foo,env:staging": 1.0,
-                            "service:,env:": 0.8
-                        }
-                    }"#;
-        let traces_endpoint = server.mock(|when, then| {
-            when.method(POST).path(V05_TRACES_ENDPOINT).is_true(|req| {
-                let bytes = libdd_tinybytes::Bytes::copy_from_slice(req.body_ref());
-                bytes.to_vec() == V5_EMPTY
-            });
-            then.status(200)
-                .header("content-type", "application/json")
-                .body(response_body);
-        });
-
-        let metrics_endpoint = server.mock(|when, then| {
-            when.method(POST)
-                .body_includes("\"metric\":\"trace_api.bytes\"")
-                .path("/telemetry/proxy/api/v2/apmtelemetry");
-            then.status(200)
-                .header("content-type", "application/json")
-                .body("");
-        });
-
-        let mut builder = TraceExporter::<NativeCapabilities, ForkSafeRuntime>::builder();
-        builder
-            .set_url(&server.url("/"))
-            .set_service("foo")
-            .set_env("foo-env")
-            .set_tracer_version("v0.1")
-            .set_language("nodejs")
-            .set_language_version("1.0")
-            .set_language_interpreter("v8")
-            .enable_telemetry(TelemetryConfig {
-                heartbeat: 100,
-                ..Default::default()
-            })
-            .set_input_format(TraceExporterInputFormat::V04)
-            .set_output_format(TraceExporterOutputFormat::V05);
-
-        let exporter = builder.build::<NativeCapabilities>().unwrap();
-
-        let traces = vec![0x90];
-        let result = exporter.send(traces.as_ref()).unwrap();
-        let AgentResponse::Changed { body } = result else {
-            panic!("Expected Changed response");
-        };
-        assert_eq!(body, response_body);
-
-        traces_endpoint.assert_calls(1);
-        while metrics_endpoint.calls() == 0 {
-            std::thread::sleep(Duration::from_millis(100));
-        }
-        metrics_endpoint.assert_calls(1);
-    }
-
-    #[test]
-    #[cfg_attr(miri, ignore)]
     /// Tests that if agent_response_payload_version is not enabled
     /// the exporter always returns the response body
     fn test_agent_response_payload_version_disabled() {
@@ -2481,6 +2312,188 @@ mod tests {
         let data = msgpack_encoder::v04::to_vec(&traces);
         exporter.send(data.as_ref()).unwrap();
         mock_intake.assert();
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "telemetry")]
+mod telemetry_metrics_tests {
+    use super::*;
+    use crate::trace_exporter::tests::build_test_exporter;
+    use httpmock::prelude::*;
+    use httpmock::MockServer;
+    use libdd_capabilities_impl::NativeCapabilities;
+    use libdd_shared_runtime::ForkSafeRuntime;
+    use libdd_tinybytes::BytesString;
+    use libdd_trace_utils::span::v05;
+
+    // v05 messagepack empty payload -> [[""], []]
+    const V5_EMPTY: [u8; 4] = [0x92, 0x91, 0xA0, 0x90];
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_exporter_metrics_v4() {
+        let server = MockServer::start();
+        let response_body = r#"{
+                    "rate_by_service": {
+                        "service:foo,env:staging": 1.0,
+                        "service:,env:": 0.8
+                    }
+                }"#;
+        let traces_endpoint = server.mock(|when, then| {
+            when.method(POST).path(V04_TRACES_ENDPOINT);
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(response_body);
+        });
+
+        let metrics_endpoint = server.mock(|when, then| {
+            when.method(POST)
+                .body_includes("\"metric\":\"trace_api.bytes\"")
+                .path("/telemetry/proxy/api/v2/apmtelemetry");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body("");
+        });
+
+        let mut builder = TraceExporter::<NativeCapabilities, ForkSafeRuntime>::builder();
+        builder
+            .set_url(&server.url("/"))
+            .set_service("foo")
+            .set_env("foo-env")
+            .set_tracer_version("v0.1")
+            .set_language("nodejs")
+            .set_language_version("1.0")
+            .set_language_interpreter("v8")
+            .enable_telemetry(TelemetryConfig {
+                heartbeat: 100,
+                ..Default::default()
+            });
+        let exporter = builder.build::<NativeCapabilities>().unwrap();
+
+        let traces = vec![0x90];
+        let result = exporter.send(traces.as_ref()).unwrap();
+        let AgentResponse::Changed { body } = result else {
+            panic!("Expected Changed response");
+        };
+        assert_eq!(body, response_body);
+
+        traces_endpoint.assert_calls(1);
+        while metrics_endpoint.calls() == 0 {
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        metrics_endpoint.assert_calls(1);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_exporter_metrics_v5() {
+        let server = MockServer::start();
+        let response_body = r#"{
+                    "rate_by_service": {
+                        "service:foo,env:staging": 1.0,
+                        "service:,env:": 0.8
+                    }
+                }"#;
+        let traces_endpoint = server.mock(|when, then| {
+            when.method(POST).path(V05_TRACES_ENDPOINT);
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(response_body);
+        });
+
+        let metrics_endpoint = server.mock(|when, then| {
+            when.method(POST)
+                .body_includes("\"metric\":\"trace_api.bytes\"")
+                .path("/telemetry/proxy/api/v2/apmtelemetry");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body("");
+        });
+
+        let exporter = build_test_exporter(
+            server.url("/"),
+            None,
+            TraceExporterInputFormat::V05,
+            TraceExporterOutputFormat::V05,
+            true,
+            true,
+        );
+
+        let v5: (Vec<BytesString>, Vec<Vec<v05::Span>>) = (vec![], vec![]);
+        let traces = rmp_serde::to_vec(&v5).unwrap();
+        let result = exporter.send(traces.as_ref()).unwrap();
+        let AgentResponse::Changed { body } = result else {
+            panic!("Expected Changed response");
+        };
+        assert_eq!(body, response_body);
+
+        traces_endpoint.assert_calls(1);
+        while metrics_endpoint.calls() == 0 {
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        metrics_endpoint.assert_calls(1);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_exporter_metrics_v4_to_v5() {
+        let server = MockServer::start();
+        let response_body = r#"{
+                    "rate_by_service": {
+                        "service:foo,env:staging": 1.0,
+                        "service:,env:": 0.8
+                    }
+                }"#;
+        let traces_endpoint = server.mock(|when, then| {
+            when.method(POST).path(V05_TRACES_ENDPOINT).is_true(|req| {
+                let bytes = libdd_tinybytes::Bytes::copy_from_slice(req.body_ref());
+                bytes.to_vec() == V5_EMPTY
+            });
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(response_body);
+        });
+
+        let metrics_endpoint = server.mock(|when, then| {
+            when.method(POST)
+                .body_includes("\"metric\":\"trace_api.bytes\"")
+                .path("/telemetry/proxy/api/v2/apmtelemetry");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body("");
+        });
+
+        let mut builder = TraceExporter::<NativeCapabilities, ForkSafeRuntime>::builder();
+        builder
+            .set_url(&server.url("/"))
+            .set_service("foo")
+            .set_env("foo-env")
+            .set_tracer_version("v0.1")
+            .set_language("nodejs")
+            .set_language_version("1.0")
+            .set_language_interpreter("v8")
+            .enable_telemetry(TelemetryConfig {
+                heartbeat: 100,
+                ..Default::default()
+            })
+            .set_input_format(TraceExporterInputFormat::V04)
+            .set_output_format(TraceExporterOutputFormat::V05);
+
+        let exporter = builder.build::<NativeCapabilities>().unwrap();
+
+        let traces = vec![0x90];
+        let result = exporter.send(traces.as_ref()).unwrap();
+        let AgentResponse::Changed { body } = result else {
+            panic!("Expected Changed response");
+        };
+        assert_eq!(body, response_body);
+
+        traces_endpoint.assert_calls(1);
+        while metrics_endpoint.calls() == 0 {
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        metrics_endpoint.assert_calls(1);
     }
 }
 

--- a/libdd-data-pipeline/src/trace_exporter/stats.rs
+++ b/libdd-data-pipeline/src/trace_exporter/stats.rs
@@ -332,6 +332,8 @@ pub(crate) fn process_traces_for_stats<T: libdd_trace_utils::span::TraceData>(
     } = &**status
     {
         let dropped_by_trace_filter = trace_filterer.filter_traces(traces);
+        #[cfg(not(all(not(target_arch = "wasm32"), feature = "telemetry")))]
+        let _ = dropped_by_trace_filter;
 
         if !client_computed_top_level {
             for chunk in traces.iter_mut() {


### PR DESCRIPTION
# What does this PR do?

Building the crate with `--no-default-features` (telemetry off) failed to compile because several tests and one example referenced `TelemetryConfig` and `TraceExporterBuilder::enable_telemetry`, both of which are gated behind the `telemetry` feature.

Gate the telemetry-dependent test code and the `send-traces-with-stats` example accordingly, and silence an unused-variable warning in stats.rs for non-telemetry builds. Non-telemetry tests in `test_new`/`test_new_defaults` still run.
