### PR TITLE
ci: exclude release-proposal wfs from green_ci and exclude benchmarks on release* branches

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -81,6 +81,7 @@ scripts/check_crypto_providers.sh    @DataDog/libdatadog-core
 scripts/commits-since-release.sh     @DataDog/libdatadog-core
 scripts/create-release.sh            @DataDog/apm-common-components-core
 scripts/crates-to-package.sh         @DataDog/libdatadog-core
+scripts/exclude-from-green-ci.sh     @DataDog/libdatadog-core
 scripts/major-bumps-level.sh         @DataDog/libdatadog-core
 scripts/publication-order.sh         @DataDog/libdatadog-core
 scripts/reformat_copyright.sh        @DataDog/libdatadog-core

--- a/.github/workflows/release-proposal-dispatch.yml
+++ b/.github/workflows/release-proposal-dispatch.yml
@@ -45,32 +45,14 @@ jobs:
       crates_branch: ${{ steps.normalize.outputs.crates_branch }}
       count: ${{ steps.normalize.outputs.count }}
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+
       - name: Exclude from Green CI
         env:
           DATADOG_SITE: datadoghq.com
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
-        run: |
-          # Download the pinned, checksum-verified datadog-ci binary instead of
-          # `npm install -g`, so no third-party install-time code runs with the
-          # Datadog API key in its environment.
-          URL="https://github.com/DataDog/datadog-ci/releases/download/v5.21.0/datadog-ci_linux-x64"
-          OUTPUT="datadog-ci"
-          EXPECTED_CHECKSUM="be4a6473fc451fec967ff277df3856060814b9a54d707d055a9c1542ae2869f0"
+        run: ./scripts/exclude-from-green-ci.sh
 
-          echo "Downloading datadog-ci from $URL"
-          curl -L --fail --retry 3 -o "$OUTPUT" "$URL"
-          chmod +x "$OUTPUT"
-
-          ACTUAL_CHECKSUM=$(sha256sum "$OUTPUT" | cut -d' ' -f1)
-          if [ "$ACTUAL_CHECKSUM" != "$EXPECTED_CHECKSUM" ]; then
-            echo "Checksum verification failed! expected=$EXPECTED_CHECKSUM actual=$ACTUAL_CHECKSUM"
-            exit 1
-          fi
-          echo "Checksum verification passed"
-
-          ./"$OUTPUT" tag --level pipeline --tags green_ci.excluded:true
-
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - name: Normalize and validate crate list
         id: normalize
         env:

--- a/.github/workflows/release-proposal-dispatch.yml
+++ b/.github/workflows/release-proposal-dispatch.yml
@@ -50,8 +50,25 @@ jobs:
           DATADOG_SITE: datadoghq.com
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
         run: |
-          npm install -g @datadog/datadog-ci
-          datadog-ci tag --level pipeline --tags green_ci.excluded:true
+          # Download the pinned, checksum-verified datadog-ci binary instead of
+          # `npm install -g`, so no third-party install-time code runs with the
+          # Datadog API key in its environment.
+          URL="https://github.com/DataDog/datadog-ci/releases/download/v5.21.0/datadog-ci_linux-x64"
+          OUTPUT="datadog-ci"
+          EXPECTED_CHECKSUM="be4a6473fc451fec967ff277df3856060814b9a54d707d055a9c1542ae2869f0"
+
+          echo "Downloading datadog-ci from $URL"
+          curl -L --fail --retry 3 -o "$OUTPUT" "$URL"
+          chmod +x "$OUTPUT"
+
+          ACTUAL_CHECKSUM=$(sha256sum "$OUTPUT" | cut -d' ' -f1)
+          if [ "$ACTUAL_CHECKSUM" != "$EXPECTED_CHECKSUM" ]; then
+            echo "Checksum verification failed! expected=$EXPECTED_CHECKSUM actual=$ACTUAL_CHECKSUM"
+            exit 1
+          fi
+          echo "Checksum verification passed"
+
+          ./"$OUTPUT" tag --level pipeline --tags green_ci.excluded:true
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - name: Normalize and validate crate list

--- a/.github/workflows/release-proposal-dispatch.yml
+++ b/.github/workflows/release-proposal-dispatch.yml
@@ -45,6 +45,14 @@ jobs:
       crates_branch: ${{ steps.normalize.outputs.crates_branch }}
       count: ${{ steps.normalize.outputs.count }}
     steps:
+      - name: Exclude from Green CI
+        env:
+          DATADOG_SITE: datadoghq.com
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+        run: |
+          npm install -g @datadog/datadog-ci
+          datadog-ci tag --level pipeline --tags green_ci.excluded:true
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - name: Normalize and validate crate list
         id: normalize

--- a/.github/workflows/release-proposal-test.yml
+++ b/.github/workflows/release-proposal-test.yml
@@ -16,6 +16,14 @@ jobs:
     outputs:
       upload_artifact: ${{ steps.package-crates.outputs.upload_artifact }}
     steps:
+      - name: Exclude from Green CI
+        env:
+          DATADOG_SITE: datadoghq.com
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+        run: |
+          npm install -g @datadog/datadog-ci
+          datadog-ci tag --level pipeline --tags green_ci.excluded:true
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
         with:
           fetch-depth: 0

--- a/.github/workflows/release-proposal-test.yml
+++ b/.github/workflows/release-proposal-test.yml
@@ -21,8 +21,25 @@ jobs:
           DATADOG_SITE: datadoghq.com
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
         run: |
-          npm install -g @datadog/datadog-ci
-          datadog-ci tag --level pipeline --tags green_ci.excluded:true
+          # Download the pinned, checksum-verified datadog-ci binary instead of
+          # `npm install -g`, so no third-party install-time code runs with the
+          # Datadog API key in its environment.
+          URL="https://github.com/DataDog/datadog-ci/releases/download/v5.21.0/datadog-ci_linux-x64"
+          OUTPUT="datadog-ci"
+          EXPECTED_CHECKSUM="be4a6473fc451fec967ff277df3856060814b9a54d707d055a9c1542ae2869f0"
+
+          echo "Downloading datadog-ci from $URL"
+          curl -L --fail --retry 3 -o "$OUTPUT" "$URL"
+          chmod +x "$OUTPUT"
+
+          ACTUAL_CHECKSUM=$(sha256sum "$OUTPUT" | cut -d' ' -f1)
+          if [ "$ACTUAL_CHECKSUM" != "$EXPECTED_CHECKSUM" ]; then
+            echo "Checksum verification failed! expected=$EXPECTED_CHECKSUM actual=$ACTUAL_CHECKSUM"
+            exit 1
+          fi
+          echo "Checksum verification passed"
+
+          ./"$OUTPUT" tag --level pipeline --tags green_ci.excluded:true
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
         with:

--- a/.github/workflows/release-proposal-test.yml
+++ b/.github/workflows/release-proposal-test.yml
@@ -16,36 +16,18 @@ jobs:
     outputs:
       upload_artifact: ${{ steps.package-crates.outputs.upload_artifact }}
     steps:
-      - name: Exclude from Green CI
-        env:
-          DATADOG_SITE: datadoghq.com
-          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
-        run: |
-          # Download the pinned, checksum-verified datadog-ci binary instead of
-          # `npm install -g`, so no third-party install-time code runs with the
-          # Datadog API key in its environment.
-          URL="https://github.com/DataDog/datadog-ci/releases/download/v5.21.0/datadog-ci_linux-x64"
-          OUTPUT="datadog-ci"
-          EXPECTED_CHECKSUM="be4a6473fc451fec967ff277df3856060814b9a54d707d055a9c1542ae2869f0"
-
-          echo "Downloading datadog-ci from $URL"
-          curl -L --fail --retry 3 -o "$OUTPUT" "$URL"
-          chmod +x "$OUTPUT"
-
-          ACTUAL_CHECKSUM=$(sha256sum "$OUTPUT" | cut -d' ' -f1)
-          if [ "$ACTUAL_CHECKSUM" != "$EXPECTED_CHECKSUM" ]; then
-            echo "Checksum verification failed! expected=$EXPECTED_CHECKSUM actual=$ACTUAL_CHECKSUM"
-            exit 1
-          fi
-          echo "Checksum verification passed"
-
-          ./"$OUTPUT" tag --level pipeline --tags green_ci.excluded:true
-
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
         with:
           fetch-depth: 0
           # Checkout PR head (not the synthetic merge commit) so version comparison matches the proposal branch.
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
+      - name: Exclude from Green CI
+        env:
+          DATADOG_SITE: datadoghq.com
+          DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
+        run: ./scripts/exclude-from-green-ci.sh
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: 1.92.0

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -12,6 +12,8 @@ benchmarks:
     # Don't run on merge-queue working branches
     - if: '$CI_COMMIT_BRANCH =~ /^mq-working-branch-/'
       when: never
+    - if: '$CI_COMMIT_BRANCH =~ /^release([-\/]|$)/'
+      when: never
     - if: $CI_COMMIT_BRANCH == "main"
       interruptible: false
     - interruptible: true

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -10,9 +10,9 @@ variables:
 .benchmark_run_rules: &benchmark_run_rules
   - if: '$CI_COMMIT_BRANCH =~ /^mq-working-branch-/'
     when: never
-  - if: '$CI_COMMIT_BRANCH =~ /^(release|hotfix)\//'
+  - if: '$CI_COMMIT_BRANCH =~ /^(release|hotfix)[-\/]/'
     when: never
-  - if: '$CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME =~ /^(release|hotfix)\//'
+  - if: '$CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME =~ /^(release|hotfix)[-\/]/'
     when: never
   - if: '$CI_COMMIT_BRANCH == "main"'
     interruptible: false

--- a/scripts/exclude-from-green-ci.sh
+++ b/scripts/exclude-from-green-ci.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tags the current CI pipeline as excluded from Green CI (green_ci.excluded:true).
+#
+# Downloads the pinned, checksum-verified datadog-ci binary instead of `npm install -g`,
+# so no third-party install-time code runs with the Datadog API key in its environment.
+#
+# Requires DATADOG_SITE and DATADOG_API_KEY in the environment.
+
+set -euo pipefail
+
+URL="https://github.com/DataDog/datadog-ci/releases/download/v5.21.0/datadog-ci_linux-x64"
+OUTPUT="datadog-ci"
+EXPECTED_CHECKSUM="be4a6473fc451fec967ff277df3856060814b9a54d707d055a9c1542ae2869f0"
+
+echo "Downloading datadog-ci from $URL"
+curl -L --fail --retry 3 -o "$OUTPUT" "$URL"
+chmod +x "$OUTPUT"
+
+ACTUAL_CHECKSUM=$(sha256sum "$OUTPUT" | cut -d' ' -f1)
+if [ "$ACTUAL_CHECKSUM" != "$EXPECTED_CHECKSUM" ]; then
+  echo "Checksum verification failed! expected=$EXPECTED_CHECKSUM actual=$ACTUAL_CHECKSUM"
+  exit 1
+fi
+echo "Checksum verification passed"
+
+./"$OUTPUT" tag --level pipeline --tags green_ci.excluded:true


### PR DESCRIPTION
# What does this PR do?

- Exclude from Green CI `release-proposal-dispatch.yml` and `release-proposal-test.yml`
- Exclude benchmarks on `release`, `release-proposal`, `release-*` branches
