### PR TITLE
fix(crashtracker): exclude crashing thread from ptrace stack collection

### DIFF
--- a/libdd-crashtracker/src/receiver/ptrace_collector.rs
+++ b/libdd-crashtracker/src/receiver/ptrace_collector.rs
@@ -558,47 +558,6 @@ mod tests {
         }
     }
 
-    #[test]
-    #[cfg_attr(miri, ignore)]
-    fn stream_excludes_crashing_tid() {
-        let barrier = Arc::new(Barrier::new(2));
-        let b: Arc<Barrier> = Arc::clone(&barrier);
-        let (tx, rx) = std::sync::mpsc::channel();
-
-        let handle = std::thread::spawn(move || {
-            tx.send(current_tid()).unwrap();
-            b.wait();
-        });
-
-        let worker_tid = rx.recv().unwrap();
-
-        let mut seen_worker = false;
-        let mut seen_self = false;
-        let self_tid = current_tid();
-        // Declare the current thread as the crashing TID; it must be skipped.
-        let _ = stream_thread_contexts(
-            std::process::id() as libc::pid_t,
-            self_tid,
-            64,
-            Duration::from_secs(5),
-            crate::StacktraceCollection::Disabled,
-            |tid, _ctx| {
-                if tid == worker_tid {
-                    seen_worker = true;
-                }
-                if tid == self_tid {
-                    seen_self = true;
-                }
-            },
-        );
-
-        assert!(seen_worker, "worker thread should appear in callbacks");
-        assert!(!seen_self, "crashing_tid should not appear in callbacks");
-
-        barrier.wait();
-        handle.join().unwrap();
-    }
-
     /// Regression test: a thread blocked in poll() passed as crashing_tid must not
     /// be ptraced. Previously, PTRACE_INTERRUPT would fire inside the signal handler's
     /// poll() call causing an EINTR loop that hung the receiver indefinitely.

--- a/libdd-crashtracker/src/receiver/ptrace_collector.rs
+++ b/libdd-crashtracker/src/receiver/ptrace_collector.rs
@@ -568,7 +568,11 @@ mod tests {
         let (tx, rx) = std::sync::mpsc::channel();
         let handle = std::thread::spawn(move || {
             tx.send(current_tid()).unwrap();
-            let mut pfd = libc::pollfd { fd: read_fd, events: libc::POLLHUP, revents: 0 };
+            let mut pfd = libc::pollfd {
+                fd: read_fd,
+                events: libc::POLLHUP,
+                revents: 0,
+            };
             unsafe { libc::poll(&mut pfd, 1, 10_000) };
             unsafe { libc::close(read_fd) };
         });

--- a/libdd-crashtracker/src/receiver/ptrace_collector.rs
+++ b/libdd-crashtracker/src/receiver/ptrace_collector.rs
@@ -463,6 +463,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // gettid() returns a Miri-virtual TID that /proc/self/task/ doesn't list
     fn enumerate_discovers_spawned_thread() {
         let barrier = Arc::new(Barrier::new(2));
         let b = Arc::clone(&barrier);

--- a/libdd-crashtracker/src/receiver/ptrace_collector.rs
+++ b/libdd-crashtracker/src/receiver/ptrace_collector.rs
@@ -399,10 +399,9 @@ where
     F: FnMut(libc::pid_t, Option<&CapturedThreadContext>),
 {
     let overall_deadline = Instant::now() + timeout;
-    // Exclude the crashing thread: it is blocked in the signal handler waiting
-    // for the receiver to finish. Ptracing it from the receiver causes PTRACE_INTERRUPT
-    // to fire inside the signal handler, and libunwind cannot walk the alternate
-    // signal stack through the signal frame, consistently crashing the receiver.
+    // Skip the crashing thread: it is blocked in poll() in its signal handler.
+    // PTRACE_INTERRUPT would cause an EINTR loop and libunwind cannot walk the
+    // alternate signal stack. Crash-site registers are captured separately.
     let tids: Vec<_> = enumerate_threads(parent_pid)?
         .into_iter()
         .filter(|&tid| tid != crashing_tid)
@@ -558,18 +557,15 @@ mod tests {
         }
     }
 
-    /// Regression test: a thread blocked in poll() passed as crashing_tid must not
-    /// be ptraced. Previously, PTRACE_INTERRUPT would fire inside the signal handler's
-    /// poll() call causing an EINTR loop that hung the receiver indefinitely.
+    // Regression: crashing_tid blocked in poll() must not be ptraced.
     #[test]
     #[cfg_attr(miri, ignore)]
     fn stream_excludes_crashing_tid_blocked_in_poll() {
-        let mut pipe_fds = [0i32; 2];
-        assert_eq!(unsafe { libc::pipe(pipe_fds.as_mut_ptr()) }, 0);
-        let [read_fd, write_fd] = pipe_fds;
+        let mut fds = [0i32; 2];
+        unsafe { libc::pipe(fds.as_mut_ptr()) };
+        let [read_fd, write_fd] = fds;
 
         let (tx, rx) = std::sync::mpsc::channel();
-
         let handle = std::thread::spawn(move || {
             tx.send(current_tid()).unwrap();
             let mut pfd = libc::pollfd { fd: read_fd, events: libc::POLLHUP, revents: 0 };
@@ -578,22 +574,16 @@ mod tests {
         });
 
         let blocking_tid = rx.recv().unwrap();
-
-        let mut seen_blocking = false;
+        let mut seen = false;
         let _ = stream_thread_contexts(
             std::process::id() as libc::pid_t,
             blocking_tid,
             64,
             Duration::from_secs(5),
             crate::StacktraceCollection::Disabled,
-            |tid, _ctx| {
-                if tid == blocking_tid {
-                    seen_blocking = true;
-                }
-            },
+            |tid, _| seen |= tid == blocking_tid,
         );
-
-        assert!(!seen_blocking, "thread blocked in poll() must not be ptraced as crashing_tid");
+        assert!(!seen);
 
         unsafe { libc::close(write_fd) };
         handle.join().unwrap();

--- a/libdd-crashtracker/src/receiver/ptrace_collector.rs
+++ b/libdd-crashtracker/src/receiver/ptrace_collector.rs
@@ -598,4 +598,45 @@ mod tests {
         barrier.wait();
         handle.join().unwrap();
     }
+
+    /// Regression test: a thread blocked in poll() passed as crashing_tid must not
+    /// be ptraced. Previously, PTRACE_INTERRUPT would fire inside the signal handler's
+    /// poll() call causing an EINTR loop that hung the receiver indefinitely.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn stream_excludes_crashing_tid_blocked_in_poll() {
+        let mut pipe_fds = [0i32; 2];
+        assert_eq!(unsafe { libc::pipe(pipe_fds.as_mut_ptr()) }, 0);
+        let [read_fd, write_fd] = pipe_fds;
+
+        let (tx, rx) = std::sync::mpsc::channel();
+
+        let handle = std::thread::spawn(move || {
+            tx.send(current_tid()).unwrap();
+            let mut pfd = libc::pollfd { fd: read_fd, events: libc::POLLHUP, revents: 0 };
+            unsafe { libc::poll(&mut pfd, 1, 10_000) };
+            unsafe { libc::close(read_fd) };
+        });
+
+        let blocking_tid = rx.recv().unwrap();
+
+        let mut seen_blocking = false;
+        let _ = stream_thread_contexts(
+            std::process::id() as libc::pid_t,
+            blocking_tid,
+            64,
+            Duration::from_secs(5),
+            crate::StacktraceCollection::Disabled,
+            |tid, _ctx| {
+                if tid == blocking_tid {
+                    seen_blocking = true;
+                }
+            },
+        );
+
+        assert!(!seen_blocking, "thread blocked in poll() must not be ptraced as crashing_tid");
+
+        unsafe { libc::close(write_fd) };
+        handle.join().unwrap();
+    }
 }

--- a/libdd-crashtracker/src/receiver/ptrace_collector.rs
+++ b/libdd-crashtracker/src/receiver/ptrace_collector.rs
@@ -371,12 +371,13 @@ const STOP_TIMEOUT_PER_THREAD: Duration = Duration::from_millis(50);
 
 /// Stream thread contexts to a callback one at a time.
 ///
-/// For each thread in the process the callback receives the TID and an optional
+/// For each non-crashing thread the callback receives the TID and an optional
 /// `CapturedThreadContext` (None if attachment or unwinding failed).
 ///
-/// The `crashing_tid` is always processed first (regardless of `/proc` iteration
-/// order) to guarantee it appears in the output even when the `max_threads` cap
-/// truncates collection.
+/// The crashing thread is excluded: it is executing a signal handler on the
+/// alternate signal stack, so ptrace-based unwinding cannot traverse the signal
+/// frame and consistently crashes the receiver. The crash-site registers are
+/// already captured from the signal context before this function is called.
 ///
 /// Two deadlines bound collection:
 /// - An *overall* deadline derived from `timeout`, shared across all threads.
@@ -398,7 +399,14 @@ where
     F: FnMut(libc::pid_t, Option<&CapturedThreadContext>),
 {
     let overall_deadline = Instant::now() + timeout;
-    let tids = enumerate_threads(parent_pid)?;
+    // Exclude the crashing thread: it is blocked in the signal handler waiting
+    // for the receiver to finish. Ptracing it from the receiver causes PTRACE_INTERRUPT
+    // to fire inside the signal handler, and libunwind cannot walk the alternate
+    // signal stack through the signal frame, consistently crashing the receiver.
+    let tids: Vec<_> = enumerate_threads(parent_pid)?
+        .into_iter()
+        .filter(|&tid| tid != crashing_tid)
+        .collect();
     let total_eligible = tids.len();
     let mut processed = 0;
 
@@ -410,19 +418,7 @@ where
         return Ok(true); // treat as incomplete; nothing was collected
     };
 
-    // Process the crashing thread first so it is never dropped by the cap.
-    if crashing_tid != 0 && tids.contains(&crashing_tid) {
-        let stop_deadline = (Instant::now() + STOP_TIMEOUT_PER_THREAD).min(overall_deadline);
-        let context =
-            capture_thread_context(crashing_tid, resolve_frames, addr_space, stop_deadline).ok();
-        callback(crashing_tid, context.as_ref());
-        processed += 1;
-    }
-
     for tid in tids {
-        if tid == crashing_tid {
-            continue;
-        }
         let now = Instant::now();
         if now >= overall_deadline || processed >= max_threads {
             break;
@@ -556,8 +552,7 @@ mod tests {
             |_tid, _ctx| collected += 1,
         );
 
-        // max_threads=2 but crashing_tid is always included, so up to 3
-        assert!(collected <= 3, "collected {collected}, expected <= 3");
+        assert!(collected <= 2, "collected {collected}, expected <= 2");
         for h in handles {
             h.join().unwrap();
         }
@@ -565,7 +560,7 @@ mod tests {
 
     #[test]
     #[cfg_attr(miri, ignore)]
-    fn stream_includes_all_threads() {
+    fn stream_excludes_crashing_tid() {
         let barrier = Arc::new(Barrier::new(2));
         let b: Arc<Barrier> = Arc::clone(&barrier);
         let (tx, rx) = std::sync::mpsc::channel();
@@ -580,6 +575,7 @@ mod tests {
         let mut seen_worker = false;
         let mut seen_self = false;
         let self_tid = current_tid();
+        // Declare the current thread as the crashing TID; it must be skipped.
         let _ = stream_thread_contexts(
             std::process::id() as libc::pid_t,
             self_tid,
@@ -597,7 +593,7 @@ mod tests {
         );
 
         assert!(seen_worker, "worker thread should appear in callbacks");
-        assert!(seen_self, "current thread should appear in callbacks");
+        assert!(!seen_self, "crashing_tid should not appear in callbacks");
 
         barrier.wait();
         handle.join().unwrap();

--- a/libdd-crashtracker/src/receiver/receive_report.rs
+++ b/libdd-crashtracker/src/receiver/receive_report.rs
@@ -584,13 +584,34 @@ fn collect_and_add_thread_contexts(
             };
 
             collected_threads.push(ThreadData {
-                crashed: tid == crashing_tid,
+                crashed: false,
                 name,
                 stack,
                 state,
             });
         },
     )?;
+
+    // Add the crashing thread separately: it is excluded from ptrace collection
+    // because PTRACE_INTERRUPT inside its signal handler causes an EINTR loop.
+    // Its stack comes from the crash-site data already captured by the signal handler.
+    if crashing_tid != 0 {
+        let (name, state) = read_thread_stat(parent_pid, crashing_tid);
+        let name = name
+            .or_else(|| builder.error.thread_name.clone())
+            .unwrap_or_else(|| crashing_tid.to_string());
+        let stack = builder
+            .error
+            .stack
+            .clone()
+            .unwrap_or_else(StackTrace::new_incomplete);
+        collected_threads.push(ThreadData {
+            crashed: true,
+            name,
+            stack,
+            state,
+        });
+    }
 
     if incomplete {
         let _ = builder.with_counter("threads_incomplete".to_string(), 1);


### PR DESCRIPTION
## Problem

In v37, `stream_thread_contexts` began including `crashing_tid` in ptrace
collection, processing it first to guarantee it appears even when the thread
cap is reached.

The crashing thread is blocked in `poll()` inside its signal handler on the
alternate signal stack. When the receiver calls `PTRACE_INTERRUPT` on it,
`poll()` returns `EINTR`, the retry loop restarts `poll()`, and libunwind then
tries to unwind through the signal frame — which it cannot traverse correctly.
On Python 3.14 this `EINTR` loop is indefinite, hanging the receiver before the
crash report is delivered.

Discovered via `test_crashtracker_native_extension_crash` in dd-trace-py after
bumping to libdatadog v37. dd-trace-py is currently pinned to this fix commit
pending a tagged release.

## Fix

Restore the v35 behaviour: exclude `crashing_tid` from `stream_thread_contexts`.
The crash-site register context is already captured from `ucontext_t` in the
signal handler before ptrace collection runs, so no information is lost.

## Changes

- `libdd-crashtracker/src/receiver/ptrace_collector.rs`: filter out `crashing_tid`
  from the ptrace loop; update doc comment and two unit tests accordingly.