### PR TITLE
feat(telemetry)!: Add Installation signature and AppProduct changes payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3435,6 +3435,8 @@ dependencies = [
  "libdd-shared-runtime",
  "serde",
  "serde_json",
+ "strum",
+ "strum_macros",
  "sys-info",
  "tokio",
  "tokio-util",

--- a/datadog-live-debugger/src/sender.rs
+++ b/datadog-live-debugger/src/sender.rs
@@ -322,7 +322,7 @@ pub struct PayloadSender {
 }
 
 const BOUNDARY: &str = "------------------------44617461646f67";
-const BOUNDARY_LINE: &str = concat!("--", BOUNDARY, "\r\n");
+const BOUNDARY_LINE: &str = concat!("--", BOUNDARY);
 
 impl PayloadSender {
     pub fn new(
@@ -426,10 +426,11 @@ impl PayloadSender {
             SenderFuture::Outstanding(future) => {
                 if self.needs_boundary {
                     let header = concat!(
-                        BOUNDARY_LINE,
-                        "Content-Disposition: form-data; name=\"event\"; filename=\"event.json\"\r\n",
-                        "Content-Type: application/json\r\n",
-                        "\r\n",
+                    BOUNDARY_LINE,
+                    "\r\n",
+                    "Content-Disposition: form-data; name=\"event\"; filename=\"event.json\"\r\n",
+                    "Content-Type: application/json\r\n",
+                    "\r\n",
                     );
                     self.sender.send_chunk(header.into()).await?;
                 }
@@ -463,7 +464,7 @@ impl PayloadSender {
             // insert a trailing ]
             if self.needs_boundary {
                 self.sender
-                    .send_chunk(concat!("]\r\n", BOUNDARY_LINE).into())
+                    .send_chunk(concat!("]\r\n", BOUNDARY_LINE, "--\r\n").into())
                     .await?;
             } else {
                 self.sender.send_chunk(Bytes::from_static(b"]")).await?;

--- a/datadog-live-debugger/src/sender.rs
+++ b/datadog-live-debugger/src/sender.rs
@@ -305,12 +305,22 @@ pub fn generate_tags(
     percent_encode(tags.as_bytes(), CONTROLS).to_string()
 }
 
+/// Owns the spawned request task and aborts it when dropped.
+struct AbortOnDrop(JoinHandle<anyhow::Result<http::Response<Bytes>>>);
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        // A no-op once the task has completed, so the success path is unaffected.
+        self.0.abort();
+    }
+}
+
 #[derive(Default)]
 enum SenderFuture {
     #[default]
     Error,
     Outstanding(ResponseFuture),
-    Submitted(JoinHandle<anyhow::Result<http::Response<Bytes>>>),
+    Submitted(AbortOnDrop),
 }
 
 pub struct PayloadSender {
@@ -435,10 +445,10 @@ impl PayloadSender {
                     self.sender.send_chunk(header.into()).await?;
                 }
 
-                self.future = SenderFuture::Submitted(tokio::spawn(async move {
+                self.future = SenderFuture::Submitted(AbortOnDrop(tokio::spawn(async move {
                     let resp = future.await?;
                     Ok(resp)
-                }));
+                })));
                 true
             }
             future => {
@@ -473,17 +483,14 @@ impl PayloadSender {
             drop(self.sender);
             // Once the body is fully sent, bound the wait for the response headers and (if
             // needed) the response body under a single timeout - a slow/stalled server must
-            // not be able to hang this indefinitely. Abort the spawned task on timeout so the
-            // underlying request is actually cancelled instead of left running detached.
+            // not be able to hang this indefinitely. Returning here drops `future`, whose
+            // `AbortOnDrop` cancels the underlying request rather than detaching it.
             let response =
-                match tokio::time::timeout(Duration::from_millis(self.timeout_ms), &mut future)
+                match tokio::time::timeout(Duration::from_millis(self.timeout_ms), &mut future.0)
                     .await
                 {
                     Ok(joined) => joined??,
-                    Err(_) => {
-                        future.abort();
-                        return Err(anyhow::anyhow!("debugger payload request timed out"));
-                    }
+                    Err(_) => return Err(anyhow::anyhow!("debugger payload request timed out")),
                 };
 
             let status = response.status().as_u16();
@@ -674,7 +681,10 @@ pub fn generate_new_id() -> Uuid {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use libdd_capabilities::{ChunkFuture, HttpError, MaybeSend, StreamingBodySender};
     use std::borrow::Cow;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
 
     fn agent_endpoint() -> Endpoint {
         Endpoint::from_slice("http://localhost:8126")
@@ -785,6 +795,107 @@ mod tests {
         for endpoint in diagnostics {
             assert_eq!(endpoint.url.path(), "/api/v2/debugger");
         }
+    }
+
+    struct SetOnDrop(Arc<AtomicBool>);
+
+    impl Drop for SetOnDrop {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    /// A response that never arrives, holding `guard` for as long as it lives.
+    ///
+    /// The guard is captured by move rather than constructed in the body, because an
+    /// async block does not run its body until first polled: a task aborted before
+    /// its first poll would otherwise never arm the observer.
+    async fn stalled_response(guard: SetOnDrop) -> Result<http::Response<Bytes>, HttpError> {
+        let _guard = guard;
+        future::pending::<()>().await;
+        unreachable!()
+    }
+
+    /// Accepts and discards body chunks, so the test's stalled response future is the
+    /// only thing the spawned task ever waits on.
+    struct DiscardingBodySender;
+
+    impl StreamingBodySender for DiscardingBodySender {
+        fn send_chunk(&mut self, _data: Bytes) -> ChunkFuture<'_> {
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    /// A client whose requests never complete, so a test can observe what happens to
+    /// the in-flight task once the sender goes away. The flag is set when the
+    /// response future is dropped, which happens only if the spawned task was
+    /// aborted rather than detached.
+    ///
+    /// `request_streamed` is overridden rather than relying on the default
+    /// implementation: that one parks on the body channel until the `BodySender` is
+    /// dropped, so a task abandoned before `finish()` would be cancelled before it
+    /// ever reached `request()` and the flag would never be armed.
+    #[derive(Clone, Debug)]
+    struct StalledClient(Arc<AtomicBool>);
+
+    impl HttpClientCapability for StalledClient {
+        fn new_client() -> Self {
+            Self(Arc::new(AtomicBool::new(false)))
+        }
+
+        fn new_without_connection_pooling() -> Self {
+            Self::new_client()
+        }
+
+        fn request(
+            &self,
+            _req: http::Request<Bytes>,
+        ) -> impl std::future::Future<Output = Result<http::Response<Bytes>, HttpError>> + MaybeSend
+        {
+            stalled_response(SetOnDrop(self.0.clone()))
+        }
+
+        fn request_streamed(&self, _req: http::Request<()>) -> (BodySender, ResponseFuture) {
+            (
+                Box::new(DiscardingBodySender),
+                Box::pin(stalled_response(SetOnDrop(self.0.clone()))),
+            )
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dropping_payload_sender_aborts_in_flight_request() {
+        let cancelled = Arc::new(AtomicBool::new(false));
+
+        let mut config = Config::default();
+        config.set_endpoint(agent_endpoint()).unwrap();
+
+        let mut sender = PayloadSender::new_to_endpoint_with_client(
+            config.snapshots_endpoint.as_ref().unwrap(),
+            DebuggerType::Snapshots,
+            "",
+            StalledClient(cancelled.clone()),
+        )
+        .unwrap();
+
+        // Spawns the request task, which then never completes.
+        sender.append(b"[{}]").await.unwrap();
+
+        // Abandoning the sender (an enclosing timeout, a `select!`, a cancelled task)
+        // must cancel that request instead of leaving it running with its connection.
+        drop(sender);
+
+        for _ in 0..100 {
+            if cancelled.load(Ordering::SeqCst) {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+
+        assert!(
+            cancelled.load(Ordering::SeqCst),
+            "in-flight request was detached instead of aborted"
+        );
     }
 
     #[test]

--- a/datadog-sidecar-ffi/src/lib.rs
+++ b/datadog-sidecar-ffi/src/lib.rs
@@ -515,6 +515,8 @@ pub unsafe extern "C" fn ddog_sidecar_telemetry_addDependency(
     let dependency = TelemetryActions::AddDependency(Dependency {
         name: dependency_name.to_utf8_lossy().into_owned(),
         version,
+        hash: None,
+        metadata: None,
     });
 
     try_c!(blocking::enqueue_actions(

--- a/datadog-sidecar-ffi/src/lib.rs
+++ b/datadog-sidecar-ffi/src/lib.rs
@@ -487,6 +487,7 @@ pub unsafe extern "C" fn ddog_sidecar_telemetry_addEndpoint(
         path: Some(path.to_utf8_lossy().into_owned()),
         operation_name: operation_name.to_utf8_lossy().into_owned(),
         resource_name: resource_name.to_utf8_lossy().into_owned(),
+        request_body_type: None,
         response_body_type: None,
         response_code: None,
     });

--- a/datadog-sidecar-ffi/src/lib.rs
+++ b/datadog-sidecar-ffi/src/lib.rs
@@ -487,6 +487,8 @@ pub unsafe extern "C" fn ddog_sidecar_telemetry_addEndpoint(
         path: Some(path.to_utf8_lossy().into_owned()),
         operation_name: operation_name.to_utf8_lossy().into_owned(),
         resource_name: resource_name.to_utf8_lossy().into_owned(),
+        response_body_type: None,
+        response_code: None,
     });
 
     try_c!(blocking::enqueue_actions(
@@ -549,6 +551,7 @@ pub unsafe extern "C" fn ddog_sidecar_telemetry_addIntegration(
         version,
         compatible: None,
         auto_enabled: None,
+        error: None,
     });
 
     try_c!(blocking::enqueue_actions(

--- a/datadog-sidecar-ffi/src/lib.rs
+++ b/datadog-sidecar-ffi/src/lib.rs
@@ -456,7 +456,7 @@ pub unsafe extern "C" fn ddog_sidecar_telemetry_enqueueConfig(
     let seq_id = seq_id.to_std();
     let config_entry = TelemetryActions::AddConfig(data::Configuration {
         name: config_key.to_utf8_lossy().into_owned(),
-        value: config_value.to_utf8_lossy().into_owned(),
+        value: Some(config_value.to_utf8_lossy().into_owned()),
         origin,
         config_id,
         seq_id,

--- a/libdd-capabilities-impl/src/http.rs
+++ b/libdd-capabilities-impl/src/http.rs
@@ -59,23 +59,51 @@ mod native {
         }
     }
 
-    /// Write `body` as a newline-terminated record to the file referenced by `uri` (which must
-    /// have a `file://` scheme), then return a synthetic 202 response.
+    /// Record `body` to the on-disk location referenced by `uri` (which must have a `file://`
+    /// scheme), then return a synthetic 202 response.
+    ///
+    /// If the location is a directory (the path ends with a separator, as the offline
+    /// telemetry writer passes `file:///dir/`), each request is written to its own
+    /// `telemetry-<seq>-<pid>-<ts>.json` file inside it — ordinal-first so a lexicographic sort
+    /// reproduces emission order. Otherwise the body is appended as a newline-terminated record to
+    /// that single file.
     fn write_to_file_endpoint(
         uri: &http::Uri,
         body: bytes::Bytes,
     ) -> Result<http::Response<bytes::Bytes>, HttpError> {
         let path = libdd_common::decode_uri_path_in_authority(uri)
             .map_err(|e| HttpError::Other(anyhow::anyhow!("invalid file:// URI: {e}")))?;
-        let mut file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&path)
-            .map_err(|e| HttpError::Other(anyhow::anyhow!("opening {path:?}: {e}")))?;
-        let mut record = body.to_vec();
-        record.push(b'\n');
-        file.write_all(&record)
-            .map_err(|e| HttpError::Other(anyhow::anyhow!("writing {path:?}: {e}")))?;
+
+        let is_dir = path.to_string_lossy().ends_with(std::path::MAIN_SEPARATOR) || path.is_dir();
+        if is_dir {
+            std::fs::create_dir_all(&path)
+                .map_err(|e| HttpError::Other(anyhow::anyhow!("creating {path:?}: {e}")))?;
+            // Process-wide sequence so successive requests get distinct, ordered filenames.
+            static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+            let seq = SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let ts = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0);
+            let name = format!("telemetry-{seq:020}-{}-{ts}.json", std::process::id());
+            // Write to a temp file then rename, so a concurrent reader never sees a partial file.
+            let dest = path.join(name);
+            let tmp = dest.with_extension("json.tmp");
+            std::fs::write(&tmp, &body)
+                .map_err(|e| HttpError::Other(anyhow::anyhow!("writing {tmp:?}: {e}")))?;
+            std::fs::rename(&tmp, &dest)
+                .map_err(|e| HttpError::Other(anyhow::anyhow!("renaming to {dest:?}: {e}")))?;
+        } else {
+            let mut file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)
+                .map_err(|e| HttpError::Other(anyhow::anyhow!("opening {path:?}: {e}")))?;
+            let mut record = body.to_vec();
+            record.push(b'\n');
+            file.write_all(&record)
+                .map_err(|e| HttpError::Other(anyhow::anyhow!("writing {path:?}: {e}")))?;
+        }
 
         http::Response::builder()
             .status(http::StatusCode::ACCEPTED)

--- a/libdd-common/src/dump_server.rs
+++ b/libdd-common/src/dump_server.rs
@@ -10,7 +10,12 @@
 
 use anyhow::Context;
 use std::path::PathBuf;
-use tokio::io::AsyncReadExt;
+use std::sync::atomic::{AtomicU64, Ordering};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+/// Monotonic counter for directory-mode dump filenames, so each captured request lands in
+/// its own lexicographically-ordered file instead of overwriting a single one.
+static DUMP_SEQ: AtomicU64 = AtomicU64::new(0);
 
 /// Helper to find subsequence in bytes
 fn find_subsequence(haystack: &[u8], needle: &[u8]) -> Option<usize> {
@@ -385,13 +390,55 @@ async fn write_request_to_file(
         return Ok(());
     }
 
+    // A path ending in a separator (e.g. `file:///dir/`) selects "directory mode": write each
+    // request's body as its own lexicographically-ordered file so requests accumulate instead of
+    // overwriting a single dump file.
+    let path_str = output_path.as_os_str().to_string_lossy();
+    if path_str.ends_with('/') || path_str.ends_with(std::path::MAIN_SEPARATOR) {
+        let body = if parsed_request.is_chunked {
+            decode_chunked_body(&parsed_request.raw_data[parsed_request.headers_len..])?
+        } else {
+            parsed_request.raw_data[parsed_request.headers_len..].to_vec()
+        };
+        if body.is_empty() {
+            return Ok(());
+        }
+        tokio::fs::create_dir_all(output_path)
+            .await
+            .context("Failed to create dump directory")?;
+        // Ordinal-first name so files sort in emission order; the PID avoids cross-process
+        // collisions when several processes share the directory.
+        let name = format!(
+            "{:020}-{}.json",
+            DUMP_SEQ.fetch_add(1, Ordering::Relaxed),
+            std::process::id()
+        );
+        let dest = output_path.join(&name);
+        let tmp = output_path.join(format!("{name}.tmp"));
+        {
+            let mut file = tokio::fs::File::create(&tmp)
+                .await
+                .context("Failed to create dump file")?;
+            file.write_all(&body)
+                .await
+                .context("Failed to write request dump")?;
+            file.sync_all()
+                .await
+                .context("Failed to sync request dump to disk")?;
+        }
+        // Atomic publish via rename so readers never observe a partial file.
+        tokio::fs::rename(&tmp, &dest)
+            .await
+            .context("Failed to publish request dump")?;
+        return Ok(());
+    }
+
     let data_to_write = if parsed_request.is_chunked && parsed_request.headers_len > 0 {
         reconstruct_with_content_length(&parsed_request.raw_data, parsed_request.headers_len)?
     } else {
         parsed_request.raw_data.clone()
     };
 
-    use tokio::io::AsyncWriteExt;
     let mut file = tokio::fs::File::create(output_path)
         .await
         .context("Failed to create dump file")?;

--- a/libdd-common/src/dump_server.rs
+++ b/libdd-common/src/dump_server.rs
@@ -9,8 +9,8 @@
 //! This is primarily used for testing to validate the exact bytes sent over the wire.
 
 use anyhow::Context;
+use core::sync::atomic::{AtomicU64, Ordering};
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 /// Monotonic counter for directory-mode dump filenames, so each captured request lands in

--- a/libdd-data-pipeline/src/telemetry/mod.rs
+++ b/libdd-data-pipeline/src/telemetry/mod.rs
@@ -190,6 +190,16 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> std
     }
 }
 
+impl TelemetryClient {
+    /// Allow sharing a telemetry worker with data-pipeline
+    pub fn with_handle(handle: TelemetryWorkerHandle) -> Self {
+        TelemetryClient {
+            metrics: Metrics::new(&handle),
+            worker: handle,
+        }
+    }
+}
+
 /// Telemetry describing the sending of a trace payload
 /// It can be produced from a [`SendWithRetryResult`] or from a [`SendDataResult`].
 #[derive(PartialEq, Debug, Default)]

--- a/libdd-data-pipeline/src/telemetry/mod.rs
+++ b/libdd-data-pipeline/src/telemetry/mod.rs
@@ -190,9 +190,9 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> std
     }
 }
 
-impl TelemetryClient {
+impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> TelemetryClient<C> {
     /// Allow sharing a telemetry worker with data-pipeline
-    pub fn with_handle(handle: TelemetryWorkerHandle) -> Self {
+    pub fn with_handle(handle: TelemetryWorkerHandle<C>) -> Self {
         TelemetryClient {
             metrics: Metrics::new(&handle),
             worker: handle,

--- a/libdd-data-pipeline/src/trace_exporter/builder.rs
+++ b/libdd-data-pipeline/src/trace_exporter/builder.rs
@@ -81,6 +81,7 @@ pub struct TraceExporterBuilder<R: SharedRuntime> {
     client_side_stats_obfuscation_enabled: bool,
     #[cfg(feature = "telemetry")]
     telemetry: Option<TelemetryConfig>,
+    #[cfg(feature = "telemetry")]
     telemetry_instrumentation_sessions: TelemetryInstrumentationSessions,
     shared_runtime: Option<Arc<R>>,
     health_metrics_enabled: bool,
@@ -383,6 +384,7 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
         self
     }
 
+    #[cfg(feature = "telemetry")]
     /// Sets optional instrumentation session headers on telemetry requests (`dd-session-id`, etc.).
     pub fn set_telemetry_instrumentation_sessions(
         &mut self,

--- a/libdd-data-pipeline/src/trace_exporter/builder.rs
+++ b/libdd-data-pipeline/src/trace_exporter/builder.rs
@@ -6,7 +6,7 @@ use crate::agentless::config::{AgentlessTraceConfig, DEFAULT_AGENTLESS_TIMEOUT};
 use crate::otlp::config::{OtlpProtocol, DEFAULT_OTLP_TIMEOUT};
 use crate::otlp::{OtlpMetricsConfig, OtlpResourceInfo, OtlpTraceConfig};
 #[cfg(feature = "telemetry")]
-use crate::telemetry::TelemetryClientBuilder;
+use crate::telemetry::{TelemetryClient, TelemetryClientBuilder};
 use crate::trace_exporter::agent_response::AgentResponsePayloadVersion;
 use crate::trace_exporter::error::BuilderErrorKind;
 use crate::trace_exporter::log_writer::DEFAULT_LOG_MAX_LINE_SIZE;
@@ -25,6 +25,8 @@ use libdd_dogstatsd_client::DogStatsDClient;
 use libdd_shared_runtime::SharedRuntime;
 #[cfg(not(target_arch = "wasm32"))]
 use libdd_shared_runtime::{BlockingRuntime, ForkSafeRuntime};
+#[cfg(all(not(target_arch = "wasm32"), feature = "telemetry"))]
+use libdd_telemetry::worker::TelemetryWorkerHandle;
 use libdd_trace_stats::span_concentrator::CardinalityLimitConfig;
 use libdd_trace_utils::trace_filter::TraceFilterer;
 use std::sync::Arc;
@@ -81,6 +83,8 @@ pub struct TraceExporterBuilder<R: SharedRuntime> {
     client_side_stats_obfuscation_enabled: bool,
     #[cfg(feature = "telemetry")]
     telemetry: Option<TelemetryConfig>,
+    #[cfg(feature = "telemetry")]
+    telemetry_handle: Option<TelemetryWorkerHandle>,
     telemetry_instrumentation_sessions: TelemetryInstrumentationSessions,
     shared_runtime: Option<Arc<R>>,
     health_metrics_enabled: bool,
@@ -153,6 +157,8 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
             client_side_stats_obfuscation_enabled: false,
             #[cfg(feature = "telemetry")]
             telemetry: None,
+            #[cfg(feature = "telemetry")]
+            telemetry_handle: None,
             telemetry_instrumentation_sessions: TelemetryInstrumentationSessions::default(),
             shared_runtime: None,
             health_metrics_enabled: false,
@@ -379,6 +385,12 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
     /// Enables sending telemetry metrics.
     pub fn enable_telemetry(&mut self, cfg: TelemetryConfig) -> &mut Self {
         self.telemetry = Some(cfg);
+        self
+    }
+
+    #[cfg(feature = "telemetry")]
+    pub fn set_telemetry_handle(&mut self, handle: TelemetryWorkerHandle) -> &mut Self {
+        self.telemetry_handle = Some(handle);
         self
     }
 
@@ -661,59 +673,64 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
         }
 
         #[cfg(feature = "telemetry")]
-        let (telemetry_client, telemetry_handle) = {
-            let sessions = self.telemetry_instrumentation_sessions;
-            // Telemetry talks to the agent; disable it in agentless and log-export modes.
-            let telemetry = self
-                .telemetry
-                .filter(|_| !(agentless_enabled || self.output_to_log))
-                .map(|telemetry_config| -> Result<_, TraceExporterError> {
-                    let mut tb = TelemetryClientBuilder::default()
-                        .set_language(&self.language)
-                        .set_language_version(&self.language_version)
-                        .set_service_name(&self.service)
-                        .set_service_version(&self.app_version)
-                        .set_env(&self.env)
-                        .set_tracer_version(&self.tracer_version)
-                        .set_heartbeat(telemetry_config.heartbeat)
-                        .set_url(base_url)
-                        .set_debug_enabled(telemetry_config.debug_enabled);
-                    if let Some(id) = telemetry_config.runtime_id {
-                        tb = tb.set_runtime_id(&id);
-                    }
-                    if let Some(ref id) = sessions.session_id {
-                        tb = tb.set_session_id(id);
-                    }
-                    if let Some(ref id) = sessions.root_session_id {
-                        tb = tb.set_root_session_id(id);
-                    }
-                    if let Some(ref id) = sessions.parent_session_id {
-                        tb = tb.set_parent_session_id(id);
-                    }
-                    tb.build::<C>().map_err(|e| {
-                        TraceExporterError::Builder(BuilderErrorKind::InvalidConfiguration(
-                            e.to_string(),
-                        ))
+        let (telemetry_client, telemetry_handle) =
+            if let Some(shared_handle) = self.telemetry_handle {
+                // Consolidated path: report health metrics through the externally-owned worker.
+                // We do not own it (no spawn, no start, no shutdown handle).
+                (Some(TelemetryClient::with_handle(shared_handle)), None)
+            } else {
+                let sessions = self.telemetry_instrumentation_sessions;
+                // Telemetry talks to the agent; disable it in agentless and log-export modes.
+                let telemetry = self
+                    .telemetry
+                    .filter(|_| !(agentless_enabled || self.output_to_log))
+                    .map(|telemetry_config| -> Result<_, TraceExporterError> {
+                        let mut tb = TelemetryClientBuilder::default()
+                            .set_language(&self.language)
+                            .set_language_version(&self.language_version)
+                            .set_service_name(&self.service)
+                            .set_service_version(&self.app_version)
+                            .set_env(&self.env)
+                            .set_tracer_version(&self.tracer_version)
+                            .set_heartbeat(telemetry_config.heartbeat)
+                            .set_url(base_url)
+                            .set_debug_enabled(telemetry_config.debug_enabled);
+                        if let Some(id) = telemetry_config.runtime_id {
+                            tb = tb.set_runtime_id(&id);
+                        }
+                        if let Some(ref id) = sessions.session_id {
+                            tb = tb.set_session_id(id);
+                        }
+                        if let Some(ref id) = sessions.root_session_id {
+                            tb = tb.set_root_session_id(id);
+                        }
+                        if let Some(ref id) = sessions.parent_session_id {
+                            tb = tb.set_parent_session_id(id);
+                        }
+                        tb.build::<C>().map_err(|e| {
+                            TraceExporterError::Builder(BuilderErrorKind::InvalidConfiguration(
+                                e.to_string(),
+                            ))
+                        })
                     })
-                })
-                .transpose()?;
-            match telemetry {
-                Some((client_tel, worker)) => {
-                    let handle = shared_runtime
-                        .spawn_worker(worker, self.restart_after_fork)
-                        .map_err(|e| {
+                    .transpose()?;
+                match telemetry {
+                    Some((client_tel, worker)) => {
+                        let handle = shared_runtime
+                            .spawn_worker(worker, self.restart_after_fork)
+                            .map_err(|e| {
                             TraceExporterError::Builder(BuilderErrorKind::InvalidConfiguration(
                                 e.to_string(),
                             ))
                         })?;
-                    if let Err(e) = client_tel.start() {
-                        tracing::warn!("Failed to start telemetry: {e}");
+                        if let Err(e) = client_tel.start() {
+                            tracing::warn!("Failed to start telemetry: {e}");
+                        }
+                        (Some(client_tel), Some(handle))
                     }
-                    (Some(client_tel), Some(handle))
+                    None => (None, None),
                 }
-                None => (None, None),
-            }
-        };
+            };
 
         // Transport selection: agentless is mutually exclusive with both OTLP and a
         // user-supplied agent URL; OTLP and the agent URL may coexist. All exclusion

--- a/libdd-data-pipeline/src/trace_exporter/builder.rs
+++ b/libdd-data-pipeline/src/trace_exporter/builder.rs
@@ -6,7 +6,7 @@ use crate::agentless::config::{AgentlessTraceConfig, DEFAULT_AGENTLESS_TIMEOUT};
 use crate::otlp::config::{OtlpProtocol, DEFAULT_OTLP_TIMEOUT};
 use crate::otlp::{OtlpMetricsConfig, OtlpResourceInfo, OtlpTraceConfig};
 #[cfg(feature = "telemetry")]
-use crate::telemetry::{TelemetryClient, TelemetryClientBuilder};
+use crate::telemetry::TelemetryClientBuilder;
 use crate::trace_exporter::agent_response::AgentResponsePayloadVersion;
 use crate::trace_exporter::error::BuilderErrorKind;
 use crate::trace_exporter::log_writer::DEFAULT_LOG_MAX_LINE_SIZE;
@@ -18,15 +18,13 @@ use crate::trace_exporter::{
     TraceExporterError, TraceExporterInputFormat, TraceExporterOutputFormat, TraceSerializer,
     TracerMetadata, INFO_ENDPOINT,
 };
-use arc_swap::ArcSwap;
+use arc_swap::{ArcSwap, ArcSwapOption};
 use libdd_capabilities::{HttpClientCapability, LogWriterCapability, MaybeSend, SleepCapability};
 use libdd_common::{parse_uri, tag, Endpoint};
 use libdd_dogstatsd_client::DogStatsDClient;
 use libdd_shared_runtime::SharedRuntime;
 #[cfg(not(target_arch = "wasm32"))]
 use libdd_shared_runtime::{BlockingRuntime, ForkSafeRuntime};
-#[cfg(all(not(target_arch = "wasm32"), feature = "telemetry"))]
-use libdd_telemetry::worker::TelemetryWorkerHandle;
 use libdd_trace_stats::span_concentrator::CardinalityLimitConfig;
 use libdd_trace_utils::trace_filter::TraceFilterer;
 use std::sync::Arc;
@@ -50,12 +48,6 @@ fn build_otlp_header_map(headers: Vec<(String, String)>) -> http::HeaderMap {
     }
     out
 }
-
-/// Externally-owned telemetry worker to consolidate through; Boxed to avoid depending on C.
-#[cfg(all(feature = "telemetry", not(target_arch = "wasm32")))]
-type BoxedTelemetryHandle = Box<dyn ::std::any::Any + Sync + Send>;
-#[cfg(all(feature = "telemetry", target_arch = "wasm32"))]
-type BoxedTelemetryHandle = Box<dyn ::std::any::Any>;
 
 #[allow(missing_docs)]
 #[derive(Debug)]
@@ -89,8 +81,6 @@ pub struct TraceExporterBuilder<R: SharedRuntime> {
     client_side_stats_obfuscation_enabled: bool,
     #[cfg(feature = "telemetry")]
     telemetry: Option<TelemetryConfig>,
-    #[cfg(feature = "telemetry")]
-    telemetry_handle: Option<BoxedTelemetryHandle>,
     telemetry_instrumentation_sessions: TelemetryInstrumentationSessions,
     shared_runtime: Option<Arc<R>>,
     health_metrics_enabled: bool,
@@ -164,7 +154,6 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
             #[cfg(feature = "telemetry")]
             telemetry: None,
             #[cfg(feature = "telemetry")]
-            telemetry_handle: None,
             telemetry_instrumentation_sessions: TelemetryInstrumentationSessions::default(),
             shared_runtime: None,
             health_metrics_enabled: false,
@@ -391,17 +380,6 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
     /// Enables sending telemetry metrics.
     pub fn enable_telemetry(&mut self, cfg: TelemetryConfig) -> &mut Self {
         self.telemetry = Some(cfg);
-        self
-    }
-
-    #[cfg(feature = "telemetry")]
-    pub fn set_telemetry_handle<
-        C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static,
-    >(
-        &mut self,
-        handle: TelemetryWorkerHandle<C>,
-    ) -> &mut Self {
-        self.telemetry_handle = Some(Box::new(handle));
         self
     }
 
@@ -684,67 +662,59 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
         }
 
         #[cfg(feature = "telemetry")]
-        let (telemetry_client, telemetry_handle) =
-            // Consolidated path: report health metrics through the externally-owned worker.
-            // We do not own it (no spawn, no start, no shutdown handle).
-            if let Some(shared_handle) = self
-                .telemetry_handle
-                .and_then(|h| h.downcast::<TelemetryWorkerHandle<C>>().ok())
-            {
-                (Some(TelemetryClient::with_handle(*shared_handle)), None)
-            } else {
-                let sessions = self.telemetry_instrumentation_sessions;
-                // Telemetry talks to the agent; disable it in agentless and log-export modes.
-                let telemetry = self
-                    .telemetry
-                    .filter(|_| !(agentless_enabled || self.output_to_log))
-                    .map(|telemetry_config| -> Result<_, TraceExporterError> {
-                        let mut tb = TelemetryClientBuilder::default()
-                            .set_language(&self.language)
-                            .set_language_version(&self.language_version)
-                            .set_service_name(&self.service)
-                            .set_service_version(&self.app_version)
-                            .set_env(&self.env)
-                            .set_tracer_version(&self.tracer_version)
-                            .set_heartbeat(telemetry_config.heartbeat)
-                            .set_url(base_url)
-                            .set_debug_enabled(telemetry_config.debug_enabled);
-                        if let Some(id) = telemetry_config.runtime_id {
-                            tb = tb.set_runtime_id(&id);
-                        }
-                        if let Some(ref id) = sessions.session_id {
-                            tb = tb.set_session_id(id);
-                        }
-                        if let Some(ref id) = sessions.root_session_id {
-                            tb = tb.set_root_session_id(id);
-                        }
-                        if let Some(ref id) = sessions.parent_session_id {
-                            tb = tb.set_parent_session_id(id);
-                        }
-                        tb.build::<C>().map_err(|e| {
-                            TraceExporterError::Builder(BuilderErrorKind::InvalidConfiguration(
-                                e.to_string(),
-                            ))
-                        })
+        let (telemetry_client, telemetry_handle) = {
+            let sessions = self.telemetry_instrumentation_sessions;
+            // Telemetry talks to the agent; disable it in agentless and log-export modes.
+            let telemetry = self
+                .telemetry
+                .filter(|_| !(agentless_enabled || self.output_to_log))
+                .map(|telemetry_config| -> Result<_, TraceExporterError> {
+                    let mut tb = TelemetryClientBuilder::default()
+                        .set_language(&self.language)
+                        .set_language_version(&self.language_version)
+                        .set_service_name(&self.service)
+                        .set_service_version(&self.app_version)
+                        .set_env(&self.env)
+                        .set_tracer_version(&self.tracer_version)
+                        .set_heartbeat(telemetry_config.heartbeat)
+                        .set_url(base_url)
+                        .set_debug_enabled(telemetry_config.debug_enabled);
+                    if let Some(id) = telemetry_config.runtime_id {
+                        tb = tb.set_runtime_id(&id);
+                    }
+                    if let Some(ref id) = sessions.session_id {
+                        tb = tb.set_session_id(id);
+                    }
+                    if let Some(ref id) = sessions.root_session_id {
+                        tb = tb.set_root_session_id(id);
+                    }
+                    if let Some(ref id) = sessions.parent_session_id {
+                        tb = tb.set_parent_session_id(id);
+                    }
+                    tb.build::<C>().map_err(|e| {
+                        TraceExporterError::Builder(BuilderErrorKind::InvalidConfiguration(
+                            e.to_string(),
+                        ))
                     })
-                    .transpose()?;
-                match telemetry {
-                    Some((client_tel, worker)) => {
-                        let handle = shared_runtime
-                            .spawn_worker(worker, self.restart_after_fork)
-                            .map_err(|e| {
+                })
+                .transpose()?;
+            match telemetry {
+                Some((client_tel, worker)) => {
+                    let handle = shared_runtime
+                        .spawn_worker(worker, self.restart_after_fork)
+                        .map_err(|e| {
                             TraceExporterError::Builder(BuilderErrorKind::InvalidConfiguration(
                                 e.to_string(),
                             ))
                         })?;
-                        if let Err(e) = client_tel.start() {
-                            tracing::warn!("Failed to start telemetry: {e}");
-                        }
-                        (Some(client_tel), Some(handle))
+                    if let Err(e) = client_tel.start() {
+                        tracing::warn!("Failed to start telemetry: {e}");
                     }
-                    None => (None, None),
+                    (Some(client_tel), Some(handle))
                 }
-            };
+                None => (None, None),
+            }
+        };
 
         // Transport selection: agentless is mutually exclusive with both OTLP and a
         // user-supplied agent URL; OTLP and the agent URL may coexist. All exclusion
@@ -898,7 +868,7 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
             previous_info_state: arc_swap::ArcSwapOption::new(None),
             info_response_observer,
             #[cfg(feature = "telemetry")]
-            telemetry: telemetry_client,
+            telemetry: ArcSwapOption::from(telemetry_client.map(Arc::new)),
             health_metrics_enabled: self.health_metrics_enabled,
             capabilities,
             workers: TraceExporterWorkers {
@@ -1086,7 +1056,7 @@ mod tests {
         assert_eq!(otlp_config.instrumentation_scope_version, "7.0.0-pre");
         assert!(!exporter.restart_after_fork);
         #[cfg(feature = "telemetry")]
-        assert!(exporter.telemetry.is_some());
+        assert!(exporter.telemetry.load().is_some());
     }
 
     #[cfg_attr(miri, ignore)]
@@ -1110,7 +1080,7 @@ mod tests {
         assert!(!exporter.metadata.client_computed_stats);
         assert!(exporter.restart_after_fork);
         #[cfg(feature = "telemetry")]
-        assert!(exporter.telemetry.is_none());
+        assert!(exporter.telemetry.load().is_none());
     }
 
     #[cfg_attr(miri, ignore)]
@@ -1255,7 +1225,7 @@ mod tests {
         assert!(exporter.workers.info_fetcher.is_none());
         // Telemetry talks to the agent base URL and is also skipped.
         assert!(exporter.workers.telemetry.is_none());
-        assert!(exporter.telemetry.is_none());
+        assert!(exporter.telemetry.load().is_none());
         // Sanity: the agentless transport is actually configured.
         assert!(exporter.agentless_config.is_some());
     }

--- a/libdd-data-pipeline/src/trace_exporter/builder.rs
+++ b/libdd-data-pipeline/src/trace_exporter/builder.rs
@@ -51,6 +51,12 @@ fn build_otlp_header_map(headers: Vec<(String, String)>) -> http::HeaderMap {
     out
 }
 
+/// Externally-owned telemetry worker to consolidate through; Boxed to avoid depending on C.
+#[cfg(all(feature = "telemetry", not(target_arch = "wasm32")))]
+type BoxedTelemetryHandle = Box<dyn ::std::any::Any + Sync + Send>;
+#[cfg(all(feature = "telemetry", target_arch = "wasm32"))]
+type BoxedTelemetryHandle = Box<dyn ::std::any::Any>;
+
 #[allow(missing_docs)]
 #[derive(Debug)]
 pub struct TraceExporterBuilder<R: SharedRuntime> {
@@ -84,7 +90,7 @@ pub struct TraceExporterBuilder<R: SharedRuntime> {
     #[cfg(feature = "telemetry")]
     telemetry: Option<TelemetryConfig>,
     #[cfg(feature = "telemetry")]
-    telemetry_handle: Option<TelemetryWorkerHandle>,
+    telemetry_handle: Option<BoxedTelemetryHandle>,
     telemetry_instrumentation_sessions: TelemetryInstrumentationSessions,
     shared_runtime: Option<Arc<R>>,
     health_metrics_enabled: bool,
@@ -389,8 +395,13 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
     }
 
     #[cfg(feature = "telemetry")]
-    pub fn set_telemetry_handle(&mut self, handle: TelemetryWorkerHandle) -> &mut Self {
-        self.telemetry_handle = Some(handle);
+    pub fn set_telemetry_handle<
+        C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static,
+    >(
+        &mut self,
+        handle: TelemetryWorkerHandle<C>,
+    ) -> &mut Self {
+        self.telemetry_handle = Some(Box::new(handle));
         self
     }
 
@@ -674,10 +685,13 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
 
         #[cfg(feature = "telemetry")]
         let (telemetry_client, telemetry_handle) =
-            if let Some(shared_handle) = self.telemetry_handle {
-                // Consolidated path: report health metrics through the externally-owned worker.
-                // We do not own it (no spawn, no start, no shutdown handle).
-                (Some(TelemetryClient::with_handle(shared_handle)), None)
+            // Consolidated path: report health metrics through the externally-owned worker.
+            // We do not own it (no spawn, no start, no shutdown handle).
+            if let Some(shared_handle) = self
+                .telemetry_handle
+                .and_then(|h| h.downcast::<TelemetryWorkerHandle<C>>().ok())
+            {
+                (Some(TelemetryClient::with_handle(*shared_handle)), None)
             } else {
                 let sessions = self.telemetry_instrumentation_sessions;
                 // Telemetry talks to the agent; disable it in agentless and log-export modes.

--- a/libdd-data-pipeline/src/trace_exporter/mod.rs
+++ b/libdd-data-pipeline/src/trace_exporter/mod.rs
@@ -47,6 +47,8 @@ use libdd_dogstatsd_client::DogStatsDClient;
 #[cfg(not(target_arch = "wasm32"))]
 use libdd_shared_runtime::BlockingRuntime;
 use libdd_shared_runtime::{SharedRuntime, WorkerHandle};
+#[cfg(feature = "telemetry")]
+use libdd_telemetry::worker::TelemetryWorkerHandle;
 use libdd_trace_utils::msgpack_decoder;
 use libdd_trace_utils::send_with_retry::{
     send_with_retry, CompressionStrategy, RetryStrategy, SendWithRetryError, SendWithRetryResult,
@@ -260,7 +262,7 @@ pub struct TraceExporter<
     previous_info_state: ArcSwapOption<String>,
     info_response_observer: ResponseObserver,
     #[cfg(feature = "telemetry")]
-    telemetry: Option<TelemetryClient<C>>,
+    telemetry: ArcSwapOption<TelemetryClient<C>>,
     health_metrics_enabled: bool,
     capabilities: C,
     workers: TraceExporterWorkers,
@@ -292,6 +294,18 @@ impl<
     #[allow(missing_docs)]
     pub fn builder() -> TraceExporterBuilder<R> {
         TraceExporterBuilder::new()
+    }
+
+    /// Re-point health-metric reporting at a different telemetry worker, or at none.
+    ///
+    /// Libraries might need to update the used telemetry worker at runtime. This allows doing so
+    /// without rebuilding the whole trace exporter.
+    ///
+    /// Pass `None` on telemetry shut down, so reporting stops rather than targeting a dead worker.
+    #[cfg(feature = "telemetry")]
+    pub fn set_telemetry_handle(&self, handle: Option<TelemetryWorkerHandle<C>>) {
+        self.telemetry
+            .store(handle.map(|h| Arc::new(TelemetryClient::with_handle(h))));
     }
 
     /// Stop the background workers owned by this exporter.
@@ -474,7 +488,11 @@ impl<
                         None
                     },
                     #[cfg(feature = "telemetry")]
-                    telemetry: self.telemetry.as_ref().map(|t| t.clone_handle()),
+                    telemetry: self
+                        .telemetry
+                        .load_full()
+                        .as_ref()
+                        .map(|t| t.clone_handle()),
                     #[cfg(not(feature = "telemetry"))]
                     _phantom: std::marker::PhantomData,
                 };
@@ -733,7 +751,7 @@ impl<
         .await;
 
         #[cfg(feature = "telemetry")]
-        if let Some(telemetry) = &self.telemetry {
+        if let Some(telemetry) = self.telemetry.load_full().as_deref() {
             if let Err(e) = telemetry.send(&SendPayloadTelemetry::from_retry_result(
                 &result,
                 payload_len as u64,
@@ -804,7 +822,7 @@ impl<
             self.client_computed_top_level,
             &self.trace_filterer.load(),
             #[cfg(feature = "telemetry")]
-            self.telemetry.as_ref(),
+            self.telemetry.load_full().as_deref(),
         );
 
         for chunk in &mut traces {

--- a/libdd-telemetry-ffi/src/builder.rs
+++ b/libdd-telemetry-ffi/src/builder.rs
@@ -118,7 +118,7 @@ pub unsafe extern "C" fn ddog_telemetry_builder_with_config(
     let seq_id = seq_id.to_std();
     builder.configurations.insert(data::Configuration {
         name,
-        value,
+        value: Some(value),
         origin,
         config_id,
         seq_id,

--- a/libdd-telemetry-ffi/src/worker_handle.rs
+++ b/libdd-telemetry-ffi/src/worker_handle.rs
@@ -25,7 +25,7 @@ pub unsafe extern "C" fn ddog_telemetry_handle_add_dependency(
 ) -> MaybeError {
     let name = crate::try_c!(dependency_name.try_to_string());
     let version = crate::try_c!(dependency_version.try_to_string_option());
-    crate::try_c!(handle.add_dependency(name, version));
+    crate::try_c!(handle.add_dependency(name, version, None));
     MaybeError::None
 }
 

--- a/libdd-telemetry-ffi/src/worker_handle.rs
+++ b/libdd-telemetry-ffi/src/worker_handle.rs
@@ -47,6 +47,7 @@ pub unsafe extern "C" fn ddog_telemetry_handle_add_integration(
         version,
         compatible.into(),
         auto_enabled.into(),
+        None,
     ));
     MaybeError::None
 }

--- a/libdd-telemetry/Cargo.toml
+++ b/libdd-telemetry/Cargo.toml
@@ -25,6 +25,8 @@ futures.workspace = true
 http = "1"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
+strum = { version = "0.26", default-features = false }
+strum_macros = "0.26"
 tokio = { workspace = true, features = ["sync", "io-util"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 tracing.workspace = true

--- a/libdd-telemetry/examples/tm-ping.rs
+++ b/libdd-telemetry/examples/tm-ping.rs
@@ -24,6 +24,9 @@ fn build_app_started_payload() -> AppStarted {
         configuration: Vec::new(),
         dependencies: Vec::new(),
         integrations: Vec::new(),
+        install_signature: None,
+        products: Default::default(),
+        error: None,
     }
 }
 

--- a/libdd-telemetry/src/config.rs
+++ b/libdd-telemetry/src/config.rs
@@ -58,6 +58,15 @@ pub struct Config {
     pub parent_session_id: Option<String>,
     #[serde(default)]
     pub root_session_id: Option<String>,
+
+    /// Whether to emit the `app-started`/`app-closing` lifecycle payloads.
+    /// Forked processes may not be required to emit these.
+    #[serde(default = "default_true")]
+    pub emit_app_lifecycle: bool,
+}
+
+fn default_true() -> bool {
+    true
 }
 
 fn endpoint_with_telemetry_path(
@@ -195,6 +204,7 @@ impl Default for Config {
             session_id: None,
             parent_session_id: None,
             root_session_id: None,
+            emit_app_lifecycle: true,
         }
     }
 }
@@ -334,6 +344,7 @@ impl Config {
             session_id: None,
             parent_session_id: None,
             root_session_id: None,
+            emit_app_lifecycle: true,
         };
 
         _ = this.set_endpoint(TelemetryEndpoint {

--- a/libdd-telemetry/src/config.rs
+++ b/libdd-telemetry/src/config.rs
@@ -63,10 +63,20 @@ pub struct Config {
     /// Forked processes may not be required to emit these.
     #[serde(default = "default_true")]
     pub emit_app_lifecycle: bool,
+
+    /// Maximum number of endpoints serialized into one payload
+    /// (`DD_API_SECURITY_ENDPOINT_COLLECTION_MESSAGE_LIMIT` in the tracers).
+    /// Endpoints sending is batched per heartbeat interval.
+    #[serde(default = "default_endpoints_message_limit")]
+    pub endpoints_message_limit: u32,
 }
 
 fn default_true() -> bool {
     true
+}
+
+fn default_endpoints_message_limit() -> u32 {
+    300
 }
 
 fn endpoint_with_telemetry_path(
@@ -107,6 +117,7 @@ pub struct Settings {
     pub telemetry_dd_url: Option<String>,
     pub telemetry_heartbeat_interval: Duration,
     pub telemetry_extended_heartbeat_interval: Duration,
+    pub endpoints_message_limit: u32,
     pub shared_lib_debug: bool,
 
     // Filesystem check
@@ -126,6 +137,7 @@ impl Default for Settings {
             telemetry_dd_url: None,
             telemetry_heartbeat_interval: Duration::from_secs(60),
             telemetry_extended_heartbeat_interval: Duration::from_secs(60 * 60 * 24),
+            endpoints_message_limit: default_endpoints_message_limit(),
             shared_lib_debug: false,
 
             agent_uds_socket_found: false,
@@ -151,6 +163,8 @@ impl Settings {
     const DD_TELEMETRY_HEARTBEAT_INTERVAL: &'static str = "DD_TELEMETRY_HEARTBEAT_INTERVAL";
     const DD_TELEMETRY_EXTENDED_HEARTBEAT_INTERVAL: &'static str =
         "DD_TELEMETRY_EXTENDED_HEARTBEAT_INTERVAL";
+    const DD_API_SECURITY_ENDPOINT_COLLECTION_MESSAGE_LIMIT: &'static str =
+        "DD_API_SECURITY_ENDPOINT_COLLECTION_MESSAGE_LIMIT";
     const _DD_SHARED_LIB_DEBUG: &'static str = "_DD_SHARED_LIB_DEBUG";
 
     pub fn from_env() -> Self {
@@ -180,6 +194,10 @@ impl Settings {
             )
             .unwrap_or(Duration::from_secs(60 * 60 * 24)),
             shared_lib_debug: parse_env::bool(Self::_DD_SHARED_LIB_DEBUG).unwrap_or(false),
+            endpoints_message_limit: parse_env::int(
+                Self::DD_API_SECURITY_ENDPOINT_COLLECTION_MESSAGE_LIMIT,
+            )
+            .unwrap_or(default_endpoints_message_limit()),
 
             agent_uds_socket_found: (|| {
                 #[cfg(unix)]
@@ -205,6 +223,7 @@ impl Default for Config {
             parent_session_id: None,
             root_session_id: None,
             emit_app_lifecycle: true,
+            endpoints_message_limit: default_endpoints_message_limit(),
         }
     }
 }
@@ -345,6 +364,7 @@ impl Config {
             parent_session_id: None,
             root_session_id: None,
             emit_app_lifecycle: true,
+            endpoints_message_limit: settings.endpoints_message_limit,
         };
 
         _ = this.set_endpoint(TelemetryEndpoint {

--- a/libdd-telemetry/src/data/common.rs
+++ b/libdd-telemetry/src/data/common.rs
@@ -63,6 +63,8 @@ pub struct Host {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub os_version: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub architecture: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub kernel_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kernel_release: Option<String>,

--- a/libdd-telemetry/src/data/metrics.rs
+++ b/libdd-telemetry/src/data/metrics.rs
@@ -36,8 +36,20 @@ pub enum SerializedSketch {
     B64 { sketch_b64: String },
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+#[derive(
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    strum_macros::Display,
+    strum_macros::EnumIter,
+)]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 #[repr(C)]
 pub enum MetricNamespace {
     Tracers,
@@ -51,13 +63,29 @@ pub enum MetricNamespace {
     Telemetry,
     Apm,
     Sidecar,
+    Civisibility,
+    Mlobs,
+    Ddtraceapi,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(
+    Serialize,
+    Deserialize,
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    strum_macros::Display,
+    strum_macros::EnumIter,
+)]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 #[repr(C)]
 pub enum MetricType {
     Gauge,
     Count,
+    Rate,
     Distribution,
 }

--- a/libdd-telemetry/src/data/metrics.rs
+++ b/libdd-telemetry/src/data/metrics.rs
@@ -86,6 +86,6 @@ pub enum MetricNamespace {
 pub enum MetricType {
     Gauge,
     Count,
-    Rate,
     Distribution,
+    Rate,
 }

--- a/libdd-telemetry/src/data/metrics.rs
+++ b/libdd-telemetry/src/data/metrics.rs
@@ -47,6 +47,7 @@ pub enum SerializedSketch {
     Hash,
     strum_macros::Display,
     strum_macros::EnumIter,
+    strum_macros::IntoStaticStr,
 )]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
@@ -79,6 +80,7 @@ pub enum MetricNamespace {
     Hash,
     strum_macros::Display,
     strum_macros::EnumIter,
+    strum_macros::IntoStaticStr,
 )]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]

--- a/libdd-telemetry/src/data/metrics.rs
+++ b/libdd-telemetry/src/data/metrics.rs
@@ -67,6 +67,7 @@ pub enum MetricNamespace {
     Civisibility,
     Mlobs,
     Ddtraceapi,
+    AiGuard,
 }
 
 #[derive(

--- a/libdd-telemetry/src/data/payload.rs
+++ b/libdd-telemetry/src/data/payload.rs
@@ -11,6 +11,7 @@ pub enum Payload {
     AppStarted(AppStarted),
     AppDependenciesLoaded(AppDependenciesLoaded),
     AppIntegrationsChange(AppIntegrationsChange),
+    AppProductChange(AppProductChange),
     AppClientConfigurationChange(AppClientConfigurationChange),
     AppEndpoints(AppEndpoints),
     AppHeartbeat(#[serde(skip_serializing)] ()),
@@ -29,6 +30,7 @@ impl Payload {
             AppStarted(_) => "app-started",
             AppDependenciesLoaded(_) => "app-dependencies-loaded",
             AppIntegrationsChange(_) => "app-integrations-change",
+            AppProductChange(_) => "app-product-change",
             AppClientConfigurationChange(_) => "app-client-configuration-change",
             AppEndpoints(_) => "app-endpoints",
             AppHeartbeat(_) => "app-heartbeat",
@@ -68,6 +70,9 @@ mod tests {
             ],
             dependencies: Vec::new(),
             integrations: Vec::new(),
+            install_signature: None,
+            products: Default::default(),
+            error: None,
         });
 
         let serialized = serde_json::to_value(&payload).unwrap();
@@ -106,10 +111,11 @@ mod tests {
                 Dependency {
                     name: "tokio".to_string(),
                     version: Some("1.32.0".to_string()),
+                    ..Default::default()
                 },
                 Dependency {
                     name: "serde".to_string(),
-                    version: None,
+                    ..Default::default()
                 },
             ],
         });
@@ -485,6 +491,100 @@ mod tests {
     }
 
     #[test]
+    fn test_app_product_change_serialization() {
+        let mut products = std::collections::HashMap::new();
+        products.insert(
+            "appsec".to_string(),
+            ProductState {
+                enabled: true,
+                version: Some("1.2.3".to_string()),
+                error: None,
+            },
+        );
+        let payload = Payload::AppProductChange(AppProductChange { products });
+
+        let serialized = serde_json::to_value(&payload).unwrap();
+
+        let expected = json!({
+            "request_type": "app-product-change",
+            "payload": {
+                "products": {
+                    "appsec": {
+                        "enabled": true,
+                        "version": "1.2.3"
+                    }
+                }
+            }
+        });
+
+        assert_eq!(serialized, expected);
+    }
+
+    #[test]
+    fn test_dependency_metadata_serialization() {
+        // A plain dependency (no metadata) omits both `hash` and `metadata`.
+        let plain = Payload::AppDependenciesLoaded(AppDependenciesLoaded {
+            dependencies: vec![Dependency {
+                name: "requests".to_string(),
+                version: Some("2.0".to_string()),
+                ..Default::default()
+            }],
+        });
+        assert_eq!(
+            serde_json::to_value(&plain).unwrap(),
+            json!({
+                "request_type": "app-dependencies-loaded",
+                "payload": { "dependencies": [{ "name": "requests", "version": "2.0" }] }
+            })
+        );
+
+        // With SCA metadata: per the telemetry schema, `type` names the metadata kind and
+        // `value` is an opaque stringified-JSON payload that consumers must parse.
+        let with_sca = Payload::AppDependenciesLoaded(AppDependenciesLoaded {
+            dependencies: vec![Dependency {
+                name: "requests".to_string(),
+                version: Some("2.0".to_string()),
+                metadata: Some(vec![DependencyMetadata {
+                    r#type: "reachability".to_string(),
+                    value: "{\"id\":\"CVE-2024-1\",\"reached\":true}".to_string(),
+                }]),
+                ..Default::default()
+            }],
+        });
+        assert_eq!(
+            serde_json::to_value(&with_sca).unwrap(),
+            json!({
+                "request_type": "app-dependencies-loaded",
+                "payload": { "dependencies": [{
+                    "name": "requests",
+                    "version": "2.0",
+                    "metadata": [{
+                        "type": "reachability",
+                        "value": "{\"id\":\"CVE-2024-1\",\"reached\":true}"
+                    }]
+                }] }
+            })
+        );
+
+        // SCA enabled with no findings: `metadata` is present-but-empty (distinct from omitted).
+        let empty_meta = Payload::AppDependenciesLoaded(AppDependenciesLoaded {
+            dependencies: vec![Dependency {
+                name: "requests".to_string(),
+                version: Some("2.0".to_string()),
+                metadata: Some(vec![]),
+                ..Default::default()
+            }],
+        });
+        assert_eq!(
+            serde_json::to_value(&empty_meta).unwrap(),
+            json!({
+                "request_type": "app-dependencies-loaded",
+                "payload": { "dependencies": [{ "name": "requests", "version": "2.0", "metadata": [] }] }
+            })
+        );
+    }
+
+    #[test]
     fn test_app_extended_heartbeat_serialization() {
         let payload = Payload::AppExtendedHeartbeat(AppStarted {
             configuration: vec![Configuration {
@@ -496,6 +596,9 @@ mod tests {
             }],
             dependencies: Vec::new(),
             integrations: Vec::new(),
+            install_signature: None,
+            products: Default::default(),
+            error: None,
         });
 
         let serialized = serde_json::to_value(&payload).unwrap();

--- a/libdd-telemetry/src/data/payload.rs
+++ b/libdd-telemetry/src/data/payload.rs
@@ -55,14 +55,14 @@ mod tests {
             configuration: vec![
                 Configuration {
                     name: "sampling_rate".to_string(),
-                    value: "0.5".to_string(),
+                    value: Some("0.5".to_string()),
                     origin: ConfigurationOrigin::EnvVar,
                     config_id: Some("config-123".to_string()),
                     seq_id: Some(42),
                 },
                 Configuration {
                     name: "log_level".to_string(),
-                    value: "debug".to_string(),
+                    value: Some("debug".to_string()),
                     origin: ConfigurationOrigin::Code,
                     config_id: None,
                     seq_id: None,
@@ -198,7 +198,7 @@ mod tests {
         let payload = Payload::AppClientConfigurationChange(AppClientConfigurationChange {
             configuration: vec![Configuration {
                 name: "timeout".to_string(),
-                value: "30s".to_string(),
+                value: Some("30s".to_string()),
                 origin: ConfigurationOrigin::RemoteConfig,
                 config_id: Some("remote-1".to_string()),
                 seq_id: Some(10),
@@ -598,7 +598,7 @@ mod tests {
         let payload = Payload::AppExtendedHeartbeat(AppStarted {
             configuration: vec![Configuration {
                 name: "feature_flag".to_string(),
-                value: "enabled".to_string(),
+                value: Some("enabled".to_string()),
                 origin: ConfigurationOrigin::Default,
                 config_id: None,
                 seq_id: None,

--- a/libdd-telemetry/src/data/payload.rs
+++ b/libdd-telemetry/src/data/payload.rs
@@ -155,6 +155,7 @@ mod tests {
                     version: Some("0.19.0".to_string()),
                     compatible: Some(true),
                     auto_enabled: Some(false),
+                    ..Default::default()
                 },
                 Integration {
                     name: "redis".to_string(),
@@ -162,6 +163,7 @@ mod tests {
                     version: None,
                     compatible: None,
                     auto_enabled: None,
+                    error: Some("patch failed: boom".to_string()),
                 },
             ],
         });
@@ -177,14 +179,16 @@ mod tests {
                         "enabled": true,
                         "version": "0.19.0",
                         "compatible": true,
-                        "auto_enabled": false
+                        "auto_enabled": false,
+                        "error": null
                     },
                     {
                         "name": "redis",
                         "enabled": false,
                         "version": null,
                         "compatible": null,
-                        "auto_enabled": null
+                        "auto_enabled": null,
+                        "error": "patch failed: boom"
                     }
                 ]
             }
@@ -250,7 +254,7 @@ mod tests {
         let expected = json!({
             "request_type": "app-endpoints",
             "payload": {
-                "is-first": true,
+                "is_first": true,
                 "endpoints": [
                     {
                         "method": "GET",

--- a/libdd-telemetry/src/data/payload.rs
+++ b/libdd-telemetry/src/data/payload.rs
@@ -128,11 +128,15 @@ mod tests {
                 "dependencies": [
                     {
                         "name": "tokio",
-                        "version": "1.32.0"
+                        "version": "1.32.0",
+                        "hash": null,
+                        "metadata": null
                     },
                     {
                         "name": "serde",
-                        "version": null
+                        "version": null,
+                        "hash": null,
+                        "metadata": null
                     }
                 ]
             }
@@ -246,7 +250,7 @@ mod tests {
         let expected = json!({
             "request_type": "app-endpoints",
             "payload": {
-                "is_first": true,
+                "is-first": true,
                 "endpoints": [
                     {
                         "method": "GET",
@@ -511,7 +515,8 @@ mod tests {
                 "products": {
                     "appsec": {
                         "enabled": true,
-                        "version": "1.2.3"
+                        "version": "1.2.3",
+                        "error": null
                     }
                 }
             }
@@ -522,7 +527,6 @@ mod tests {
 
     #[test]
     fn test_dependency_metadata_serialization() {
-        // A plain dependency (no metadata) omits both `hash` and `metadata`.
         let plain = Payload::AppDependenciesLoaded(AppDependenciesLoaded {
             dependencies: vec![Dependency {
                 name: "requests".to_string(),
@@ -534,7 +538,9 @@ mod tests {
             serde_json::to_value(&plain).unwrap(),
             json!({
                 "request_type": "app-dependencies-loaded",
-                "payload": { "dependencies": [{ "name": "requests", "version": "2.0" }] }
+                "payload": { "dependencies": [{
+                    "name": "requests", "version": "2.0", "hash": null, "metadata": null
+                }] }
             })
         );
 
@@ -558,6 +564,7 @@ mod tests {
                 "payload": { "dependencies": [{
                     "name": "requests",
                     "version": "2.0",
+                    "hash": null,
                     "metadata": [{
                         "type": "reachability",
                         "value": "{\"id\":\"CVE-2024-1\",\"reached\":true}"
@@ -579,7 +586,9 @@ mod tests {
             serde_json::to_value(&empty_meta).unwrap(),
             json!({
                 "request_type": "app-dependencies-loaded",
-                "payload": { "dependencies": [{ "name": "requests", "version": "2.0", "metadata": [] }] }
+                "payload": { "dependencies": [{
+                    "name": "requests", "version": "2.0", "hash": null, "metadata": []
+                }] }
             })
         );
     }

--- a/libdd-telemetry/src/data/payloads.rs
+++ b/libdd-telemetry/src/data/payloads.rs
@@ -1,6 +1,7 @@
 // Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
 use std::hash::Hasher;
 
 use crate::data::metrics;
@@ -11,6 +12,16 @@ use serde::{Deserialize, Serialize};
 pub struct Dependency {
     pub name: String,
     pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Vec<DependencyMetadata>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Hash, PartialEq, Eq, Clone, Default)]
+pub struct DependencyMetadata {
+    pub r#type: String,
+    pub value: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Hash, PartialEq, Eq, Clone, Default)]
@@ -31,11 +42,24 @@ pub struct Configuration {
     pub seq_id: Option<u64>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Hash, PartialEq, Eq, Clone)]
+#[derive(
+    Serialize,
+    Deserialize,
+    Debug,
+    Hash,
+    PartialEq,
+    Eq,
+    Clone,
+    Copy,
+    strum_macros::Display,
+    strum_macros::EnumIter,
+)]
 #[repr(C)]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum ConfigurationOrigin {
     EnvVar,
+    OtelEnvVar,
     Code,
     DdConfig,
     RemoteConfig,
@@ -43,6 +67,13 @@ pub enum ConfigurationOrigin {
     LocalStableConfig,
     FleetStableConfig,
     Calculated,
+    Unknown,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub struct Error {
+    pub code: Option<i64>,
+    pub message: Option<String>,
 }
 
 #[derive(Serialize, Debug)]
@@ -50,11 +81,37 @@ pub struct AppStarted {
     pub configuration: Vec<Configuration>,
     pub dependencies: Vec<Dependency>,
     pub integrations: Vec<Integration>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub install_signature: Option<InstallSignature>,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub products: HashMap<String, ProductState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<Error>,
+}
+
+#[derive(Serialize, Debug, Clone)]
+pub struct InstallSignature {
+    pub install_id: Option<String>,
+    pub install_type: Option<String>,
+    pub install_time: Option<String>,
 }
 
 #[derive(Serialize, Debug)]
 pub struct AppDependenciesLoaded {
     pub dependencies: Vec<Dependency>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub struct ProductState {
+    pub enabled: bool,
+    pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<Error>,
+}
+
+#[derive(Serialize, Debug)]
+pub struct AppProductChange {
+    pub products: HashMap<String, ProductState>,
 }
 
 #[derive(Serialize, Debug)]
@@ -99,8 +156,20 @@ pub struct Log {
     pub is_crash: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(
+    Serialize,
+    Deserialize,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Clone,
+    Copy,
+    strum_macros::Display,
+    strum_macros::EnumIter,
+)]
 #[serde(rename_all = "UPPERCASE")]
+#[strum(serialize_all = "UPPERCASE")]
 #[repr(C)]
 pub enum LogLevel {
     Error,

--- a/libdd-telemetry/src/data/payloads.rs
+++ b/libdd-telemetry/src/data/payloads.rs
@@ -18,6 +18,26 @@ pub struct Dependency {
     pub metadata: Option<Vec<DependencyMetadata>>,
 }
 
+/// SCA metadata may be attached to a dependency after it was first reported; keying the store
+/// by this instead of the full struct means that update refreshes the existing entry instead of
+/// being stored (and re-sent) as a second entry for the same package/version.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DependencyKey {
+    name: String,
+    version: Option<String>,
+    hash: Option<String>,
+}
+
+impl crate::worker::store::Keyed<DependencyKey> for Dependency {
+    fn key(&self) -> DependencyKey {
+        DependencyKey {
+            name: self.name.clone(),
+            version: self.version.clone(),
+            hash: self.hash.clone(),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Hash, PartialEq, Eq, Clone, Default)]
 pub struct DependencyMetadata {
     pub r#type: String,

--- a/libdd-telemetry/src/data/payloads.rs
+++ b/libdd-telemetry/src/data/payloads.rs
@@ -79,7 +79,6 @@ pub struct Configuration {
 #[strum(serialize_all = "snake_case")]
 pub enum ConfigurationOrigin {
     EnvVar,
-    OtelEnvVar,
     Code,
     DdConfig,
     RemoteConfig,
@@ -87,6 +86,7 @@ pub enum ConfigurationOrigin {
     LocalStableConfig,
     FleetStableConfig,
     Calculated,
+    OtelEnvVar,
     Unknown,
 }
 

--- a/libdd-telemetry/src/data/payloads.rs
+++ b/libdd-telemetry/src/data/payloads.rs
@@ -12,9 +12,7 @@ use serde::{Deserialize, Serialize};
 pub struct Dependency {
     pub name: String,
     pub version: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub hash: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Vec<DependencyMetadata>>,
 }
 
@@ -88,6 +86,7 @@ pub enum ConfigurationOrigin {
     FleetStableConfig,
     Calculated,
     OtelEnvVar,
+    Ini,
     Unknown,
 }
 
@@ -126,7 +125,6 @@ pub struct AppDependenciesLoaded {
 pub struct ProductState {
     pub enabled: bool,
     pub version: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<Error>,
 }
 
@@ -147,6 +145,7 @@ pub struct AppClientConfigurationChange {
 
 #[derive(Debug, Serialize)]
 pub struct AppEndpoints {
+    #[serde(rename = "is-first")]
     pub is_first: bool,
     pub endpoints: Vec<serde_json::Value>,
 }

--- a/libdd-telemetry/src/data/payloads.rs
+++ b/libdd-telemetry/src/data/payloads.rs
@@ -241,6 +241,8 @@ pub struct Endpoint {
     pub operation_name: String,
     pub resource_name: String,
     #[serde(default)]
+    pub request_body_type: Option<Vec<String>>,
+    #[serde(default)]
     pub response_body_type: Option<Vec<String>>,
     #[serde(default)]
     pub response_code: Option<Vec<u32>>,

--- a/libdd-telemetry/src/data/payloads.rs
+++ b/libdd-telemetry/src/data/payloads.rs
@@ -232,6 +232,10 @@ pub struct Endpoint {
     pub path: Option<String>,
     pub operation_name: String,
     pub resource_name: String,
+    #[serde(default)]
+    pub response_body_type: Option<Vec<String>>,
+    #[serde(default)]
+    pub response_code: Option<Vec<u32>>,
 }
 
 impl PartialEq for Endpoint {

--- a/libdd-telemetry/src/data/payloads.rs
+++ b/libdd-telemetry/src/data/payloads.rs
@@ -147,13 +147,6 @@ pub struct AppClientConfigurationChange {
 
 #[derive(Debug, Serialize)]
 pub struct AppEndpoints {
-    /// Flags the first app-endpoints payload of the process.
-    ///
-    /// Serialized as `is_first`: that is what every tracer actually puts on the wire (dd-trace-py
-    /// shipped `{"is_first": ...}` from its Python implementation) and what system-tests asserts
-    /// on. The backend's `AppEndpointsPayload` struct tags this `json:"is-first"`, but no producer
-    /// sends the hyphenated form, so that tag matches nothing today - do not "fix" this to match
-    /// it without changing the producers too, or the flag silently stops arriving.
     pub is_first: bool,
     pub endpoints: Vec<serde_json::Value>,
 }

--- a/libdd-telemetry/src/data/payloads.rs
+++ b/libdd-telemetry/src/data/payloads.rs
@@ -152,8 +152,8 @@ pub struct AppEndpoints {
     /// Serialized as `is_first`: that is what every tracer actually puts on the wire (dd-trace-py
     /// shipped `{"is_first": ...}` from its Python implementation) and what system-tests asserts
     /// on. The backend's `AppEndpointsPayload` struct tags this `json:"is-first"`, but no producer
-    /// sends the hyphenated form, so that tag matches nothing today - do not "fix" this to match it
-    /// without changing the producers too, or the flag silently stops arriving.
+    /// sends the hyphenated form, so that tag matches nothing today - do not "fix" this to match
+    /// it without changing the producers too, or the flag silently stops arriving.
     pub is_first: bool,
     pub endpoints: Vec<serde_json::Value>,
 }

--- a/libdd-telemetry/src/data/payloads.rs
+++ b/libdd-telemetry/src/data/payloads.rs
@@ -49,12 +49,14 @@ pub struct Integration {
     pub version: Option<String>,
     pub compatible: Option<bool>,
     pub auto_enabled: Option<bool>,
+    #[serde(default)]
+    pub error: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Hash, PartialEq, Eq, Clone)]
 pub struct Configuration {
     pub name: String,
-    pub value: Option<String>,  // distinguish `null` from ""
+    pub value: Option<String>, // distinguish `null` from ""
     pub origin: ConfigurationOrigin,
     pub config_id: Option<String>,
     pub seq_id: Option<u64>,
@@ -145,7 +147,13 @@ pub struct AppClientConfigurationChange {
 
 #[derive(Debug, Serialize)]
 pub struct AppEndpoints {
-    #[serde(rename = "is-first")]
+    /// Flags the first app-endpoints payload of the process.
+    ///
+    /// Serialized as `is_first`: that is what every tracer actually puts on the wire (dd-trace-py
+    /// shipped `{"is_first": ...}` from its Python implementation) and what system-tests asserts
+    /// on. The backend's `AppEndpointsPayload` struct tags this `json:"is-first"`, but no producer
+    /// sends the hyphenated form, so that tag matches nothing today - do not "fix" this to match it
+    /// without changing the producers too, or the flag silently stops arriving.
     pub is_first: bool,
     pub endpoints: Vec<serde_json::Value>,
 }

--- a/libdd-telemetry/src/data/payloads.rs
+++ b/libdd-telemetry/src/data/payloads.rs
@@ -73,6 +73,7 @@ pub struct Configuration {
     Copy,
     strum_macros::Display,
     strum_macros::EnumIter,
+    strum_macros::IntoStaticStr,
 )]
 #[repr(C)]
 #[serde(rename_all = "snake_case")]
@@ -187,6 +188,8 @@ pub struct Log {
     Copy,
     strum_macros::Display,
     strum_macros::EnumIter,
+    // IntoStaticStr: required by the pre-9488 `ConvertToPyO3Enum` macro; see metrics.rs.
+    strum_macros::IntoStaticStr,
 )]
 #[serde(rename_all = "UPPERCASE")]
 #[strum(serialize_all = "UPPERCASE")]

--- a/libdd-telemetry/src/data/payloads.rs
+++ b/libdd-telemetry/src/data/payloads.rs
@@ -54,7 +54,7 @@ pub struct Integration {
 #[derive(Serialize, Deserialize, Debug, Hash, PartialEq, Eq, Clone)]
 pub struct Configuration {
     pub name: String,
-    pub value: String,
+    pub value: Option<String>,  // distinguish `null` from ""
     pub origin: ConfigurationOrigin,
     pub config_id: Option<String>,
     pub seq_id: Option<u64>,

--- a/libdd-telemetry/src/info.rs
+++ b/libdd-telemetry/src/info.rs
@@ -20,6 +20,10 @@ pub mod os {
         std::env::consts::OS
     }
 
+    pub const fn architecture() -> &'static str {
+        std::env::consts::ARCH
+    }
+
     #[cfg(not(target_arch = "wasm32"))]
     pub fn os_version() -> anyhow::Result<String> {
         sys_info::os_release().map_err(|e| e.into())

--- a/libdd-telemetry/src/lib.rs
+++ b/libdd-telemetry/src/lib.rs
@@ -18,6 +18,9 @@ pub mod info;
 pub mod metrics;
 pub mod worker;
 
+pub use libdd_common::tag::{parse_tags, Tag};
+pub use libdd_common::{parse_uri, Endpoint};
+
 pub fn build_host() -> data::Host {
     debug!("Building telemetry host information");
     let hostname = info::os::real_hostname().unwrap_or_else(|_| String::from("unknown_hostname"));

--- a/libdd-telemetry/src/lib.rs
+++ b/libdd-telemetry/src/lib.rs
@@ -32,6 +32,7 @@ pub fn build_host() -> data::Host {
         host.container_id = ?container_id,
         host.os = info::os::os_name(),
         host.os_version = ?os_version,
+        host.architecture = info::os::architecture(),
         "Built telemetry host information"
     );
 
@@ -40,6 +41,7 @@ pub fn build_host() -> data::Host {
         container_id,
         os: Some(String::from(info::os::os_name())),
         os_version,
+        architecture: Some(String::from(info::os::architecture())),
         kernel_name: info::os::os_type(),
         kernel_release: info::os::os_release(),
         #[cfg(unix)]

--- a/libdd-telemetry/src/metrics.rs
+++ b/libdd-telemetry/src/metrics.rs
@@ -121,7 +121,7 @@ impl MetricBuckets {
             extra_tags,
         };
         match context_key.1 {
-            metrics::MetricType::Count => self
+            metrics::MetricType::Count | metrics::MetricType::Rate => self
                 .buckets
                 .entry(bucket_key)
                 .or_insert_with(|| MetricBucket {

--- a/libdd-telemetry/src/metrics.rs
+++ b/libdd-telemetry/src/metrics.rs
@@ -52,6 +52,24 @@ impl MetricBucket {
 #[repr(C)]
 pub struct ContextKey(u32, metrics::MetricType);
 
+impl ContextKey {
+    /// The index into the metric-context store.
+    pub(crate) fn index(self) -> u32 {
+        self.0
+    }
+
+    /// The metric type this context was registered with.
+    pub(crate) fn metric_type(self) -> metrics::MetricType {
+        self.1
+    }
+
+    /// Reconstruct a key from its parts (used by the metric ring buffer, which encodes the key
+    /// into an atomic slot). Only valid for indices/types produced by [`MetricContexts`].
+    pub(crate) fn from_parts(index: u32, metric_type: metrics::MetricType) -> Self {
+        ContextKey(index, metric_type)
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Hash)]
 struct BucketKey {
     context_key: ContextKey,

--- a/libdd-telemetry/src/worker/metric_ring.rs
+++ b/libdd-telemetry/src/worker/metric_ring.rs
@@ -1,0 +1,292 @@
+// Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+//! A bounded multi-producer / single-consumer ring buffer for metric points.
+//!
+//! Metric points are the highest-frequency telemetry action, so routing every point through the
+//! worker's tokio mpsc channel — a heap-boxed [`TelemetryActions`] message plus a receiver wakeup
+//! per point — dominates the per-`add_point` cost. This ring buffer replaces that per-point cost
+//! with:
+//!   * a wait-free reserve (`fetch_add` on the write cursor) followed by a release-store publish,
+//!   * a single consumer (the telemetry worker) that batch-drains all pending points,
+//!   * an amortized wakeup — the consumer is notified once every [`NOTIFY_INTERVAL`] points (and
+//!     whenever a producer has to wait for back-pressure), not once per point, and
+//!   * synchronous back-pressure — a producer that would lap the consumer spins/yields until the
+//!     consumer has caught up, bounding memory without dropping points.
+//!
+//! # Protocol (Disruptor-style, one writer per slot)
+//!
+//! Each slot's ready flag is an encoded `Option<ContextKey>`: `0` means "empty", any other value
+//! means "a fully-written point" (the [`ContextKey`] is stashed in the high-and-low bits with a
+//! sentinel bit so it is never `0`). A producer reserves a unique sequence with `fetch_add`, writes
+//! `value`/`tags` into that slot's cells, then **release-stores** the encoded key. The consumer
+//! reads slots in sequence order; it **acquire-loads** the flag and stops at the first `0` (a point
+//! not yet published), so the producers' field writes are always visible before the consumer reads
+//! them, and points are consumed in publication order. After reading, the consumer restores `0`.
+//!
+//! # Safety
+//!
+//! Each slot's [`UnsafeCell`]s are written by exactly one producer (the thread that reserved that
+//! sequence) and read by exactly one consumer (the worker), and the two are ordered by the
+//! release/acquire on the ready flag. No two threads ever touch the same slot's cells concurrently,
+//! which is what makes the `unsafe impl Sync` sound.
+
+use std::cell::UnsafeCell;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use tokio::sync::Notify;
+
+use crate::data::metrics::MetricType;
+use crate::metrics::ContextKey;
+use crate::Tag;
+
+/// Number of slots. Must be a power of two.
+const RING_SIZE: usize = 2048;
+const RING_MASK: u64 = RING_SIZE as u64 - 1;
+/// Notify the consumer once every this many published points. Power of two, `<= RING_SIZE`.
+const NOTIFY_INTERVAL: u64 = 1024;
+const NOTIFY_MASK: u64 = NOTIFY_INTERVAL - 1;
+
+/// Sentinel bit that makes an encoded [`ContextKey`] non-zero (so `0` unambiguously means "empty"
+/// even for context index `0`, metric type `Gauge`).
+const READY_BIT: u64 = 1 << 63;
+
+struct Slot {
+    value: UnsafeCell<f64>,
+    tags: UnsafeCell<Vec<Tag>>,
+    /// Encoded `Option<ContextKey>`: `0` = empty, otherwise a published point (see module docs).
+    ready: AtomicU64,
+}
+
+impl Slot {
+    fn empty() -> Self {
+        Slot {
+            value: UnsafeCell::new(0.0),
+            tags: UnsafeCell::new(Vec::new()),
+            ready: AtomicU64::new(0),
+        }
+    }
+}
+
+fn metric_type_to_bits(t: MetricType) -> u64 {
+    match t {
+        MetricType::Gauge => 0,
+        MetricType::Count => 1,
+        MetricType::Distribution => 2,
+        MetricType::Rate => 3,
+    }
+}
+
+fn metric_type_from_bits(b: u64) -> MetricType {
+    match b & 0b11 {
+        0 => MetricType::Gauge,
+        1 => MetricType::Count,
+        2 => MetricType::Distribution,
+        _ => MetricType::Rate,
+    }
+}
+
+fn encode_key(key: ContextKey) -> u64 {
+    READY_BIT | (metric_type_to_bits(key.metric_type()) << 32) | key.index() as u64
+}
+
+fn decode_key(v: u64) -> ContextKey {
+    ContextKey::from_parts((v & 0xFFFF_FFFF) as u32, metric_type_from_bits(v >> 32))
+}
+
+pub struct MetricRing {
+    slots: Box<[Slot]>,
+    /// Next sequence to reserve; producers `fetch_add` to claim a slot.
+    write_pos: AtomicU64,
+    /// Next sequence to consume; published by the single consumer and read by producers to detect
+    /// back-pressure.
+    read_pos: AtomicU64,
+    /// Wakes the consumer. Notified every [`NOTIFY_INTERVAL`] points and on back-pressure.
+    notify: Notify,
+}
+
+// SAFETY: see the module-level "Safety" note — per-slot cells have a single writer and a single
+// reader, ordered by the release/acquire on `ready`.
+unsafe impl Send for MetricRing {}
+unsafe impl Sync for MetricRing {}
+
+impl MetricRing {
+    pub fn new() -> Self {
+        let slots = (0..RING_SIZE).map(|_| Slot::empty()).collect::<Vec<_>>();
+        MetricRing {
+            slots: slots.into_boxed_slice(),
+            write_pos: AtomicU64::new(0),
+            read_pos: AtomicU64::new(0),
+            notify: Notify::new(),
+        }
+    }
+
+    /// A future the consumer awaits to be woken when points are available.
+    pub fn notified(&self) -> impl std::future::Future<Output = ()> + '_ {
+        self.notify.notified()
+    }
+
+    /// Publish a metric point. Wait-free unless the buffer is full, in which case it spins/yields
+    /// (waking the consumer) until a slot frees up. Safe to call from any thread.
+    pub fn push(&self, value: f64, key: ContextKey, tags: Vec<Tag>) {
+        let seq = self.write_pos.fetch_add(1, Ordering::Relaxed);
+
+        // Back-pressure: our slot still holds an un-consumed point from `seq - RING_SIZE` until the
+        // consumer advances `read_pos` past it. Wait for that, waking the consumer so it drains.
+        let mut spins = 0u32;
+        while seq.wrapping_sub(self.read_pos.load(Ordering::Acquire)) >= RING_SIZE as u64 {
+            self.notify.notify_one();
+            spins += 1;
+            if spins < 64 {
+                std::hint::spin_loop();
+            } else {
+                std::thread::yield_now();
+            }
+        }
+
+        let slot = &self.slots[(seq & RING_MASK) as usize];
+        // SAFETY: we exclusively own this slot until we publish (release-store `ready`); the
+        // consumer will not touch it until then, and back-pressure guarantees the previous occupant
+        // has been fully consumed.
+        unsafe {
+            *slot.value.get() = value;
+            *slot.tags.get() = tags;
+        }
+        slot.ready.store(encode_key(key), Ordering::Release);
+
+        // Amortized wakeup: nudge the consumer once per NOTIFY_INTERVAL points.
+        if seq & NOTIFY_MASK == NOTIFY_MASK {
+            self.notify.notify_one();
+        }
+    }
+
+    /// Drain all currently-published points in order, invoking `f` for each. Single-consumer only.
+    pub fn drain(&self, mut f: impl FnMut(f64, ContextKey, Vec<Tag>)) {
+        loop {
+            // Only the consumer writes `read_pos`, so a relaxed load of our own cursor is fine.
+            let seq = self.read_pos.load(Ordering::Relaxed);
+            let slot = &self.slots[(seq & RING_MASK) as usize];
+            let encoded = slot.ready.load(Ordering::Acquire);
+            if encoded == 0 {
+                // Next point not published yet: stop (points are consumed strictly in order).
+                break;
+            }
+            // SAFETY: `ready != 0` (acquire) happens-after the producer's release-store, so its
+            // field writes to this slot are visible and complete.
+            let value = unsafe { *slot.value.get() };
+            let tags = unsafe { std::mem::take(&mut *slot.tags.get()) };
+            let key = decode_key(encoded);
+
+            // Free the slot, then advance the cursor so producers waiting on back-pressure proceed.
+            slot.ready.store(0, Ordering::Release);
+            self.read_pos.store(seq.wrapping_add(1), Ordering::Release);
+
+            f(value, key, tags);
+        }
+    }
+}
+
+impl Default for MetricRing {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+    use std::sync::Arc;
+
+    fn key(index: u32, t: MetricType) -> ContextKey {
+        ContextKey::from_parts(index, t)
+    }
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        for (idx, t) in [
+            (0u32, MetricType::Gauge),
+            (1, MetricType::Count),
+            (u32::MAX, MetricType::Distribution),
+            (12345, MetricType::Rate),
+        ] {
+            let k = key(idx, t);
+            let e = encode_key(k);
+            assert_ne!(e, 0, "encoded key must never collide with the empty sentinel");
+            assert_eq!(decode_key(e), k);
+        }
+    }
+
+    #[test]
+    fn single_producer_single_consumer_preserves_all_points() {
+        let ring = MetricRing::new();
+        let n = RING_SIZE as u32 * 4; // force wraparound several times
+        let mut consumed = 0u64;
+        let mut sum = 0.0f64;
+        let mut next_expected = 0u32;
+        for i in 0..n {
+            ring.push(i as f64, key(i, MetricType::Count), Vec::new());
+            // Drain frequently so the single-threaded producer never blocks on a full ring.
+            ring.drain(|v, k, _| {
+                assert_eq!(k.index(), next_expected, "points must arrive in order");
+                assert_eq!(v as u32, next_expected);
+                next_expected += 1;
+                consumed += 1;
+                sum += v;
+            });
+        }
+        assert_eq!(consumed, n as u64);
+        assert_eq!(sum, (0..n).map(|i| i as f64).sum::<f64>());
+    }
+
+    #[test]
+    fn multi_producer_batch_drain_loses_nothing() {
+        let ring = Arc::new(MetricRing::new());
+        let producers = 4u32;
+        let per_producer = 50_000u32;
+        let done = Arc::new(AtomicBool::new(false));
+        let consumed = Arc::new(AtomicU64::new(0));
+        let value_sum = Arc::new(AtomicU64::new(0)); // sum of integer values, as bits
+
+        // Consumer thread: drain until every point is accounted for.
+        let consumer = {
+            let ring = ring.clone();
+            let done = done.clone();
+            let consumed = consumed.clone();
+            let value_sum = value_sum.clone();
+            std::thread::spawn(move || loop {
+                ring.drain(|v, _k, _t| {
+                    consumed.fetch_add(1, Ordering::Relaxed);
+                    value_sum.fetch_add(v as u64, Ordering::Relaxed);
+                });
+                if done.load(Ordering::Acquire)
+                    && ring.read_pos.load(Ordering::Acquire)
+                        == ring.write_pos.load(Ordering::Acquire)
+                {
+                    break;
+                }
+                std::hint::spin_loop();
+            })
+        };
+
+        let mut handles = Vec::new();
+        for _ in 0..producers {
+            let ring = ring.clone();
+            handles.push(std::thread::spawn(move || {
+                for i in 0..per_producer {
+                    ring.push(i as f64, key(i, MetricType::Count), Vec::new());
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        done.store(true, Ordering::Release);
+        consumer.join().unwrap();
+
+        let total = (producers * per_producer) as u64;
+        assert_eq!(consumed.load(Ordering::Relaxed), total, "no points lost or duplicated");
+        let expected_sum = producers as u64 * (0..per_producer as u64).sum::<u64>();
+        assert_eq!(value_sum.load(Ordering::Relaxed), expected_sum);
+    }
+}

--- a/libdd-telemetry/src/worker/metric_ring.rs
+++ b/libdd-telemetry/src/worker/metric_ring.rs
@@ -212,7 +212,10 @@ mod tests {
         ] {
             let k = key(idx, t);
             let e = encode_key(k);
-            assert_ne!(e, 0, "encoded key must never collide with the empty sentinel");
+            assert_ne!(
+                e, 0,
+                "encoded key must never collide with the empty sentinel"
+            );
             assert_eq!(decode_key(e), k);
         }
     }
@@ -285,7 +288,11 @@ mod tests {
         consumer.join().unwrap();
 
         let total = (producers * per_producer) as u64;
-        assert_eq!(consumed.load(Ordering::Relaxed), total, "no points lost or duplicated");
+        assert_eq!(
+            consumed.load(Ordering::Relaxed),
+            total,
+            "no points lost or duplicated"
+        );
         let expected_sum = producers as u64 * (0..per_producer as u64).sum::<u64>();
         assert_eq!(value_sum.load(Ordering::Relaxed), expected_sum);
     }

--- a/libdd-telemetry/src/worker/mod.rs
+++ b/libdd-telemetry/src/worker/mod.rs
@@ -7,7 +7,10 @@ pub mod store;
 
 use crate::{
     config::Config,
-    data::{self, Application, Dependency, Endpoint, Host, Integration, Log, Payload, Telemetry},
+    data::{
+        self, Application, Dependency, Endpoint, Host, Integration, Log, Payload, ProductState,
+        Telemetry,
+    },
     metrics::{ContextKey, MetricBuckets, MetricContexts},
 };
 
@@ -85,7 +88,7 @@ macro_rules! telemetry_worker_log {
                 $($arg)*
             );
             if $worker.config.telemetry_debug_logging_enabled {
-                println!(concat!("{}: Telemetry worker DEBUG: ", $fmt_str), time_now(), $($arg)*);
+                eprintln!(concat!("{}: Telemetry worker DEBUG: ", $fmt_str), time_now(), $($arg)*);
             }
         }
     };
@@ -97,6 +100,7 @@ pub enum TelemetryActions {
     AddConfig(data::Configuration),
     AddDependency(Dependency),
     AddIntegration(Integration),
+    AddProductChange((String, ProductState)),
     AddLog((LogIdentifier, Log)),
     AddEndpoint(Endpoint),
     Lifecycle(LifecycleAction),
@@ -131,11 +135,14 @@ struct TelemetryWorkerData {
     configurations: store::Store<data::Configuration>,
     integrations: store::Store<data::Integration>,
     endpoints: HashSet<data::Endpoint>,
+    products: std::collections::HashMap<String, ProductState>,
+    products_pending: HashSet<String>,
     logs: store::QueueHashMap<LogIdentifier, Log>,
     metric_contexts: MetricContexts,
     metric_buckets: MetricBuckets,
     host: Host,
     app: Application,
+    install_signature: Option<data::InstallSignature>,
 }
 
 /// `C` is the capability bundle. Leaf crates pin it to a concrete type
@@ -238,6 +245,8 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> Wor
         self.data.integrations.clear();
         self.data.configurations.clear();
         self.data.endpoints.clear();
+        self.data.products.clear();
+        self.data.products_pending.clear();
     }
 
     async fn shutdown(&mut self) {
@@ -408,6 +417,7 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> Tel
             AddConfig(_)
             | AddDependency(_)
             | AddIntegration(_)
+            | AddProductChange(_)
             | AddEndpoint(_)
             | Lifecycle(ExtendedHeartbeat) => {}
             Lifecycle(Stop) => {
@@ -450,10 +460,12 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> Tel
         match action {
             Lifecycle(Start) => {
                 if !self.data.started {
-                    let app_started = data::Payload::AppStarted(self.build_app_started());
-                    match self.send_payload(&app_started).await {
-                        Ok(()) => self.payload_sent_success(&app_started),
-                        Err(err) => self.log_err(&err),
+                    if self.config.emit_app_lifecycle {
+                        let app_started = data::Payload::AppStarted(self.build_app_started());
+                        match self.send_payload(&app_started).await {
+                            Ok(()) => self.payload_sent_success(&app_started),
+                            Err(err) => self.log_err(&err),
+                        }
                     }
 
                     #[allow(clippy::unwrap_used)]
@@ -476,6 +488,10 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> Tel
             }
             AddDependency(dep) => self.data.dependencies.insert(dep),
             AddIntegration(integration) => self.data.integrations.insert(integration),
+            AddProductChange((name, state)) => {
+                self.data.products.insert(name.clone(), state);
+                self.data.products_pending.insert(name);
+            }
             AddConfig(cfg) => self.data.configurations.insert(cfg),
             AddEndpoint(endpoint) => {
                 self.data.endpoints.insert(endpoint);
@@ -538,6 +554,21 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> Tel
                     Ok(()) => self.payload_sent_success(&extended_hb),
                     Err(err) => self.log_err(&err),
                 }
+
+                if !self.data.products.is_empty() {
+                    let products = self
+                        .data
+                        .products
+                        .iter()
+                        .map(|(name, state)| (name.clone(), state.clone()))
+                        .collect();
+                    let product_change =
+                        data::Payload::AppProductChange(data::AppProductChange { products });
+                    match self.send_payload(&product_change).await {
+                        Ok(()) => self.payload_sent_success(&product_change),
+                        Err(err) => self.log_err(&err),
+                    }
+                }
                 // Only re-schedule self. Resetting `FlushData` here would replace its
                 // existing deadline with `now + heartbeat_interval`, starving FlushData
                 // when `extended_heartbeat_interval < heartbeat_interval` because each
@@ -554,7 +585,9 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> Tel
                 self.data.metric_buckets.flush_aggregates();
 
                 let mut app_events = self.build_app_events_batch();
-                app_events.push(data::Payload::AppClosing(()));
+                if self.config.emit_app_lifecycle {
+                    app_events.push(data::Payload::AppClosing(()));
+                }
 
                 let observability_events = self.build_observability_batch();
 
@@ -614,6 +647,22 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> Tel
                     integrations: self.data.integrations.unflushed().cloned().collect(),
                 },
             ))
+        }
+        if !self.data.products_pending.is_empty() {
+            let products = self
+                .data
+                .products_pending
+                .iter()
+                .filter_map(|name| {
+                    self.data
+                        .products
+                        .get(name)
+                        .map(|state| (name.clone(), state.clone()))
+                })
+                .collect();
+            payloads.push(data::Payload::AppProductChange(data::AppProductChange {
+                products,
+            }))
         }
         if self.data.configurations.flush_not_empty() {
             payloads.push(data::Payload::AppClientConfigurationChange(
@@ -714,6 +763,9 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> Tel
             configuration: self.data.configurations.unflushed().cloned().collect(),
             dependencies: self.data.dependencies.unflushed().cloned().collect(),
             integrations: self.data.integrations.unflushed().cloned().collect(),
+            install_signature: self.data.install_signature.clone(),
+            products: self.data.products.clone(),
+            error: None,
         }
     }
 
@@ -723,6 +775,7 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> Tel
             .removed_flushed(p.configuration.len());
         self.data.dependencies.removed_flushed(p.dependencies.len());
         self.data.integrations.removed_flushed(p.integrations.len());
+        self.data.products_pending.clear();
     }
 
     fn payload_sent_success(&mut self, payload: &data::Payload) {
@@ -735,6 +788,11 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> Tel
             }
             AppIntegrationsChange(p) => {
                 self.data.integrations.removed_flushed(p.integrations.len())
+            }
+            AppProductChange(p) => {
+                for name in p.products.keys() {
+                    self.data.products_pending.remove(name);
+                }
             }
             AppClientConfigurationChange(p) => self
                 .data
@@ -1108,12 +1166,36 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static>
         self.wait_for_shutdown()
     }
 
-    pub fn add_dependency(&self, name: String, version: Option<String>) -> anyhow::Result<()> {
+    pub fn add_dependency(
+        &self,
+        name: String,
+        version: Option<String>,
+        metadata: Option<Vec<data::DependencyMetadata>>,
+    ) -> anyhow::Result<()> {
         self.sender
             .try_send(TelemetryActions::AddDependency(Dependency {
                 name,
                 version,
+                hash: None,
+                metadata,
             }))?;
+        Ok(())
+    }
+
+    pub fn add_product_change(
+        &self,
+        product: String,
+        enabled: bool,
+        version: Option<String>,
+    ) -> anyhow::Result<()> {
+        self.sender.try_send(TelemetryActions::AddProductChange((
+            product,
+            ProductState {
+                enabled,
+                version,
+                error: None,
+            },
+        )))?;
         Ok(())
     }
 
@@ -1211,6 +1293,7 @@ pub struct TelemetryWorkerBuilder {
     pub rust_shared_lib_deps: bool,
     pub config: Config,
     pub flavor: TelemetryWorkerFlavor,
+    pub install_signature: Option<data::InstallSignature>,
 }
 
 impl TelemetryWorkerBuilder {
@@ -1262,6 +1345,7 @@ impl TelemetryWorkerBuilder {
             rust_shared_lib_deps: false,
             config: Config::default(),
             flavor: TelemetryWorkerFlavor::default(),
+            install_signature: None,
         }
     }
 
@@ -1294,11 +1378,14 @@ impl TelemetryWorkerBuilder {
                 integrations: self.integrations,
                 configurations: self.configurations,
                 endpoints: self.endpoints,
+                products: std::collections::HashMap::new(),
+                products_pending: HashSet::new(),
                 logs: store::QueueHashMap::default(),
                 metric_contexts: contexts.clone(),
                 metric_buckets: MetricBuckets::default(),
                 host: self.host,
                 app: self.application,
+                install_signature: self.install_signature,
             },
             config,
             mailbox,
@@ -1701,7 +1788,7 @@ mod tests {
             // Populate every data field that reset() should clear.
             worker.data.dependencies.insert(Dependency {
                 name: "dep".to_string(),
-                version: None,
+                ..Default::default()
             });
             worker.data.integrations.insert(Integration {
                 name: "integration".to_string(),
@@ -1788,7 +1875,7 @@ mod tests {
             handle
                 .try_send_msg(TelemetryActions::AddDependency(Dependency {
                     name: "dep".to_string(),
-                    version: None,
+                    ..Default::default()
                 }))
                 .unwrap();
             let (id, log) = make_log(1, "pre-fork log");

--- a/libdd-telemetry/src/worker/mod.rs
+++ b/libdd-telemetry/src/worker/mod.rs
@@ -131,7 +131,7 @@ pub struct LogIdentifier {
 #[derive(Debug)]
 struct TelemetryWorkerData {
     started: bool,
-    dependencies: store::Store<Dependency>,
+    dependencies: store::Store<data::Dependency, data::DependencyKey>,
     configurations: store::Store<data::Configuration>,
     integrations: store::Store<data::Integration>,
     endpoints: HashSet<data::Endpoint>,
@@ -1285,7 +1285,7 @@ pub struct TelemetryWorkerBuilder {
     pub host: Host,
     pub application: Application,
     pub runtime_id: Option<String>,
-    pub dependencies: store::Store<data::Dependency>,
+    pub dependencies: store::Store<data::Dependency, data::DependencyKey>,
     pub integrations: store::Store<data::Integration>,
     pub configurations: store::Store<data::Configuration>,
     pub endpoints: HashSet<data::Endpoint>,

--- a/libdd-telemetry/src/worker/mod.rs
+++ b/libdd-telemetry/src/worker/mod.rs
@@ -335,8 +335,14 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> Tel
     async fn recv_next_action(&mut self) -> TelemetryActions {
         let action = if let Some((deadline, deadline_action)) = self.deadlines.next_deadline() {
             let deadline_action = *deadline_action;
-            // If deadline passed, directly return associated action
+            // If deadline passed, service any already-queued mailbox action first, then
+            // return the associated action.
+            // This avoids pathological cases with a very short heartbeat, which would hang a
+            // synchronous flush()/stop() (whose FlushData/CollectStats never get processed) then.
             let Some(remaining) = deadline.checked_duration_since(time::Instant::now()) else {
+                if let Ok(mailbox_action) = self.mailbox.try_recv() {
+                    return mailbox_action;
+                }
                 return TelemetryActions::Lifecycle(deadline_action);
             };
 

--- a/libdd-telemetry/src/worker/mod.rs
+++ b/libdd-telemetry/src/worker/mod.rs
@@ -1901,7 +1901,7 @@ mod tests {
             });
             worker.data.configurations.insert(Configuration {
                 name: "cfg".to_string(),
-                value: "true".to_string(),
+                value: Some("true".to_string()),
                 origin: ConfigurationOrigin::Code,
                 config_id: None,
                 seq_id: None,

--- a/libdd-telemetry/src/worker/mod.rs
+++ b/libdd-telemetry/src/worker/mod.rs
@@ -1275,6 +1275,7 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static>
         version: Option<String>,
         compatible: Option<bool>,
         auto_enabled: Option<bool>,
+        error: Option<String>,
     ) -> anyhow::Result<()> {
         self.sender
             .try_send(TelemetryActions::AddIntegration(Integration {
@@ -1283,6 +1284,7 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static>
                 compatible,
                 enabled,
                 auto_enabled,
+                error,
             }))?;
         Ok(())
     }
@@ -1951,6 +1953,7 @@ mod tests {
                 enabled: true,
                 compatible: None,
                 auto_enabled: None,
+                ..Default::default()
             });
             worker.data.configurations.insert(Configuration {
                 name: "cfg".to_string(),

--- a/libdd-telemetry/src/worker/mod.rs
+++ b/libdd-telemetry/src/worker/mod.rs
@@ -137,7 +137,8 @@ struct TelemetryWorkerData {
     dependencies: store::Store<data::Dependency, data::DependencyKey>,
     configurations: store::Store<data::Configuration>,
     integrations: store::Store<data::Integration>,
-    endpoints: HashSet<data::Endpoint>,
+    endpoints: store::Store<data::Endpoint>,
+    endpoints_is_first: bool,
     products: std::collections::HashMap<String, ProductState>,
     products_pending: HashSet<String>,
     logs: store::QueueHashMap<LogIdentifier, Log>,
@@ -253,6 +254,7 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> Wor
         self.data.integrations.clear();
         self.data.configurations.clear();
         self.data.endpoints.clear();
+        self.data.endpoints_is_first = true;
         self.data.products.clear();
         self.data.products_pending.clear();
     }
@@ -724,13 +726,16 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> Tel
                 },
             ))
         }
-        if !self.data.endpoints.is_empty() {
+        if self.data.endpoints.flush_not_empty() {
             payloads.push(data::Payload::AppEndpoints(data::AppEndpoints {
-                is_first: true,
+                is_first: self.data.endpoints_is_first,
+                // Only the first `endpoints_message_limit` of the queue: the rest is left
+                // unflushed and picked up by the next payload.
                 endpoints: self
                     .data
                     .endpoints
-                    .iter()
+                    .unflushed()
+                    .take(self.config.endpoints_message_limit as usize)
                     .map(|e| e.to_json_value().unwrap_or_default())
                     .filter(|e| e.is_object())
                     .collect(),
@@ -864,7 +869,12 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> Tel
                 .data
                 .configurations
                 .removed_flushed(p.configuration.len()),
-            AppEndpoints(_) => self.data.endpoints.clear(),
+            AppEndpoints(p) => {
+                // Drops exactly the endpoints this payload carried, so anything the message limit
+                // held back is still queued for the next one.
+                self.data.endpoints.removed_flushed(p.endpoints.len());
+                self.data.endpoints_is_first = false;
+            }
             MessageBatch(batch) => {
                 for p in batch {
                     self.payload_sent_success(p);
@@ -1360,7 +1370,7 @@ pub struct TelemetryWorkerBuilder {
     pub dependencies: store::Store<data::Dependency, data::DependencyKey>,
     pub integrations: store::Store<data::Integration>,
     pub configurations: store::Store<data::Configuration>,
-    pub endpoints: HashSet<data::Endpoint>,
+    pub endpoints: store::Store<data::Endpoint>,
     pub native_deps: bool,
     pub rust_shared_lib_deps: bool,
     pub config: Config,
@@ -1412,7 +1422,7 @@ impl TelemetryWorkerBuilder {
             dependencies: store::Store::new(MAX_ITEMS),
             integrations: store::Store::new(MAX_ITEMS),
             configurations: store::Store::new(MAX_ITEMS),
-            endpoints: HashSet::new(),
+            endpoints: store::Store::new(10000),
             native_deps: true,
             rust_shared_lib_deps: false,
             config: Config::default(),
@@ -1451,6 +1461,7 @@ impl TelemetryWorkerBuilder {
                 integrations: self.integrations,
                 configurations: self.configurations,
                 endpoints: self.endpoints,
+                endpoints_is_first: true,
                 products: std::collections::HashMap::new(),
                 products_pending: HashSet::new(),
                 logs: store::QueueHashMap::default(),
@@ -1724,6 +1735,49 @@ mod tests {
         b.flavor = flavor;
         b.build_worker::<NativeCapabilities>(Some(tokio::runtime::Handle::current()))
             .1
+    }
+
+    /// `endpoints_message_limit` caps one payload, it does not discard the rest: the overflow has
+    /// to come back in later payloads, and only the very first of them may set `is_first` (the
+    /// backend replaces its endpoint set on a first payload and merges on the others).
+    #[tokio::test]
+    #[cfg_attr(miri, ignore)] // reqwest in build_worker
+    async fn endpoints_message_limit_chunks_payloads_and_flags_only_the_first() {
+        let mut worker = build_test_worker_with_flavor(TelemetryWorkerFlavor::Full);
+        worker.config.endpoints_message_limit = 2;
+
+        for i in 0..5 {
+            worker.data.endpoints.insert(crate::data::Endpoint {
+                operation_name: "http.request".to_string(),
+                resource_name: format!("GET /r{i}"),
+                ..Default::default()
+            });
+        }
+
+        let mut chunks = Vec::new();
+        // Each round: build the payload the flush would send, then account for a successful send.
+        while worker.data.endpoints.flush_not_empty() {
+            let payloads = worker.build_app_events_batch();
+            let endpoints = payloads
+                .iter()
+                .find_map(|p| match p {
+                    crate::data::Payload::AppEndpoints(e) => Some(e),
+                    _ => None,
+                })
+                .expect("an app-endpoints payload while endpoints are queued");
+            chunks.push((endpoints.is_first, endpoints.endpoints.len()));
+            let sent = crate::data::Payload::AppEndpoints(crate::data::AppEndpoints {
+                is_first: endpoints.is_first,
+                endpoints: endpoints.endpoints.clone(),
+            });
+            worker.payload_sent_success(&sent);
+        }
+
+        assert_eq!(
+            chunks,
+            vec![(true, 2), (false, 2), (false, 1)],
+            "5 endpoints at a limit of 2 should be 2+2+1 with is_first only on the first payload"
+        );
     }
 
     /// Every event with a delay must be scheduled on Start; otherwise it sits in
@@ -2016,9 +2070,14 @@ mod tests {
                 stats.metric_buckets.series, 0,
                 "metric series should be cleared"
             );
-            assert!(
-                worker.data.endpoints.is_empty(),
+            assert_eq!(
+                worker.data.endpoints.len_stored(),
+                0,
                 "endpoints should be cleared"
+            );
+            assert!(
+                worker.data.endpoints_is_first,
+                "the child's first app-endpoints payload is a first one again"
             );
             assert!(worker.next_action.is_none(), "next_action should be None");
         }

--- a/libdd-telemetry/src/worker/mod.rs
+++ b/libdd-telemetry/src/worker/mod.rs
@@ -587,6 +587,16 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> Tel
                 }
             }
             Lifecycle(ExtendedHeartbeat) => {
+                // Flush the data before submitting a heartbeat to ensure completeness.
+                let delta = self.build_app_events_batch();
+                if !delta.is_empty() {
+                    let payload = data::Payload::MessageBatch(delta);
+                    match self.send_payload(&payload).await {
+                        Ok(()) => self.payload_sent_success(&payload),
+                        Err(err) => self.log_err(&err),
+                    }
+                }
+
                 self.data.dependencies.unflush_stored();
                 self.data.integrations.unflush_stored();
                 self.data.configurations.unflush_stored();

--- a/libdd-telemetry/src/worker/mod.rs
+++ b/libdd-telemetry/src/worker/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod http_client;
+pub mod metric_ring;
 mod scheduler;
 pub mod store;
 
@@ -13,6 +14,8 @@ use crate::{
     },
     metrics::{ContextKey, MetricBuckets, MetricContexts},
 };
+
+use crate::worker::metric_ring::MetricRing;
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -160,6 +163,9 @@ pub struct TelemetryWorker<C: HttpClientCapability + SleepCapability + MaybeSend
     data: TelemetryWorkerData,
     next_action: Option<TelemetryActions>,
     stopped: bool,
+    /// Shared with the handle: producers publish metric points here instead of the mailbox, and
+    /// this worker batch-drains them into `data.metric_buckets` (see `metric_ring`).
+    metric_ring: Arc<MetricRing>,
 }
 
 impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> Debug
@@ -241,6 +247,8 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> Wor
         // Clear all unbuffered telemetry data; the child must not send pre-fork data.
         self.data.logs = store::QueueHashMap::default();
         self.data.metric_buckets = MetricBuckets::default();
+        // Discard points published to the ring buffer before the fork (single-threaded here).
+        self.metric_ring.drain(|_, _, _| {});
         self.data.dependencies.clear();
         self.data.integrations.clear();
         self.data.configurations.clear();
@@ -332,37 +340,65 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> Tel
         telemetry_worker_log!(self, ERROR, "{}", err);
     }
 
+    /// Drain all metric points published to the ring buffer into the aggregation buckets.
+    fn drain_metric_ring(&mut self) {
+        // Clone the Arc so the drain closure can mutably borrow `data.metric_buckets` without also
+        // borrowing `self.metric_ring`.
+        let ring = self.metric_ring.clone();
+        let buckets = &mut self.data.metric_buckets;
+        ring.drain(|value, key, extra_tags| buckets.add_point(key, value, extra_tags));
+    }
+
+    /// Drain any ring-buffered points, then roll the aggregation buckets into series/distributions.
+    fn flush_metric_aggregates(&mut self) {
+        self.drain_metric_ring();
+        self.data.metric_buckets.flush_aggregates();
+    }
+
     async fn recv_next_action(&mut self) -> TelemetryActions {
-        let action = if let Some((deadline, deadline_action)) = self.deadlines.next_deadline() {
-            let deadline_action = *deadline_action;
-            // If deadline passed, service any already-queued mailbox action first, then
-            // return the associated action.
-            // This avoids pathological cases with a very short heartbeat, which would hang a
-            // synchronous flush()/stop() (whose FlushData/CollectStats never get processed) then.
-            let Some(remaining) = deadline.checked_duration_since(time::Instant::now()) else {
-                if let Ok(mailbox_action) = self.mailbox.try_recv() {
-                    return mailbox_action;
+        loop {
+            // Fold any points published to the ring buffer into the aggregates before we wait.
+            self.drain_metric_ring();
+
+            let action = if let Some((deadline, deadline_action)) = self.deadlines.next_deadline() {
+                let deadline_action = *deadline_action;
+                // If deadline passed, service any already-queued mailbox action first, then
+                // return the associated action.
+                // This avoids pathological cases with a very short heartbeat, which would hang a
+                // synchronous flush()/stop() (whose FlushData/CollectStats never get processed).
+                let Some(remaining) = deadline.checked_duration_since(time::Instant::now()) else {
+                    if let Ok(mailbox_action) = self.mailbox.try_recv() {
+                        return mailbox_action;
+                    }
+                    return TelemetryActions::Lifecycle(deadline_action);
+                };
+
+                let sleeper = <C as SleepCapability>::new();
+                let ring = self.metric_ring.clone();
+                tokio::select! {
+                    biased;
+                    mailbox_action = self.mailbox.recv() => mailbox_action,
+                    _ = sleeper.sleep(remaining) => Some(TelemetryActions::Lifecycle(deadline_action)),
+                    // The ring buffer has points to drain: loop back to fold them in.
+                    _ = ring.notified() => continue,
                 }
-                return TelemetryActions::Lifecycle(deadline_action);
+            } else {
+                let ring = self.metric_ring.clone();
+                tokio::select! {
+                    biased;
+                    mailbox_action = self.mailbox.recv() => mailbox_action,
+                    _ = ring.notified() => continue,
+                }
             };
 
-            let sleeper = <C as SleepCapability>::new();
-            tokio::select! {
-                biased;
-                mailbox_action = self.mailbox.recv() => mailbox_action,
-                _ = sleeper.sleep(remaining) => Some(TelemetryActions::Lifecycle(deadline_action)),
-            }
-        } else {
-            self.mailbox.recv().await
-        };
-
-        // if no action is received, then it means the channel is stopped
-        action.unwrap_or_else(|| {
-            // the worker handle no longer lives - we must remove restartable here to avoid leaks
-            self.config.restartable = false;
-            self.stopped = true;
-            TelemetryActions::Lifecycle(LifecycleAction::Stop)
-        })
+            // if no action is received, then it means the channel is stopped
+            return action.unwrap_or_else(|| {
+                // the worker handle no longer lives - remove restartable here to avoid leaks
+                self.config.restartable = false;
+                self.stopped = true;
+                TelemetryActions::Lifecycle(LifecycleAction::Stop)
+            });
+        }
     }
 
     async fn dispatch_metrics_logs_action(&mut self, action: TelemetryActions) -> ControlFlow<()> {
@@ -394,7 +430,7 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> Tel
                 self.data.metric_buckets.add_point(key, point, extra_tags)
             }
             Lifecycle(FlushMetricAggr) => {
-                self.data.metric_buckets.flush_aggregates();
+                self.flush_metric_aggregates();
 
                 #[allow(clippy::unwrap_used)]
                 self.deadlines
@@ -430,7 +466,7 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> Tel
                 if !self.data.started {
                     return BREAK;
                 }
-                self.data.metric_buckets.flush_aggregates();
+                self.flush_metric_aggregates();
 
                 let batch = self.build_observability_batch();
                 if !batch.is_empty() {
@@ -512,7 +548,7 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> Tel
                 self.data.metric_buckets.add_point(key, point, extra_tags)
             }
             Lifecycle(FlushMetricAggr) => {
-                self.data.metric_buckets.flush_aggregates();
+                self.flush_metric_aggregates();
 
                 #[allow(clippy::unwrap_used)]
                 self.deadlines
@@ -589,7 +625,7 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> Tel
                 if !self.data.started {
                     return BREAK;
                 }
-                self.data.metric_buckets.flush_aggregates();
+                self.flush_metric_aggregates();
 
                 let mut app_events = self.build_app_events_batch();
                 if self.config.emit_app_lifecycle {
@@ -1068,6 +1104,8 @@ pub struct TelemetryWorkerHandle<
     #[cfg(not(target_arch = "wasm32"))]
     runtime: Option<runtime::Handle>,
     contexts: MetricContexts,
+    /// Shared with the worker: `add_point` publishes here (see `metric_ring`).
+    metric_ring: Arc<MetricRing>,
     _phantom: PhantomData<fn() -> C>,
 }
 
@@ -1083,6 +1121,7 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> Clo
             #[cfg(not(target_arch = "wasm32"))]
             runtime: self.runtime.clone(),
             contexts: self.contexts.clone(),
+            metric_ring: self.metric_ring.clone(),
             _phantom: PhantomData,
         }
     }
@@ -1270,8 +1309,9 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static>
         context: &ContextKey,
         extra_tags: Vec<Tag>,
     ) -> anyhow::Result<()> {
-        self.sender
-            .try_send(TelemetryActions::AddPoint((value, *context, extra_tags)))?;
+        // Points are the highest-frequency action; publish to the lock-free ring buffer rather
+        // than boxing a message + waking the receiver per point. The worker batch-drains it.
+        self.metric_ring.push(value, *context, extra_tags);
         Ok(())
     }
 
@@ -1381,6 +1421,7 @@ impl TelemetryWorkerBuilder {
             condvar: Condvar::new(),
         });
         let contexts = MetricContexts::default();
+        let metric_ring = Arc::new(MetricRing::new());
         let token = CancellationToken::new();
         let config = self.config;
         let telemetry_heartbeat_interval = config.telemetry_heartbeat_interval;
@@ -1426,6 +1467,7 @@ impl TelemetryWorkerBuilder {
             cancellation_token: token.clone(),
             next_action: None,
             stopped: false,
+            metric_ring: metric_ring.clone(),
         };
 
         (
@@ -1437,6 +1479,7 @@ impl TelemetryWorkerBuilder {
                 #[cfg(not(target_arch = "wasm32"))]
                 runtime: tokio_runtime,
                 contexts,
+                metric_ring,
                 _phantom: PhantomData,
             },
             worker,

--- a/libdd-telemetry/src/worker/mod.rs
+++ b/libdd-telemetry/src/worker/mod.rs
@@ -555,7 +555,8 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> Tel
                 self.data.integrations.unflush_stored();
                 self.data.configurations.unflush_stored();
 
-                let extended_hb = data::Payload::AppExtendedHeartbeat(self.build_app_started());
+                let extended_hb =
+                    data::Payload::AppExtendedHeartbeat(self.build_extended_heartbeat());
                 match self.send_payload(&extended_hb).await {
                     Ok(()) => self.payload_sent_success(&extended_hb),
                     Err(err) => self.log_err(&err),
@@ -765,6 +766,19 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> Tel
     }
 
     fn build_app_started(&mut self) -> data::AppStarted {
+        // This needs to be distinct from heartbeat:
+        // the backend fully rejects AppStarted payloads with contained integrations or dependencies
+        data::AppStarted {
+            configuration: self.data.configurations.unflushed().cloned().collect(),
+            dependencies: Vec::new(),
+            integrations: Vec::new(),
+            install_signature: self.data.install_signature.clone(),
+            products: self.data.products.clone(),
+            error: None,
+        }
+    }
+
+    fn build_extended_heartbeat(&mut self) -> data::AppStarted {
         data::AppStarted {
             configuration: self.data.configurations.unflushed().cloned().collect(),
             dependencies: self.data.dependencies.unflushed().cloned().collect(),
@@ -1744,6 +1758,88 @@ mod tests {
             flush_data_before, flush_data_after,
             "ExtendedHeartbeat must not reset FlushData's deadline",
         );
+    }
+
+    /// On api v2 the intake rejects an entire `app-started` payload whose `dependencies` or
+    /// `integrations` is non-empty ("v2 no longer accepts this field in app-started"), while
+    /// `app-extended-heartbeat` is validated with the v1 rules and is expected to carry both.
+    /// Both events are built from the same `data::AppStarted` shape, so it is easy to regress one
+    /// into the other.
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn app_started_omits_dependencies_and_integrations() {
+        let mut worker = build_test_worker_with_flavor(TelemetryWorkerFlavor::Full);
+
+        let _ = worker
+            .dispatch_action(TelemetryActions::AddDependency(crate::data::Dependency {
+                name: "monolog/monolog".into(),
+                version: Some("3.5.0".into()),
+                ..Default::default()
+            }))
+            .await;
+        let _ = worker
+            .dispatch_action(TelemetryActions::AddIntegration(crate::data::Integration {
+                name: "curl".into(),
+                enabled: true,
+                ..Default::default()
+            }))
+            .await;
+
+        let app_started = worker.build_app_started();
+        assert!(
+            app_started.dependencies.is_empty(),
+            "app-started must not carry dependencies; the intake rejects the whole payload",
+        );
+        assert!(
+            app_started.integrations.is_empty(),
+            "app-started must not carry integrations; the intake rejects the whole payload",
+        );
+
+        // The data is not lost: it stays unflushed and goes out as its own events.
+        let batch = worker.build_app_events_batch();
+        assert!(
+            batch.iter().any(|p| matches!(
+                p,
+                crate::data::Payload::AppDependenciesLoaded(d) if !d.dependencies.is_empty()
+            )),
+            "dependencies registered before Start must still be reported via \
+             app-dependencies-loaded, got {batch:?}",
+        );
+        assert!(
+            batch.iter().any(|p| matches!(
+                p,
+                crate::data::Payload::AppIntegrationsChange(i) if !i.integrations.is_empty()
+            )),
+            "integrations registered before Start must still be reported via \
+             app-integrations-change, got {batch:?}",
+        );
+    }
+
+    /// The counterpart to the above: the extended heartbeat re-states the full accumulated
+    /// application state, dependencies and integrations included.
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn extended_heartbeat_carries_dependencies_and_integrations() {
+        let mut worker = build_test_worker_with_flavor(TelemetryWorkerFlavor::Full);
+
+        let _ = worker
+            .dispatch_action(TelemetryActions::AddDependency(crate::data::Dependency {
+                name: "monolog/monolog".into(),
+                version: Some("3.5.0".into()),
+                ..Default::default()
+            }))
+            .await;
+        let _ = worker
+            .dispatch_action(TelemetryActions::AddIntegration(crate::data::Integration {
+                name: "curl".into(),
+                enabled: true,
+                ..Default::default()
+            }))
+            .await;
+
+        let hb = worker.build_extended_heartbeat();
+        assert_eq!(1, hb.dependencies.len(), "{hb:?}");
+        assert_eq!(1, hb.integrations.len(), "{hb:?}");
     }
 
     mod reset {

--- a/libdd-telemetry/src/worker/store.rs
+++ b/libdd-telemetry/src/worker/store.rs
@@ -65,6 +65,14 @@ mod queuehashmap {
             Some(&self.items[*idx - self.popped].1)
         }
 
+        pub fn get_mut(&mut self, k: &K) -> Option<&mut V> {
+            let hash = make_hash(&self.hash_builder, k);
+            let idx = *self
+                .table
+                .find(hash, |other| &self.items[other - self.popped].0 == k)?;
+            Some(&mut self.items[idx - self.popped].1)
+        }
+
         pub fn get_idx(&self, idx: usize) -> Option<&(K, V)> {
             self.items.get(idx - self.popped)
         }
@@ -143,6 +151,17 @@ mod queuehashmap {
 
 pub use queuehashmap::QueueHashMap;
 
+/// Stable key to use as hash for stored items.
+pub trait Keyed<K> {
+    fn key(&self) -> K;
+}
+
+impl<T: Clone> Keyed<T> for T {
+    fn key(&self) -> T {
+        self.clone()
+    }
+}
+
 #[derive(Debug, Default)]
 /// Stores telemetry data item, like dependencies and integrations
 ///
@@ -150,16 +169,17 @@ pub use queuehashmap::QueueHashMap;
 /// * Tries to keep a list of items that it has seen (within max number of items)
 /// * Tries to keep a list of items that haven't been sent to datadog yet
 /// * Deduplicates items, to make sure we don't send the item twice
-pub struct Store<T> {
+pub struct Store<T, K = T> {
     // unflushed and set contain indices into
     unflushed: VecDeque<usize>,
-    items: QueueHashMap<T, ()>,
+    items: QueueHashMap<K, T>,
     max_items: usize,
 }
 
-impl<T> Store<T>
+impl<T, K> Store<T, K>
 where
-    T: PartialEq + Eq + Hash,
+    T: Keyed<K>,
+    K: PartialEq + Eq + Hash + Clone,
 {
     pub fn new(max_items: usize) -> Self {
         Self {
@@ -170,13 +190,15 @@ where
     }
 
     pub fn insert(&mut self, item: T) {
-        if self.items.get(&item).is_some() {
+        let key = item.key();
+        if let Some(existing) = self.items.get_mut(&key) {
+            *existing = item;
             return;
         }
         if self.items.len() == self.max_items {
             self.items.pop_front();
         }
-        let (idx, _) = self.items.insert(item, ());
+        let (idx, _) = self.items.insert(key, item);
         if self.unflushed.len() == self.max_items {
             self.unflushed.pop_front();
         }
@@ -205,7 +227,7 @@ where
     pub fn unflushed(&self) -> impl Iterator<Item = &T> {
         self.unflushed
             .iter()
-            .flat_map(|i| Some(&self.items.get_idx(*i)?.0))
+            .flat_map(|i| Some(&self.items.get_idx(*i)?.1))
     }
 
     pub fn len_unflushed(&self) -> usize {
@@ -223,9 +245,10 @@ where
     }
 }
 
-impl<T> Extend<T> for Store<T>
+impl<T, K> Extend<T> for Store<T, K>
 where
-    T: PartialEq + Eq + Hash,
+    T: Keyed<K>,
+    K: PartialEq + Eq + Hash + Clone,
 {
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         for i in iter {

--- a/libdd-telemetry/src/worker/store.rs
+++ b/libdd-telemetry/src/worker/store.rs
@@ -178,7 +178,7 @@ pub struct Store<T, K = T> {
 
 impl<T, K> Store<T, K>
 where
-    T: Keyed<K>,
+    T: Keyed<K> + PartialEq,
     K: PartialEq + Eq + Hash + Clone,
 {
     pub fn new(max_items: usize) -> Self {
@@ -191,8 +191,17 @@ where
 
     pub fn insert(&mut self, item: T) {
         let key = item.key();
-        if let Some(existing) = self.items.get_mut(&key) {
-            *existing = item;
+        if let Some(existing) = self.items.get(&key) {
+            if *existing == item {
+                // Exact duplicate: already stored, and already sent or queued.
+                return;
+            }
+            // The entry was refreshed rather than duplicated (e.g. SCA attaching CVE reachability
+            // metadata to a dependency that was already reported). Re-queue it to actually deliver.
+            let (idx, _) = self.items.insert(key, item);
+            if !self.unflushed.contains(&idx) {
+                self.unflushed.push_back(idx);
+            }
             return;
         }
         if self.items.len() == self.max_items {
@@ -247,7 +256,7 @@ where
 
 impl<T, K> Extend<T> for Store<T, K>
 where
-    T: Keyed<K>,
+    T: Keyed<K> + PartialEq,
     K: PartialEq + Eq + Hash + Clone,
 {
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
@@ -282,6 +291,51 @@ mod tests {
 
         store.insert("hello");
         assert!(store.unflushed().next().is_none());
+    }
+
+    /// A keyed item whose value can change while its key stays the same, mirroring a Dependency
+    /// that gets SCA reachability metadata attached after it was first reported.
+    #[derive(Debug, PartialEq, Clone)]
+    struct Keyish(&'static str, u32);
+
+    impl Keyed<&'static str> for Keyish {
+        fn key(&self) -> &'static str {
+            self.0
+        }
+    }
+
+    #[test]
+    fn test_updated_item_is_requeued_for_flush() {
+        let mut store: Store<Keyish, &'static str> = Store::new(10);
+        store.insert(Keyish("requests", 0));
+        store.removed_flushed(1);
+        assert!(store.unflushed().next().is_none(), "initial send drains");
+
+        // Same key, unchanged value: deduplicated, nothing to re-send.
+        store.insert(Keyish("requests", 0));
+        assert!(
+            store.unflushed().next().is_none(),
+            "identical re-insert must not re-queue"
+        );
+
+        // Same key, updated value: must be re-queued so the update is actually delivered.
+        store.insert(Keyish("requests", 1));
+        assert_eq!(
+            store.items.len(),
+            1,
+            "update refreshes in place, no duplicate entry"
+        );
+        assert_eq!(
+            store.unflushed().collect::<Vec<_>>(),
+            &[&Keyish("requests", 1)]
+        );
+
+        // Updating again while still queued must not enqueue it twice.
+        store.insert(Keyish("requests", 2));
+        assert_eq!(
+            store.unflushed().collect::<Vec<_>>(),
+            &[&Keyish("requests", 2)]
+        );
     }
 
     #[test]


### PR DESCRIPTION
And some smaller stuff like more metric namespaces.

Adding endpoint batching as well.

This bridges the gap to the current capabilities exposed by dd-trace-py.

Also contains a small debugger change to abort on timeout.