### PR TITLE
chore(ci): improve clippy annotation reporter comment

### DIFF
--- a/.github/actions/ci-shared/src/crate_detection.rs
+++ b/.github/actions/ci-shared/src/crate_detection.rs
@@ -74,10 +74,7 @@ pub fn parse_crate_info(manifest: &Path) -> Result<CrateInfo> {
         .to_string();
 
     // publish = false means not publishable; anything else (missing, true, list) means publishable
-    let publish = match package.get("publish") {
-        Some(Value::Boolean(false)) => false,
-        _ => true,
-    };
+    let publish = !matches!(package.get("publish"), Some(Value::Boolean(false)));
 
     let path = manifest
         .parent()

--- a/.github/actions/clippy-annotation-reporter/src/analyzer/git.rs
+++ b/.github/actions/clippy-annotation-reporter/src/analyzer/git.rs
@@ -100,7 +100,7 @@ impl<T: CommandExecutor> GitOperations<T> {
 // Default implementation for GitOperations with RealCommandExecutor
 impl Default for GitOperations<RealCommandExecutor> {
     fn default() -> Self {
-        Self::new(RealCommandExecutor::default())
+        Self::new(RealCommandExecutor)
     }
 }
 

--- a/.github/actions/clippy-annotation-reporter/src/analyzer/git.rs
+++ b/.github/actions/clippy-annotation-reporter/src/analyzer/git.rs
@@ -38,8 +38,12 @@ impl<T: CommandExecutor> GitOperations<T> {
         Self { executor }
     }
 
-    /// Get file content from a specific branch
-    pub fn get_file_content(&self, file: &str, branch: &str) -> Result<String> {
+    /// Get the content of a file at a specific git ref.
+    ///
+    /// Returns `Ok(None)` when the file does not exist in that ref — a normal
+    /// outcome for files added, deleted, or renamed in the PR, which are absent
+    /// from one of the two branches. `Err` is reserved for genuine git failures.
+    pub fn get_file_content(&self, file: &str, branch: &str) -> Result<Option<String>> {
         debug!("Getting content for {} from {}", file, branch);
 
         let output = self
@@ -49,27 +53,16 @@ impl<T: CommandExecutor> GitOperations<T> {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
+            if is_missing_path(&stderr) {
+                return Ok(None);
+            }
             anyhow::bail!("Git show command failed: {}", stderr);
         }
 
         let content =
             String::from_utf8(output.stdout).context("Failed to parse file content as UTF-8")?;
 
-        Ok(content)
-    }
-
-    /// Get file content from a branch, handling common errors
-    pub fn get_branch_content(&self, file: &str, branch: &str) -> String {
-        match self.get_file_content(file, branch) {
-            Ok(content) => content,
-            Err(e) => {
-                // Skip errors for files that might not exist in one branch
-                if !e.to_string().contains("did not match any file") {
-                    log::warn!("Failed to get {} content from {}: {}", file, branch, e);
-                }
-                String::new()
-            }
-        }
+        Ok(Some(content))
     }
 
     /// Get all Rust files in the repository
@@ -95,6 +88,14 @@ impl<T: CommandExecutor> GitOperations<T> {
 
         Ok(rust_files)
     }
+}
+
+/// Whether git's stderr indicates the path simply does not exist in the ref,
+/// as opposed to a genuine failure.
+fn is_missing_path(stderr: &str) -> bool {
+    stderr.contains("does not exist in")
+        || stderr.contains("exists on disk, but not in")
+        || stderr.contains("did not match any file")
 }
 
 // Default implementation for GitOperations with RealCommandExecutor
@@ -183,8 +184,7 @@ mod tests {
 
         let result = git_ops.get_file_content("src/test.rs", "main");
 
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), "fn test() {}\n");
+        assert_eq!(result.unwrap(), Some("fn test() {}\n".to_owned()));
     }
 
     #[test]
@@ -214,7 +214,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_file_content_git_error() {
+    fn test_get_file_content_missing_file() {
         let mut mock_executor = MockCommandExecutor::new();
 
         mock_executor
@@ -238,6 +238,30 @@ mod tests {
 
         let result = git_ops.get_file_content("src/nonexistent.rs", "main");
 
+        // A file that doesn't exist in the ref is a normal outcome, not an error.
+        assert_eq!(result.unwrap(), None);
+    }
+
+    #[test]
+    fn test_get_file_content_other_error() {
+        let mut mock_executor = MockCommandExecutor::new();
+
+        mock_executor
+            .expect_execute_command()
+            .withf(|cmd, args| {
+                cmd == "git"
+                    && args.len() == 2
+                    && args[0] == "show"
+                    && args[1] == "bad-ref:src/test.rs"
+            })
+            .times(1)
+            .returning(|_, _| create_mock_output(128, "", "fatal: invalid object name 'bad-ref'"));
+
+        let git_ops = GitOperations::new(mock_executor);
+
+        let result = git_ops.get_file_content("src/test.rs", "bad-ref");
+
+        // A genuine git failure still surfaces as an error.
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
@@ -278,80 +302,6 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("Failed to parse file content as UTF-8"));
-    }
-
-    #[test]
-    fn test_get_branch_content_success() {
-        let mut mock_executor = MockCommandExecutor::new();
-
-        mock_executor
-            .expect_execute_command()
-            .withf(|cmd, args| {
-                cmd == "git"
-                    && args.len() == 2
-                    && args[0] == "show"
-                    && args[1] == "main:src/test.rs"
-            })
-            .times(1)
-            .returning(|_, _| create_mock_output(0, "fn test() {}\n", ""));
-
-        let git_ops = GitOperations::new(mock_executor);
-
-        let result = git_ops.get_branch_content("src/test.rs", "main");
-
-        assert_eq!(result, "fn test() {}\n");
-    }
-
-    #[test]
-    fn test_get_branch_content_file_not_found() {
-        let mut mock_executor = MockCommandExecutor::new();
-
-        mock_executor
-            .expect_execute_command()
-            .withf(|cmd, args| {
-                cmd == "git"
-                    && args.len() == 2
-                    && args[0] == "show"
-                    && args[1] == "main:src/nonexistent.rs"
-            })
-            .times(1)
-            .returning(|_, _| {
-                create_mock_output(
-                    1,
-                    "",
-                    "fatal: Path 'src/nonexistent.rs' does not exist in 'main'",
-                )
-            });
-
-        let git_ops = GitOperations::new(mock_executor);
-
-        let result = git_ops.get_branch_content("src/nonexistent.rs", "main");
-
-        assert_eq!(result, ""); // Should return empty string for non-existent file
-    }
-
-    #[test]
-    fn test_get_branch_content_other_error() {
-        let mut mock_executor = MockCommandExecutor::new();
-
-        mock_executor
-            .expect_execute_command()
-            .withf(|cmd, args| {
-                cmd == "git"
-                    && args.len() == 2
-                    && args[0] == "show"
-                    && args[1] == "invalid-branch:src/test.rs"
-            })
-            .times(1)
-            .returning(|_, _| {
-                create_mock_output(1, "", "fatal: invalid branch name: invalid-branch")
-            });
-
-        let git_ops = GitOperations::new(mock_executor);
-
-        let result = git_ops.get_branch_content("src/test.rs", "invalid-branch");
-
-        assert_eq!(result, ""); // Should return empty string for any error
     }
 
     #[test]

--- a/.github/actions/clippy-annotation-reporter/src/analyzer/mod.rs
+++ b/.github/actions/clippy-annotation-reporter/src/analyzer/mod.rs
@@ -12,7 +12,7 @@ use crate::analyzer::annotation::{
 };
 use crate::analyzer::git::{get_changed_files, GitOperations};
 use anyhow::Result;
-use log::{debug, info, warn};
+use log::{debug, info};
 use octocrab::Octocrab;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
@@ -104,23 +104,14 @@ fn analyze_annotations(
     for file in files {
         changed_files.insert(file.clone());
 
-        // most likely reason for errors is the files don't exist in the respective branch.
-
-        let base_content = match git_ops.get_file_content(file, base_branch) {
-            Ok(content) => content,
-            Err(e) => {
-                warn!("Failed to get {} content from {}: {}", file, base_branch, e);
-                String::new()
-            }
-        };
-
-        let head_content = match git_ops.get_file_content(file, head_branch) {
-            Ok(content) => content,
-            Err(e) => {
-                warn!("Failed to get {} content from {}: {}", file, head_branch, e);
-                String::new()
-            }
-        };
+        // A file added or removed in the PR won't exist in one of the branches;
+        // `get_file_content` returns `None` for that, which we treat as empty.
+        let base_content = git_ops
+            .get_file_content(file, base_branch)?
+            .unwrap_or_default();
+        let head_content = git_ops
+            .get_file_content(file, head_branch)?
+            .unwrap_or_default();
 
         // Find annotations in base branch
         find_annotations(
@@ -186,8 +177,12 @@ fn analyze_all_files_for_crates(
 
     let git_ops = GitOperations::default();
     for file in files {
-        let base_content = git_ops.get_branch_content(file, base_branch);
-        let head_content = git_ops.get_branch_content(file, head_branch);
+        let base_content = git_ops
+            .get_file_content(file, base_branch)?
+            .unwrap_or_default();
+        let head_content = git_ops
+            .get_file_content(file, head_branch)?
+            .unwrap_or_default();
 
         // Find annotations in base branch
         find_annotations(

--- a/.github/actions/clippy-annotation-reporter/src/analyzer/mod.rs
+++ b/.github/actions/clippy-annotation-reporter/src/analyzer/mod.rs
@@ -57,11 +57,13 @@ pub async fn run_analysis(
     base_branch: &str,
     head_branch: &str,
     rules: &[String],
-) -> Result<AnalysisResult> {
+) -> Result<Option<AnalysisResult>> {
     let changed_files = get_changed_files(octocrab, owner, repo, pr_number).await?;
 
+    // No Rust files changed is a valid outcome, not an error: there is simply
+    // nothing to analyze.
     if changed_files.is_empty() {
-        return Err(anyhow::anyhow!("No Rust files changed in this PR"));
+        return Ok(None);
     }
     let git_ops = GitOperations::default();
 
@@ -70,7 +72,7 @@ pub async fn run_analysis(
     let (repo_base_crate_counts, repo_head_crate_counts) =
         analyze_all_files_for_crates(&all_files, base_branch, head_branch, rules)?;
 
-    Ok(AnalysisResult {
+    Ok(Some(AnalysisResult {
         base_annotations: pr_analysis.base_annotations,
         head_annotations: pr_analysis.head_annotations,
         base_counts: pr_analysis.base_counts,
@@ -78,7 +80,7 @@ pub async fn run_analysis(
         changed_files: pr_analysis.changed_files,
         base_crate_counts: repo_base_crate_counts,
         head_crate_counts: repo_head_crate_counts,
-    })
+    }))
 }
 /// Analyze clippy annotations in base and head branches
 fn analyze_annotations(

--- a/.github/actions/clippy-annotation-reporter/src/analyzer/mod.rs
+++ b/.github/actions/clippy-annotation-reporter/src/analyzer/mod.rs
@@ -20,6 +20,9 @@ use std::rc::Rc;
 mod annotation;
 mod git;
 
+/// Map of a rule or crate name to the number of annotations counted for it.
+type AnnotationCounts = HashMap<Rc<String>, usize>;
+
 /// Represents a clippy annotation in code
 #[derive(Debug, Clone)]
 pub struct ClippyAnnotation {
@@ -36,6 +39,14 @@ pub struct AnalysisResult {
     pub changed_files: HashSet<String>,
     pub base_crate_counts: HashMap<Rc<String>, usize>,
     pub head_crate_counts: HashMap<Rc<String>, usize>,
+}
+
+impl AnalysisResult {
+    /// Whether the number of tracked annotations differs between the base and
+    /// PR branches. When this is false there is nothing to report.
+    pub fn has_changes(&self) -> bool {
+        self.base_counts != self.head_counts
+    }
 }
 
 pub async fn run_analysis(
@@ -159,7 +170,7 @@ fn analyze_all_files_for_crates(
     base_branch: &str,
     head_branch: &str,
     rules: &[String],
-) -> Result<(HashMap<Rc<String>, usize>, HashMap<Rc<String>, usize>)> {
+) -> Result<(AnnotationCounts, AnnotationCounts)> {
     info!(
         "Analyzing all {} Rust files for crate-level statistics...",
         files.len()

--- a/.github/actions/clippy-annotation-reporter/src/commenter.rs
+++ b/.github/actions/clippy-annotation-reporter/src/commenter.rs
@@ -50,6 +50,37 @@ pub async fn post_comment(
     Ok(())
 }
 
+/// Delete the bot's comment on a PR if one exists.
+///
+/// Used when a PR no longer has any tracked annotation changes, so a stale
+/// report left over from an earlier revision does not linger.
+pub async fn delete_comment_if_exists(
+    octocrab: &Octocrab,
+    owner: &str,
+    repo: &str,
+    pr_number: u64,
+    signature: Option<&str>,
+) -> Result<()> {
+    let signature = signature.unwrap_or("<!-- clippy-annotation-reporter-comment -->");
+
+    info!("Checking for stale comment to delete on PR #{}", pr_number);
+    match find_existing_comment(octocrab, owner, repo, pr_number, signature).await? {
+        Some(comment_id) => {
+            info!("Deleting stale comment #{}", comment_id);
+            octocrab
+                .issues(owner, repo)
+                .delete_comment(comment_id.into())
+                .await
+                .context("Failed to delete stale comment")?;
+        }
+        None => {
+            info!("No existing comment to delete on PR #{}", pr_number);
+        }
+    }
+
+    Ok(())
+}
+
 /// Find existing comment by the bot on a PR
 async fn find_existing_comment(
     octocrab: &Octocrab,
@@ -511,5 +542,88 @@ mod tests {
         assert!(result.is_err());
         list_comments_mock.assert();
         update_comment_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_delete_comment_if_exists_deletes() {
+        let server = MockServer::start();
+
+        // An existing bot comment is present.
+        let list_comments_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/repos/test-owner/test-repo/issues/123/comments")
+                .query_param("per_page", "100");
+
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([create_comment_json(
+                    456,
+                    "Old report\n\n<!-- test-signature -->"
+                )]));
+        });
+
+        let delete_comment_mock = server.mock(|when, then| {
+            when.method(DELETE)
+                .path("/repos/test-owner/test-repo/issues/comments/456");
+
+            then.status(204);
+        });
+
+        let octocrab = create_test_octocrab(&server);
+
+        let result = delete_comment_if_exists(
+            &octocrab,
+            "test-owner",
+            "test-repo",
+            123,
+            Some("<!-- test-signature -->"),
+        )
+        .await;
+
+        assert!(result.is_ok());
+        list_comments_mock.assert();
+        delete_comment_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_delete_comment_if_exists_no_comment() {
+        let server = MockServer::start();
+
+        // No comments on the PR.
+        let list_comments_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/repos/test-owner/test-repo/issues/123/comments")
+                .query_param("per_page", "100");
+
+            then.status(200)
+                .header("content-type", "application/json")
+                .json_body(json!([]));
+        });
+
+        let delete_comment_mock = server.mock(|when, then| {
+            when.method(DELETE)
+                .path("/repos/test-owner/test-repo/issues/comments/456");
+
+            then.status(204);
+        });
+
+        let octocrab = create_test_octocrab(&server);
+
+        let result = delete_comment_if_exists(
+            &octocrab,
+            "test-owner",
+            "test-repo",
+            123,
+            Some("<!-- test-signature -->"),
+        )
+        .await;
+
+        assert!(result.is_ok());
+        list_comments_mock.assert();
+        assert_eq!(
+            delete_comment_mock.hits(),
+            0,
+            "Delete must not be called when no comment exists"
+        );
     }
 }

--- a/.github/actions/clippy-annotation-reporter/src/main.rs
+++ b/.github/actions/clippy-annotation-reporter/src/main.rs
@@ -55,12 +55,27 @@ async fn main() -> Result<()> {
         }
     };
 
+    // Nothing changed: don't post a comment, and remove any stale one left over
+    // from an earlier revision of this PR.
+    if !analysis_result.has_changes() {
+        info!("No changes to tracked clippy annotations; removing any stale comment.");
+        commenter::delete_comment_if_exists(
+            &octocrab,
+            &config.owner,
+            &config.repo,
+            config.pr_number,
+            None,
+        )
+        .await?;
+        info!("Process completed successfully!");
+        return Ok(());
+    }
+
     let report = generate_report(
         &analysis_result,
         &config.rules,
         &config.repository,
         &config.base_branch,
-        &config.head_branch,
     );
 
     commenter::post_comment(

--- a/.github/actions/clippy-annotation-reporter/src/main.rs
+++ b/.github/actions/clippy-annotation-reporter/src/main.rs
@@ -43,15 +43,22 @@ async fn main() -> Result<()> {
         &config.head_branch,
         &config.rules,
     )
-    .await
+    .await?
     {
-        Ok(result) => result,
-        Err(e) => {
-            if e.to_string().contains("No Rust files changed") {
-                info!("No Rust files changed in this PR, nothing to analyze.");
-                return Ok(());
-            }
-            return Err(e);
+        Some(result) => result,
+        None => {
+            // No Rust files changed. A prior revision of this PR may have touched
+            // Rust and posted a comment, so remove any stale one.
+            info!("No Rust files changed in this PR; removing any stale comment.");
+            commenter::delete_comment_if_exists(
+                &octocrab,
+                &config.owner,
+                &config.repo,
+                config.pr_number,
+                None,
+            )
+            .await?;
+            return Ok(());
         }
     };
 

--- a/.github/actions/clippy-annotation-reporter/src/report_generator.rs
+++ b/.github/actions/clippy-annotation-reporter/src/report_generator.rs
@@ -1,207 +1,165 @@
 // Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-//! Report generator module for clippy-annotation-reporter
+//! Generates the compact PR comment from annotation analysis results.
 //!
-//! This module handles the logic for generating formatted reports
-//! based on annotation analysis results.
+//! Only rows whose count actually changed between the base and PR branches are
+//! rendered. The comment is only generated when there is at least one change;
+//! see `AnalysisResult::has_changes`.
 
 use crate::analyzer::AnalysisResult;
+use std::cmp::Ordering;
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
-/// Generate a detailed report for PR comment
+/// Generate the PR comment body for the given analysis.
 pub fn generate_report(
     analysis: &AnalysisResult,
     rules: &[String],
     repository: &str,
     base_branch: &str,
-    head_branch: &str,
 ) -> String {
     let mut report = String::new();
 
-    // Add header and branch information
-    add_header(&mut report, repository, base_branch, head_branch);
-
-    // Add rule summary section
-    add_rule_summary(&mut report, analysis, rules);
-
-    // Add file-level section
-    add_file_level_section(&mut report, analysis);
-
-    // Add crate-level section
-    add_crate_level_section(&mut report, analysis);
-
-    // Add explanation
+    add_header(&mut report, analysis, repository, base_branch);
+    add_rule_table(&mut report, analysis, rules);
+    add_details(&mut report, analysis);
     add_explanation(&mut report);
 
     report
 }
 
-/// Add report header and branch information
-fn add_header(report: &mut String, repository: &str, base_branch: &str, head_branch: &str) {
+/// Add the title and one-line headline with the net change.
+fn add_header(report: &mut String, analysis: &AnalysisResult, repository: &str, base_branch: &str) {
+    // Display the branch without the `origin/` prefix used internally.
+    let branch = base_branch.strip_prefix("origin/").unwrap_or(base_branch);
+    let (base_total, head_total) = tracked_totals(analysis);
+    let delta = format_delta(head_total as isize - base_total as isize);
+
     report.push_str("## Clippy Allow Annotation Report\n\n");
-
-    // Add branch information with link to base branch
-    let base_branch_for_url = base_branch.strip_prefix("origin/").unwrap_or(base_branch);
-
-    report.push_str("Comparing clippy allow annotations between branches:\n");
     report.push_str(&format!(
-        "- **Base Branch**: [{}](https://github.com/{}/tree/{})\n",
-        base_branch, repository, base_branch_for_url
+        "Tracked Clippy `allow` annotations changed vs [`{}`](https://github.com/{}/tree/{}): {} ({} → {})\n\n",
+        branch, repository, branch, delta, base_total, head_total
     ));
-    report.push_str(&format!("- **PR Branch**: {}\n\n", head_branch));
 }
 
-/// Add summary table by rule
-fn add_rule_summary(report: &mut String, analysis: &AnalysisResult, rules: &[String]) {
-    report.push_str("### Summary by Rule\n\n");
-    report.push_str("| Rule | Base Branch | PR Branch | Change |\n");
-    report.push_str("|------|------------|-----------|--------|\n");
+/// Add the by-rule table, listing only rules whose count changed.
+fn add_rule_table(report: &mut String, analysis: &AnalysisResult, rules: &[String]) {
+    report.push_str("| Rule | Base | PR | Δ |\n");
+    report.push_str("|------|------|----|---|\n");
 
-    let mut total_base = 0;
-    let mut total_head = 0;
-
-    // Add row for each rule
     for rule in rules {
-        let base_count = *analysis.base_counts.get(rule).unwrap_or(&0);
-        let head_count = *analysis.head_counts.get(rule).unwrap_or(&0);
-
-        total_base += base_count;
-        total_head += head_count;
-
-        add_table_row(report, rule, base_count, head_count);
+        let base = *analysis.base_counts.get(rule).unwrap_or(&0);
+        let head = *analysis.head_counts.get(rule).unwrap_or(&0);
+        if base == head {
+            continue;
+        }
+        report.push_str(&format_row(rule, base, head));
     }
 
-    // Add total row
-    add_table_row(report, "**Total**", total_base, total_head);
     report.push('\n');
 }
 
-/// Add section showing annotation counts by file
-fn add_file_level_section(report: &mut String, analysis: &AnalysisResult) {
-    if analysis.changed_files.is_empty() {
+/// Add the collapsed by-file and by-crate breakdown, listing only changed rows.
+fn add_details(report: &mut String, analysis: &AnalysisResult) {
+    let file_rows = build_file_rows(analysis);
+    let crate_rows = build_crate_rows(analysis);
+
+    if file_rows.is_empty() && crate_rows.is_empty() {
         return;
     }
 
-    report.push_str("### Annotation Counts by File\n\n");
-    report.push_str("| File | Base Branch | PR Branch | Change |\n");
-    report.push_str("|------|------------|-----------|--------|\n");
+    report.push_str("<details>\n<summary>By file and crate</summary>\n\n");
 
-    // Count annotations by file
-    let base_file_counts = count_annotations_by_file(&analysis.base_annotations);
-    let head_file_counts = count_annotations_by_file(&analysis.head_annotations);
-
-    // Get sorted list of changed files
-    let mut all_files: Vec<String> = analysis.changed_files.iter().cloned().collect();
-    all_files.sort();
-
-    // Add row for each file
-    for file in all_files {
-        let base_count = *base_file_counts.get(&file).unwrap_or(&0);
-        let head_count = *head_file_counts.get(&file).unwrap_or(&0);
-
-        // Skip files with no annotations in either branch
-        if base_count == 0 && head_count == 0 {
-            continue;
-        }
-
-        add_table_row(report, &format!("`{}`", file), base_count, head_count);
+    if !file_rows.is_empty() {
+        report.push_str("**By file**\n\n");
+        report.push_str("| File | Base | PR | Δ |\n");
+        report.push_str("|------|------|----|---|\n");
+        report.push_str(&file_rows);
+        report.push('\n');
     }
 
-    report.push('\n');
-}
-
-/// Add section showing annotation stats by crate
-fn add_crate_level_section(report: &mut String, analysis: &AnalysisResult) {
-    report.push_str("### Annotation Stats by Crate\n\n");
-    report.push_str("| Crate | Base Branch | PR Branch | Change |\n");
-    report.push_str("|-------|------------|-----------|--------|\n");
-
-    // Get all crates from both base and head
-    let all_crates = get_all_keys(&analysis.base_crate_counts, &analysis.head_crate_counts);
-
-    let mut total_base = 0;
-    let mut total_head = 0;
-
-    // Add row for each crate
-    for crate_name in all_crates {
-        let base_count = *analysis.base_crate_counts.get(&crate_name).unwrap_or(&0);
-        let head_count = *analysis.head_crate_counts.get(&crate_name).unwrap_or(&0);
-
-        // Skip crates with no annotations in either branch
-        if base_count == 0 && head_count == 0 {
-            continue;
-        }
-
-        total_base += base_count;
-        total_head += head_count;
-
-        add_table_row(report, &format!("`{}`", crate_name), base_count, head_count);
+    if !crate_rows.is_empty() {
+        report.push_str("**By crate**\n\n");
+        report.push_str("| Crate | Base | PR | Δ |\n");
+        report.push_str("|-------|------|----|---|\n");
+        report.push_str(&crate_rows);
+        report.push('\n');
     }
 
-    // Add total row
-    add_table_row(report, "**Total**", total_base, total_head);
-    report.push('\n');
+    report.push_str("</details>\n\n");
 }
 
-/// Add report explanation footer
+/// Add the report explanation.
 fn add_explanation(report: &mut String) {
     report.push_str("### About This Report\n\n");
     report.push_str("This report tracks Clippy allow annotations for specific rules, ");
     report.push_str("showing how they've changed in this PR. ");
-    report
-        .push_str("Decreasing the number of these annotations generally improves code quality.\n");
+    report.push_str("Decreasing the number of these annotations generally improves code quality. ");
+    report.push_str("Panic-inducing macros in particular should be avoided. ");
+    report.push_str("In the future, this report may become a PR-blocking quality gate.\n");
 }
 
-/// Add a table row with counts and change
-fn add_table_row(report: &mut String, label: &str, base_count: usize, head_count: usize) {
-    let change = head_count as isize - base_count as isize;
-
-    // Skip rows with no change and no counts
-    if change == 0 && base_count == 0 && head_count == 0 {
-        return;
-    }
-
-    // Calculate percentage change
-    let percent_change = calculate_percent_change(base_count, change);
-
-    // Format the change string with percentage
-    let change_str = format_change_string(change, percent_change);
-
-    report.push_str(&format!(
-        "| {} | {} | {} | {} |\n",
-        label, base_count, head_count, change_str
-    ));
+/// Total tracked annotations in the PR's changed files, for base and PR branches.
+fn tracked_totals(analysis: &AnalysisResult) -> (usize, usize) {
+    let base: usize = analysis.base_counts.values().sum();
+    let head: usize = analysis.head_counts.values().sum();
+    (base, head)
 }
 
-/// Calculate percentage change
-fn calculate_percent_change(base_count: usize, change: isize) -> f64 {
-    if base_count > 0 {
-        (change as f64 / base_count as f64) * 100.0
-    } else if change > 0 {
-        f64::INFINITY
-    } else {
-        0.0
-    }
-}
+/// Build the changed-file rows for the by-file table (empty string if none).
+fn build_file_rows(analysis: &AnalysisResult) -> String {
+    let base_counts = count_annotations_by_file(&analysis.base_annotations);
+    let head_counts = count_annotations_by_file(&analysis.head_annotations);
 
-/// Format change string with appropriate icon and percentage
-fn format_change_string(change: isize, percent_change: f64) -> String {
-    if change > 0 {
-        if percent_change.is_infinite() {
-            format!("⚠️ +{} (N/A)", change)
-        } else {
-            format!("⚠️ +{} (+{:.1}%)", change, percent_change)
+    let mut files: Vec<String> = analysis.changed_files.iter().cloned().collect();
+    files.sort();
+
+    let mut rows = String::new();
+    for file in files {
+        let base = *base_counts.get(&file).unwrap_or(&0);
+        let head = *head_counts.get(&file).unwrap_or(&0);
+        if base == head {
+            continue;
         }
-    } else if change < 0 {
-        format!("✅ {} ({:.1}%)", change, percent_change)
-    } else {
-        "No change (0%)".to_owned()
+        rows.push_str(&format_row(&format!("`{}`", file), base, head));
+    }
+    rows
+}
+
+/// Build the changed-crate rows for the by-crate table (empty string if none).
+fn build_crate_rows(analysis: &AnalysisResult) -> String {
+    let crates = get_all_keys(&analysis.base_crate_counts, &analysis.head_crate_counts);
+
+    let mut rows = String::new();
+    for crate_name in crates {
+        let base = *analysis.base_crate_counts.get(&crate_name).unwrap_or(&0);
+        let head = *analysis.head_crate_counts.get(&crate_name).unwrap_or(&0);
+        if base == head {
+            continue;
+        }
+        rows.push_str(&format_row(&format!("`{}`", crate_name), base, head));
+    }
+    rows
+}
+
+/// Format a single table row with counts and change indicator.
+fn format_row(label: &str, base: usize, head: usize) -> String {
+    let delta = format_delta(head as isize - base as isize);
+    format!("| {} | {} | {} | {} |\n", label, base, head, delta)
+}
+
+/// Format a signed change with an icon: `⚠️ +N` for increases, `✅ -N` for
+/// decreases, `↔ ±0` when the net is unchanged.
+fn format_delta(change: isize) -> String {
+    match change.cmp(&0) {
+        Ordering::Greater => format!("⚠️ +{}", change),
+        Ordering::Less => format!("✅ {}", change),
+        Ordering::Equal => "↔ ±0".to_owned(),
     }
 }
 
-/// Count annotations by file
+/// Count annotations by file.
 fn count_annotations_by_file(
     annotations: &[crate::analyzer::ClippyAnnotation],
 ) -> HashMap<Rc<String>, usize> {
@@ -214,7 +172,7 @@ fn count_annotations_by_file(
     counts
 }
 
-/// Get all unique keys from two HashMaps, sorted
+/// Get all unique keys from two HashMaps, sorted.
 fn get_all_keys<K: Clone + Ord + std::hash::Hash, V>(
     map1: &HashMap<K, V>,
     map2: &HashMap<K, V>,
@@ -329,155 +287,87 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_generate_report_basic() {
-        let analysis = create_analysis_result();
-        let rules = vec![
+    fn default_rules() -> Vec<String> {
+        vec![
             "clippy::unwrap_used".to_owned(),
             "clippy::match_bool".to_owned(),
             "clippy::unused_imports".to_owned(),
-        ];
+        ]
+    }
 
-        let report = generate_report(
-            &analysis,
-            &rules,
-            "test-owner/test-repo",
-            "main",
-            "feature-branch",
-        );
+    #[test]
+    fn test_generate_report_structure() {
+        let analysis = create_analysis_result();
+        let report = generate_report(&analysis, &default_rules(), "test-owner/test-repo", "main");
 
-        // Verify the report contains expected sections
+        // Title, rule table, collapsed details and explanation are present.
         assert!(report.contains("## Clippy Allow Annotation Report"));
-        assert!(report.contains("### Summary by Rule"));
-        assert!(report.contains("### Annotation Counts by File"));
-        assert!(report.contains("### Annotation Stats by Crate"));
+        assert!(report.contains("| Rule | Base | PR | Δ |"));
+        assert!(report.contains("<details>"));
+        assert!(report.contains("By file and crate"));
         assert!(report.contains("### About This Report"));
 
-        // Verify the report contains repository and branch information
+        // Repository and base branch information appear in the headline link.
         assert!(report.contains("test-owner/test-repo"));
-        assert!(report.contains("main"));
-        assert!(report.contains("feature-branch"));
+        assert!(report.contains("[`main`]"));
     }
 
     #[test]
-    fn test_generate_report_rule_summary() {
+    fn test_generate_report_headline_total() {
         let analysis = create_analysis_result();
-        let rules = vec![
-            "clippy::unwrap_used".to_owned(),
-            "clippy::match_bool".to_owned(),
-            "clippy::unused_imports".to_owned(),
-        ];
+        let report = generate_report(&analysis, &default_rules(), "test-owner/test-repo", "main");
 
-        let report = generate_report(
-            &analysis,
-            &rules,
-            "test-owner/test-repo",
-            "main",
-            "feature-branch",
-        );
-
-        // Verify rule summary contains all rules
-        assert!(report.contains("clippy::unwrap_used"));
-        assert!(report.contains("clippy::match_bool"));
-        assert!(report.contains("clippy::unused_imports"));
-
-        // Verify counts and changes
-        assert!(report.contains("5")); // Base count for unwrap_used
-        assert!(report.contains("3")); // Head count for unwrap_used
-        assert!(report.contains("-2")); // Change for unwrap_used
-
-        assert!(report.contains("3")); // Base count for match_bool
-        assert!(report.contains("4")); // Head count for match_bool
-        assert!(report.contains("+1")); // Change for match_bool
-
-        assert!(report.contains("10")); // Base count for unused_imports
-        assert!(report.contains("5")); // Head count for unused_imports
-        assert!(report.contains("-5")); // Change for unused_imports
+        // Base total 18 → head total 12, a net decrease of 6.
+        assert!(report.contains("✅ -6 (18 → 12)"));
     }
 
     #[test]
-    fn test_generate_report_file_section() {
+    fn test_generate_report_only_changed_rules() {
         let analysis = create_analysis_result();
-        let rules = vec![
-            "clippy::unwrap_used".to_owned(),
-            "clippy::match_bool".to_owned(),
-            "clippy::unused_imports".to_owned(),
-        ];
+        let report = generate_report(&analysis, &default_rules(), "test-owner/test-repo", "main");
 
-        let report = generate_report(
-            &analysis,
-            &rules,
-            "test-owner/test-repo",
-            "main",
-            "feature-branch",
-        );
+        // Every tracked rule changed, so all three appear with signed deltas.
+        assert!(report.contains("| clippy::unwrap_used | 5 | 3 | ✅ -2 |"));
+        assert!(report.contains("| clippy::match_bool | 3 | 4 | ⚠️ +1 |"));
+        assert!(report.contains("| clippy::unused_imports | 10 | 5 | ✅ -5 |"));
+    }
 
-        // Verify file section contains the changed files
-        assert!(report.contains("src/file1.rs"));
-        assert!(report.contains("src/file2.rs"));
+    #[test]
+    fn test_generate_report_skips_unchanged_rule() {
+        let mut analysis = create_analysis_result();
+        // Make match_bool unchanged (3 in both branches).
+        let rule2 = Rc::new("clippy::match_bool".to_owned());
+        analysis.head_counts.insert(rule2, 3);
 
-        // Verify file counts for file1.rs
-        // In the base branch, file1.rs has 3 annotations (2 unwrap_used, 1 match_bool)
-        // In the head branch, file1.rs has 3 annotations (1 unwrap_used, 2 match_bool)
-        let file1_pattern = r"`src/file1\.rs`\s*\|\s*3\s*\|\s*3\s*\|\s*No change";
+        let report = generate_report(&analysis, &default_rules(), "test-owner/test-repo", "main");
+
+        assert!(report.contains("| clippy::unwrap_used | 5 | 3 | ✅ -2 |"));
         assert!(
-            report.contains("| `src/file1.rs` | 3 | 3 |")
-                || regex::Regex::new(file1_pattern).unwrap().is_match(&report),
-            "File1 count information not found in report"
-        );
-
-        // Verify file counts for file2.rs
-        // In the base branch, file2.rs has 2 annotations (1 unwrap_used, 1 unused_imports)
-        // In the head branch, file2.rs has 1 annotation (1 unused_imports)
-        let file2_pattern = r"`src/file2\.rs`\s*\|\s*2\s*\|\s*1\s*\|\s*.*-1";
-        assert!(
-            report.contains("| `src/file2.rs` | 2 | 1 |")
-                || regex::Regex::new(file2_pattern).unwrap().is_match(&report),
-            "File2 count information not found in report"
-        );
-
-        // Make sure the change column has the correct indicators
-        assert!(
-            report.contains("No change") || report.contains("(0%)"),
-            "No change indicator missing for file1"
-        );
-        assert!(
-            report.contains("✅ -1"),
-            "Decrease indicator missing for file2"
+            !report.contains("clippy::match_bool"),
+            "unchanged rule should be omitted from the table"
         );
     }
 
     #[test]
-    fn test_generate_report_crate_section() {
+    fn test_generate_report_only_changed_files() {
         let analysis = create_analysis_result();
-        let rules = vec![
-            "clippy::unwrap_used".to_owned(),
-            "clippy::match_bool".to_owned(),
-            "clippy::unused_imports".to_owned(),
-        ];
+        let report = generate_report(&analysis, &default_rules(), "test-owner/test-repo", "main");
 
-        let report = generate_report(
-            &analysis,
-            &rules,
-            "test-owner/test-repo",
-            "main",
-            "feature-branch",
+        // file2 changed (2 → 1); file1 did not (3 → 3) and must be omitted.
+        assert!(report.contains("| `src/file2.rs` | 2 | 1 | ✅ -1 |"));
+        assert!(
+            !report.contains("`src/file1.rs`"),
+            "unchanged file should be omitted from the table"
         );
+    }
 
-        // Verify crate section contains the crates
-        assert!(report.contains("`crate1`"));
-        assert!(report.contains("`crate2`"));
+    #[test]
+    fn test_generate_report_only_changed_crates() {
+        let analysis = create_analysis_result();
+        let report = generate_report(&analysis, &default_rules(), "test-owner/test-repo", "main");
 
-        // Verify crate counts
-        // Base count for crate1: 8, Head count: 5
-        assert!(report.contains("8"));
-        assert!(report.contains("5"));
-        assert!(report.contains("-3")); // Change
-
-        // Base count for crate2: 10, Head count: 12
-        assert!(report.contains("10"));
-        assert!(report.contains("12"));
-        assert!(report.contains("+2")); // Change
+        assert!(report.contains("| `crate1` | 8 | 5 | ✅ -3 |"));
+        assert!(report.contains("| `crate2` | 10 | 12 | ⚠️ +2 |"));
     }
 
     #[test]
@@ -485,109 +375,51 @@ mod tests {
         let mut analysis = create_analysis_result();
         analysis.changed_files.clear();
 
-        let rules = vec![
-            "clippy::unwrap_used".to_owned(),
-            "clippy::match_bool".to_owned(),
-            "clippy::unused_imports".to_owned(),
-        ];
+        let report = generate_report(&analysis, &default_rules(), "test-owner/test-repo", "main");
 
-        let report = generate_report(
-            &analysis,
-            &rules,
-            "test-owner/test-repo",
-            "main",
-            "feature-branch",
-        );
-
-        // Verify that the file-level section is not included when there are no changed files
-        assert!(!report.contains("### Annotation Counts by File"));
-
-        // But other sections should still be present
-        assert!(report.contains("### Summary by Rule"));
-        assert!(report.contains("### Annotation Stats by Crate"));
-    }
-
-    #[test]
-    fn test_generate_report_formatting() {
-        let analysis = create_analysis_result();
-        let rules = vec![
-            "clippy::unwrap_used".to_owned(),
-            "clippy::match_bool".to_owned(),
-            "clippy::unused_imports".to_owned(),
-        ];
-
-        let report = generate_report(
-            &analysis,
-            &rules,
-            "test-owner/test-repo",
-            "main",
-            "feature-branch",
-        );
-
-        // Verify positive changes are formatted with ⚠️
-        assert!(report.contains("⚠️ +1"));
-
-        // Verify negative changes are formatted with ✅
-        assert!(report.contains("✅ -2"));
-
-        // Verify total row exists
-        assert!(report.contains("**Total**"));
+        // No changed files means no by-file section, but the by-crate section
+        // and rule table remain.
+        assert!(!report.contains("**By file**"));
+        assert!(report.contains("**By crate**"));
+        assert!(report.contains("| Rule | Base | PR | Δ |"));
     }
 
     #[test]
     fn test_generate_report_with_origin_prefix() {
         let analysis = create_analysis_result();
-        let rules = vec![
-            "clippy::unwrap_used".to_owned(),
-            "clippy::match_bool".to_owned(),
-            "clippy::unused_imports".to_owned(),
-        ];
-
-        // Test with origin/ prefix in base branch
         let report = generate_report(
             &analysis,
-            &rules,
+            &default_rules(),
             "test-owner/test-repo",
             "origin/main",
-            "feature-branch",
         );
 
-        // Verify the origin/ prefix is removed in the link URL
+        // The origin/ prefix is stripped for both the label and the URL.
         assert!(report.contains("https://github.com/test-owner/test-repo/tree/main"));
-        assert!(report.contains("origin/main"));
+        assert!(report.contains("[`main`]"));
+        assert!(!report.contains("origin/main"));
     }
 
     #[test]
     fn test_generate_report_new_annotations() {
-        // Create an analysis where annotations are added in the head branch
         let mut analysis = create_analysis_result();
 
-        // Add a new rule that only appears in the head counts
+        // A rule that only appears in the head branch (0 → 2).
         let new_rule = Rc::new("clippy::new_rule".to_owned());
-        analysis.head_counts.insert(new_rule.clone(), 2);
+        analysis.head_counts.insert(new_rule, 2);
 
-        let rules = vec![
-            "clippy::unwrap_used".to_owned(),
-            "clippy::match_bool".to_owned(),
-            "clippy::unused_imports".to_owned(),
-            "clippy::new_rule".to_owned(),
-        ];
+        let mut rules = default_rules();
+        rules.push("clippy::new_rule".to_owned());
 
-        let report = generate_report(
-            &analysis,
-            &rules,
-            "test-owner/test-repo",
-            "main",
-            "feature-branch",
-        );
+        let report = generate_report(&analysis, &rules, "test-owner/test-repo", "main");
 
-        // Verify that new rule appears with appropriate formatting
-        assert!(report.contains("clippy::new_rule"));
-        assert!(report.contains("0")); // Base count should be 0
-        assert!(report.contains("2")); // Head count should be 2
-        assert!(report.contains("⚠️ +2")); // Change should be +2
+        assert!(report.contains("| clippy::new_rule | 0 | 2 | ⚠️ +2 |"));
+    }
 
-        // Also verify N/A for the percentage since base count is 0
-        assert!(report.contains("N/A"));
+    #[test]
+    fn test_format_delta() {
+        assert_eq!(format_delta(3), "⚠️ +3");
+        assert_eq!(format_delta(-2), "✅ -2");
+        assert_eq!(format_delta(0), "↔ ±0");
     }
 }

--- a/.github/actions/crates-reporter/src/main.rs
+++ b/.github/actions/crates-reporter/src/main.rs
@@ -74,20 +74,20 @@ fn collect_changed_crates(changed_files: &[String], members: &[Package], workspa
                 continue;
             };
             let relative_dir_str = relative_dir.as_str();
-            if file == relative_dir_str || file.starts_with(&format!("{relative_dir_str}/")) {
-                if crate_inventory.insert(member.name.to_string()) {
-                    crates.push(CrateInfo {
-                        name: member.name.to_string(),
-                        version: member.version.to_string(),
-                        manifest: member.manifest_path.clone().into(),
-                        path: member.manifest_path.parent().unwrap().into(),
-                        publish: if let Some(publishable) = &member.publish {
-                            !publishable.is_empty()
-                        } else {
-                            true
-                        },
-                    });
-                }
+            if (file == relative_dir_str || file.starts_with(&format!("{relative_dir_str}/")))
+                && crate_inventory.insert(member.name.to_string())
+            {
+                crates.push(CrateInfo {
+                    name: member.name.to_string(),
+                    version: member.version.to_string(),
+                    manifest: member.manifest_path.clone().into(),
+                    path: member.manifest_path.parent().unwrap().into(),
+                    publish: if let Some(publishable) = &member.publish {
+                        !publishable.is_empty()
+                    } else {
+                        true
+                    },
+                });
             }
         }
     }


### PR DESCRIPTION
# What does this PR do?

- Only post a comment when there are diffs from baseline
- Only show crates with annotation changes, not every crate in the repo

# Motivation

libdatadog guild request

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Temporarily added annotations to this PR to validate comment creation and suppression when no changes.
