### PR TITLE
feat(otlp): add instrumentation scope metadata

### DIFF
--- a/libdd-data-pipeline/src/trace_exporter/builder.rs
+++ b/libdd-data-pipeline/src/trace_exporter/builder.rs
@@ -40,6 +40,8 @@ pub struct TraceExporterBuilder {
     language_version: String,
     language_interpreter: String,
     language_interpreter_vendor: String,
+    instrumentation_scope_name: String,
+    instrumentation_scope_version: String,
     git_commit_sha: String,
     process_tags: String,
     input_format: TraceExporterInputFormat,
@@ -158,6 +160,13 @@ impl TraceExporterBuilder {
     /// Set the `Datadog-Meta-Lang-Interpreter-Vendor` header
     pub fn set_language_interpreter_vendor(&mut self, lang_interpreter_vendor: &str) -> &mut Self {
         lang_interpreter_vendor.clone_into(&mut self.language_interpreter_vendor);
+        self
+    }
+
+    /// Set OTLP trace instrumentation scope metadata.
+    pub fn set_otlp_instrumentation_scope(&mut self, name: &str, version: &str) -> &mut Self {
+        name.clone_into(&mut self.instrumentation_scope_name);
+        version.clone_into(&mut self.instrumentation_scope_version);
         self
     }
 
@@ -485,6 +494,8 @@ impl TraceExporterBuilder {
             #[cfg(all(not(target_arch = "wasm32"), feature = "telemetry"))]
             telemetry: telemetry_client,
             health_metrics_enabled: self.health_metrics_enabled,
+            otlp_instrumentation_scope_name: self.instrumentation_scope_name,
+            otlp_instrumentation_scope_version: self.instrumentation_scope_version,
             capabilities,
             #[cfg(not(target_arch = "wasm32"))]
             workers: TraceExporterWorkers {

--- a/libdd-data-pipeline/src/trace_exporter/mod.rs
+++ b/libdd-data-pipeline/src/trace_exporter/mod.rs
@@ -236,6 +236,8 @@ pub struct TraceExporter<C: HttpClientCapability + SleepCapability + MaybeSend +
     agent_payload_response_version: Option<AgentResponsePayloadVersion>,
     /// When set, traces are exported via OTLP HTTP/JSON instead of the Datadog agent.
     otlp_config: Option<OtlpTraceConfig>,
+    otlp_instrumentation_scope_name: String,
+    otlp_instrumentation_scope_version: String,
 }
 
 impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> TraceExporter<C> {
@@ -518,6 +520,8 @@ impl<C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static> Tra
             r.language = self.metadata.language.clone();
             r.tracer_version = self.metadata.tracer_version.clone();
             r.runtime_id = self.metadata.runtime_id.clone();
+            r.instrumentation_scope_name = self.otlp_instrumentation_scope_name.clone();
+            r.instrumentation_scope_version = self.otlp_instrumentation_scope_version.clone();
             r
         };
         let request = map_traces_to_otlp(traces, &resource_info);

--- a/libdd-trace-utils/src/otlp_encoder/mapper.rs
+++ b/libdd-trace-utils/src/otlp_encoder/mapper.rs
@@ -18,7 +18,7 @@ const MAX_ATTRIBUTES_PER_SPAN: usize = 128;
 /// Maps Datadog trace chunks and resource info to an OTLP ExportTraceServiceRequest.
 ///
 /// Resource: SDK-level attributes (service.name, deployment.environment.name, telemetry.sdk.*,
-/// runtime-id). InstrumentationScope: present but empty (DD SDKs don't have a scope concept).
+/// runtime-id). InstrumentationScope: optional tracer scope name/version.
 /// All analogous DD span fields are mapped; meta→attributes (string), metrics→attributes
 /// (int/double), links and events mapped to OTLP links and events. Status from span.error and
 /// meta["error.msg"].
@@ -34,7 +34,10 @@ pub fn map_traces_to_otlp<T: TraceData>(
         }
     }
     let scope_spans = ScopeSpans {
-        scope: Some(InstrumentationScope::default()),
+        scope: Some(InstrumentationScope {
+            name: non_empty_string(&resource_info.instrumentation_scope_name),
+            version: non_empty_string(&resource_info.instrumentation_scope_version),
+        }),
         spans: all_spans,
         schema_url: None,
     };
@@ -45,6 +48,10 @@ pub fn map_traces_to_otlp<T: TraceData>(
     ExportTraceServiceRequest {
         resource_spans: vec![resource_spans],
     }
+}
+
+fn non_empty_string(value: &str) -> Option<String> {
+    (!value.is_empty()).then(|| value.to_string())
 }
 
 fn build_resource(resource_info: &OtlpResourceInfo) -> Resource {
@@ -385,6 +392,28 @@ mod tests {
         assert_eq!(otlp_span.start_time_unix_nano, "1544712660000000000");
         assert_eq!(otlp_span.end_time_unix_nano, "1544712661000000000");
         assert_eq!(rs.scope_spans[0].scope.as_ref().unwrap().name, None);
+    }
+
+    #[test]
+    fn test_instrumentation_scope_from_resource_info() {
+        let resource_info = OtlpResourceInfo {
+            instrumentation_scope_name: "dd-trace-js".to_string(),
+            instrumentation_scope_version: "7.0.0-pre".to_string(),
+            ..Default::default()
+        };
+        let span: Span<BytesData> = Span {
+            trace_id: 1,
+            span_id: 2,
+            name: libdd_tinybytes::BytesString::from_static("s"),
+            start: 0,
+            duration: 1,
+            ..Default::default()
+        };
+
+        let req = map_traces_to_otlp(vec![vec![span]], &resource_info);
+        let scope = req.resource_spans[0].scope_spans[0].scope.as_ref().unwrap();
+        assert_eq!(scope.name.as_deref(), Some("dd-trace-js"));
+        assert_eq!(scope.version.as_deref(), Some("7.0.0-pre"));
     }
 
     #[test]

--- a/libdd-trace-utils/src/otlp_encoder/mod.rs
+++ b/libdd-trace-utils/src/otlp_encoder/mod.rs
@@ -22,4 +22,6 @@ pub struct OtlpResourceInfo {
     pub language: String,
     pub tracer_version: String,
     pub runtime_id: String,
+    pub instrumentation_scope_name: String,
+    pub instrumentation_scope_version: String,
 }


### PR DESCRIPTION
# What does this PR do?

Adds OTLP instrumentation scope metadata to the trace exporter path.

The trace mapper now copies `instrumentation_scope_name` and `instrumentation_scope_version` from `OtlpResourceInfo` into `ScopeSpans.scope`. `TraceExporterBuilder` gets a setter for the OTLP trace scope, and the exporter stores those values privately before building the per-send `OtlpResourceInfo`.

# Motivation

`dd-trace-js` native OTLP trace export emitted `scope: {}`. Its Platform OTLP integration test expects the Datadog tracer scope (`name: dd-trace-js`) and a tracer version, matching the OTel scope semantics already used by the JS metric exporter.

# Additional Notes

The new fields are added to `OtlpResourceInfo`, which is already `#[non_exhaustive]`. The public `TracerMetadata` struct is unchanged; scope values are stored in private `TraceExporter` fields to avoid a source-breaking struct-literal change.

# How to test the change?

- `cargo test -p libdd-trace-utils otlp_encoder::mapper --lib`
- `cargo check -p libdd-data-pipeline`
- `cargo fmt --check -p libdd-trace-utils -p libdd-data-pipeline`
