### PR TITLE
feat(otlp): add instrumentation scope metadata

### DIFF
--- a/libdd-data-pipeline-ffi/src/trace_exporter.rs
+++ b/libdd-data-pipeline-ffi/src/trace_exporter.rs
@@ -88,6 +88,8 @@ pub struct TraceExporterConfig {
     shared_runtime: Option<Arc<ForkSafeRuntime>>,
     otlp_endpoint: Option<String>,
     otlp_protocol: Option<OtlpProtocol>,
+    otlp_instrumentation_scope_name: Option<String>,
+    otlp_instrumentation_scope_version: Option<String>,
     output_to_log: bool,
     log_max_line_size: Option<usize>,
     stats_cardinality_limit: Option<usize>,
@@ -544,6 +546,37 @@ pub unsafe extern "C" fn ddog_trace_exporter_config_set_otlp_protocol(
     )
 }
 
+/// Sets OTLP trace instrumentation scope metadata.
+///
+/// Has no effect unless an OTLP endpoint is also configured via
+/// `ddog_trace_exporter_config_set_otlp_endpoint`; without one, traces are sent to the
+/// Datadog agent and this scope metadata is ignored.
+#[no_mangle]
+pub unsafe extern "C" fn ddog_trace_exporter_config_set_otlp_instrumentation_scope(
+    config: Option<&mut TraceExporterConfig>,
+    name: CharSlice,
+    version: CharSlice,
+) -> Option<Box<ExporterError>> {
+    catch_panic!(
+        if let Some(handle) = config {
+            let name = match sanitize_string(name) {
+                Ok(s) => s,
+                Err(e) => return Some(e),
+            };
+            let version = match sanitize_string(version) {
+                Ok(s) => s,
+                Err(e) => return Some(e),
+            };
+            handle.otlp_instrumentation_scope_name = Some(name);
+            handle.otlp_instrumentation_scope_version = Some(version);
+            None
+        } else {
+            gen_error!(ErrorCode::InvalidArgument)
+        },
+        gen_error!(ErrorCode::Panic)
+    )
+}
+
 /// Sets the cardinality limit for client-side stats computation.
 ///
 /// When the number of distinct stats groups exceeds `limit`, additional groups are
@@ -679,6 +712,16 @@ pub unsafe extern "C" fn ddog_trace_exporter_new(
                 if let Some(protocol) = config.otlp_protocol {
                     builder.set_otlp_protocol(protocol);
                 }
+                builder.set_otlp_instrumentation_scope(
+                    config
+                        .otlp_instrumentation_scope_name
+                        .as_deref()
+                        .unwrap_or(""),
+                    config
+                        .otlp_instrumentation_scope_version
+                        .as_deref()
+                        .unwrap_or(""),
+                );
             }
 
             if config.output_to_log {
@@ -783,6 +826,8 @@ mod tests {
             assert!(!cfg.output_to_log);
             assert_eq!(cfg.log_max_line_size, None);
             assert_eq!(cfg.stats_cardinality_limit, None);
+            assert!(cfg.otlp_instrumentation_scope_name.is_none());
+            assert!(cfg.otlp_instrumentation_scope_version.is_none());
 
             ddog_trace_exporter_config_free(cfg);
         }
@@ -1459,6 +1504,49 @@ mod tests {
             );
             assert_eq!(error.as_ref().unwrap().code, ErrorCode::InvalidInput);
             ddog_trace_exporter_error_free(error);
+        }
+    }
+
+    #[test]
+    fn config_otlp_instrumentation_scope_test() {
+        unsafe {
+            let error = ddog_trace_exporter_config_set_otlp_instrumentation_scope(
+                None,
+                CharSlice::from("dd-trace-js"),
+                CharSlice::from("7.0.0-pre"),
+            );
+            assert_eq!(error.as_ref().unwrap().code, ErrorCode::InvalidArgument);
+            ddog_trace_exporter_error_free(error);
+
+            let mut config = Some(TraceExporterConfig::default());
+            let error = ddog_trace_exporter_config_set_otlp_instrumentation_scope(
+                config.as_mut(),
+                CharSlice::from("dd-trace-js"),
+                CharSlice::from("7.0.0-pre"),
+            );
+            assert_eq!(error, None);
+            let cfg = config.as_ref().unwrap();
+            assert_eq!(
+                cfg.otlp_instrumentation_scope_name.as_deref(),
+                Some("dd-trace-js")
+            );
+            assert_eq!(
+                cfg.otlp_instrumentation_scope_version.as_deref(),
+                Some("7.0.0-pre")
+            );
+
+            let mut config = Some(TraceExporterConfig::default());
+            let invalid: [u8; 2] = [0x80u8, 0xFFu8];
+            let error = ddog_trace_exporter_config_set_otlp_instrumentation_scope(
+                config.as_mut(),
+                CharSlice::from_bytes(&invalid),
+                CharSlice::from("7.0.0-pre"),
+            );
+            assert_eq!(error.as_ref().unwrap().code, ErrorCode::InvalidInput);
+            ddog_trace_exporter_error_free(error);
+            let cfg = config.as_ref().unwrap();
+            assert!(cfg.otlp_instrumentation_scope_name.is_none());
+            assert!(cfg.otlp_instrumentation_scope_version.is_none());
         }
     }
 

--- a/libdd-data-pipeline/src/otlp/config.rs
+++ b/libdd-data-pipeline/src/otlp/config.rs
@@ -76,6 +76,10 @@ pub struct OtlpTraceConfig {
     pub timeout: Duration,
     /// OTLP export protocol (selects body encoding and content-type).
     pub protocol: OtlpProtocol,
+    /// OTLP instrumentation scope name for exported traces.
+    pub instrumentation_scope_name: String,
+    /// OTLP instrumentation scope version for exported traces.
+    pub instrumentation_scope_version: String,
     /// When `true`, omit DD-specific per-span attributes (`service.name`, `operation.name`,
     /// `resource.name`, `span.type`, `error.*`, `span.kind`) from the OTLP payload.
     pub otel_trace_semantics_enabled: bool,

--- a/libdd-data-pipeline/src/trace_exporter/builder.rs
+++ b/libdd-data-pipeline/src/trace_exporter/builder.rs
@@ -62,6 +62,8 @@ pub struct TraceExporterBuilder<R: SharedRuntime> {
     language_version: String,
     language_interpreter: String,
     language_interpreter_vendor: String,
+    instrumentation_scope_name: String,
+    instrumentation_scope_version: String,
     git_commit_sha: String,
     process_tags: String,
     input_format: TraceExporterInputFormat,
@@ -132,6 +134,8 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
             language_version: String::new(),
             language_interpreter: String::new(),
             language_interpreter_vendor: String::new(),
+            instrumentation_scope_name: String::new(),
+            instrumentation_scope_version: String::new(),
             git_commit_sha: String::new(),
             process_tags: String::new(),
             input_format: TraceExporterInputFormat::default(),
@@ -231,6 +235,13 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
 
     pub fn set_process_tags(&mut self, process_tags: &str) -> &mut Self {
         process_tags.clone_into(&mut self.process_tags);
+        self
+    }
+
+    /// Set OTLP trace instrumentation scope metadata.
+    pub fn set_otlp_instrumentation_scope(&mut self, name: &str, version: &str) -> &mut Self {
+        name.clone_into(&mut self.instrumentation_scope_name);
+        version.clone_into(&mut self.instrumentation_scope_version);
         self
     }
 
@@ -714,6 +725,8 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
             headers: build_otlp_header_map(self.otlp_headers),
             timeout: otlp_timeout,
             protocol: self.otlp_protocol,
+            instrumentation_scope_name: self.instrumentation_scope_name,
+            instrumentation_scope_version: self.instrumentation_scope_version,
             otel_trace_semantics_enabled: self.otel_trace_semantics_enabled,
         });
 
@@ -984,6 +997,8 @@ mod tests {
             .set_language_interpreter("v8")
             .set_language_interpreter_vendor("node")
             .set_git_commit_sha("797e9ea")
+            .set_otlp_endpoint("http://localhost:4318/v1/traces")
+            .set_otlp_instrumentation_scope("dd-trace-js", "7.0.0-pre")
             .set_input_format(TraceExporterInputFormat::V04)
             .set_output_format(TraceExporterOutputFormat::V04)
             .set_client_computed_stats();
@@ -1010,6 +1025,9 @@ mod tests {
         assert_eq!(exporter.metadata.language_interpreter_vendor, "node");
         assert_eq!(exporter.metadata.git_commit_sha, "797e9ea");
         assert!(exporter.metadata.client_computed_stats);
+        let otlp_config = exporter.otlp_config.as_ref().unwrap();
+        assert_eq!(otlp_config.instrumentation_scope_name, "dd-trace-js");
+        assert_eq!(otlp_config.instrumentation_scope_version, "7.0.0-pre");
         #[cfg(feature = "telemetry")]
         assert!(exporter.telemetry.is_some());
     }

--- a/libdd-data-pipeline/src/trace_exporter/mod.rs
+++ b/libdd-data-pipeline/src/trace_exporter/mod.rs
@@ -677,6 +677,8 @@ impl<
             r.tracer_version = self.metadata.tracer_version.clone();
             r.runtime_id = self.metadata.runtime_id.clone();
             r.client_computed_stats = self.otlp_stats_enabled;
+            r.instrumentation_scope_name = config.instrumentation_scope_name.clone();
+            r.instrumentation_scope_version = config.instrumentation_scope_version.clone();
             r
         };
         // Single prost OTLP IR; the configured protocol encodes the same request to its wire

--- a/libdd-trace-utils/src/otlp_encoder/mapper.rs
+++ b/libdd-trace-utils/src/otlp_encoder/mapper.rs
@@ -289,7 +289,7 @@ fn collect_event_attributes<T: TraceData>(ev: &SpanEvent<T>) -> Vec<ProtoKeyValu
 /// directly from the native span fields (no hex/decimal round trip — the prost types are the IR).
 ///
 /// Resource: SDK-level attributes (service.name, deployment.environment.name, telemetry.sdk.*,
-/// runtime-id). InstrumentationScope: present but empty (DD SDKs don't have a scope concept).
+/// runtime-id). InstrumentationScope: optional tracer scope name/version.
 /// All analogous DD span fields are mapped; meta→attributes (string), metrics→attributes
 /// (int/double), links and events mapped to OTLP links and events. Status from span.error and
 /// meta["error.msg"] or meta["error.message"].
@@ -326,8 +326,8 @@ pub fn map_traces_to_otlp<T: TraceData>(
             resource: Some(resource),
             scope_spans: vec![ProtoScopeSpans {
                 scope: Some(ProtoScope {
-                    name: String::new(),
-                    version: String::new(),
+                    name: resource_info.instrumentation_scope_name.clone(),
+                    version: resource_info.instrumentation_scope_version.clone(),
                     attributes: Vec::new(),
                     dropped_attributes_count: 0,
                 }),
@@ -537,6 +537,28 @@ mod tests {
             count.value.as_ref().unwrap().value,
             Some(PV::IntValue(42))
         ));
+    }
+
+    #[test]
+    fn instrumentation_scope_from_resource_info() {
+        let resource_info = OtlpResourceInfo {
+            instrumentation_scope_name: "dd-trace-js".to_string(),
+            instrumentation_scope_version: "7.0.0-pre".to_string(),
+            ..Default::default()
+        };
+        let span: Span<BytesData> = Span {
+            trace_id: 1,
+            span_id: 2,
+            name: libdd_tinybytes::BytesString::from_static("s"),
+            start: 0,
+            duration: 1,
+            ..Default::default()
+        };
+
+        let req = map_traces_to_otlp(vec![vec![span]], &resource_info, false);
+        let scope = req.resource_spans[0].scope_spans[0].scope.as_ref().unwrap();
+        assert_eq!(scope.name, "dd-trace-js");
+        assert_eq!(scope.version, "7.0.0-pre");
     }
 
     #[test]

--- a/libdd-trace-utils/src/otlp_encoder/mod.rs
+++ b/libdd-trace-utils/src/otlp_encoder/mod.rs
@@ -38,6 +38,8 @@ pub struct OtlpResourceInfo {
     pub runtime_id: String,
     pub hostname: String,
     pub process_tags: String,
+    pub instrumentation_scope_name: String,
+    pub instrumentation_scope_version: String,
     /// When true, emits `_dd.stats_computed: "true"` on the OTLP resource to prevent
     /// double-counted APM metrics in Datadog Agent OTLP receivers (backwards compatible).
     pub client_computed_stats: bool,


### PR DESCRIPTION
# What does this PR do?

Adds OTLP instrumentation scope metadata to the current trace exporter path.

The trace mapper now copies `instrumentation_scope_name` and `instrumentation_scope_version` from `OtlpResourceInfo` into `ScopeSpans.scope`. `TraceExporterBuilder` gets a setter for OTLP trace scope metadata, stores those values in `OtlpTraceConfig`, and the exporter copies them into each OTLP trace `OtlpResourceInfo` before mapping.

The C FFI exporter config also exposes the same scope setter so non-Rust tracer callers can configure the scope when they enable OTLP export.

# Motivation

`dd-trace-js` native OTLP trace export emitted `scope: {}` through `@datadog/libdatadog@0.16.0`. Its Platform OTLP integration test expects the Datadog tracer scope (`name: dd-trace-js`) and a tracer version.

# Additional Notes

This branch was ported from the old v37-based patch onto current `main`; it is one commit ahead of `main` and no longer carries the release-line diff that made the earlier draft conflicting.

DataDog/libdatadog-nodejs#173 currently pins this PR head (`8cd68ab922fb7aade0f089ccfc91291d874673af`) only as a temporary unreleased dependency. Once libdatadog publishes an official release/tag containing this change, libdatadog-nodejs should move to that release/tag.

# How to test the change?

- `cargo +nightly-2026-02-08 fmt --all -- --check`
- `cargo test -p libdd-trace-utils otlp_encoder::mapper --lib` (26 pass)
- `cargo test -p libdd-data-pipeline trace_exporter::builder::tests::test_new --lib` (1 pass)
- `cargo test -p libdd-data-pipeline-ffi config_otlp_instrumentation_scope_test --lib` (2 pass)
- `cargo check -p libdd-trace-utils`
- `cargo check -p libdd-data-pipeline`
- `cargo check -p libdd-data-pipeline-ffi`
- `cargo test -p libdd-data-pipeline-ffi trace_exporter --lib` (28 pass)
- Reviewer: `LibdatadogReviewFeedbackFix` approved with no findings
