### PR TITLE
feat(heap-profiling): make heap crates publishable

### DIFF
--- a/libdd-profiling-heap-allocator/Cargo.toml
+++ b/libdd-profiling-heap-allocator/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/DataDog/libdatadog/tree/main/libdd-profiling-he
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
-publish = false
 
 [lib]
 bench = false
@@ -22,7 +21,7 @@ bench = false
 live-heap = ["libdd-profiling-heap-sampler/live-heap"]
 
 [dependencies]
-libdd-profiling-heap-sampler = { path = "../libdd-profiling-heap-sampler" }
+libdd-profiling-heap-sampler = { version = "0.1.0", path = "../libdd-profiling-heap-sampler" }
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/libdd-profiling-heap-gotter/Cargo.toml
+++ b/libdd-profiling-heap-gotter/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/DataDog/libdatadog/tree/main/libdd-profiling-he
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
-publish = false
 
 [lib]
 crate-type = ["lib", "cdylib"]
@@ -26,7 +25,7 @@ test-support = []
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = "0.2"
-libdd-profiling-heap-sampler = { path = "../libdd-profiling-heap-sampler" }
+libdd-profiling-heap-sampler = { version = "0.1.0", path = "../libdd-profiling-heap-sampler" }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 libc = "0.2"

--- a/libdd-profiling-heap-sampler/Cargo.toml
+++ b/libdd-profiling-heap-sampler/Cargo.toml
@@ -10,7 +10,6 @@ repository = "https://github.com/DataDog/libdatadog/tree/main/libdd-profiling-he
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
-publish = false
 
 [lib]
 crate-type = ["lib", "staticlib"]

--- a/libdd-profiling-heap-sampler/NOTICE
+++ b/libdd-profiling-heap-sampler/NOTICE
@@ -1,0 +1,12 @@
+Datadog libdatadog
+Copyright 2021-2022 Datadog, Inc.
+
+This product includes software developed at Datadog (<https://www.datadoghq.com/>).
+
+--
+
+This product bundles a copy of the libbpf/usdt single-header USDT
+library in `libdd-profiling-heap-sampler/vendor/usdt.h`. That file is licensed
+under the BSD 2-Clause License, Copyright (c) 2024 Meta Platforms, Inc.
+and affiliates. The SPDX identifier and copyright notice are retained
+verbatim in the file header. Upstream: <https://github.com/libbpf/usdt>.


### PR DESCRIPTION
## Status
Superseded for now by dd-source consuming the allocator from a pinned libdatadog Git revision, with the required dd-source policy exception and Bazel submodule configuration. Keeping this draft open for the Profiling team to decide whether these crates should nevertheless become publishable/released.

## Proposed changes
- remove `publish = false` from `libdd-profiling-heap-sampler` and `libdd-profiling-heap-allocator`
- add the sampler version requirement to the allocator’s path dependency, as required for published `libdd-*` dependencies

The sampler must publish before the allocator.

## Validation
- `./scripts/check_cargo_metadata.sh libdd-profiling-heap-sampler libdd-profiling-heap-allocator`
- `cargo +nightly-2026-02-08 fmt --all -- --check`
- `cargo check -p libdd-profiling-heap-sampler -p libdd-profiling-heap-allocator`
- `cargo package -p libdd-profiling-heap-sampler --allow-dirty`