### PR TITLE
feat(data-pipeline): decouple OTLP trace timeout from agent connection timeout

### DIFF
--- a/libdd-data-pipeline-ffi/src/trace_exporter.rs
+++ b/libdd-data-pipeline-ffi/src/trace_exporter.rs
@@ -85,6 +85,7 @@ pub struct TraceExporterConfig {
     process_tags: Option<String>,
     test_session_token: Option<String>,
     connection_timeout: Option<u64>,
+    otlp_timeout: Option<u64>,
     shared_runtime: Option<Arc<ForkSafeRuntime>>,
     otlp_endpoint: Option<String>,
     otlp_protocol: Option<OtlpProtocol>,
@@ -438,6 +439,9 @@ pub unsafe extern "C" fn ddog_trace_exporter_config_set_test_session_token(
 }
 
 /// Sets the timeout in ms for all agent's connections.
+///
+/// When `ddog_trace_exporter_config_set_otlp_timeout` is unset, this value is also used as the
+/// OTLP trace-export timeout.
 #[no_mangle]
 pub unsafe extern "C" fn ddog_trace_exporter_config_set_connection_timeout(
     config: Option<&mut TraceExporterConfig>,
@@ -446,6 +450,28 @@ pub unsafe extern "C" fn ddog_trace_exporter_config_set_connection_timeout(
     catch_panic!(
         if let Option::Some(handle) = config {
             handle.connection_timeout = Some(timeout_ms);
+            None
+        } else {
+            gen_error!(ErrorCode::InvalidArgument)
+        },
+        gen_error!(ErrorCode::Panic)
+    )
+}
+
+/// Sets the OTLP trace-export request timeout in ms, independent of the agent connection timeout.
+///
+/// Applies only to the OTLP export path (see
+/// `ddog_trace_exporter_config_set_otlp_endpoint`). When left unset, the OTLP timeout falls back
+/// to `ddog_trace_exporter_config_set_connection_timeout`; setting it here leaves the agent
+/// connection timeout untouched.
+#[no_mangle]
+pub unsafe extern "C" fn ddog_trace_exporter_config_set_otlp_timeout(
+    config: Option<&mut TraceExporterConfig>,
+    timeout_ms: u64,
+) -> Option<Box<ExporterError>> {
+    catch_panic!(
+        if let Option::Some(handle) = config {
+            handle.otlp_timeout = Some(timeout_ms);
             None
         } else {
             gen_error!(ErrorCode::InvalidArgument)
@@ -712,6 +738,7 @@ pub unsafe extern "C" fn ddog_trace_exporter_new(
                 if let Some(protocol) = config.otlp_protocol {
                     builder.set_otlp_protocol(protocol);
                 }
+                builder.set_otlp_timeout(config.otlp_timeout);
                 builder.set_otlp_instrumentation_scope(
                     config
                         .otlp_instrumentation_scope_name
@@ -1170,6 +1197,19 @@ mod tests {
 
             ddog_trace_exporter_config_set_connection_timeout(Some(&mut cfg), 1000);
             assert_eq!(cfg.connection_timeout.unwrap(), 1000);
+        }
+    }
+
+    #[test]
+    fn config_otlp_timeout_test() {
+        unsafe {
+            let mut cfg = TraceExporterConfig::default();
+            assert!(cfg.otlp_timeout.is_none());
+
+            // Setting the OTLP timeout leaves the agent connection timeout untouched.
+            ddog_trace_exporter_config_set_otlp_timeout(Some(&mut cfg), 250);
+            assert_eq!(cfg.otlp_timeout.unwrap(), 250);
+            assert!(cfg.connection_timeout.is_none());
         }
     }
 

--- a/libdd-data-pipeline/src/trace_exporter/builder.rs
+++ b/libdd-data-pipeline/src/trace_exporter/builder.rs
@@ -32,6 +32,25 @@ use std::time::Duration;
 
 const DEFAULT_AGENT_URL: &str = "http://127.0.0.1:8126";
 
+/// Resolves the `(trace, metrics)` OTLP request timeouts from the builder's timeout inputs.
+///
+/// The trace timeout prefers the dedicated `otlp_timeout`, falling back to `connection_timeout`
+/// then the default. The metrics timeout is driven only by `connection_timeout`, so a
+/// traces-scoped `otlp_timeout` never shortens OTLP metrics/stats requests.
+fn resolve_otlp_timeouts(
+    otlp_timeout: Option<u64>,
+    connection_timeout: Option<u64>,
+) -> (Duration, Duration) {
+    let trace_timeout = otlp_timeout
+        .or(connection_timeout)
+        .map(Duration::from_millis)
+        .unwrap_or(DEFAULT_OTLP_TIMEOUT);
+    let metrics_timeout = connection_timeout
+        .map(Duration::from_millis)
+        .unwrap_or(DEFAULT_OTLP_TIMEOUT);
+    (trace_timeout, metrics_timeout)
+}
+
 /// Build an [`http::HeaderMap`] from key/value pairs, skipping malformed entries.
 fn build_otlp_header_map(headers: Vec<(String, String)>) -> http::HeaderMap {
     let mut out = http::HeaderMap::new();
@@ -89,6 +108,7 @@ pub struct TraceExporterBuilder<R: SharedRuntime> {
     test_session_token: Option<String>,
     agent_rates_payload_version_enabled: bool,
     connection_timeout: Option<u64>,
+    otlp_timeout: Option<u64>,
     otlp_endpoint: Option<String>,
     otlp_headers: Vec<(String, String)>,
     agentless_endpoint: Option<String>,
@@ -160,6 +180,7 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
             test_session_token: None,
             agent_rates_payload_version_enabled: false,
             connection_timeout: None,
+            otlp_timeout: None,
             otlp_endpoint: None,
             otlp_headers: Vec::new(),
             otlp_protocol: OtlpProtocol::default(),
@@ -405,8 +426,25 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
     }
 
     /// Sets the agent's connection timeout.
+    ///
+    /// This governs the timeout for requests to the Datadog agent (agent info, stats, Remote
+    /// Config, telemetry, and agent-path trace sends). To set the OTLP trace-export request
+    /// timeout independently, use [`Self::set_otlp_timeout`]; when that is unset, the OTLP timeout
+    /// falls back to this value for backward compatibility.
     pub fn set_connection_timeout(&mut self, timeout_ms: Option<u64>) -> &mut Self {
         self.connection_timeout = timeout_ms;
+        self
+    }
+
+    /// Sets the OTLP trace-export request timeout, independent of the agent connection timeout.
+    ///
+    /// Applies only to OTLP trace export (see [`Self::set_otlp_endpoint`]); OTLP metrics export
+    /// stays on [`Self::set_connection_timeout`]. The host language resolves this from its
+    /// configuration (e.g. `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT`). When left unset, the OTLP trace
+    /// timeout falls back to [`Self::set_connection_timeout`] and then the default; setting it here
+    /// leaves the agent connection timeout untouched.
+    pub fn set_otlp_timeout(&mut self, timeout_ms: Option<u64>) -> &mut Self {
+        self.otlp_timeout = timeout_ms;
         self
     }
 
@@ -721,17 +759,18 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
             _ => None,
         };
 
-        let otlp_timeout = self
-            .connection_timeout
-            .map(Duration::from_millis)
-            .unwrap_or(DEFAULT_OTLP_TIMEOUT);
+        // OTLP timeouts are independent of the agent `Endpoint.timeout_ms` below, which stays
+        // driven solely by `connection_timeout` — so setting only `otlp_timeout` never shortens
+        // agent-path requests (info / stats / Remote Config / telemetry).
+        let (otlp_trace_timeout, otlp_metrics_timeout) =
+            resolve_otlp_timeouts(self.otlp_timeout, self.connection_timeout);
 
         // `self.otlp_protocol` is always an HTTP encoding here: gRPC is rejected at the parse
         // boundary (`OtlpProtocol::from_str`) and so can never be constructed.
         let otlp_config = otlp_endpoint.map(|url| OtlpTraceConfig {
             endpoint_url: url,
             headers: build_otlp_header_map(self.otlp_headers),
-            timeout: otlp_timeout,
+            timeout: otlp_trace_timeout,
             protocol: self.otlp_protocol,
             instrumentation_scope_name: self.instrumentation_scope_name,
             instrumentation_scope_version: self.instrumentation_scope_version,
@@ -741,7 +780,7 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
         let otlp_metrics_config = self.otlp_metrics_endpoint.map(|url| OtlpMetricsConfig {
             endpoint_url: url,
             headers: build_otlp_header_map(self.otlp_metrics_headers),
-            timeout: otlp_timeout,
+            timeout: otlp_metrics_timeout,
             protocol: OtlpProtocol::HttpJson,
             otel_trace_semantics_enabled: self.otel_trace_semantics_enabled,
         });
@@ -1170,6 +1209,33 @@ mod tests {
         assert!(
             msg.contains("agent URL") && msg.contains("agentless"),
             "unexpected error message: {msg}"
+        );
+    }
+
+    #[test]
+    fn resolve_otlp_timeouts_scopes_trace_and_metrics_independently() {
+        let default = DEFAULT_OTLP_TIMEOUT;
+
+        // Neither set: both fall back to the default.
+        assert_eq!(resolve_otlp_timeouts(None, None), (default, default));
+
+        // Only the OTLP timeout set: traces use it, metrics keep the default (a traces-scoped
+        // timeout must never shorten OTLP metrics/stats requests).
+        assert_eq!(
+            resolve_otlp_timeouts(Some(250), None),
+            (Duration::from_millis(250), default)
+        );
+
+        // Only the connection timeout set: it drives both (the OTLP trace fallback and metrics).
+        assert_eq!(
+            resolve_otlp_timeouts(None, Some(1234)),
+            (Duration::from_millis(1234), Duration::from_millis(1234))
+        );
+
+        // Both set: traces use the OTLP timeout, metrics use the connection timeout.
+        assert_eq!(
+            resolve_otlp_timeouts(Some(250), Some(1234)),
+            (Duration::from_millis(250), Duration::from_millis(1234))
         );
     }
 

--- a/libdd-data-pipeline/src/trace_exporter/mod.rs
+++ b/libdd-data-pipeline/src/trace_exporter/mod.rs
@@ -2166,6 +2166,63 @@ mod tests {
 
     #[test]
     #[cfg_attr(miri, ignore)]
+    fn test_otlp_timeout_decoupled_from_agent_connection_timeout() {
+        use crate::otlp::config::DEFAULT_OTLP_TIMEOUT;
+        use std::time::Duration;
+
+        let otlp_endpoint = "http://127.0.0.1:4318/v1/traces";
+
+        // Only the OTLP timeout is set: OTLP uses it; the agent endpoint keeps its default.
+        let mut builder = TraceExporterBuilder::default();
+        builder
+            .set_otlp_endpoint(otlp_endpoint)
+            .set_otlp_timeout(Some(250));
+        let exporter = builder.build::<NativeCapabilities>().unwrap();
+        assert_eq!(exporter.endpoint.timeout_ms, Endpoint::default().timeout_ms);
+        assert_eq!(
+            exporter.otlp_config.as_ref().unwrap().timeout,
+            Duration::from_millis(250)
+        );
+
+        // Only the connection timeout is set: it drives the agent endpoint and, for backward
+        // compatibility, is also used as the OTLP timeout fallback.
+        let mut builder = TraceExporterBuilder::default();
+        builder
+            .set_otlp_endpoint(otlp_endpoint)
+            .set_connection_timeout(Some(1234));
+        let exporter = builder.build::<NativeCapabilities>().unwrap();
+        assert_eq!(exporter.endpoint.timeout_ms, 1234);
+        assert_eq!(
+            exporter.otlp_config.as_ref().unwrap().timeout,
+            Duration::from_millis(1234)
+        );
+
+        // Both set: the OTLP timeout wins for OTLP while the agent endpoint keeps its own value.
+        let mut builder = TraceExporterBuilder::default();
+        builder
+            .set_otlp_endpoint(otlp_endpoint)
+            .set_connection_timeout(Some(1234))
+            .set_otlp_timeout(Some(250));
+        let exporter = builder.build::<NativeCapabilities>().unwrap();
+        assert_eq!(exporter.endpoint.timeout_ms, 1234);
+        assert_eq!(
+            exporter.otlp_config.as_ref().unwrap().timeout,
+            Duration::from_millis(250)
+        );
+
+        // Neither set: OTLP uses its default, agent endpoint uses its default.
+        let mut builder = TraceExporterBuilder::default();
+        builder.set_otlp_endpoint(otlp_endpoint);
+        let exporter = builder.build::<NativeCapabilities>().unwrap();
+        assert_eq!(exporter.endpoint.timeout_ms, Endpoint::default().timeout_ms);
+        assert_eq!(
+            exporter.otlp_config.as_ref().unwrap().timeout,
+            DEFAULT_OTLP_TIMEOUT
+        );
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_otlp_export_via_builder() {
         let server = MockServer::start();
         let mock_otlp = server.mock(|when, then| {


### PR DESCRIPTION
# What does this PR do?

Adds a dedicated `set_otlp_timeout` setter to `TraceExporterBuilder` (and the FFI equivalent `ddog_trace_exporter_config_set_otlp_timeout`) that sets the **OTLP trace-export request timeout** independently of the agent connection timeout.

Before this change, `set_connection_timeout` was the only timeout knob, and its value was wired into three places at build time:
- the agent `Endpoint.timeout_ms` (agent info, stats, Remote Config, telemetry, agent-path trace sends),
- the OTLP **trace** config timeout, and
- the OTLP **metrics** config timeout.

After this change:
- The OTLP **trace** timeout resolves from `otlp_timeout` → `connection_timeout` → default.
- The agent `Endpoint.timeout_ms` is driven **solely** by `connection_timeout`.
- The OTLP **metrics** timeout is driven **solely** by `connection_timeout` (unchanged), so a traces-scoped `otlp_timeout` never shortens OTLP metrics/stats requests.

Timeout resolution is centralized in a small `resolve_otlp_timeouts` helper.

# Motivation

A host tracer that maps `OTEL_EXPORTER_OTLP_TRACES_TIMEOUT` onto `set_connection_timeout` (the only available knob) silently reshapes agent-side request timeouts. A short OTLP timeout tuned for a fast collector shortens `/info`, Remote Config, and telemetry requests — disabling client-side stats, blocking RC, and dropping telemetry — while the OTLP default (10s) conversely loosens the agent's 3s default. The two concerns need separate knobs; `OtlpTraceConfig` already carries its own `timeout` field, so only the builder's input plumbing was conflated.

This was surfaced while wiring OTLP trace export in dd-trace-rs (DataDog/dd-trace-rs#251), which will call `set_otlp_timeout` once a release containing this change ships.

# Additional Notes

- **Backward compatible:** callers that set only `connection_timeout` are unaffected — the OTLP trace timeout still falls back to it, and the agent endpoint timeout is unchanged.
- FFI: the new setter mirrors `set_connection_timeout` conventions; the C header is cbindgen-generated at build time (no checked-in header to edit).
- Metrics timeout behavior is deliberately left on `connection_timeout` to avoid a regression where a traces-scoped timeout would govern OTLP metrics/stats export.

# How to test the change?

New unit tests (all passing):
- `resolve_otlp_timeouts_scopes_trace_and_metrics_independently` (builder) — asserts the `(trace, metrics)` timeout resolution across all `otlp_timeout`/`connection_timeout` combinations, proving metrics never picks up the traces-scoped value.
- `test_otlp_timeout_decoupled_from_agent_connection_timeout` (trace_exporter) — builds exporters and asserts the agent `Endpoint.timeout_ms` and OTLP config timeout independently across the four combinations.
- `config_otlp_timeout_test` (FFI) — asserts the setter stores the OTLP timeout and leaves `connection_timeout` untouched.

The existing `test_connection_timeout` and OTLP export integration tests continue to pass; `cargo fmt` and `cargo clippy` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)