### PR TITLE
fix(libdd-otel-thread-ffi): hide sanity check symbols behind a symbol

### DIFF
--- a/libdd-otel-thread-ctx-ffi/cbindgen.toml
+++ b/libdd-otel-thread-ctx-ffi/cbindgen.toml
@@ -17,6 +17,9 @@ sys_includes = ["stdbool.h", "stddef.h", "stdint.h"]
 parse_deps = true
 include = ["libdd-common-ffi", "libdd-otel-thread-ctx"]
 
+[defines]
+"feature = sanity-check" = "DDOG_OTEL_THREAD_CTX_SANITY_CHECK"
+
 [export]
 prefix = "ddog_"
 renaming_overrides_prefixing = true


### PR DESCRIPTION
# What does this PR do?

Hides sanity check symbols behind a symbol which is defined if `sanity-check` feature is enabled.

# Motivation

While reviewing #2181 I noticed that the sanity check symbol was included in the header unconditionally.

