### PR TITLE
ci: avoid running out of space when miri workflow is run

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -56,6 +56,16 @@ jobs:
       CARGO_INCREMENTAL: 0
       PROPTEST_CASES: 1
     steps:
+      - name: Free Disk Space (Ubuntu only)
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # 1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: true
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
         with:
           submodules: recursive


### PR DESCRIPTION
# What does this PR do?

Clean up unnecessary stuff from ubuntu runner in order to prevent running out of space when executing miri.

# Motivation

Lately this worflow [failed](https://github.com/DataDog/libdatadog/actions/runs/29132114832/job/86489319516)

