### PR TITLE
perf(profiling): reduce ProfilesDictionary arena footprint

### DIFF
--- a/libdd-profiling/src/profiles/collections/parallel/slice_set.rs
+++ b/libdd-profiling/src/profiles/collections/parallel/slice_set.rs
@@ -10,7 +10,7 @@ use std::ops::Deref;
 /// Number of shards used by the parallel slice set and (by extension)
 /// the string-specific parallel set. Kept as a constant so tests and
 /// related code can refer to the same value.
-pub const N_SHARDS: usize = 16;
+pub const N_SHARDS: usize = 4;
 
 /// The initial capacities for Rust's hash map (and set) currently go
 /// like this: 3, 7, 14, 28. We want to avoid some of the smaller sizes so
@@ -64,9 +64,9 @@ impl<T: Copy + hash::Hash + Eq + 'static> ParallelSliceSet<T> {
     pub const fn select_shard(hash: u64) -> usize {
         // Use lower bits for shard selection to avoid interfering with
         // Swiss tables' internal SIMD comparisons that use upper 7 bits.
-        // Using 4 bits provides resilience against hash function deficiencies
-        // and optimal scaling for low thread counts.
-        (hash & 0b1111) as usize
+        // N_SHARDS is a power of two, so this maps the hash uniformly into the
+        // shard index range.
+        (hash as usize) & (N_SHARDS - 1)
     }
 
     /// Tries to create a new parallel slice set.

--- a/libdd-profiling/src/profiles/collections/set.rs
+++ b/libdd-profiling/src/profiles/collections/set.rs
@@ -61,7 +61,7 @@ pub struct Set<T: Hash + Eq + 'static> {
 }
 
 impl<T: Eq + Hash + 'static> Set<T> {
-    pub const SIZE_HINT: usize = 1024 * 1024;
+    pub const SIZE_HINT: usize = 256 * 1024;
 
     pub fn try_new() -> Result<Self, SetError> {
         Self::try_with_capacity(SET_MIN_CAPACITY)

--- a/libdd-profiling/src/profiles/collections/slice_set.rs
+++ b/libdd-profiling/src/profiles/collections/slice_set.rs
@@ -23,7 +23,7 @@ pub struct SliceSet<T: Copy + Hash + Eq + 'static> {
 }
 
 impl<T: Copy + Hash + Eq + 'static> SliceSet<T> {
-    const SIZE_HINT: usize = 1024 * 1024;
+    const SIZE_HINT: usize = 256 * 1024;
 
     pub fn try_with_capacity(capacity: usize) -> Result<Self, SetError> {
         let arena = ChainAllocator::new_in(Self::SIZE_HINT, VirtualAllocator {});


### PR DESCRIPTION
# What does this PR do?

Reduces the memory floor of the profiling `ProfilesDictionary` arena-backed storage by changing existing shard count and arena chunk size constants.

Specifically:

- `ParallelSliceSet` / `ParallelStringSet` shard count changes from 16 to 4.
- `SliceSet` arena size hint changes from 1 MiB to 256 KiB.
- `Set<T>` arena size hint changes from 1 MiB to 256 KiB, reducing the per-shard floor for function and mapping sets.
- string shard selection now derives from `N_SHARDS` instead of hardcoding a 4-bit mask.

This changes the approximate `ProfilesDictionary` arena floor from:

```text
functions: 4 * 1 MiB   = 4 MiB
mappings:  2 * 1 MiB   = 2 MiB
strings:   16 * 1 MiB  = 16 MiB
--------------------------------
total:                  22 MiB
```

to:

```text
functions: 4 * 256 KiB = 1 MiB
mappings:  2 * 256 KiB = 512 KiB
strings:   4 * 256 KiB = 1 MiB
--------------------------------
total:                  2.5 MiB
```

No allocator APIs are added or changed in this PR.

# Motivation

In Python profiling memory experiments, the profiles dictionary storage showed up as a meaningful virtual memory floor. The goal is to make the dictionary storage floor smaller by reducing the string shard multiplicity and reducing arena chunk sizes for strings, functions, and mappings.

This PR intentionally leaves the profile-local `StringTable` chunk size unchanged. That can be evaluated separately if needed.

# Additional Notes

The main trade-off is potentially higher string insertion contention because the string set now has 4 shards instead of 16. For Python profiling, this should be acceptable, but we should validate with workload benchmarks and profile counts/sizes.

Function shards remain at 4. Mapping shards remain at 2. This PR only reduces their per-shard arena size.

# How to test the change?

Ran:

```sh
cargo fmt
cargo test -p libdd-profiling --lib
```

Final result:

```text
141 passed, 0 failed
```
