### PR TITLE
docs: scope agent validation commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 ### Validating after changes
 
-Iterate fastest with `cargo check -p <crate>` while editing; the full validation steps below are what should be green before declaring work done.
+Iterate fastest with `cargo check -p <crate>` while editing; validate each affected crate before declaring work done. Run workspace-wide checks only for repo-wide changes.
 
 1. **Compile** — use `cargo check -p <crate>` for fast iteration on a single crate; run the full workspace build only when changes are repo-wide:
    ```bash
@@ -14,17 +14,22 @@ Iterate fastest with `cargo check -p <crate>` while editing; the full validation
    cargo build --workspace --exclude builder    # full build (repo-wide changes only)
    ```
 
-2. **Format and lint** — always run on every crate that was touched, before finishing:
+2. **Format and lint** — run for every crate that was touched, before finishing:
    ```bash
    cargo +nightly-2026-02-08 fmt --all -- --check
-   cargo +stable clippy --workspace --all-targets --all-features -- -D warnings
+   cargo +stable clippy -p <crate> --all-targets -- -D warnings
    ```
+   Add the feature flags affected by the change. Use `--all-features` only when the crate supports enabling all features together.
 
-3. **Run tests** with nextest plus doc tests:
+3. **Run tests** for every crate that was touched:
+   ```bash
+   cargo nextest run -p <crate>
+   ```
+   If documentation, examples, or a public API changed, run `cargo test -p <crate> --doc`.
+
+   For repo-wide changes, also run:
    ```bash
    cargo nextest run --workspace --no-fail-fast
-   cargo nextest run --workspace --all-features --exclude builder --exclude test_spawn_from_lib
-   cargo test --doc
    ```
    Run a single test by substring: `cargo nextest run -p <crate-name> <test-name>`.
 


### PR DESCRIPTION
Basically the default AGENTS.md cause a lot of full rebuilds on every checkpoint. The updated AGENTS.md teaches the agents to only rerun validations to actualy modified creates. 

At a risk of skipping some downstream crates. Which in either way will still be caught by the CI




## Summary

- scope the default Clippy and nextest commands to affected crates
- reserve workspace-wide build and test commands for repo-wide changes
- make doc tests conditional on documentation, example, or public API changes

## Why

The previous guidance required several exhaustive workspace checks for routine crate-level changes. This keeps validation proportional to the change while retaining workspace coverage for repo-wide work.

## Validation

- `git diff --check`
