### PR TITLE
fix(stats-exporter): disable retries for stats payload sends [APMSP-3362]

### DIFF
--- a/libdd-trace-stats/src/stats_exporter.rs
+++ b/libdd-trace-stats/src/stats_exporter.rs
@@ -17,7 +17,7 @@ use libdd_capabilities::{HttpClientCapability, MaybeSend, SleepCapability};
 use libdd_common::Endpoint;
 use libdd_shared_runtime::Worker;
 use libdd_trace_protobuf::pb;
-use libdd_trace_utils::send_with_retry::{send_with_retry, RetryStrategy};
+use libdd_trace_utils::send_with_retry::{send_with_retry, RetryBackoffType, RetryStrategy};
 use libdd_trace_utils::trace_utils::TracerHeaderTags;
 use libdd_trace_utils::tracer_metadata::TracerMetadata;
 use std::fmt::Debug;
@@ -248,7 +248,7 @@ impl<Cap: HttpClientCapability + SleepCapability, Con: FlushableConcentrator>
             &self.endpoint,
             body,
             &headers,
-            &RetryStrategy::default(),
+            &RetryStrategy::new(0, 0, RetryBackoffType::Constant, None),
         )
         .await;
 

--- a/libdd-trace-stats/src/stats_exporter.rs
+++ b/libdd-trace-stats/src/stats_exporter.rs
@@ -464,8 +464,8 @@ mod tests {
         send_status.unwrap_err();
 
         assert!(
-            poll_for_mock_hit(&mut mock, 10, 100, 6, true).await,
-            "Expected max retry attempts"
+            poll_for_mock_hit(&mut mock, 10, 100, 1, true).await,
+            "Expected a single attempt with no retries"
         );
     }
 


### PR DESCRIPTION
<!-- dd-meta {"pullId":"00000000-0000-0000-0000-000000000000","source":"chat","resourceId":"48be2bed-ec7a-473d-9be7-96bb35908e0d","workflowId":"64f3e7b1-1b3b-459d-afdd-6ba7d2445b18","codeChangeId":"64f3e7b1-1b3b-459d-afdd-6ba7d2445b18","sourceType":"chat"} -->
## What does this PR do?

Makes `StatsExporter` send stats payloads with no retries (single attempt) instead of the default 5-retry exponential backoff.

## Motivation

The Client-Side Stats spec (v1.2.0, Flush Requirements) mandates "No Retry Logic: Stats are fire-and-forget; failed payloads are not retried" and that transport errors must not block stats computation. 

Spec: datadoghq.atlassian.net/wiki/spaces/APM/pages/5758458333/v1.2.0#Flush-Requirements

## Changes

- `send_payload` now passes `RetryStrategy::new(0, 0, RetryBackoffType::Constant, None)` instead of `RetryStrategy::default()`.
- Updated `test_send_stats_fail` to expect a single request attempt instead of 6 (initial + 5 retries).

## How to test the change?

`cargo check -p libdd-trace-stats` and `cargo nextest run -p libdd-trace-stats` (couldn't run in sandbox: a git dependency is blocked by the network allowlist).

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/48be2bed-ec7a-473d-9be7-96bb35908e0d)

Comment @datadog to request changes