### PR TITLE
chore(profiling): add missing version to libdd-profiling-heap-gotter to fix publish [PROF-15190]

### DIFF
--- a/libdd-profiling-heap-gotter/Cargo.toml
+++ b/libdd-profiling-heap-gotter/Cargo.toml
@@ -29,5 +29,5 @@ libdd-profiling-heap-sampler = { version = "0.1.0", path = "../libdd-profiling-h
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 libc = "0.2"
-libdd-profiling-heap-sampler = { path = "../libdd-profiling-heap-sampler" }
+libdd-profiling-heap-sampler = { version = "0.1.0", path = "../libdd-profiling-heap-sampler" }
 serial_test = "3.2"


### PR DESCRIPTION
# What does this PR do?
Adds a missing version to a dep so publish will run.  Tested with:
```
cargo +1.92.0 package --all-features -p libdd-profiling-heap-allocator -p libdd-profiling-heap-gotter -p libdd-profiling-heap-sampler
```

A brief description of the change being made with this pull request.

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
