### PR TITLE
test: stabilize flaky tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,6 +122,10 @@ jobs:
         with:
           cache-targets: true # cache build artifacts
           cache-bin: true # cache the ~/.cargo/bin directory
+      - name: "Clear macOS panic-abort cache"
+        if: runner.os == 'macOS'
+        shell: bash
+        run: rm -rf target/panic-abort
       - name: "Remove nextest CI report"
         shell: bash
         run: rm -rf target/nextest/ci/junit.xml

--- a/libdd-common/src/dump_server.rs
+++ b/libdd-common/src/dump_server.rs
@@ -35,11 +35,18 @@ const HTTP_200_RESPONSE: &[u8] = b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"
 pub fn spawn_dump_server(output_path: PathBuf) -> anyhow::Result<PathBuf> {
     use tokio::net::UnixListener;
 
-    // Create a temporary socket path with randomness to avoid collisions
-    // Retry if the path already exists (highly unlikely with 64-bit random IDs)
+    // Create a short temporary socket path with randomness to avoid collisions.
+    // Unix socket paths have a small platform-dependent limit (notably on macOS),
+    // and std::env::temp_dir() can be too long.
+    let socket_dir = PathBuf::from("/tmp");
+    let socket_dir = if socket_dir.is_dir() {
+        socket_dir
+    } else {
+        std::env::temp_dir()
+    };
     let socket_path = loop {
         let random_id: u64 = rand::random();
-        let path = std::env::temp_dir().join(format!(
+        let path = socket_dir.join(format!(
             "libdatadog_dump_{}_{:x}.sock",
             std::process::id(),
             random_id

--- a/libdd-crashtracker/src/receiver/ptrace_collector.rs
+++ b/libdd-crashtracker/src/receiver/ptrace_collector.rs
@@ -557,6 +557,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn enumerate_discovers_spawned_thread() {
         let barrier = Arc::new(Barrier::new(2));
         let b = Arc::clone(&barrier);

--- a/libdd-data-pipeline-ffi/src/trace_exporter.rs
+++ b/libdd-data-pipeline-ffi/src/trace_exporter.rs
@@ -1407,7 +1407,7 @@ mod tests {
                 input_format: TraceExporterInputFormat::V04,
                 output_format: TraceExporterOutputFormat::V04,
                 telemetry_cfg: Some(TelemetryConfig {
-                    heartbeat: 10000,
+                    heartbeat: 100,
                     runtime_id: Some("foo".to_string()),
                     debug_enabled: true,
                 }),
@@ -1437,6 +1437,13 @@ mod tests {
                 String::from_utf8_lossy(&response.assume_init().body.unwrap()),
                 response_body
             );
+
+            for _ in 0..50 {
+                if mock_metrics.calls() >= 1 {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
 
             ddog_trace_exporter_free(exporter);
             // It should receive 1 metrics payload (excluding heartbeats)

--- a/libdd-profiling/src/exporter/exporter_manager.rs
+++ b/libdd-profiling/src/exporter/exporter_manager.rs
@@ -206,7 +206,7 @@ mod tests {
     use super::*;
     use crate::exporter::config;
     use crate::internal::EncodedProfile;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     /// Test fixture that sets up a manager with a file-based exporter
     struct TestFixture {
@@ -262,6 +262,17 @@ mod tests {
         fn wait_for_processing(&self, ms: u64) {
             std::thread::sleep(Duration::from_millis(ms));
         }
+
+        fn wait_for_request(&self, timeout: Duration) -> bool {
+            let deadline = Instant::now() + timeout;
+            while Instant::now() < deadline {
+                if self.has_request() {
+                    return true;
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            self.has_request()
+        }
     }
 
     #[test]
@@ -307,10 +318,12 @@ mod tests {
         let mut fixture = TestFixture::new("test_sent");
 
         fixture.queue_profile().expect("Failed to queue profile");
-        fixture.wait_for_processing(200);
 
         // Verify the request was written
-        assert!(fixture.has_request(), "Expected request to be sent");
+        assert!(
+            fixture.wait_for_request(Duration::from_secs(5)),
+            "Expected request to be sent"
+        );
 
         fixture.manager.abort().expect("Failed to abort");
         // Worker thread should have processed it, so no inflight messages
@@ -332,11 +345,10 @@ mod tests {
         fixture
             .queue_profiles(3, 50)
             .expect("Failed to queue profiles");
-        fixture.wait_for_processing(400);
 
         // At least the last one should have been sent
         assert!(
-            fixture.has_request(),
+            fixture.wait_for_request(Duration::from_secs(5)),
             "Expected at least one request to be sent"
         );
 
@@ -369,10 +381,11 @@ mod tests {
             .queue_profiles(2, 0)
             .expect("Should queue 2 profiles");
 
-        fixture.wait_for_processing(400);
-
         // Verify at least one was processed
-        assert!(fixture.has_request(), "At least one request should be sent");
+        assert!(
+            fixture.wait_for_request(Duration::from_secs(5)),
+            "At least one request should be sent"
+        );
 
         fixture.manager.abort().expect("Failed to abort");
     }
@@ -384,7 +397,10 @@ mod tests {
         let file_path = fixture.file_path.clone();
 
         fixture.queue_profile().expect("Failed to queue profile");
-        fixture.wait_for_processing(200);
+        assert!(
+            fixture.wait_for_request(Duration::from_secs(5)),
+            "Request should be sent"
+        );
 
         // Prefork should work just like abort
         fixture.manager.prefork().expect("Failed to prefork");
@@ -419,10 +435,11 @@ mod tests {
             )
             .expect("Failed to queue profile with additional data");
 
-        fixture.wait_for_processing(200);
-
         // Verify the request was sent
-        assert!(fixture.has_request(), "Request should be sent");
+        assert!(
+            fixture.wait_for_request(Duration::from_secs(5)),
+            "Request should be sent"
+        );
 
         // Read and verify the request contains our custom data
         let content = std::fs::read(&fixture.file_path).expect("Failed to read file");


### PR DESCRIPTION
# What does this PR do?

Skips one ptrace thread-enumeration test under Miri.

Makes async test assertions wait for the expected request instead of relying on fixed sleeps.

Clears the macOS `target/panic-abort` cache before tests as a short-term workaround for stale cached build artifacts.

# Motivation

These flaky tests and the macOS cache issue are currently blocking builds.

# Additional Notes

The macOS cache cleanup is intended as a short-term unblocker. A separate draft PR moves panic-abort artifacts outside the cached target tree.

# How to test the change?

- `cargo +nightly-2026-02-08 fmt --all -- --check`
- `cargo test -q -p libdd-data-pipeline-ffi exporter_send_telemetry_test`
- `cargo test -q -p libdd-profiling exporter::exporter_manager::tests -- --nocapture`
- `cargo test -q -p libdd-common --features reqwest test_file_dump_captures_http_request -- --nocapture`
- Linux workspace: `cargo test -q -p libdd-data-pipeline-ffi exporter_send_telemetry_test` repeated 30 times
- Linux workspace: `RUSTUP_TOOLCHAIN=nightly-2026-02-08 MIRIFLAGS="-Zmiri-disable-isolation" cargo miri test -p libdd-crashtracker enumerate_discovers_spawned_thread -- --nocapture`
