### PR TITLE
feat(data-pipeline): emit additional_metric_tags on OTLP span duration metric

### DIFF
--- a/libdd-data-pipeline/src/otlp/metrics.rs
+++ b/libdd-data-pipeline/src/otlp/metrics.rs
@@ -181,6 +181,11 @@ fn build_attributes(
             push(k, v);
         }
     }
+    for tag in &group.additional_metric_tags {
+        if let Some((k, v)) = tag.split_once(':') {
+            push(k, v);
+        }
+    }
     if !otel_trace_semantics_enabled {
         push("datadog.operation.name", &group.name);
         push("datadog.span.type", &group.r#type);
@@ -578,6 +583,38 @@ mod tests {
         let ok_s = ok_pt["sum"].as_f64().unwrap();
         let err_s = err_pt["sum"].as_f64().unwrap();
         assert_eq!(ok_s + err_s, ns_to_s(combined_ns));
+    }
+
+    #[test]
+    fn emits_additional_metric_tags_as_attributes() {
+        let g = group_with_exact(&[1_000_000_000], &[], |g| {
+            g.additional_metric_tags = vec![
+                "custom.primary:a".into(),
+                "region:us-east".into(),
+                // Only the first `:` is a delimiter; the value keeps any embedded `:`.
+                "endpoint:https://host:8080".into(),
+            ];
+        });
+        let req = map_stats_to_otlp_metrics(&buckets(vec![g.clone()]), &resource(), false).unwrap();
+        let a = points(&req)[0]["attributes"].as_array().unwrap();
+        assert_eq!(str_at(a, "custom.primary"), Some("a"));
+        assert_eq!(str_at(a, "region"), Some("us-east"));
+        assert_eq!(str_at(a, "endpoint"), Some("https://host:8080"));
+
+        // Additional metric tags are user/tracer-defined (not Datadog-internal), so unlike
+        // `datadog.*` attributes they still pass through in OTel-semantics mode.
+        let req = map_stats_to_otlp_metrics(&buckets(vec![g]), &resource(), true).unwrap();
+        let a = points(&req)[0]["attributes"].as_array().unwrap();
+        assert_eq!(str_at(a, "custom.primary"), Some("a"));
+
+        // Malformed (no `:`) or empty-value entries are skipped rather than emitted verbatim.
+        let g = group_with_exact(&[1_000_000_000], &[], |g| {
+            g.additional_metric_tags = vec!["malformed".into(), "empty:".into()];
+        });
+        let req = map_stats_to_otlp_metrics(&buckets(vec![g]), &resource(), false).unwrap();
+        let a = points(&req)[0]["attributes"].as_array().unwrap();
+        assert!(!a.iter().any(|kv| kv["key"] == "malformed"));
+        assert!(!a.iter().any(|kv| kv["key"] == "empty"));
     }
 
     #[test]


### PR DESCRIPTION
## What does this PR do?

#2170 added `additional_metric_tags` to `ClientGroupedStats` in `libdd-trace-stats`, letting tracers attach extra tracer/customer-configured key/value dimensions (up to 4 keys, values capped at 200 chars) to stats aggregation. That change only wired the tags into the native `/v0.6/stats` agent payload.

This PR extends the OTLP stats path (`libdd-data-pipeline/src/otlp/metrics.rs`) so the same `additional_metric_tags` are also serialized as data-point attributes on the `traces.span.sdk.metrics.duration` OTLP histogram metric, mirroring the existing `peer_tags` handling.

## Motivation

Consumers of the OTLP metrics export (e.g. via an OTel collector) were silently missing these additional tags/dimensions that are already present in the native stats payload, creating a parity gap between the two export paths.

## Additional Notes

- These tags are user/tracer-defined (not Datadog-internal), so — like `peer_tags` — they are emitted in both normal and `otel_trace_semantics_enabled` (OTel-semantics) mode; they're not stripped like `datadog.*` attributes.
- `additional_metric_tags` entries are `"key:value"` strings; splitting on the first `:` (not `split(':')`/last) correctly preserves values containing embedded colons (e.g. URLs), matching how `peer_tags` are handled.

## How to test the change?

- Added `emits_additional_metric_tags_as_attributes` unit test in `libdd-data-pipeline/src/otlp/metrics.rs` covering: normal emission, values containing embedded colons, pass-through under `otel_trace_semantics_enabled`, and skipping malformed/empty-value entries.
- `cargo nextest run -p libdd-data-pipeline` and `cargo +stable clippy -p libdd-data-pipeline --all-targets -- -D warnings` pass locally.