### PR TITLE
feat(profiling): add USDT semaphores to skip slow path around heap profile sampler

### DIFF
--- a/libdd-profiling-heap-allocator/benches/sampler_overhead.rs
+++ b/libdd-profiling-heap-allocator/benches/sampler_overhead.rs
@@ -17,7 +17,7 @@ mod linux_bench {
     use libdd_profiling_heap_allocator::SampledAllocator;
     use libdd_profiling_heap_sampler::{
         dd_allocation_created, dd_allocation_freed, dd_allocation_requested,
-        dd_tl_state_get_or_init,
+        dd_test_set_profiler_active, dd_tl_state_get_or_init,
     };
     use std::alloc::{GlobalAlloc, Layout, System};
     use std::hint::black_box;
@@ -210,6 +210,25 @@ mod linux_bench {
         group.finish();
     }
 
+    fn bench_sampled_noop_slow_path_force_attach(c: &mut Criterion) {
+        let alloc = SampledAllocator::new(NoopAllocator);
+        let mut group = c.benchmark_group("alloc_free/sampled_noop_slow_path_force_attach");
+        unsafe { dd_test_set_profiler_active(true) };
+        for &size in SIZES {
+            let layout = Layout::from_size_align(size, ALIGN).unwrap();
+            group.bench_with_input(BenchmarkId::from_parameter(size), &layout, |b, &layout| {
+                b.iter(|| unsafe {
+                    force_next_allocation_to_sample();
+                    let ptr = alloc.alloc(layout);
+                    black_box(ptr);
+                    alloc.dealloc(ptr, layout);
+                });
+            });
+        }
+        group.finish();
+        unsafe { dd_test_set_profiler_active(false) };
+    }
+
     fn bench_sampler_only_slow_path(c: &mut Criterion) {
         let mut group = c.benchmark_group("sampler_only/slow_path");
         for &size in SIZES {
@@ -235,6 +254,7 @@ mod linux_bench {
         bench_sampler_only,
         bench_sampled_system_slow_path,
         bench_sampled_noop_slow_path,
+        bench_sampled_noop_slow_path_force_attach,
         bench_sampler_only_slow_path,
     );
 } // mod linux_bench

--- a/libdd-profiling-heap-allocator/benches/sampler_overhead.rs
+++ b/libdd-profiling-heap-allocator/benches/sampler_overhead.rs
@@ -15,10 +15,7 @@ criterion::criterion_main!(linux_bench::benches);
 mod linux_bench {
     use criterion::{criterion_group, BenchmarkId, Criterion};
     use libdd_profiling_heap_allocator::SampledAllocator;
-    use libdd_profiling_heap_sampler::{
-        dd_allocation_created, dd_allocation_freed, dd_allocation_requested,
-        dd_test_set_profiler_active, dd_tl_state_get_or_init,
-    };
+    use libdd_profiling_heap_sampler::{dd_test_set_profiler_active, dd_tl_state_get_or_init};
     use std::alloc::{GlobalAlloc, Layout, System};
     use std::hint::black_box;
     use std::ptr;
@@ -35,21 +32,16 @@ mod linux_bench {
 
     unsafe impl GlobalAlloc for NoopAllocator {
         unsafe fn alloc(&self, _layout: Layout) -> *mut u8 {
-            // Return a stable aligned pointer with mapped bytes before it. The sampler's free path
-            // may inspect header-sized bytes immediately before the user pointer when
-            // checking for sampled allocations.
-            //
-            // Always returns the same fixed pointer. This allocator isn't tracking real
-            // capacity or state; it exists purely to eliminate the real allocator's cost
-            // from the benchmark so it measures the sampler's own overhead.
+            // Return a stable aligned pointer with mapped bytes before it.
+            // The sampler's free path may inspect header-sized bytes
+            // immediately before the user pointer when checking for sampled
+            // allocations. Always returns the same fixed pointer - this
+            // allocator exists purely to eliminate the real allocator's cost
+            // from benchmarks.
             unsafe { ptr::addr_of_mut!(NOOP_BUFFER.0).cast::<u8>().add(4096) }
         }
 
         unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {}
-    }
-
-    unsafe fn noop_user_ptr() -> *mut u8 {
-        unsafe { ptr::addr_of_mut!(NOOP_BUFFER.0).cast::<u8>().add(4096) }
     }
 
     /// # Safety
@@ -95,6 +87,9 @@ mod linux_bench {
         }
     }
 
+    // ── Baseline ───────────────────────────────────────────────────────────
+    // Pure system allocator cost with no sampler in the picture.
+
     fn bench_system_alloc_free(c: &mut Criterion) {
         let mut group = c.benchmark_group("alloc_free/system");
         for &size in SIZES {
@@ -110,9 +105,22 @@ mod linux_bench {
         group.finish();
     }
 
-    fn bench_sampled_system_alloc_free(c: &mut Criterion) {
+    // ── Profiler attached (semaphore ON) ─────────────────────────────────
+    // The primary benchmark set. Semaphore is flipped on to simulate a
+    // profiler being attached. This is the realistic production scenario.
+    //
+    // Fast-path: `remaining_bytes` is pinned far from zero so allocations
+    // are never sampled. Measures per-allocation overhead when the profiler
+    // is attached but this particular alloc isn't selected.
+    //
+    // Slow-path: `force_next_allocation_to_sample()` triggers sampling
+    // every iteration. The USDT probe fires (into a NOP since no real
+    // consumer is attached to the uprobe).
+
+    fn bench_fast_path_system(c: &mut Criterion) {
         let alloc = SampledAllocator::new(System);
-        let mut group = c.benchmark_group("alloc_free/sampled_system_fast_path");
+        let mut group = c.benchmark_group("profiler_attached/fast_path_system");
+        unsafe { dd_test_set_profiler_active(true) };
         for &size in SIZES {
             let layout = Layout::from_size_align(size, ALIGN).unwrap();
             group.bench_with_input(BenchmarkId::from_parameter(size), &layout, |b, &layout| {
@@ -125,27 +133,13 @@ mod linux_bench {
             });
         }
         group.finish();
+        unsafe { dd_test_set_profiler_active(false) };
     }
 
-    fn bench_noop_alloc_free(c: &mut Criterion) {
-        let alloc = NoopAllocator;
-        let mut group = c.benchmark_group("alloc_free/noop");
-        for &size in SIZES {
-            let layout = Layout::from_size_align(size, ALIGN).unwrap();
-            group.bench_with_input(BenchmarkId::from_parameter(size), &layout, |b, &layout| {
-                b.iter(|| unsafe {
-                    let ptr = alloc.alloc(layout);
-                    black_box(ptr);
-                    alloc.dealloc(ptr, layout);
-                });
-            });
-        }
-        group.finish();
-    }
-
-    fn bench_sampled_noop_alloc_free(c: &mut Criterion) {
+    fn bench_fast_path_noop(c: &mut Criterion) {
         let alloc = SampledAllocator::new(NoopAllocator);
-        let mut group = c.benchmark_group("alloc_free/sampled_noop_fast_path");
+        let mut group = c.benchmark_group("profiler_attached/fast_path_noop");
+        unsafe { dd_test_set_profiler_active(true) };
         for &size in SIZES {
             let layout = Layout::from_size_align(size, ALIGN).unwrap();
             group.bench_with_input(BenchmarkId::from_parameter(size), &layout, |b, &layout| {
@@ -158,61 +152,12 @@ mod linux_bench {
             });
         }
         group.finish();
+        unsafe { dd_test_set_profiler_active(false) };
     }
 
-    fn bench_sampler_only(c: &mut Criterion) {
-        let mut group = c.benchmark_group("sampler_only/fast_path");
-        for &size in SIZES {
-            group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &size| {
-                unsafe { pin_sampler_to_fast_path() };
-                b.iter(|| unsafe {
-                    let req = dd_allocation_requested(black_box(size), black_box(ALIGN));
-                    let user = dd_allocation_created(black_box(noop_user_ptr()).cast(), req);
-                    let freed = dd_allocation_freed(user, black_box(size), black_box(ALIGN));
-                    black_box(freed);
-                });
-            });
-        }
-        group.finish();
-    }
-
-    fn bench_sampled_system_slow_path(c: &mut Criterion) {
+    fn bench_slow_path_system(c: &mut Criterion) {
         let alloc = SampledAllocator::new(System);
-        let mut group = c.benchmark_group("alloc_free/sampled_system_slow_path");
-        for &size in SIZES {
-            let layout = Layout::from_size_align(size, ALIGN).unwrap();
-            group.bench_with_input(BenchmarkId::from_parameter(size), &layout, |b, &layout| {
-                b.iter(|| unsafe {
-                    force_next_allocation_to_sample();
-                    let ptr = alloc.alloc(layout);
-                    black_box(ptr);
-                    alloc.dealloc(ptr, layout);
-                });
-            });
-        }
-        group.finish();
-    }
-
-    fn bench_sampled_noop_slow_path(c: &mut Criterion) {
-        let alloc = SampledAllocator::new(NoopAllocator);
-        let mut group = c.benchmark_group("alloc_free/sampled_noop_slow_path");
-        for &size in SIZES {
-            let layout = Layout::from_size_align(size, ALIGN).unwrap();
-            group.bench_with_input(BenchmarkId::from_parameter(size), &layout, |b, &layout| {
-                b.iter(|| unsafe {
-                    force_next_allocation_to_sample();
-                    let ptr = alloc.alloc(layout);
-                    black_box(ptr);
-                    alloc.dealloc(ptr, layout);
-                });
-            });
-        }
-        group.finish();
-    }
-
-    fn bench_sampled_noop_slow_path_force_attach(c: &mut Criterion) {
-        let alloc = SampledAllocator::new(NoopAllocator);
-        let mut group = c.benchmark_group("alloc_free/sampled_noop_slow_path_force_attach");
+        let mut group = c.benchmark_group("profiler_attached/slow_path_system");
         unsafe { dd_test_set_profiler_active(true) };
         for &size in SIZES {
             let layout = Layout::from_size_align(size, ALIGN).unwrap();
@@ -229,16 +174,42 @@ mod linux_bench {
         unsafe { dd_test_set_profiler_active(false) };
     }
 
-    fn bench_sampler_only_slow_path(c: &mut Criterion) {
-        let mut group = c.benchmark_group("sampler_only/slow_path");
+    fn bench_slow_path_noop(c: &mut Criterion) {
+        let alloc = SampledAllocator::new(NoopAllocator);
+        let mut group = c.benchmark_group("profiler_attached/slow_path_noop");
+        unsafe { dd_test_set_profiler_active(true) };
         for &size in SIZES {
-            group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, &size| {
+            let layout = Layout::from_size_align(size, ALIGN).unwrap();
+            group.bench_with_input(BenchmarkId::from_parameter(size), &layout, |b, &layout| {
                 b.iter(|| unsafe {
                     force_next_allocation_to_sample();
-                    let req = dd_allocation_requested(black_box(size), black_box(ALIGN));
-                    let user = dd_allocation_created(black_box(noop_user_ptr()).cast(), req);
-                    let freed = dd_allocation_freed(user, black_box(size), black_box(ALIGN));
-                    black_box(freed);
+                    let ptr = alloc.alloc(layout);
+                    black_box(ptr);
+                    alloc.dealloc(ptr, layout);
+                });
+            });
+        }
+        group.finish();
+        unsafe { dd_test_set_profiler_active(false) };
+    }
+
+    // ── Short-circuit regression (semaphore OFF) ─────────────────────────
+    // Single benchmark with the semaphore off (no profiler attached).
+    // The semaphore check in dd_allocation_requested short-circuits before
+    // any TLS access or sampling logic. This validates that the
+    // short-circuit path stays near-zero cost.
+
+    fn bench_short_circuit(c: &mut Criterion) {
+        let alloc = SampledAllocator::new(System);
+        let mut group = c.benchmark_group("no_profiler/short_circuit");
+        // Semaphore is off by default - don't flip it on.
+        for &size in SIZES {
+            let layout = Layout::from_size_align(size, ALIGN).unwrap();
+            group.bench_with_input(BenchmarkId::from_parameter(size), &layout, |b, &layout| {
+                b.iter(|| unsafe {
+                    let ptr = alloc.alloc(layout);
+                    black_box(ptr);
+                    alloc.dealloc(ptr, layout);
                 });
             });
         }
@@ -248,13 +219,10 @@ mod linux_bench {
     criterion_group!(
         benches,
         bench_system_alloc_free,
-        bench_sampled_system_alloc_free,
-        bench_noop_alloc_free,
-        bench_sampled_noop_alloc_free,
-        bench_sampler_only,
-        bench_sampled_system_slow_path,
-        bench_sampled_noop_slow_path,
-        bench_sampled_noop_slow_path_force_attach,
-        bench_sampler_only_slow_path,
+        bench_fast_path_system,
+        bench_fast_path_noop,
+        bench_slow_path_system,
+        bench_slow_path_noop,
+        bench_short_circuit,
     );
 } // mod linux_bench

--- a/libdd-profiling-heap-allocator/src/allocator.rs
+++ b/libdd-profiling-heap-allocator/src/allocator.rs
@@ -151,23 +151,18 @@ mod tests {
     // Touches sampler TLS internals, which only exist on Linux.
     #[cfg(target_os = "linux")]
     #[test]
-    fn lazy_init_populates_tls_on_first_alloc() {
-        // Spin a fresh thread so we start with uninitialized sampler TLS.
+    fn alloc_skips_tls_when_no_profiler_attached() {
+        // With the USDT semaphore inactive, alloc should not touch TLS.
         std::thread::spawn(|| unsafe {
-            assert!(
-                dd_tl_state_get().is_null(),
-                "fresh thread should have NULL sampler TLS"
-            );
+            assert!(dd_tl_state_get().is_null());
 
             let sampled = SampledAllocator::<System>::DEFAULT;
             let layout = Layout::from_size_align(64, 8).unwrap();
             let p = sampled.alloc(layout);
             assert!(!p.is_null());
 
-            assert!(
-                !dd_tl_state_get().is_null(),
-                "TLS should be populated after the first alloc"
-            );
+            // Semaphore inactive: TLS never initialized.
+            assert!(dd_tl_state_get().is_null());
 
             sampled.dealloc(p, layout);
         })

--- a/libdd-profiling-heap-allocator/src/lib.rs
+++ b/libdd-profiling-heap-allocator/src/lib.rs
@@ -21,7 +21,9 @@
 //! # Example
 //!
 //! ```no_run
-//! use libdd_profiling_heap_allocator::{set_default_sampling_distance, SampledAllocator};
+//! use libdd_profiling_heap_allocator::{
+//!     is_profiler_attached, set_default_sampling_distance, SampledAllocator,
+//! };
 //! use std::alloc::System;
 //!
 //! #[global_allocator]
@@ -40,6 +42,17 @@
 mod allocator;
 
 pub use allocator::SampledAllocator;
+
+/// Returns true when an external profiler is currently attached to the
+/// allocator's `ddheap:alloc` USDT.
+///
+/// This is a point-in-time read of the USDT semaphore. A profiler can attach
+/// or detach immediately after this returns. Use it as a diagnostic/readiness
+/// signal, not as a synchronization primitive.
+#[inline]
+pub fn is_profiler_attached() -> bool {
+    libdd_profiling_heap_sampler::is_profiler_attached()
+}
 
 /// Set the default mean sample distance (bytes between samples) for the
 /// heap sampler.

--- a/libdd-profiling-heap-gotter/tests/install.rs
+++ b/libdd-profiling-heap-gotter/tests/install.rs
@@ -21,7 +21,9 @@
 
 use std::ffi::c_void;
 
-use libdd_profiling_heap_sampler::{dd_sample_flag_peek, dd_tl_state_get_or_init};
+use libdd_profiling_heap_sampler::{
+    dd_sample_flag_peek, dd_test_set_profiler_active, dd_tl_state_get_or_init,
+};
 use serial_test::serial;
 
 /// Warn (once) when these tests aren't running under nextest. The GOT install
@@ -86,6 +88,10 @@ fn install_produces_sampled_allocations() {
     assert!(installed);
 
     unsafe {
+        // Activate the USDT semaphore so the fast-path guard in
+        // dd_allocation_requested allows sampling without a real profiler.
+        dd_test_set_profiler_active(true);
+
         // Ensure sampler TLS is materialised on this thread.
         let tl = dd_tl_state_get_or_init();
         assert!(!tl.is_null());
@@ -116,6 +122,8 @@ fn install_produces_sampled_allocations() {
         // Free via libc::free which goes through gotter_free; it
         // handles the tagged pointer correctly (check + free raw).
         libc::free(p);
+
+        dd_test_set_profiler_active(false);
     }
 }
 
@@ -130,6 +138,10 @@ fn realloc_null_produces_sampled_allocation() {
     assert!(installed);
 
     unsafe {
+        // Activate the USDT semaphore so the fast-path guard in
+        // dd_allocation_requested allows sampling without a real profiler.
+        dd_test_set_profiler_active(true);
+
         let tl = dd_tl_state_get_or_init();
         assert!(!tl.is_null());
         (*tl).sampling_interval = 1;
@@ -148,6 +160,8 @@ fn realloc_null_produces_sampled_allocation() {
         );
 
         libc::free(p);
+
+        dd_test_set_profiler_active(false);
     }
 }
 
@@ -164,6 +178,10 @@ fn page_aligned_allocations_are_unsampled() {
     assert!(installed);
 
     unsafe {
+        // Activate the USDT semaphore so we actually exercise the sampling
+        // decision path (which should still reject page-aligned pointers).
+        dd_test_set_profiler_active(true);
+
         let tl = dd_tl_state_get_or_init();
         assert!(!tl.is_null());
         (*tl).sampling_interval = 1;
@@ -183,6 +201,8 @@ fn page_aligned_allocations_are_unsampled() {
         );
 
         libc::free(p);
+
+        dd_test_set_profiler_active(false);
     }
 }
 
@@ -197,6 +217,10 @@ fn realloc_of_sampled_allocation_preserves_data() {
     assert!(installed);
 
     unsafe {
+        // Activate the USDT semaphore so the fast-path guard in
+        // dd_allocation_requested allows sampling without a real profiler.
+        dd_test_set_profiler_active(true);
+
         let tl = dd_tl_state_get_or_init();
         assert!(!tl.is_null());
         (*tl).sampling_interval = 1;
@@ -239,6 +263,8 @@ fn realloc_of_sampled_allocation_preserves_data() {
         }
 
         libc::free(p2 as *mut c_void);
+
+        dd_test_set_profiler_active(false);
     }
 }
 
@@ -299,6 +325,10 @@ fn realloc_stress_across_alignments_preserves_data() {
     let mut saw_sampled = false;
 
     unsafe {
+        // Activate the USDT semaphore so the fast-path guard in
+        // dd_allocation_requested allows sampling without a real profiler.
+        dd_test_set_profiler_active(true);
+
         let tl = dd_tl_state_get_or_init();
         assert!(!tl.is_null());
         // Force every allocation to sample so the tagged-pointer /
@@ -355,6 +385,8 @@ fn realloc_stress_across_alignments_preserves_data() {
 
             libc::free(p as *mut c_void);
         }
+
+        dd_test_set_profiler_active(false);
     }
 
     // Only meaningful with live-heap tracking on; without it nothing is

--- a/libdd-profiling-heap-sampler/include/datadog/heap/allocation_freed.h
+++ b/libdd-profiling-heap-sampler/include/datadog/heap/allocation_freed.h
@@ -67,6 +67,11 @@ dd_alloc_freed_t dd_allocation_freed_slow(void *ptr, void *raw, size_t size,
 static inline __attribute__((always_inline))
 dd_alloc_freed_t dd_allocation_freed(void *ptr, size_t size, size_t alignment) {
 #if DD_HEAP_LIVE_TRACKING
+    /* N.B. We cannot gate this with USDT_SEMA_IS_ACTIVE. A profiler may have
+     * been attached (semaphore on) when the allocation was sampled and flagged,
+     * then detached (semaphore off) before the free. We must still detect the
+     * flag to recover the raw pointer (x86-64 header offset / arm64 TBI tag);
+     * skipping this would pass the wrong pointer to the real free. */
     void *raw;
     if (__builtin_expect(dd_sample_flag_check_and_clear(ptr, &raw), 0)) {
         return dd_allocation_freed_slow(ptr, raw, size, alignment);

--- a/libdd-profiling-heap-sampler/include/datadog/heap/allocation_requested.h
+++ b/libdd-profiling-heap-sampler/include/datadog/heap/allocation_requested.h
@@ -33,12 +33,7 @@
 #include <stdint.h>
 
 #include <datadog/heap/tl_state.h>
-
-#ifdef __linux__
-#  include <usdt.h>
-#else
-#  define USDT_IS_ACTIVE(group, name) (1)
-#endif
+#include <datadog/heap/probes.h>
 
 /*
  * Return type for dd_allocation_requested, paired with the `req`
@@ -113,8 +108,8 @@ static inline __attribute__((always_inline, warn_unused_result))
 dd_alloc_req_t dd_allocation_requested(size_t size, size_t alignment) {
     dd_alloc_req_t out = { size, size, alignment, 0 };
 
-    // If no tracer is attached to ddheap:alloc, skip all sampling logic.
-    if (__builtin_expect(!USDT_IS_ACTIVE(ddheap, alloc), 1)) return out;
+    // If no tracer is attached to ddheap, skip all sampling logic.
+    if (__builtin_expect(!USDT_SEMA_IS_ACTIVE(ddheap_alloc), 1)) return out;
 
     // If we don't have TLS yet (this is defensive and should never happen), or
     // the reentry guard is set (meaning a sampled allocation is already in

--- a/libdd-profiling-heap-sampler/include/datadog/heap/allocation_requested.h
+++ b/libdd-profiling-heap-sampler/include/datadog/heap/allocation_requested.h
@@ -34,6 +34,12 @@
 
 #include <datadog/heap/tl_state.h>
 
+#ifdef __linux__
+#  include <usdt.h>
+#else
+#  define USDT_IS_ACTIVE(group, name) (1)
+#endif
+
 /*
  * Return type for dd_allocation_requested, paired with the `req`
  * argument of dd_allocation_created.
@@ -106,6 +112,9 @@ dd_alloc_req_t dd_allocation_requested_slow(dd_tl_state_t *tl, size_t size,
 static inline __attribute__((always_inline, warn_unused_result))
 dd_alloc_req_t dd_allocation_requested(size_t size, size_t alignment) {
     dd_alloc_req_t out = { size, size, alignment, 0 };
+
+    // If no tracer is attached to ddheap:alloc, skip all sampling logic.
+    if (__builtin_expect(!USDT_IS_ACTIVE(ddheap, alloc), 1)) return out;
 
     // If we don't have TLS yet (this is defensive and should never happen), or
     // the reentry guard is set (meaning a sampled allocation is already in

--- a/libdd-profiling-heap-sampler/include/datadog/heap/probes.h
+++ b/libdd-profiling-heap-sampler/include/datadog/heap/probes.h
@@ -12,6 +12,7 @@
 #ifndef DD_SAMPLERS_PROBES_H
 #define DD_SAMPLERS_PROBES_H
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #ifdef __linux__
@@ -41,5 +42,26 @@ void dd_probe_alloc(void *user, uint64_t size, uint64_t weight);
  * support live-heap correlation.
  */
 void dd_probe_free(void *ptr);
+
+/*
+ * Returns true when an external profiler is currently attached to the
+ * ddheap:alloc USDT in this object file.
+ *
+ * This is a point-in-time read of the alloc probe's USDT semaphore. A profiler
+ * can attach or detach immediately after this returns. Use it as a
+ * diagnostic/readiness signal, not as a synchronization primitive.
+ */
+bool dd_heap_profiler_attached(void);
+
+/*
+ * Test-only: manually activate the ddheap:alloc USDT semaphore so that
+ * dd_allocation_requested's fast-path guard allows sampling in a process
+ * where no real profiler is attached. Call with `active=true` before
+ * exercising the sampler and `active=false` to restore the default state.
+ *
+ * This writes the same 2-byte counter the kernel would increment when
+ * bpftrace/eBPF attaches to the USDT.
+ */
+void dd_test_set_profiler_active(bool active);
 
 #endif

--- a/libdd-profiling-heap-sampler/include/datadog/heap/probes.h
+++ b/libdd-profiling-heap-sampler/include/datadog/heap/probes.h
@@ -20,8 +20,14 @@
     * the variadic USDT() macro that emits the same v3 ELF-note format
     * that bpftrace, systemtap, and BPF tracers all consume. */
 #  include <usdt.h>
+   /* Shared explicit semaphore for the ddheap provider. Defined in probes.c;
+    * declared here so that other TUs (e.g. allocation_requested.h) can check
+    * USDT_SEMA_IS_ACTIVE(ddheap_alloc) without emitting their own implicit
+    * semaphore definitions. */
+   USDT_DECLARE_SEMA(ddheap_alloc);
 #else
 #  define USDT(provider, name, ...) ((void)0)
+#  define USDT_SEMA_IS_ACTIVE(sema) (1)
 #endif
 
 /*

--- a/libdd-profiling-heap-sampler/src/generated/bindings.rs
+++ b/libdd-profiling-heap-sampler/src/generated/bindings.rs
@@ -50,6 +50,18 @@ unsafe extern "C" {
     #[link_name = "dd_tl_state_get_or_init__extern"]
     pub fn dd_tl_state_get_or_init() -> *mut dd_tl_state_t;
 }
+unsafe extern "C" {
+    pub fn dd_probe_alloc(user: *mut ::std::os::raw::c_void, size: u64, weight: u64);
+}
+unsafe extern "C" {
+    pub fn dd_probe_free(ptr: *mut ::std::os::raw::c_void);
+}
+unsafe extern "C" {
+    pub fn dd_heap_profiler_attached() -> bool;
+}
+unsafe extern "C" {
+    pub fn dd_test_set_profiler_active(active: bool);
+}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct dd_alloc_req_t {
@@ -194,16 +206,4 @@ unsafe extern "C" {
         new_raw: *mut ::std::os::raw::c_void,
         prep: dd_realloc_prep_t,
     ) -> *mut ::std::os::raw::c_void;
-}
-unsafe extern "C" {
-    pub fn dd_probe_alloc(user: *mut ::std::os::raw::c_void, size: u64, weight: u64);
-}
-unsafe extern "C" {
-    pub fn dd_probe_free(ptr: *mut ::std::os::raw::c_void);
-}
-unsafe extern "C" {
-    pub fn dd_heap_profiler_attached() -> bool;
-}
-unsafe extern "C" {
-    pub fn dd_test_set_profiler_active(active: bool);
 }

--- a/libdd-profiling-heap-sampler/src/generated/bindings.rs
+++ b/libdd-profiling-heap-sampler/src/generated/bindings.rs
@@ -201,3 +201,9 @@ unsafe extern "C" {
 unsafe extern "C" {
     pub fn dd_probe_free(ptr: *mut ::std::os::raw::c_void);
 }
+unsafe extern "C" {
+    pub fn dd_heap_profiler_attached() -> bool;
+}
+unsafe extern "C" {
+    pub fn dd_test_set_profiler_active(active: bool);
+}

--- a/libdd-profiling-heap-sampler/src/lib.rs
+++ b/libdd-profiling-heap-sampler/src/lib.rs
@@ -52,6 +52,33 @@ pub fn set_default_sampling_distance(distance_bytes: u64) {
     unsafe { sys::dd_set_default_sampling_interval(distance_bytes) }
 }
 
+#[cfg(target_os = "linux")]
+extern "C" {
+    #[link_name = "dd_heap_profiler_attached"]
+    fn dd_heap_profiler_attached_ffi() -> bool;
+}
+
+/// Returns true when an external profiler is currently attached to the
+/// `ddheap:alloc` USDT in this object file.
+///
+/// This is a point-in-time read of the alloc probe's USDT semaphore. A profiler
+/// can attach or detach immediately after this returns. Use it as a
+/// diagnostic/readiness signal, not as a synchronization primitive.
+#[cfg(target_os = "linux")]
+#[inline]
+pub fn is_profiler_attached() -> bool {
+    // SAFETY: dd_heap_profiler_attached performs a single semaphore read and
+    // has no preconditions.
+    unsafe { dd_heap_profiler_attached_ffi() }
+}
+
+/// Non-Linux builds do not expose USDT heap probes.
+#[cfg(not(target_os = "linux"))]
+#[inline]
+pub fn is_profiler_attached() -> bool {
+    false
+}
+
 /// Whether heap sampling is enabled for this process. Users of this
 /// library can use this to check if they should setup allocation tracking
 /// or not.
@@ -177,19 +204,14 @@ mod tests {
     }
 
     #[test]
-    fn requested_initializes_tls_on_first_use() {
+    fn requested_skips_tls_init_when_no_profiler_attached() {
         std::thread::spawn(|| unsafe {
-            assert!(
-                dd_tl_state_get().is_null(),
-                "fresh thread should start without sampler TLS"
-            );
+            assert!(dd_tl_state_get().is_null());
             let req = dd_allocation_requested(1, 1);
             assert_eq!(req.size, 1);
             assert_eq!(req.weight, 0);
-            assert!(
-                !dd_tl_state_get().is_null(),
-                "request should initialize sampler TLS"
-            );
+            // Semaphore is inactive (no profiler), so TLS is never touched.
+            assert!(dd_tl_state_get().is_null());
         })
         .join()
         .unwrap();

--- a/libdd-profiling-heap-sampler/src/lib.rs
+++ b/libdd-profiling-heap-sampler/src/lib.rs
@@ -52,12 +52,6 @@ pub fn set_default_sampling_distance(distance_bytes: u64) {
     unsafe { sys::dd_set_default_sampling_interval(distance_bytes) }
 }
 
-#[cfg(target_os = "linux")]
-extern "C" {
-    #[link_name = "dd_heap_profiler_attached"]
-    fn dd_heap_profiler_attached_ffi() -> bool;
-}
-
 /// Returns true when an external profiler is currently attached to the
 /// `ddheap:alloc` USDT in this object file.
 ///
@@ -69,7 +63,7 @@ extern "C" {
 pub fn is_profiler_attached() -> bool {
     // SAFETY: dd_heap_profiler_attached performs a single semaphore read and
     // has no preconditions.
-    unsafe { dd_heap_profiler_attached_ffi() }
+    unsafe { sys::dd_heap_profiler_attached() }
 }
 
 /// Non-Linux builds do not expose USDT heap probes.

--- a/libdd-profiling-heap-sampler/src/probes.c
+++ b/libdd-profiling-heap-sampler/src/probes.c
@@ -21,11 +21,12 @@
 #include <datadog/heap/sample_flag.h>
 
 #include <errno.h>
+#include <stdbool.h>
 
 /* Save / restore errno: an attached USDT consumer may perturb it. */
 void dd_probe_alloc(void *user, uint64_t size, uint64_t weight) {
     int saved_errno = errno;
-    USDT(ddheap, alloc, user, size, weight);
+    USDT_WITH_SEMA(ddheap, alloc, user, size, weight);
     errno = saved_errno;
 }
 
@@ -37,4 +38,18 @@ void dd_probe_free(void *ptr) {
 #else
     (void)ptr;
 #endif
+}
+
+bool dd_heap_profiler_attached(void) {
+    return USDT_IS_ACTIVE(ddheap, alloc);
+}
+
+void dd_test_set_profiler_active(bool active) {
+    /* The implicit semaphore symbol emitted by USDT_WITH_SEMA(ddheap, alloc, ...)
+     * is __usdt_sema_ddheap__alloc (see __usdt_sema_name macro in usdt.h).
+     * Declare it extern and poke its .active field directly - this is exactly
+     * what the kernel does when an eBPF program attaches to the probe. */
+    extern struct usdt_sema __usdt_sema_ddheap__alloc
+        __asm__("__usdt_sema_ddheap__alloc");
+    __usdt_sema_ddheap__alloc.active = active ? 1 : 0;
 }

--- a/libdd-profiling-heap-sampler/src/probes.c
+++ b/libdd-profiling-heap-sampler/src/probes.c
@@ -23,17 +23,23 @@
 #include <errno.h>
 #include <stdbool.h>
 
+/* Single definition of the shared ddheap USDT semaphore. Both the alloc and
+ * free probes reference this semaphore, so attaching to either one activates
+ * sampling for the whole provider. Other TUs access it via
+ * USDT_DECLARE_SEMA(ddheap_alloc) in probes.h. */
+USDT_DEFINE_SEMA(ddheap_alloc);
+
 /* Save / restore errno: an attached USDT consumer may perturb it. */
 void dd_probe_alloc(void *user, uint64_t size, uint64_t weight) {
     int saved_errno = errno;
-    USDT_WITH_SEMA(ddheap, alloc, user, size, weight);
+    USDT_WITH_EXPLICIT_SEMA(ddheap_alloc, ddheap, alloc, user, size, weight);
     errno = saved_errno;
 }
 
 void dd_probe_free(void *ptr) {
 #if DD_HEAP_LIVE_TRACKING
     int saved_errno = errno;
-    USDT(ddheap, free, ptr);
+    USDT_WITH_EXPLICIT_SEMA(ddheap_alloc, ddheap, free, ptr);
     errno = saved_errno;
 #else
     (void)ptr;
@@ -41,15 +47,9 @@ void dd_probe_free(void *ptr) {
 }
 
 bool dd_heap_profiler_attached(void) {
-    return USDT_IS_ACTIVE(ddheap, alloc);
+    return USDT_SEMA_IS_ACTIVE(ddheap_alloc);
 }
 
 void dd_test_set_profiler_active(bool active) {
-    /* The implicit semaphore symbol emitted by USDT_WITH_SEMA(ddheap, alloc, ...)
-     * is __usdt_sema_ddheap__alloc (see __usdt_sema_name macro in usdt.h).
-     * Declare it extern and poke its .active field directly - this is exactly
-     * what the kernel does when an eBPF program attaches to the probe. */
-    extern struct usdt_sema __usdt_sema_ddheap__alloc
-        __asm__("__usdt_sema_ddheap__alloc");
-    __usdt_sema_ddheap__alloc.active = active ? 1 : 0;
+    USDT_SEMA(ddheap_alloc).active = active ? 1 : 0;
 }


### PR DESCRIPTION
When no profiler is attached, we should use USDT semaphores to skip the slow path. This was a helpful suggestion from the profiling SIG. 

Criterion benchmarks below (this is ofc without a profiler attached / USDT is a `NOP`)  - in the case where we are being loaded through a shared library and forced to use TLSDESC the cost saving is almost 40%! Said otherwise, almost half of our cost in a dynamic scenario is the TLS access itself.  The TLSDESC test involves a lot of arduous plumbing and I don't imagine we're going to touch this code much so i've opted out of comitting it. 

Some ARM64 results: 

| Benchmark | Description | No semaphore | With semaphore | Improvement |
|---|---|---|---|---|
| **Static TLS (Criterion)** | | | | |
| `sampler_only/fast_path/64` | Raw sampler calls only (no allocator), local-exec TLS | 3.33 ns | 2.82 ns | **-15%** |
| `sampled_noop_fast_path/64` | `SampledAllocator<NoopAlloc>` alloc+free, isolates sampler overhead | 3.04 ns | 2.71 ns | **-11%** |
| `sampled_system_fast_path/64` | `SampledAllocator<System>` alloc+free, real-world overhead | 9.52 ns | 9.61 ns | ~same |
| **Dynamic TLS (forcing usage through a `.so`)** | | | | |
| size=64 | Raw sampler calls through shared library, TLSDESC (dlopen/LD_PRELOAD scenario) | 6.96 ns | 4.30 ns | **-38%** |

**Cost of live heap**
While i'm here, i've added a test "sampled_noop_slow_path_force_attach", which lets uses an API i've added to flip the semaphore on in tests to measure the cost of the "real slow path". On ARM64 this yields 14.79 ns as the slow path  live heap cost.

# What does this PR do?

A brief description of the change being made with this pull request.

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
