### PR TITLE
fix(sidecar): remove spurious deletion of runtimes on set_session_config

### DIFF
--- a/datadog-sidecar/src/service/session_info.rs
+++ b/datadog-sidecar/src/service/session_info.rs
@@ -97,22 +97,6 @@ impl SessionInfo {
         future::join_all(runtimes_shutting_down).await;
     }
 
-    /// Shuts down all running instances in the session.
-    pub(crate) async fn shutdown_running_instances(&self) {
-        let runtimes: Vec<RuntimeInfo> = self
-            .lock_runtimes()
-            .drain()
-            .map(|(_, instance)| instance)
-            .collect();
-
-        let instances_shutting_down: Vec<_> = runtimes
-            .into_iter()
-            .map(|rt| tokio::spawn(async move { rt.shutdown().await }))
-            .collect();
-
-        future::join_all(instances_shutting_down).await;
-    }
-
     /// Shuts down a specific runtime in the session.
     ///
     /// # Arguments
@@ -371,17 +355,6 @@ mod tests {
 
         // Test that all runtimes are shut down
         session_info.shutdown().await;
-        assert!(session_info.runtimes.lock().unwrap().is_empty());
-    }
-
-    #[tokio::test]
-    #[cfg_attr(miri, ignore)]
-    async fn test_shutdown_running_instances() {
-        let session_info = SessionInfo::default();
-        session_info.get_runtime(&"runtime1".to_string());
-
-        // Test that all running instances are shut down
-        session_info.shutdown_running_instances().await;
         assert!(session_info.runtimes.lock().unwrap().is_empty());
     }
 

--- a/datadog-sidecar/src/service/sidecar_server.rs
+++ b/datadog-sidecar/src/service/sidecar_server.rs
@@ -679,7 +679,7 @@ impl SidecarInterface for ConnectionSidecarHandler {
         session_id: String,
         #[cfg(windows)] remote_config_notify_function: crate::service::remote_configs::RemoteConfigNotifyFunction,
         config: SessionConfig,
-        is_fork: bool,
+        _is_fork: bool,
     ) {
         if self.session_id.set(session_id.clone()).is_ok() {
             let mut counter = self.server.session_counter.lock_or_panic();
@@ -835,10 +835,6 @@ impl SidecarInterface for ConnectionSidecarHandler {
             tokio::spawn(async move {
                 completer.complete(config).await;
             });
-        }
-
-        if !is_fork {
-            session.shutdown_running_instances().await;
         }
     }
 


### PR DESCRIPTION
EDIT: After discussion, pending deeper refactoring, fix just the spurious runtime deletion on set_session_config.

# What does this PR do?

1. Ownership correction: replace the per-connection `HashSet<InstanceId>` with counted `RuntimeLeases`.
2. Reconfiguration semantics: stop treating `set_session_config()` aas a reason to destroy all existing runtimes (when is_fork=false).

First, this replaces runtime teardown based on per-connection recorded IDs and explicit shutdown RPCs with lease-based shared ownership. Each connection holds at most one RuntimeLease per InstanceId. Acquiring the first lease creates a RuntimeEntry with one owner; subsequent acquisitions increment its semantic owner count. Dropping a lease decrements that count, and dropping the final lease removes and shuts down the runtime. Non-owning runtime lookups are available where needed (peek_runtime).

Before, when a connection closed, it would calls shutdown_runtime() for every recorded id. Consequently, if two connections use the same runtime, the first one to  disconnect can remove it even while the second connection remains alive.

Secondly, `set_session_config` called `session.shutdown_running_instances()` for every non-fork connection, which drained *all* runtimes of the session. An `enqueue_actions` that was concurrently in flight then re-created an empty `RuntimeInfo`, logged "No application found" and dropped the telemetry payload. So we cannot allow session reconfiguration to bypass the lease ownership model.

Notes:

Because reclamation now happens in `Drop`, `RuntimeInfo::shutdown` and `SessionInfo::shutdown` must stay synchronous; they are, since neither awaits.

With ownership tracked by leases, the `shutdown_runtime` and `shutdown_session` RPCs and the `is_fork` argument of `set_session_config` become redundant, so they are removed from the wire interface.

# Motivation

We're seeing flaky tests in the AppSec integration tests in dd-trace-php that are very likely caused by this and also possible system-tests telemetry tests flakiness that is possibly also related (I have not investigated)

BREAKING CHANGE: removes the shutdown_runtime and shutdown_session sidecar RPCs and removes the is_fork parameter from set_session_config and  ddog_sidecar_session_set_config.