### PR TITLE
feat(remote-config)!: add AsmRawResponseBody capability

### DIFF
--- a/libdd-remote-config/src/lib.rs
+++ b/libdd-remote-config/src/lib.rs
@@ -79,6 +79,7 @@ impl Target {
     strum_macros::IntoStaticStr,
     strum_macros::Display,
 )]
+#[non_exhaustive]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum RemoteConfigCapabilities {
     AsmActivation = 1,
@@ -129,4 +130,5 @@ pub enum RemoteConfigCapabilities {
     FfeFlagConfigurationRules = 46,
     DdDataStreamsTransactionExtractors = 47,
     LlmObsActivation = 48,
+    AsmRawResponseBody = 49,
 }


### PR DESCRIPTION
# What does this PR do?

Add AsmRawResponseBody (49) to RemoteConfigCapabilities to allow tracers to advertise support for raw HTTP response body collection to the WAF via remote config.

RFC-115

