### PR TITLE
refactor(trace-utils)!: split generic TracerHeaderTags

### DIFF
--- a/datadog-sidecar-ffi/src/lib.rs
+++ b/datadog-sidecar-ffi/src/lib.rs
@@ -810,9 +810,11 @@ impl<'a> TryInto<SerializedTracerHeaderTags> for &'a TracerHeaderTags<'a> {
             lang_vendor: &self.lang_vendor.to_utf8_lossy(),
             tracer_version: &self.tracer_version.to_utf8_lossy(),
             container_id: &self.container_id.to_utf8_lossy(),
-            client_computed_top_level: self.client_computed_top_level,
-            client_computed_stats: self.client_computed_stats,
-            ..Default::default()
+            generic: libdd_trace_utils::trace_utils::TracerGenericTags {
+                client_computed_top_level: self.client_computed_top_level,
+                client_computed_stats: self.client_computed_stats,
+                ..Default::default()
+            },
         };
 
         tags.try_into().map_err(|_| {

--- a/datadog-sidecar/src/service/serialized_tracer_header_tags.rs
+++ b/datadog-sidecar/src/service/serialized_tracer_header_tags.rs
@@ -22,7 +22,7 @@ pub struct SerializedTracerHeaderTags {
 /// ```
 /// use bincode;
 /// use datadog_sidecar::service::SerializedTracerHeaderTags;
-/// use libdd_trace_utils::trace_utils::TracerHeaderTags;
+/// use libdd_trace_utils::trace_utils::{TracerGenericTags, TracerHeaderTags};
 /// use std::convert::TryInto;
 ///
 /// let tracer_header_tags = TracerHeaderTags {
@@ -32,9 +32,11 @@ pub struct SerializedTracerHeaderTags {
 ///     lang_vendor: "Mozilla",
 ///     tracer_version: "0.1.0",
 ///     container_id: "1234567890",
-///     client_computed_top_level: true,
-///     client_computed_stats: false,
-///     ..Default::default()
+///     generic: TracerGenericTags {
+///         client_computed_top_level: true,
+///         client_computed_stats: false,
+///         ..Default::default()
+///     },
 /// };
 ///
 /// let serialized: SerializedTracerHeaderTags = tracer_header_tags.try_into().unwrap();
@@ -62,7 +64,7 @@ impl<'a> TryFrom<&'a SerializedTracerHeaderTags> for TracerHeaderTags<'a> {
 ///
 /// ```
 /// use datadog_sidecar::service::SerializedTracerHeaderTags;
-/// use libdd_trace_utils::trace_utils::TracerHeaderTags;
+/// use libdd_trace_utils::trace_utils::{TracerGenericTags, TracerHeaderTags};
 /// use std::convert::TryInto;
 ///
 /// let tracer_header_tags = TracerHeaderTags {
@@ -72,9 +74,11 @@ impl<'a> TryFrom<&'a SerializedTracerHeaderTags> for TracerHeaderTags<'a> {
 ///     lang_vendor: "Mozilla",
 ///     tracer_version: "0.1.0",
 ///     container_id: "1234567890",
-///     client_computed_top_level: true,
-///     client_computed_stats: false,
-///     ..Default::default()
+///     generic: TracerGenericTags {
+///         client_computed_top_level: true,
+///         client_computed_stats: false,
+///         ..Default::default()
+///     },
 /// };
 ///
 /// let serialized: Result<SerializedTracerHeaderTags, _> = tracer_header_tags.try_into();
@@ -95,6 +99,7 @@ impl<'a> TryFrom<TracerHeaderTags<'a>> for SerializedTracerHeaderTags {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use libdd_trace_utils::trace_utils::TracerGenericTags;
     use std::convert::TryInto;
 
     #[test]
@@ -106,9 +111,11 @@ mod tests {
             lang_vendor: "Mozilla",
             tracer_version: "0.1.0",
             container_id: "1234567890",
-            client_computed_top_level: true,
-            client_computed_stats: false,
-            ..Default::default()
+            generic: TracerGenericTags {
+                client_computed_top_level: true,
+                client_computed_stats: false,
+                ..Default::default()
+            },
         };
 
         let serialized: Result<SerializedTracerHeaderTags, _> = tracer_header_tags.try_into();
@@ -125,9 +132,11 @@ mod tests {
             lang_vendor: "Mozilla",
             tracer_version: "0.1.0",
             container_id: "1234567890",
-            client_computed_top_level: true,
-            client_computed_stats: false,
-            ..Default::default()
+            generic: TracerGenericTags {
+                client_computed_top_level: true,
+                client_computed_stats: false,
+                ..Default::default()
+            },
         };
 
         let data = bincode::serialize(&tracer_header_tags).unwrap();
@@ -144,12 +153,12 @@ mod tests {
         assert_eq!(result.tracer_version, tracer_header_tags.tracer_version);
         assert_eq!(result.container_id, tracer_header_tags.container_id);
         assert_eq!(
-            result.client_computed_top_level,
-            tracer_header_tags.client_computed_top_level
+            result.generic.client_computed_top_level,
+            tracer_header_tags.generic.client_computed_top_level
         );
         assert_eq!(
-            result.client_computed_stats,
-            tracer_header_tags.client_computed_stats
+            result.generic.client_computed_stats,
+            tracer_header_tags.generic.client_computed_stats
         );
     }
 

--- a/libdd-data-pipeline/src/trace_exporter/mod.rs
+++ b/libdd-data-pipeline/src/trace_exporter/mod.rs
@@ -1132,8 +1132,8 @@ mod tests {
         assert_eq!(tracer_header_tags.lang_version, "1.52.1");
         assert_eq!(tracer_header_tags.lang_interpreter, "rustc");
         assert_eq!(tracer_header_tags.lang_vendor, "rust-lang");
-        assert!(tracer_header_tags.client_computed_stats);
-        assert!(tracer_header_tags.client_computed_top_level);
+        assert!(tracer_header_tags.generic.client_computed_stats);
+        assert!(tracer_header_tags.generic.client_computed_top_level);
     }
 
     #[test]

--- a/libdd-data-pipeline/src/trace_exporter/stats.rs
+++ b/libdd-data-pipeline/src/trace_exporter/stats.rs
@@ -342,10 +342,10 @@ pub(crate) fn process_traces_for_stats<
 
         // Update the headers to indicate that stats have been computed and forward dropped
         // traces counts
-        header_tags.client_computed_top_level = true;
-        header_tags.client_computed_stats = true;
-        header_tags.dropped_p0_traces = dropped_p0_stats.dropped_p0_traces;
-        header_tags.dropped_p0_spans = dropped_p0_stats.dropped_p0_spans;
+        header_tags.generic.client_computed_top_level = true;
+        header_tags.generic.client_computed_stats = true;
+        header_tags.generic.dropped_p0_traces = dropped_p0_stats.dropped_p0_traces;
+        header_tags.generic.dropped_p0_spans = dropped_p0_stats.dropped_p0_spans;
 
         // Send dropped P0 stats directly to telemetry if available
         #[cfg(feature = "telemetry")]

--- a/libdd-data-pipeline/src/trace_exporter/trace_serializer.rs
+++ b/libdd-data-pipeline/src/trace_exporter/trace_serializer.rs
@@ -171,7 +171,7 @@ mod tests {
     use libdd_common::header::APPLICATION_MSGPACK_STR;
     use libdd_tinybytes::BytesString;
     use libdd_trace_utils::span::v04::SpanBytes;
-    use libdd_trace_utils::trace_utils::TracerHeaderTags;
+    use libdd_trace_utils::trace_utils::{TracerGenericTags, TracerHeaderTags};
 
     fn create_test_span() -> SpanBytes {
         SpanBytes {
@@ -196,8 +196,11 @@ mod tests {
             tracer_version: "1.0.0",
             lang_interpreter: "rustc",
             lang_vendor: "rust-lang",
-            client_computed_stats: true,
-            client_computed_top_level: false,
+            generic: TracerGenericTags {
+                client_computed_stats: true,
+                client_computed_top_level: false,
+                ..Default::default()
+            },
             ..Default::default()
         }
     }
@@ -471,8 +474,11 @@ mod tests {
             tracer_version: "2.0.0",
             lang_interpreter: "cpython",
             lang_vendor: "python.org",
-            client_computed_stats: false,
-            client_computed_top_level: true,
+            generic: TracerGenericTags {
+                client_computed_stats: false,
+                client_computed_top_level: true,
+                ..Default::default()
+            },
             ..Default::default()
         };
 

--- a/libdd-trace-utils/src/send_data/mod.rs
+++ b/libdd-trace-utils/src/send_data/mod.rs
@@ -478,7 +478,7 @@ mod tests {
     use crate::send_with_retry::{RetryBackoffType, RetryStrategy};
     use crate::test_utils::create_test_no_alloc_span;
     use crate::trace_utils::{construct_trace_chunk, construct_tracer_payload, TracerPayloadTags};
-    use crate::tracer_header_tags::TracerHeaderTags;
+    use crate::tracer_header_tags::{TracerGenericTags, TracerHeaderTags};
     use httpmock::prelude::*;
     use httpmock::MockServer;
     use libdd_capabilities::HttpClientCapability;
@@ -496,10 +496,12 @@ mod tests {
         lang_vendor: "vendor",
         tracer_version: "1.0",
         container_id: "id",
-        client_computed_top_level: false,
-        client_computed_stats: false,
-        dropped_p0_traces: 0,
-        dropped_p0_spans: 0,
+        generic: TracerGenericTags {
+            client_computed_top_level: false,
+            client_computed_stats: false,
+            dropped_p0_traces: 0,
+            dropped_p0_spans: 0,
+        },
     };
 
     fn setup_payload(header_tags: &TracerHeaderTags) -> TracerPayload {

--- a/libdd-trace-utils/src/trace_utils.rs
+++ b/libdd-trace-utils/src/trace_utils.rs
@@ -5,7 +5,7 @@ pub use crate::send_data::send_data_result::SendDataResult;
 pub use crate::send_data::SendData;
 use crate::span::v05::dict::SharedDict;
 use crate::span::{v05, TraceData};
-pub use crate::tracer_header_tags::TracerHeaderTags;
+pub use crate::tracer_header_tags::{TracerGenericTags, TracerHeaderTags};
 use crate::tracer_payload::TracerPayloadCollection;
 use crate::tracer_payload::{self, TraceChunks};
 use anyhow::anyhow;
@@ -646,12 +646,12 @@ pub fn collect_pb_trace_chunks<T: tracer_payload::TraceChunkProcessor>(
 
         for span in chunk.spans.iter_mut() {
             // TODO: obfuscate & truncate spans
-            if tracer_header_tags.client_computed_top_level {
+            if tracer_header_tags.generic.client_computed_top_level {
                 update_tracer_top_level(span);
             }
         }
 
-        if !tracer_header_tags.client_computed_top_level {
+        if !tracer_header_tags.generic.client_computed_top_level {
             compute_top_level_span(&mut chunk.spans);
         }
 

--- a/libdd-trace-utils/src/tracer_header_tags.rs
+++ b/libdd-trace-utils/src/tracer_header_tags.rs
@@ -19,14 +19,12 @@ macro_rules! parse_string_header {
     }
 }
 
-#[derive(Default, Debug, Serialize, Deserialize, Clone)]
-pub struct TracerHeaderTags<'a> {
-    pub lang: &'a str,
-    pub lang_version: &'a str,
-    pub lang_interpreter: &'a str,
-    pub lang_vendor: &'a str,
-    pub tracer_version: &'a str,
-    pub container_id: &'a str,
+/// The subset of tracer header tags that are plain booleans/integers, with no string/lifetime
+/// data. Unlike the rest of [`TracerHeaderTags`], these are meaningful regardless of whether the
+/// tracer payload format carries its own lang/version metadata (e.g. the V1 msgpack payload),
+/// so they can be transferred on their own without a dedicated serialized envelope.
+#[derive(Default, Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+pub struct TracerGenericTags {
     // specifies that the client has marked top-level spans. Follows Go's isHeaderTrue rule:
     // absent/empty → false; "0"/"f"/"F"/"false"/"False"/"FALSE" → false;
     // every other non-empty value (including unparseable values like "yes") → true.
@@ -40,6 +38,17 @@ pub struct TracerHeaderTags<'a> {
     pub dropped_p0_traces: usize,
     // number of spans dropped in the tracer
     pub dropped_p0_spans: usize,
+}
+
+#[derive(Default, Debug, Serialize, Deserialize, Clone)]
+pub struct TracerHeaderTags<'a> {
+    pub lang: &'a str,
+    pub lang_version: &'a str,
+    pub lang_interpreter: &'a str,
+    pub lang_vendor: &'a str,
+    pub tracer_version: &'a str,
+    pub container_id: &'a str,
+    pub generic: TracerGenericTags,
 }
 
 impl<'a> From<TracerHeaderTags<'a>> for HeaderMap {
@@ -87,32 +96,32 @@ impl<'a> From<TracerHeaderTags<'a>> for HeaderMap {
             HeaderName::from_static("datadog-container-id"),
             tags.container_id,
         );
-        if tags.client_computed_stats {
+        if tags.generic.client_computed_stats {
             try_insert(
                 &mut headers,
                 HeaderName::from_static("datadog-client-computed-stats"),
                 HeaderValue::from_static("true"),
             );
         }
-        if tags.client_computed_top_level {
+        if tags.generic.client_computed_top_level {
             try_insert(
                 &mut headers,
                 HeaderName::from_static("datadog-client-computed-top-level"),
                 HeaderValue::from_static("true"),
             );
         }
-        if tags.dropped_p0_traces > 0 {
+        if tags.generic.dropped_p0_traces > 0 {
             try_insert(
                 &mut headers,
                 HeaderName::from_static("datadog-client-dropped-p0-traces"),
-                tags.dropped_p0_traces.to_string(),
+                tags.generic.dropped_p0_traces.to_string(),
             );
         }
-        if tags.dropped_p0_spans > 0 {
+        if tags.generic.dropped_p0_spans > 0 {
             try_insert(
                 &mut headers,
                 HeaderName::from_static("datadog-client-dropped-p0-spans"),
-                tags.dropped_p0_spans.to_string(),
+                tags.generic.dropped_p0_spans.to_string(),
             );
         }
         headers
@@ -134,20 +143,20 @@ impl<'a> From<&'a HeaderMap<HeaderValue>> for TracerHeaderTags<'a> {
             }
         );
         if let Some(v) = headers.get("datadog-client-computed-top-level") {
-            tags.client_computed_top_level = is_header_true(v.to_str().unwrap_or_default());
+            tags.generic.client_computed_top_level = is_header_true(v.to_str().unwrap_or_default());
         }
         if let Some(v) = headers.get("datadog-client-computed-stats") {
-            tags.client_computed_stats = is_header_true(v.to_str().unwrap_or_default());
+            tags.generic.client_computed_stats = is_header_true(v.to_str().unwrap_or_default());
         }
         if let Some(count) = headers.get("datadog-client-dropped-p0-traces") {
-            tags.dropped_p0_traces = count
+            tags.generic.dropped_p0_traces = count
                 .to_str()
                 .unwrap_or_default()
                 .parse()
                 .unwrap_or_default();
         }
         if let Some(count) = headers.get("datadog-client-dropped-p0-spans") {
-            tags.dropped_p0_spans = count.to_str().map_or(0, |c| c.parse().unwrap_or(0));
+            tags.generic.dropped_p0_spans = count.to_str().map_or(0, |c| c.parse().unwrap_or(0));
         }
         tags
     }
@@ -181,10 +190,12 @@ mod tests {
             lang_vendor: "vendor",
             tracer_version: "1.0",
             container_id: "id",
-            client_computed_top_level: true,
-            client_computed_stats: true,
-            dropped_p0_traces: 12,
-            dropped_p0_spans: 120,
+            generic: TracerGenericTags {
+                client_computed_top_level: true,
+                client_computed_stats: true,
+                dropped_p0_traces: 12,
+                dropped_p0_spans: 120,
+            },
         };
 
         let map: HeaderMap = header_tags.into();
@@ -217,10 +228,12 @@ mod tests {
             lang_vendor: "vendor",
             tracer_version: "1.0",
             container_id: "",
-            client_computed_top_level: false,
-            client_computed_stats: false,
-            dropped_p0_spans: 0,
-            dropped_p0_traces: 0,
+            generic: TracerGenericTags {
+                client_computed_top_level: false,
+                client_computed_stats: false,
+                dropped_p0_spans: 0,
+                dropped_p0_traces: 0,
+            },
         };
 
         let map: HeaderMap = header_tags.into();
@@ -271,10 +284,10 @@ mod tests {
         assert_eq!(tags.tracer_version, "1.0");
         assert_eq!(tags.lang_interpreter, "interpreter");
         assert_eq!(tags.container_id, "id");
-        assert!(tags.client_computed_stats);
-        assert!(!tags.client_computed_top_level);
-        assert_eq!(tags.dropped_p0_traces, 12);
-        assert_eq!(tags.dropped_p0_spans, 0);
+        assert!(tags.generic.client_computed_stats);
+        assert!(!tags.generic.client_computed_top_level);
+        assert_eq!(tags.generic.dropped_p0_traces, 12);
+        assert_eq!(tags.generic.dropped_p0_spans, 0);
     }
 
     #[test]
@@ -284,7 +297,7 @@ mod tests {
         header_map.insert("datadog-client-computed-stats", val.parse().unwrap());
         let tags: TracerHeaderTags = (&header_map).into();
         assert!(
-            !tags.client_computed_stats,
+            !tags.generic.client_computed_stats,
             "expected client_computed_stats=false for datadog-client-computed-stats header value {val:?}"
         );
     }
@@ -294,7 +307,7 @@ mod tests {
         let header_map = HeaderMap::new();
         let tags: TracerHeaderTags = (&header_map).into();
         assert!(
-            !tags.client_computed_stats,
+            !tags.generic.client_computed_stats,
             "expected client_computed_stats=false when datadog-client-computed-stats header is not set"
         );
     }
@@ -330,7 +343,7 @@ mod tests {
             header_map.insert("datadog-client-computed-stats", val.parse().unwrap());
             let tags: TracerHeaderTags = (&header_map).into();
             assert!(
-                tags.client_computed_stats,
+                tags.generic.client_computed_stats,
                 "expected client_computed_stats=true for value {val:?}"
             );
         }
@@ -343,7 +356,7 @@ mod tests {
             header_map.insert("datadog-client-computed-stats", val.parse().unwrap());
             let tags: TracerHeaderTags = (&header_map).into();
             assert!(
-                !tags.client_computed_stats,
+                !tags.generic.client_computed_stats,
                 "expected client_computed_stats=false for value {val:?}"
             );
         }
@@ -359,7 +372,7 @@ mod tests {
             header_map.insert("datadog-client-computed-top-level", val.parse().unwrap());
             let tags: TracerHeaderTags = (&header_map).into();
             assert!(
-                tags.client_computed_top_level,
+                tags.generic.client_computed_top_level,
                 "expected client_computed_top_level=true for value {val:?}"
             );
         }
@@ -372,7 +385,7 @@ mod tests {
             header_map.insert("datadog-client-computed-top-level", val.parse().unwrap());
             let tags: TracerHeaderTags = (&header_map).into();
             assert!(
-                !tags.client_computed_top_level,
+                !tags.generic.client_computed_top_level,
                 "expected client_computed_top_level=false for value {val:?}"
             );
         }
@@ -383,7 +396,7 @@ mod tests {
         let header_map = HeaderMap::new();
         let tags: TracerHeaderTags = (&header_map).into();
         assert!(
-            !tags.client_computed_top_level,
+            !tags.generic.client_computed_top_level,
             "expected client_computed_top_level=false when header is not set"
         );
     }

--- a/libdd-trace-utils/src/tracer_metadata.rs
+++ b/libdd-trace-utils/src/tracer_metadata.rs
@@ -1,7 +1,7 @@
 // Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::tracer_header_tags::TracerHeaderTags;
+use crate::tracer_header_tags::{TracerGenericTags, TracerHeaderTags};
 use http::HeaderMap;
 
 #[derive(Clone, Default, Debug)]
@@ -32,9 +32,11 @@ impl<'a> From<&'a TracerMetadata> for TracerHeaderTags<'a> {
             lang_interpreter: &tags.language_interpreter,
             lang_vendor: &tags.language_interpreter_vendor,
             container_id: &tags.container_id,
-            client_computed_stats: tags.client_computed_stats,
-            client_computed_top_level: tags.client_computed_top_level,
-            ..Default::default()
+            generic: TracerGenericTags {
+                client_computed_stats: tags.client_computed_stats,
+                client_computed_top_level: tags.client_computed_top_level,
+                ..Default::default()
+            },
         }
     }
 }


### PR DESCRIPTION
# What does this PR do?

Splits `TracerHeaderTags` into two parts: the tracer-identity strings (`lang`, `lang_version`, `tracer_version`, etc.) stay as-is, and the generic bool/int flags (`client_computed_stats`, `client_computed_top_level`, `dropped_p0_traces`, `dropped_p0_spans`) are pulled into a new standalone `TracerGenericTags` struct, embedded as `TracerHeaderTags::generic`.

# Motivation

`TracerHeaderTags` mixed tracer-identity strings with generic bool/int flags. The latter are meaningful independently of the string metadata, so pulling them into their own struct lets them be carried on their own in contexts where the string fields would be redundant (e.g. payload formats that already embed the tracer identity), without forcing a full split of the type.

# Additional Notes

Raised during review of #2156. Prepared as a separate PR to keep #2156 scoped to the sidecar-specific V04→V1 changes.

This PR alone is a no-op refactor — `TracerGenericTags` is still only used embedded in `TracerHeaderTags`. The actual payoff comes in #2156: the V1 trace-sending path already carries the tracer identity in the V1 payload itself, so `send_trace_v1` will be able to pass just `TracerGenericTags` (a small `Copy` struct, no serialization needed) across the sidecar's IPC boundary instead of the full `TracerHeaderTags`/`SerializedTracerHeaderTags`, which currently re-transmits redundant string data.