### PR TITLE
chore(lint): update nightly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         language: system
         # Nightly version is read from `nightly-toolchain.toml` at the repo root,
         # which is the single source of truth for CI and local tooling.
-        entry: bash -c 'NIGHTLY=$(grep -Po "^channel = \"\K[^\"]+" nightly-toolchain.toml) && cargo +$NIGHTLY fmt --all --'
+        entry: bash -c 'NIGHTLY=$(awk -F"\"" "/^channel[[:space:]]*=/ {print \$2}" nightly-toolchain.toml) && cargo +$NIGHTLY fmt --all --'
         types: [rust]
         pass_filenames: false
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@
 #   GIT_CONFIG_GLOBAL=/dev/null pre-commit install --hook-type pre-push
 #
 # Mirrors CI checks from .github/workflows/lint.yml:
-#   pre-commit: cargo +nightly-2026-02-08 fmt --all
+#   pre-commit: cargo +<nightly from nightly-toolchain.toml> fmt --all
 #   pre-push:   cargo clippy --workspace --all-targets --all-features -- -D warnings
 #   pre-commit: dd-rust-license-tool check (on dependency/license file changes)
 repos:
@@ -14,9 +14,9 @@ repos:
       - id: cargo-fmt
         name: cargo fmt
         language: system
-        # Nightly version must match `nightly-toolchain.toml` at the repo root,
-        # which is the source of truth that CI reads. Keep these two in sync.
-        entry: cargo +nightly-2026-02-08 fmt --all --
+        # Nightly version is read from `nightly-toolchain.toml` at the repo root,
+        # which is the single source of truth for CI and local tooling.
+        entry: bash -c 'NIGHTLY=$(grep -Po "^channel = \"\K[^\"]+" nightly-toolchain.toml) && cargo +$NIGHTLY fmt --all --'
         types: [rust]
         pass_filenames: false
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Iterate fastest with `cargo check -p <crate>` while editing; validate each affec
 
 2. **Format and lint** — run for every crate that was touched, before finishing:
    ```bash
-   cargo +nightly-2026-02-08 fmt --all -- --check
+   cargo +nightly-2026-07-26 fmt --all -- --check
    cargo +stable clippy -p <crate> --all-targets -- -D warnings
    ```
    Add the feature flags affected by the change. Use `--all-features` only when the crate supports enabling all features together.

--- a/flake.lock
+++ b/flake.lock
@@ -34,11 +34,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1782132410,
-        "narHash": "sha256-R0zNDRb/ic5M3BMDFN+h6oBX/ft4OGACDojddDc5K/g=",
+        "lastModified": 1785167313,
+        "narHash": "sha256-wJTRUJDPae8MHjk66AS8cMKxxtabKBjrpZxuiGyPUY4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "16157b94dc2865a74f968c367ed315151aa609f9",
+        "rev": "bc027e165ad28b2759f12800fef1ce0133f609ff",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781580018,
-        "narHash": "sha256-BlTedbM77FmesD2ZqR73vhFy+y77UrhefV7IYw1pDsk=",
+        "lastModified": 1785131767,
+        "narHash": "sha256-VNbQv2P0zgaNh96mT4LrnX7hdXgiC5nBH+uvyrrVX7U=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8bceba21a1ebea535c27c4dc723a0d5a4db9e386",
+        "rev": "c67ce00525464a710971351c183ce67acb6ca827",
         "type": "github"
       },
       "original": {

--- a/libdd-alloc/src/linear.rs
+++ b/libdd-alloc/src/linear.rs
@@ -34,7 +34,7 @@ impl<A: Allocator> LinearAllocator<A> {
         // SAFETY: this is the size/align of the actual allocation, so it must
         // be valid since the object exists.
         let allocation_layout =
-            unsafe { Layout::from_size_align(allocation.len(), layout.align()).unwrap_unchecked() };
+            unsafe { Layout::from_size_align_unchecked(allocation.len(), layout.align()) };
         Ok(Self {
             allocation_ptr: allocation.cast(),
             allocation_layout,

--- a/libdd-common-ffi/src/array_queue.rs
+++ b/libdd-common-ffi/src/array_queue.rs
@@ -16,7 +16,7 @@ pub struct ArrayQueue {
     // it to the correct type in the FFI functions. Also, we use NonNull instead of Box to avoid
     // getting into trouble with the drop implementation.
     inner: NonNull<ArrayQueue>,
-    item_delete_fn: unsafe extern "C" fn(*mut c_void) -> c_void,
+    item_delete_fn: unsafe extern "C" fn(*mut c_void),
 }
 
 unsafe impl Sync for ArrayQueue {}
@@ -25,7 +25,7 @@ unsafe impl Send for ArrayQueue {}
 impl ArrayQueue {
     pub fn new(
         capacity: usize,
-        item_delete_fn: Option<unsafe extern "C" fn(*mut c_void) -> c_void>,
+        item_delete_fn: Option<unsafe extern "C" fn(*mut c_void)>,
     ) -> anyhow::Result<Self, anyhow::Error> {
         anyhow::ensure!(capacity > 0, "capacity must be greater than 0");
         let item_delete_fn = item_delete_fn.context("item_delete_fn must be non-null")?;
@@ -83,7 +83,7 @@ pub enum ArrayQueueNewResult {
 #[must_use]
 pub extern "C" fn ddog_ArrayQueue_new(
     capacity: usize,
-    item_delete_fn: Option<unsafe extern "C" fn(*mut c_void) -> c_void>,
+    item_delete_fn: Option<unsafe extern "C" fn(*mut c_void)>,
 ) -> ArrayQueueNewResult {
     match ArrayQueue::new(capacity, item_delete_fn) {
         Ok(queue) => ArrayQueueNewResult::Ok(

--- a/libdd-common-ffi/src/array_queue.rs
+++ b/libdd-common-ffi/src/array_queue.rs
@@ -302,9 +302,8 @@ mod tests {
     use bolero::TypeGenerator;
     use core::sync::atomic::{AtomicUsize, Ordering};
 
-    unsafe extern "C" fn drop_item(item: *mut c_void) -> c_void {
+    unsafe extern "C" fn drop_item(item: *mut c_void) {
         _ = Box::from_raw(item as *mut i32);
-        core::mem::zeroed()
     }
 
     #[test]

--- a/libdd-profiling-heap-gotter/src/elf.rs
+++ b/libdd-profiling-heap-gotter/src/elf.rs
@@ -22,8 +22,8 @@ use std::collections::HashMap;
 use std::ffi::CStr;
 
 use libc::{
-    dl_iterate_phdr, dl_phdr_info, mprotect, sysconf, Elf64_Rel, Elf64_Rela, Elf64_Sym, PROT_EXEC,
-    PROT_READ, PROT_WRITE, PT_DYNAMIC, PT_LOAD, _SC_PAGESIZE,
+    dl_iterate_phdr, dl_phdr_info, mprotect, sysconf, Elf64_Rel, Elf64_Rela, Elf64_Sym,
+    _SC_PAGESIZE, PROT_EXEC, PROT_READ, PROT_WRITE, PT_DYNAMIC, PT_LOAD,
 };
 use std::io::{BufRead, BufReader};
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/libdd-trace-obfuscation/src/json/mod.rs
+++ b/libdd-trace-obfuscation/src/json/mod.rs
@@ -134,7 +134,7 @@ impl JsonObfuscator {
 
 /// Updates `key` and `wiped` based on the current closure stack.
 /// `key` is true at top level or when inside an object (not an array).
-fn set_key(closures: &[ClosureKind], key: &mut bool, wiped: &mut bool) {
+const fn set_key(closures: &[ClosureKind], key: &mut bool, wiped: &mut bool) {
     let n = closures.len();
     *key = n == 0 || matches!(closures[n - 1], ClosureKind::Object);
     *wiped = false;

--- a/libdd-trace-obfuscation/src/sql.rs
+++ b/libdd-trace-obfuscation/src/sql.rs
@@ -595,7 +595,7 @@ impl<'a> Tokenizer<'a> {
     }
 
     /// Consume and emit the rest of a numeric literal starting at current pos.
-    fn consume_number(&mut self) {
+    const fn consume_number(&mut self) {
         self.consume_number_inner(false);
     }
 

--- a/libdd-trace-obfuscation/src/sql.rs
+++ b/libdd-trace-obfuscation/src/sql.rs
@@ -379,13 +379,13 @@ impl<'a> Tokenizer<'a> {
         }
     }
 
-    fn skip_line_comment(&mut self) {
+    const fn skip_line_comment(&mut self) {
         while !self.at_end() && self.bytes[self.pos] != b'\n' {
             self.pos += 1;
         }
     }
 
-    fn skip_block_comment(&mut self) {
+    const fn skip_block_comment(&mut self) {
         // We've already consumed '/*', now find '*/'
         while self.pos + 1 < self.bytes.len() {
             if self.bytes[self.pos] == b'*' && self.bytes[self.pos + 1] == b'/' {
@@ -599,7 +599,7 @@ impl<'a> Tokenizer<'a> {
         self.consume_number_inner(false);
     }
 
-    fn consume_number_inner(&mut self, seen_dot: bool) {
+    const fn consume_number_inner(&mut self, seen_dot: bool) {
         // Consume digits, '.', 'e'/'E', optional sign after 'e', suffix letters.
         // `seen_dot`: true when caller already consumed the leading '.', so don't allow another.
         // This mirrors Go's scanNumber(seenDecimalPoint) which goes straight to `exponent`

--- a/libdd-trace-utils/src/send_with_retry/mod.rs
+++ b/libdd-trace-utils/src/send_with_retry/mod.rs
@@ -86,6 +86,7 @@ impl std::error::Error for SendWithRetryError {}
 /// send_with_retry(&capabilities, &target, payload, &headers, &retry_strategy).await
 /// # }
 /// ```
+#[allow(clippy::result_large_err)]
 pub async fn send_with_retry<C: HttpClientCapability + SleepCapability>(
     capabilities: &C,
     target: &Endpoint,

--- a/local-linux.Dockerfile
+++ b/local-linux.Dockerfile
@@ -44,12 +44,17 @@ RUN usermod -aG docker user
 
 WORKDIR /home/user
 
-# Install Rust toolchain for user in the usual ~/.cargo location
-# NOTE: Rust stable and nightly versions should be updated here whenever we bump the MSRV for libdatadog
+# Copy toolchain files so the Rust install reads pinned versions from source of truth
+COPY rust-toolchain.toml nightly-toolchain.toml /home/user/
+
+# Install Rust toolchain for user in the usual ~/.cargo location.
+# Stable and nightly versions are read from the toolchain files
 RUN su - user -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
 RUN su - user -c "cargo install --locked 'cargo-nextest@0.9.96'"
-RUN su - user -c "rustup install nightly-2024-12-16"
-RUN su - user -c "bash -lc 'rustup default 1.84.1'"
+RUN NIGHTLY=$(grep -Po '^channel = \"\K[^\"]+' /home/user/nightly-toolchain.toml) && \
+    su - user -c "rustup install $NIGHTLY"
+RUN STABLE=$(grep -Po '^channel = \"\K[^\"]+' /home/user/rust-toolchain.toml) && \
+    su - user -c "rustup default $STABLE"
 
 # Use a different target to not interfere with the host which may be a different arch
 RUN echo 'export CARGO_TARGET_DIR=/libdatadog/docker-linux-target' >> /home/user/.bashrc

--- a/local-linux.Dockerfile
+++ b/local-linux.Dockerfile
@@ -51,9 +51,9 @@ COPY rust-toolchain.toml nightly-toolchain.toml /home/user/
 # Stable and nightly versions are read from the toolchain files
 RUN su - user -c "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y"
 RUN su - user -c "cargo install --locked 'cargo-nextest@0.9.96'"
-RUN NIGHTLY=$(grep -Po '^channel = \"\K[^\"]+' /home/user/nightly-toolchain.toml) && \
+RUN NIGHTLY=$(awk -F'"' '/^channel[[:space:]]*=/ {print $2}' /home/user/nightly-toolchain.toml) && \
     su - user -c "rustup install $NIGHTLY"
-RUN STABLE=$(grep -Po '^channel = \"\K[^\"]+' /home/user/rust-toolchain.toml) && \
+RUN STABLE=$(awk -F'"' '/^channel[[:space:]]*=/ {print $2}' /home/user/rust-toolchain.toml) && \
     su - user -c "rustup default $STABLE"
 
 # Use a different target to not interfere with the host which may be a different arch

--- a/nightly-toolchain.toml
+++ b/nightly-toolchain.toml
@@ -7,4 +7,4 @@
 # Format mirrors `rust-toolchain.toml` so a single parser handles both files.
 
 [toolchain]
-channel = "nightly-2026-02-08"
+channel = "nightly-2026-07-26"


### PR DESCRIPTION
# What does this PR do?

My local nightly is latest. I've noticed that its fmt from `cargo +nightly fmt` differs from what CI expects.

This PR bumps nightly version, updates `.precommit-config.yaml` and the local Linux dockerfile. This PR also fixes new nightly clippy lints.

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
