### PR TITLE
refactor: migrate to workspace dependencies, phase 3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,17 +89,23 @@ authors = ["Datadog Inc. <info@datadoghq.com>"]
 # crate so that present and future crates opt into exactly what they use.
 arc-swap = { version = "1.7.1", default-features = false }
 anyhow = { version = "1.0", default-features = false }
+futures = { version = "0.3", default-features = false }
 hyper = { version = "1.6", default-features = false }
 hyper-util = { version = "0.1.10", default-features = false }
+io-lifetimes = { version = "1.0", default-features = false }
+libc = { version = "0.2", default-features = false }
 prost-build = { version = "0.14.1", default-features = false }
 protoc-bin-vendored = { version = "3.0.0", default-features = false }
+rustls = { version = "0.23", default-features = false }
 serde = { version = "1.0", default-features = false }
 # serde_json requires at least one of `std` or `alloc` (enforced via compile_error!
 # in its lib.rs). We set `alloc` here as the minimal working baseline, and to avoid
 # repeating alloc everywhere. Enabling `std` on top of it is fine.
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
+syn = { version = "^2", default-features = false }
 tokio = { version = "1.36", default-features = false }
 tracing = { version = "0.1", default-features = false }
+uuid = { version = "1.7.0", default-features = false }
 
 [profile.dev]
 debug = 2 # full debug info

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,14 +93,18 @@ futures = { version = "0.3", default-features = false }
 hyper = { version = "1.6", default-features = false }
 hyper-util = { version = "0.1.10", default-features = false }
 io-lifetimes = { version = "1.0", default-features = false }
-libc = { version = "0.2", default-features = false }
+# libc's only default feature is `std`, which is needed by virtually every
+# consumer (libc itself says that not using this feature to link libc in a
+# `no-std` environment is not the recommended way, and that this possibility
+# will be gone in future versions). We enable it by default for everyone.
+libc = { version = "0.2", default-features = true }
 prost-build = { version = "0.14.1", default-features = false }
 protoc-bin-vendored = { version = "3.0.0", default-features = false }
 rustls = { version = "0.23", default-features = false }
 serde = { version = "1.0", default-features = false }
-# serde_json requires at least one of `std` or `alloc` (enforced via compile_error!
-# in its lib.rs). We set `alloc` here as the minimal working baseline, and to avoid
-# repeating alloc everywhere. Enabling `std` on top of it is fine.
+# serde_json requires at least one of `std` or `alloc`. We set `alloc` here as
+# the minimal working baseline, and to avoid repeating alloc everywhere.
+# Enabling `std` on top of it is fine.
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 syn = { version = "^2", default-features = false }
 tokio = { version = "1.36", default-features = false }

--- a/bin_tests/Cargo.toml
+++ b/bin_tests/Cargo.toml
@@ -20,7 +20,7 @@ libdd-common = { path = "../libdd-common" }
 tempfile = "3.3"
 serde_json.workspace = true
 strum = { version = "0.26.2", features = ["derive"] }
-libc = { workspace = true, features = ["std"] }
+libc.workspace = true
 errno = "0.3"
 nix = { version = "0.29", features = ["signal", "socket"] }
 hex = "0.4"

--- a/bin_tests/Cargo.toml
+++ b/bin_tests/Cargo.toml
@@ -20,7 +20,7 @@ libdd-common = { path = "../libdd-common" }
 tempfile = "3.3"
 serde_json.workspace = true
 strum = { version = "0.26.2", features = ["derive"] }
-libc = "0.2"
+libc = { workspace = true, features = ["std"] }
 errno = "0.3"
 nix = { version = "0.29", features = ["signal", "socket"] }
 hex = "0.4"

--- a/datadog-ipc-macros/Cargo.toml
+++ b/datadog-ipc-macros/Cargo.toml
@@ -12,5 +12,5 @@ bench = false
 [dependencies]
 proc-macro2 = "1"
 quote = "^1"
-syn = { version = "^2", features = ["full"] }
+syn = { workspace = true, features = ["full", "derive", "parsing", "printing", "clone-impls", "proc-macro"] }
 heck = "0.5"

--- a/datadog-ipc-macros/Cargo.toml
+++ b/datadog-ipc-macros/Cargo.toml
@@ -12,5 +12,5 @@ bench = false
 [dependencies]
 proc-macro2 = "1"
 quote = "^1"
-syn = { workspace = true, features = ["full", "derive", "parsing", "printing", "clone-impls", "proc-macro"] }
+syn = { workspace = true, default-features = true, features = ["full"] }
 heck = "0.5"

--- a/datadog-ipc/Cargo.toml
+++ b/datadog-ipc/Cargo.toml
@@ -10,12 +10,12 @@ publish = false
 anyhow.workspace = true
 zwohash = "0.1.2"
 bincode = { version = "1" }
-futures = { version = "0.3", default-features = false }
-io-lifetimes = { version = "1.0" }
+futures.workspace = true
+io-lifetimes = { workspace = true, features = ["close"] }
 page_size = "0.6.0"
 memfd = { version = "0.6" }
 serde = { workspace = true, features = ["derive"] }
-libc = { version = "0.2" }
+libc = { workspace = true, features = ["std"] }
 libdd-tinybytes = { path = "../libdd-tinybytes", optional = true }
 
 

--- a/datadog-ipc/Cargo.toml
+++ b/datadog-ipc/Cargo.toml
@@ -15,7 +15,7 @@ io-lifetimes = { workspace = true, features = ["close"] }
 page_size = "0.6.0"
 memfd = { version = "0.6" }
 serde = { workspace = true, features = ["derive"] }
-libc = { workspace = true, features = ["std"] }
+libc.workspace = true
 libdd-tinybytes = { path = "../libdd-tinybytes", optional = true }
 
 

--- a/datadog-live-debugger-ffi/Cargo.toml
+++ b/datadog-live-debugger-ffi/Cargo.toml
@@ -16,7 +16,7 @@ datadog-live-debugger = { path = "../datadog-live-debugger" }
 libdd-common = { path = "../libdd-common" }
 libdd-common-ffi = { path = "../libdd-common-ffi", default-features = false }
 percent-encoding = "2.1"
-uuid = { version = "1.7.0", features = ["v4"] }
+uuid = { workspace = true, features = ["v4", "std"] }
 serde_json.workspace = true
 tokio = "1.36.0"
 tokio-util = { version = "0.7", features = ["rt"] }

--- a/datadog-live-debugger/Cargo.toml
+++ b/datadog-live-debugger/Cargo.toml
@@ -13,13 +13,13 @@ libdd-data-pipeline = { path = "../libdd-data-pipeline" }
 libdd-capabilities = { path = "../libdd-capabilities" }
 "http" = "1"
 bytes =  "1.11.1"
-futures = "0.3"
+futures.workspace = true
 
 percent-encoding = "2.1"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 sys-info = { version = "0.9.0" }
-uuid = { version = "1.0", features = ["v4"] }
+uuid = { workspace = true, features = ["v4", "std"] }
 smallvec = "1.13.2"
 constcat = "0.4.1"
 tokio = "1.36.0"

--- a/datadog-sidecar-ffi/Cargo.toml
+++ b/datadog-sidecar-ffi/Cargo.toml
@@ -24,7 +24,7 @@ datadog-live-debugger = { path = "../datadog-live-debugger" }
 libdd-dogstatsd-client = { path = "../libdd-dogstatsd-client" }
 libdd-tinybytes = { path = "../libdd-tinybytes", features = ["bytes_string"] }
 paste = "1"
-libc = { workspace = true, features = ["std"] }
+libc.workspace = true
 tracing.workspace = true
 rmp-serde = "1.1.1"
 serde_json.workspace = true

--- a/datadog-sidecar-ffi/Cargo.toml
+++ b/datadog-sidecar-ffi/Cargo.toml
@@ -24,7 +24,7 @@ datadog-live-debugger = { path = "../datadog-live-debugger" }
 libdd-dogstatsd-client = { path = "../libdd-dogstatsd-client" }
 libdd-tinybytes = { path = "../libdd-tinybytes", features = ["bytes_string"] }
 paste = "1"
-libc = "0.2"
+libc = { workspace = true, features = ["std"] }
 tracing.workspace = true
 rmp-serde = "1.1.1"
 serde_json.workspace = true

--- a/datadog-sidecar-macros/Cargo.toml
+++ b/datadog-sidecar-macros/Cargo.toml
@@ -10,5 +10,5 @@ proc-macro = true
 bench = false
 
 [dependencies]
-syn = { version = "^2", features = ["full"] }
+syn = { workspace = true, features = ["full", "derive", "parsing", "printing", "clone-impls", "proc-macro"] }
 quote = "^1"

--- a/datadog-sidecar-macros/Cargo.toml
+++ b/datadog-sidecar-macros/Cargo.toml
@@ -10,5 +10,5 @@ proc-macro = true
 bench = false
 
 [dependencies]
-syn = { workspace = true, features = ["full", "derive", "parsing", "printing", "clone-impls", "proc-macro"] }
+syn = { workspace = true, default-features = true, features = ["full"] }
 quote = "^1"

--- a/datadog-sidecar/Cargo.toml
+++ b/datadog-sidecar/Cargo.toml
@@ -72,7 +72,7 @@ tracing-subscriber = { version = "0.3.22", default-features = false, features = 
 ], optional = true }
 chrono = "0.4.31"
 console-subscriber = { version = "0.5", optional = true }
-libc = { workspace = true, features = ["std"] }
+libc.workspace = true
 
 # watchdog and self telemetry
 memory-stats = { version = "1.2.0", features = ["always_use_statm"] }
@@ -112,7 +112,7 @@ windows-sys = { version = "0.52.0", features = ["Win32_System_SystemInformation"
 microseh = "0.1.1"
 
 [dev-dependencies]
-libc = { workspace = true, features = ["std"] }
+libc.workspace = true
 tempfile = { version = "3.3" }
 httpmock = "0.8.0-alpha.1"
 libdd-remote-config = { path = "../libdd-remote-config", features = ["test"] }

--- a/datadog-sidecar/Cargo.toml
+++ b/datadog-sidecar/Cargo.toml
@@ -34,7 +34,7 @@ libdd-crashtracker = { path = "../libdd-crashtracker" }
 libdd-dogstatsd-client = { path = "../libdd-dogstatsd-client" }
 libdd-tinybytes = { path = "../libdd-tinybytes" }
 
-futures = { version = "0.3", default-features = false }
+futures.workspace = true
 manual_future = "0.1.1"
 http = "1.1"
 http-body-util = "0.1"
@@ -72,7 +72,7 @@ tracing-subscriber = { version = "0.3.22", default-features = false, features = 
 ], optional = true }
 chrono = "0.4.31"
 console-subscriber = { version = "0.5", optional = true }
-libc = { version = "0.2" }
+libc = { workspace = true, features = ["std"] }
 
 # watchdog and self telemetry
 memory-stats = { version = "1.2.0", features = ["always_use_statm"] }
@@ -112,7 +112,7 @@ windows-sys = { version = "0.52.0", features = ["Win32_System_SystemInformation"
 microseh = "0.1.1"
 
 [dev-dependencies]
-libc = { version = "0.2" }
+libc = { workspace = true, features = ["std"] }
 tempfile = { version = "3.3" }
 httpmock = "0.8.0-alpha.1"
 libdd-remote-config = { path = "../libdd-remote-config", features = ["test"] }

--- a/libdd-agent-client/Cargo.toml
+++ b/libdd-agent-client/Cargo.toml
@@ -35,6 +35,6 @@ tracing.workspace = true
 
 [dev-dependencies]
 httpmock = "0.8.0-alpha.1"
-rustls = { version = "0.23", default-features = false, features = ["ring"] }
+rustls = { workspace = true, features = ["ring"] }
 serial_test = "3.2"
 tokio = { version = "1.23", features = ["rt", "macros"] }

--- a/libdd-common/Cargo.toml
+++ b/libdd-common/Cargo.toml
@@ -17,7 +17,7 @@ bench = false
 
 [dependencies]
 anyhow.workspace = true
-futures = "0.3"
+futures = { workspace = true, features = ["alloc", "executor"] }
 futures-core = { version = "0.3.0", default-features = false }
 futures-util = { version = "0.3.0", default-features = false }
 hex = "0.4"
@@ -46,7 +46,7 @@ static_assertions = "1.1.0"
 const_format = "0.2.34"
 # Declare rustls and hyper-rustls without a crypto provider. The provider is
 # selected via features: `https` enables ring, `fips` enables aws-lc-rs.
-rustls = { version = "0.23.37", default-features = false, optional = true }
+rustls = { workspace = true, optional = true }
 hyper-rustls = { version = "0.27.7", default-features = false, features = [
     "http1",
     "tls12",
@@ -62,7 +62,7 @@ http-body-util = "0.1"
 tower-service = "0.3"
 cc = "1.1.31"
 pin-project = "1"
-libc = "0.2"
+libc = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "net", "io-util", "fs", "time"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]

--- a/libdd-common/Cargo.toml
+++ b/libdd-common/Cargo.toml
@@ -62,7 +62,7 @@ http-body-util = "0.1"
 tower-service = "0.3"
 cc = "1.1.31"
 pin-project = "1"
-libc = { workspace = true, features = ["std"] }
+libc.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "net", "io-util", "fs", "time"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]

--- a/libdd-crashtracker-ffi/Cargo.toml
+++ b/libdd-crashtracker-ffi/Cargo.toml
@@ -44,7 +44,7 @@ libdd-common-ffi = { path = "../libdd-common-ffi", default-features = false }
 symbolic-demangle = { version = "12.8.0", default-features = false, features = ["rust", "cpp", "msvc"], optional = true }
 symbolic-common = { version = "12.8.0", default-features = false, optional = true }
 function_name = "0.3.0"
-libc = { workspace = true, features = ["std"] }
+libc.workspace = true
 serde_json.workspace = true
 serde = { version = "1.0.214", features = ["derive"] }
 

--- a/libdd-crashtracker-ffi/Cargo.toml
+++ b/libdd-crashtracker-ffi/Cargo.toml
@@ -44,7 +44,7 @@ libdd-common-ffi = { path = "../libdd-common-ffi", default-features = false }
 symbolic-demangle = { version = "12.8.0", default-features = false, features = ["rust", "cpp", "msvc"], optional = true }
 symbolic-common = { version = "12.8.0", default-features = false, optional = true }
 function_name = "0.3.0"
-libc = "0.2.167"
+libc = { workspace = true, features = ["std"] }
 serde_json.workspace = true
 serde = { version = "1.0.214", features = ["derive"] }
 

--- a/libdd-crashtracker/Cargo.toml
+++ b/libdd-crashtracker/Cargo.toml
@@ -54,7 +54,7 @@ libdd-capabilities-impl = { version = "3.0.0", path = "../libdd-capabilities-imp
 libdd-common = { version = "5.1.0", path = "../libdd-common" }
 libdd-telemetry = { version = "6.0.0", path = "../libdd-telemetry" }
 http = "1.1"
-libc = "0.2"
+libc = { workspace = true, features = ["std"] }
 nix = { version = "0.29", features = ["poll", "signal", "socket"] }
 num-derive = "0.4.2"
 num-traits = "0.2.19"
@@ -68,7 +68,7 @@ serde_json = { workspace = true, features = ["std"] }
 symbolic-demangle = { version = "12.8.0", default-features = false, features = ["rust", "cpp", "msvc"] }
 symbolic-common = { version = "12.8.0", default-features = false }
 tokio = { workspace = true, features = ["rt", "macros", "io-std", "io-util"] }
-uuid = { version = "1.4.1", features = ["v4", "serde"] }
+uuid = { workspace = true, features = ["v4", "serde", "std"] }
 thiserror = "1.0"
 
 [target.'cfg(windows)'.dependencies]

--- a/libdd-crashtracker/Cargo.toml
+++ b/libdd-crashtracker/Cargo.toml
@@ -54,7 +54,7 @@ libdd-capabilities-impl = { version = "3.0.0", path = "../libdd-capabilities-imp
 libdd-common = { version = "5.1.0", path = "../libdd-common" }
 libdd-telemetry = { version = "6.0.0", path = "../libdd-telemetry" }
 http = "1.1"
-libc = { workspace = true, features = ["std"] }
+libc.workspace = true
 nix = { version = "0.29", features = ["poll", "signal", "socket"] }
 num-derive = "0.4.2"
 num-traits = "0.2.19"

--- a/libdd-data-pipeline/Cargo.toml
+++ b/libdd-data-pipeline/Cargo.toml
@@ -24,13 +24,13 @@ serde_json.workspace = true
 bytes = "1.11.1"
 sha2 = "0.10"
 either = "1.13.0"
-futures = { version = "0.3", default-features = false, features = ["alloc"] }
+futures = { workspace = true, features = ["alloc"] }
 tokio = { workspace = true, features = [
     "rt",
     "sync",
     "time",
 ], default-features = false }
-uuid = { version = "1.10.0", features = ["v4"] }
+uuid = { workspace = true, features = ["v4", "std"] }
 tokio-util = "0.7.11"
 libdd-capabilities = { path = "../libdd-capabilities", version = "2.1.0" }
 libdd-common = { version = "5.1.0", path = "../libdd-common", default-features = false }
@@ -55,7 +55,7 @@ libdd-capabilities-impl = { version = "3.0.0", path = "../libdd-capabilities-imp
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
-uuid = { version = "1", features = ["js"] }
+uuid = { workspace = true, features = ["js", "std"] }
 
 [lib]
 bench = false

--- a/libdd-http-client/Cargo.toml
+++ b/libdd-http-client/Cargo.toml
@@ -28,7 +28,7 @@ thiserror = "2"
 fastrand = "2"
 tokio = { workspace = true, features = ["rt", "time"] }
 reqwest = { version = "0.13", default-features = false, optional = true }
-rustls = { version = "0.23", default-features = false, optional = true }
+rustls = { workspace = true, optional = true }
 libdd-common = { version = "5.1.0", path = "../libdd-common", default-features = false, optional = true }
 hyper = { workspace = true, optional = true, features = ["http1", "client"] }
 hyper-util = { workspace = true, optional = true, features = ["http1", "client", "client-legacy"] }
@@ -37,6 +37,6 @@ http-body-util = { version = "0.1", optional = true }
 
 [dev-dependencies]
 httpmock = "0.8.0-alpha.1"
-rustls = { version = "0.23", default-features = false, features = ["ring"] }
+rustls = { workspace = true, features = ["ring"] }
 tokio = { version = "1.23", features = ["rt", "macros", "io-util", "net"] }
 tempfile = "3"

--- a/libdd-library-config/Cargo.toml
+++ b/libdd-library-config/Cargo.toml
@@ -37,7 +37,7 @@ serial_test = "3.2"
 
 [target.'cfg(unix)'.dependencies]
 memfd = { version = "0.6" }
-libc = { workspace = true, features = ["std"] }
+libc.workspace = true
 
 [lints.clippy]
 std_instead_of_alloc = "warn"

--- a/libdd-library-config/Cargo.toml
+++ b/libdd-library-config/Cargo.toml
@@ -37,7 +37,7 @@ serial_test = "3.2"
 
 [target.'cfg(unix)'.dependencies]
 memfd = { version = "0.6" }
-libc = "0.2"
+libc = { workspace = true, features = ["std"] }
 
 [lints.clippy]
 std_instead_of_alloc = "warn"

--- a/libdd-profiling-ffi/Cargo.toml
+++ b/libdd-profiling-ffi/Cargo.toml
@@ -53,10 +53,10 @@ libdd-telemetry-ffi = { path = "../libdd-telemetry-ffi", default-features = fals
 libdd-ddsketch-ffi = { path = "../libdd-ddsketch-ffi", default-features = false, optional = true }
 libdd-log-ffi = { path = "../libdd-log-ffi", default-features = false, optional = true }
 function_name = "0.3.0"
-futures = { version = "0.3", default-features = false }
+futures.workspace = true
 http-body-util = "0.1"
 hyper = { workspace = true, features = ["http1", "client"] }
-libc = "0.2"
+libc = { workspace = true, features = ["std"] }
 serde_json.workspace = true
 symbolizer-ffi = { path = "../symbolizer-ffi", optional = true, default-features = false }
 thiserror = "2"

--- a/libdd-profiling-ffi/Cargo.toml
+++ b/libdd-profiling-ffi/Cargo.toml
@@ -56,7 +56,7 @@ function_name = "0.3.0"
 futures.workspace = true
 http-body-util = "0.1"
 hyper = { workspace = true, features = ["http1", "client"] }
-libc = { workspace = true, features = ["std"] }
+libc.workspace = true
 serde_json.workspace = true
 symbolizer-ffi = { path = "../symbolizer-ffi", optional = true, default-features = false }
 thiserror = "2"

--- a/libdd-profiling-heap-gotter-ffi/Cargo.toml
+++ b/libdd-profiling-heap-gotter-ffi/Cargo.toml
@@ -34,7 +34,7 @@ libdd-common-ffi = { path = "../libdd-common-ffi", default-features = false }
 libdd-profiling-heap-gotter = { path = "../libdd-profiling-heap-gotter" }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
-libc = { workspace = true, features = ["std"] }
+libc.workspace = true
 # For the USDT-note ELF inspection test (tests/usdt_notes.rs); mirrors how
 # libdd-otel-thread-ctx-ffi pulls in its dep's `sanity-check` feature.
 libdd-profiling-heap-sampler = { path = "../libdd-profiling-heap-sampler", features = ["sanity-check"] }

--- a/libdd-profiling-heap-gotter-ffi/Cargo.toml
+++ b/libdd-profiling-heap-gotter-ffi/Cargo.toml
@@ -34,7 +34,7 @@ libdd-common-ffi = { path = "../libdd-common-ffi", default-features = false }
 libdd-profiling-heap-gotter = { path = "../libdd-profiling-heap-gotter" }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
-libc = "0.2"
+libc = { workspace = true, features = ["std"] }
 # For the USDT-note ELF inspection test (tests/usdt_notes.rs); mirrors how
 # libdd-otel-thread-ctx-ffi pulls in its dep's `sanity-check` feature.
 libdd-profiling-heap-sampler = { path = "../libdd-profiling-heap-sampler", features = ["sanity-check"] }

--- a/libdd-profiling-heap-gotter/Cargo.toml
+++ b/libdd-profiling-heap-gotter/Cargo.toml
@@ -24,10 +24,10 @@ live-heap = ["libdd-profiling-heap-sampler/live-heap"]
 test-support = []
 
 [target.'cfg(target_os = "linux")'.dependencies]
-libc = { workspace = true, features = ["std"] }
+libc.workspace = true
 libdd-profiling-heap-sampler = { version = "1.0.0", path = "../libdd-profiling-heap-sampler" }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
-libc = { workspace = true, features = ["std"] }
+libc.workspace = true
 libdd-profiling-heap-sampler = { version = "1.0.0", path = "../libdd-profiling-heap-sampler" }
 serial_test = "3.2"

--- a/libdd-profiling-heap-gotter/Cargo.toml
+++ b/libdd-profiling-heap-gotter/Cargo.toml
@@ -24,10 +24,10 @@ live-heap = ["libdd-profiling-heap-sampler/live-heap"]
 test-support = []
 
 [target.'cfg(target_os = "linux")'.dependencies]
-libc = "0.2"
+libc = { workspace = true, features = ["std"] }
 libdd-profiling-heap-sampler = { version = "1.0.0", path = "../libdd-profiling-heap-sampler" }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
-libc = "0.2"
+libc = { workspace = true, features = ["std"] }
 libdd-profiling-heap-sampler = { version = "1.0.0", path = "../libdd-profiling-heap-sampler" }
 serial_test = "3.2"

--- a/libdd-profiling/Cargo.toml
+++ b/libdd-profiling/Cargo.toml
@@ -35,7 +35,7 @@ chrono = {version = "0.4", default-features = false, features = ["std", "clock"]
 crossbeam-channel = "0.5.15"
 crossbeam-utils = { version = "0.8.21" }
 cxx = { version = "1.0", optional = true }
-futures = { version = "0.3", default-features = false }
+futures.workspace = true
 hashbrown = { version = "0.16", default-features = false }
 http = "1.1"
 http-body-util = "0.1"
@@ -67,7 +67,7 @@ tokio-util = { version = "0.7.1", default-features = false }
 zstd = { version = "0.13", default-features = false }
 # ring is the crypto provider for non-FIPS builds on all platforms.
 # FIPS builds activate aws-lc-rs via the rustls/fips feature instead.
-rustls = { version = "0.23.37", default-features = false, features = ["ring"] }
+rustls = { workspace = true, features = ["ring"] }
 
 [dev-dependencies]
 bolero = "0.13"

--- a/libdd-remote-config/Cargo.toml
+++ b/libdd-remote-config/Cargo.toml
@@ -46,7 +46,7 @@ http-body-util = {version = "0.1", optional = true }
 http = { version = "1.1", optional = true }
 base64 = { version = "0.22.1", optional = true }
 sha2 = { version = "0.10", optional = true }
-uuid = { version = "1.7.0", features = ["v4"], optional = true }
+uuid = { workspace = true, features = ["v4", "std"], optional = true }
 futures-util = { version = "0.3", optional = true }
 tokio = { workspace = true, optional = true }
 tokio-util = { version = "0.7.10",  optional = true }
@@ -69,7 +69,7 @@ hyper-util = { workspace = true, features = ["http1", "client", "client-legacy",
 libdd-capabilities-impl = { path = "../libdd-capabilities-impl", version = "3.0.0", default-features = false }
 
 [dev-dependencies]
-futures = "0.3"
+futures.workspace = true
 libdd-remote-config = { path = ".", features = ["test"] }
 
 [lib]

--- a/libdd-shared-runtime/Cargo.toml
+++ b/libdd-shared-runtime/Cargo.toml
@@ -17,7 +17,7 @@ bench = false
 
 [dependencies]
 async-trait = "0.1"
-futures = { version = "0.3", default-features = false, features = ["alloc"] }
+futures = { workspace = true, features = ["alloc"] }
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 tokio = { workspace = true, features = ["rt", "macros", "time"] }
 tokio-util = "0.7.11"
@@ -40,4 +40,4 @@ wasm-bindgen-futures = "0.4"
 futures-util = { version = "0.3", default-features = false, features = ["alloc", "channel"] }
 
 [dev-dependencies]
-futures = { version = "0.3", features = ["executor"] }
+futures = { workspace = true, features = ["executor"] }

--- a/libdd-telemetry-ffi/Cargo.toml
+++ b/libdd-telemetry-ffi/Cargo.toml
@@ -28,7 +28,7 @@ libdd-telemetry = { path = "../libdd-telemetry" }
 libdd-common = { path = "../libdd-common" }
 libdd-common-ffi = { path = "../libdd-common-ffi", default-features = false }
 function_name = "0.3"
-libc = { workspace = true, features = ["std"] }
+libc.workspace = true
 paste = "1"
 
 [dev-dependencies]

--- a/libdd-telemetry-ffi/Cargo.toml
+++ b/libdd-telemetry-ffi/Cargo.toml
@@ -28,7 +28,7 @@ libdd-telemetry = { path = "../libdd-telemetry" }
 libdd-common = { path = "../libdd-common" }
 libdd-common-ffi = { path = "../libdd-common-ffi", default-features = false }
 function_name = "0.3"
-libc = "0.2"
+libc = { workspace = true, features = ["std"] }
 paste = "1"
 
 [dev-dependencies]

--- a/libdd-telemetry/Cargo.toml
+++ b/libdd-telemetry/Cargo.toml
@@ -45,7 +45,7 @@ getrandom = { version = "0.2", features = ["js"] }
 uuid = { workspace = true, features = ["js", "std"] }
 
 [target."cfg(unix)".dependencies]
-libc = "0.2.176"
+libc.workspace = true
 
 [target."cfg(windows)".dependencies]
 winver = "1.0.0"

--- a/libdd-telemetry/Cargo.toml
+++ b/libdd-telemetry/Cargo.toml
@@ -21,14 +21,14 @@ fips = ["libdd-common/fips", "libdd-shared-runtime/fips"]
 anyhow.workspace = true
 async-trait = "0.1"
 base64 = "0.22"
-futures = { version = "0.3", default-features = false }
+futures.workspace = true
 http = "1"
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 tokio = { workspace = true, features = ["sync", "io-util"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 tracing.workspace = true
-uuid = { version = "1.3", features = ["v4"] }
+uuid = { workspace = true, features = ["v4", "std"] }
 hashbrown = "0.15"
 bytes = "1.4"
 libdd-capabilities = { version = "2.1.0", path = "../libdd-capabilities" }
@@ -42,7 +42,7 @@ sys-info = { version = "0.9.0" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
-uuid = { version = "1", features = ["js"] }
+uuid = { workspace = true, features = ["js", "std"] }
 
 [target."cfg(unix)".dependencies]
 libc = "0.2.176"

--- a/libdd-trace-stats/Cargo.toml
+++ b/libdd-trace-stats/Cargo.toml
@@ -31,7 +31,7 @@ tracing.workspace = true
 async-trait = "0.1.85"
 # Cross-platform `SystemTime`; `std::time::SystemTime::now()` panics on wasm32.
 web-time = "1"
-futures = { version = "0.3.32", default-features = false, features = ["alloc"] }
+futures = { workspace = true, features = ["alloc"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libdd-capabilities-impl = { version = "3.0.0", path = "../libdd-capabilities-impl", default-features = false }

--- a/libdd-trace-utils/Cargo.toml
+++ b/libdd-trace-utils/Cargo.toml
@@ -38,7 +38,7 @@ rmp-serde = "1.3.0"
 tracing.workspace = true
 serde_json = { workspace = true, features = ["std"] }
 serde-transcode = "1.1"
-futures = { version = "0.3", default-features = false }
+futures.workspace = true
 tokio = { workspace = true, features = ["macros"] }
 rand = "0.8.5"
 bytes = "1.11.1"

--- a/spawn_worker/Cargo.toml
+++ b/spawn_worker/Cargo.toml
@@ -9,9 +9,9 @@ bench = false
 
 [dependencies]
 anyhow.workspace = true
-io-lifetimes = { version = "1.0" }
+io-lifetimes = { workspace = true, features = ["close"] }
 fastrand = "2.0.1"
-libc = "0.2"
+libc = { workspace = true, features = ["std"] }
 
 [build-dependencies]
 cc_utils = { path = "../tools/cc_utils" }

--- a/spawn_worker/Cargo.toml
+++ b/spawn_worker/Cargo.toml
@@ -11,7 +11,7 @@ bench = false
 anyhow.workspace = true
 io-lifetimes = { workspace = true, features = ["close"] }
 fastrand = "2.0.1"
-libc = { workspace = true, features = ["std"] }
+libc.workspace = true
 
 [build-dependencies]
 cc_utils = { path = "../tools/cc_utils" }

--- a/tests/spawn_from_lib/Cargo.toml
+++ b/tests/spawn_from_lib/Cargo.toml
@@ -15,7 +15,7 @@ bench = false
 prefer-dynamic = []
 
 [dependencies]
-libc = { workspace = true, features = ["std"] }
+libc.workspace = true
 anyhow = { version = "1.0" }
 spawn_worker = { path = "../../spawn_worker" }
 tempfile = { version = "3.3" }

--- a/tests/spawn_from_lib/Cargo.toml
+++ b/tests/spawn_from_lib/Cargo.toml
@@ -15,8 +15,8 @@ bench = false
 prefer-dynamic = []
 
 [dependencies]
-libc = { version = "0.2" }
+libc = { workspace = true, features = ["std"] }
 anyhow = { version = "1.0" }
 spawn_worker = { path = "../../spawn_worker" }
 tempfile = { version = "3.3" }
-io-lifetimes = { version = "1.0" }
+io-lifetimes = { workspace = true, features = ["close"] }


### PR DESCRIPTION
Follow up of #2270.

## Summary

Move more external dependencies to workspace-level dependencies. Phase 3 of the workspace migration plan.

## Test plan
- [x] `cargo check --workspace --exclude builder` and `--all-targets --all-features`
- [x] `cargo build --workspace --exclude builder`
- [x] `cargo +nightly-2026-07-26 fmt --all -- --check`
- [x] `cargo +stable clippy --workspace --exclude builder --all-targets -- -D warnings` (and with `--all-features`)
- [x] `cargo nextest run --workspace --exclude builder -E '!test(tracing_integration_tests::)'` — 2216/2220 passed; the 4 failures (crashtracker ptrace sandbox restrictions, one FFE fixture) are pre-existing on `main`
- [x] `cargo test --workspace --exclude builder --doc`
- [x] `cargo ffi-test` — 11/15 pass; `ffe`/`profile_intern` failures are pre-existing on `main` (missing fixture file / environment-specific buffer sizing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)