### PR TITLE
fix(telemetry)!: stop sending Connection: close to the Agent

### DIFF
--- a/datadog-sidecar/src/service/ffe_exposures_flusher.rs
+++ b/datadog-sidecar/src/service/ffe_exposures_flusher.rs
@@ -270,6 +270,10 @@ mod tests {
             Self
         }
 
+        fn new_without_connection_pooling() -> Self {
+            Self
+        }
+
         fn request(
             &self,
             _req: http::Request<Bytes>,

--- a/datadog-sidecar/src/service/ffe_metrics_flusher.rs
+++ b/datadog-sidecar/src/service/ffe_metrics_flusher.rs
@@ -195,6 +195,10 @@ mod tests {
             Self
         }
 
+        fn new_without_connection_pooling() -> Self {
+            Self
+        }
+
         fn request(
             &self,
             _req: http::Request<Bytes>,

--- a/libdd-capabilities-impl/src/http.rs
+++ b/libdd-capabilities-impl/src/http.rs
@@ -8,7 +8,6 @@ mod native {
     use std::future::Future;
     use std::io::Write;
     use std::sync::{Arc, OnceLock};
-    use std::time::Duration;
 
     use libdd_capabilities::http::{
         BodySender, ChunkFuture, HttpClientCapability, HttpError, ResponseFuture,
@@ -17,23 +16,15 @@ mod native {
     use libdd_capabilities::maybe_send::MaybeSend;
     use libdd_common::connector::Connector;
     use libdd_common::http_common::{
-        new_client_periodic, new_client_with_connection_pool_idle_timeout, new_default_client,
-        Body, GenericHttpClient,
+        new_client_periodic, new_default_client, Body, GenericHttpClient,
     };
 
     use http_body_util::BodyExt;
 
-    #[derive(Clone, Copy, Debug)]
-    enum ConnectionPooling {
-        Disabled,
-        Default,
-        IdleTimeout(Duration),
-    }
-
     #[derive(Clone)]
     pub struct NativeHttpClient {
         client: Arc<OnceLock<GenericHttpClient<Connector>>>,
-        connection_pooling: ConnectionPooling,
+        connection_pooling: bool,
     }
 
     pub struct NativeBodySender(libdd_common::http_common::Sender);
@@ -63,24 +54,7 @@ mod native {
         pub fn new_without_connection_pooling() -> Self {
             Self {
                 client: Arc::new(OnceLock::new()),
-                connection_pooling: ConnectionPooling::Disabled,
-            }
-        }
-
-        pub fn new_with_connection_pool_idle_timeout(idle_timeout: Duration) -> Self {
-            Self {
-                client: Arc::new(OnceLock::new()),
-                connection_pooling: ConnectionPooling::IdleTimeout(idle_timeout),
-            }
-        }
-    }
-
-    fn build_client(connection_pooling: ConnectionPooling) -> GenericHttpClient<Connector> {
-        match connection_pooling {
-            ConnectionPooling::Disabled => new_client_periodic(),
-            ConnectionPooling::Default => new_default_client(),
-            ConnectionPooling::IdleTimeout(idle_timeout) => {
-                new_client_with_connection_pool_idle_timeout(idle_timeout)
+                connection_pooling: false,
             }
         }
     }
@@ -113,12 +87,8 @@ mod native {
         fn new_client() -> Self {
             Self {
                 client: Arc::new(OnceLock::new()),
-                connection_pooling: ConnectionPooling::Default,
+                connection_pooling: true,
             }
-        }
-
-        fn new_client_with_connection_pool_idle_timeout(idle_timeout: Duration) -> Self {
-            Self::new_with_connection_pool_idle_timeout(idle_timeout)
         }
 
         #[allow(clippy::manual_async_fn)]
@@ -137,7 +107,13 @@ mod native {
                 }
 
                 let client = client_lock
-                    .get_or_init(|| build_client(connection_pooling))
+                    .get_or_init(|| {
+                        if connection_pooling {
+                            new_default_client()
+                        } else {
+                            new_client_periodic()
+                        }
+                    })
                     .clone();
                 let hyper_req = req.map(Body::from_bytes);
 
@@ -158,10 +134,7 @@ mod native {
         }
 
         fn request_streamed(&self, req: http::Request<()>) -> (BodySender, ResponseFuture) {
-            let client = self
-                .client
-                .get_or_init(|| build_client(self.connection_pooling))
-                .clone();
+            let client = self.client.get_or_init(new_default_client).clone();
             let (sender, body) = Body::channel();
             let hyper_req = req.map(|()| body);
             let fut = async move {

--- a/libdd-capabilities-impl/src/http.rs
+++ b/libdd-capabilities-impl/src/http.rs
@@ -91,6 +91,10 @@ mod native {
             }
         }
 
+        fn new_without_connection_pooling() -> Self {
+            NativeHttpClient::new_without_connection_pooling()
+        }
+
         #[allow(clippy::manual_async_fn)]
         fn request(
             &self,

--- a/libdd-capabilities-impl/src/http.rs
+++ b/libdd-capabilities-impl/src/http.rs
@@ -8,6 +8,7 @@ mod native {
     use std::future::Future;
     use std::io::Write;
     use std::sync::{Arc, OnceLock};
+    use std::time::Duration;
 
     use libdd_capabilities::http::{
         BodySender, ChunkFuture, HttpClientCapability, HttpError, ResponseFuture,
@@ -16,15 +17,23 @@ mod native {
     use libdd_capabilities::maybe_send::MaybeSend;
     use libdd_common::connector::Connector;
     use libdd_common::http_common::{
-        new_client_periodic, new_default_client, Body, GenericHttpClient,
+        new_client_periodic, new_client_with_connection_pool_idle_timeout, new_default_client,
+        Body, GenericHttpClient,
     };
 
     use http_body_util::BodyExt;
 
+    #[derive(Clone, Copy, Debug)]
+    enum ConnectionPooling {
+        Disabled,
+        Default,
+        IdleTimeout(Duration),
+    }
+
     #[derive(Clone)]
     pub struct NativeHttpClient {
         client: Arc<OnceLock<GenericHttpClient<Connector>>>,
-        connection_pooling: bool,
+        connection_pooling: ConnectionPooling,
     }
 
     pub struct NativeBodySender(libdd_common::http_common::Sender);
@@ -54,7 +63,24 @@ mod native {
         pub fn new_without_connection_pooling() -> Self {
             Self {
                 client: Arc::new(OnceLock::new()),
-                connection_pooling: false,
+                connection_pooling: ConnectionPooling::Disabled,
+            }
+        }
+
+        pub fn new_with_connection_pool_idle_timeout(idle_timeout: Duration) -> Self {
+            Self {
+                client: Arc::new(OnceLock::new()),
+                connection_pooling: ConnectionPooling::IdleTimeout(idle_timeout),
+            }
+        }
+    }
+
+    fn build_client(connection_pooling: ConnectionPooling) -> GenericHttpClient<Connector> {
+        match connection_pooling {
+            ConnectionPooling::Disabled => new_client_periodic(),
+            ConnectionPooling::Default => new_default_client(),
+            ConnectionPooling::IdleTimeout(idle_timeout) => {
+                new_client_with_connection_pool_idle_timeout(idle_timeout)
             }
         }
     }
@@ -87,8 +113,12 @@ mod native {
         fn new_client() -> Self {
             Self {
                 client: Arc::new(OnceLock::new()),
-                connection_pooling: true,
+                connection_pooling: ConnectionPooling::Default,
             }
+        }
+
+        fn new_client_with_connection_pool_idle_timeout(idle_timeout: Duration) -> Self {
+            Self::new_with_connection_pool_idle_timeout(idle_timeout)
         }
 
         #[allow(clippy::manual_async_fn)]
@@ -107,13 +137,7 @@ mod native {
                 }
 
                 let client = client_lock
-                    .get_or_init(|| {
-                        if connection_pooling {
-                            new_default_client()
-                        } else {
-                            new_client_periodic()
-                        }
-                    })
+                    .get_or_init(|| build_client(connection_pooling))
                     .clone();
                 let hyper_req = req.map(Body::from_bytes);
 
@@ -134,7 +158,10 @@ mod native {
         }
 
         fn request_streamed(&self, req: http::Request<()>) -> (BodySender, ResponseFuture) {
-            let client = self.client.get_or_init(new_default_client).clone();
+            let client = self
+                .client
+                .get_or_init(|| build_client(self.connection_pooling))
+                .clone();
             let (sender, body) = Body::channel();
             let hyper_req = req.map(|()| body);
             let fut = async move {

--- a/libdd-capabilities-impl/src/lib.rs
+++ b/libdd-capabilities-impl/src/lib.rs
@@ -67,6 +67,15 @@ impl HttpClientCapability for NativeCapabilities {
         Self::new()
     }
 
+    fn new_without_connection_pooling() -> Self {
+        Self {
+            http: NativeHttpClient::new_without_connection_pooling(),
+            sleep: NativeSleepCapability,
+            env: NativeEnvCapability,
+            file: NativeFileCapability,
+        }
+    }
+
     fn request(
         &self,
         req: ::http::Request<bytes::Bytes>,

--- a/libdd-capabilities-impl/src/lib.rs
+++ b/libdd-capabilities-impl/src/lib.rs
@@ -67,6 +67,15 @@ impl HttpClientCapability for NativeCapabilities {
         Self::new()
     }
 
+    fn new_client_with_connection_pool_idle_timeout(idle_timeout: Duration) -> Self {
+        Self {
+            http: NativeHttpClient::new_with_connection_pool_idle_timeout(idle_timeout),
+            sleep: NativeSleepCapability,
+            env: NativeEnvCapability,
+            file: NativeFileCapability,
+        }
+    }
+
     fn request(
         &self,
         req: ::http::Request<bytes::Bytes>,

--- a/libdd-capabilities-impl/src/lib.rs
+++ b/libdd-capabilities-impl/src/lib.rs
@@ -67,15 +67,6 @@ impl HttpClientCapability for NativeCapabilities {
         Self::new()
     }
 
-    fn new_client_with_connection_pool_idle_timeout(idle_timeout: Duration) -> Self {
-        Self {
-            http: NativeHttpClient::new_with_connection_pool_idle_timeout(idle_timeout),
-            sleep: NativeSleepCapability,
-            env: NativeEnvCapability,
-            file: NativeFileCapability,
-        }
-    }
-
     fn request(
         &self,
         req: ::http::Request<bytes::Bytes>,

--- a/libdd-capabilities/src/http.rs
+++ b/libdd-capabilities/src/http.rs
@@ -56,6 +56,9 @@ pub type BodySender = Box<dyn StreamingBodySender>;
 pub trait HttpClientCapability: Clone + std::fmt::Debug {
     fn new_client() -> Self;
 
+    /// Construct a client that does not reuse connections.
+    fn new_without_connection_pooling() -> Self;
+
     fn request(
         &self,
         req: http::Request<bytes::Bytes>,

--- a/libdd-capabilities/src/http.rs
+++ b/libdd-capabilities/src/http.rs
@@ -10,7 +10,6 @@
 use crate::maybe_send::{MaybeSend, MaybeSendFuture};
 use core::future::Future;
 use core::pin::Pin;
-use core::time::Duration;
 use futures_util::StreamExt;
 
 #[derive(Debug, thiserror::Error)]
@@ -56,13 +55,6 @@ pub type BodySender = Box<dyn StreamingBodySender>;
 
 pub trait HttpClientCapability: Clone + std::fmt::Debug {
     fn new_client() -> Self;
-
-    /// Construct a client that evicts pooled connections after `idle_timeout`.
-    ///
-    /// Implementations without connection pooling may use [`Self::new_client`].
-    fn new_client_with_connection_pool_idle_timeout(_idle_timeout: Duration) -> Self {
-        Self::new_client()
-    }
 
     fn request(
         &self,

--- a/libdd-capabilities/src/http.rs
+++ b/libdd-capabilities/src/http.rs
@@ -10,6 +10,7 @@
 use crate::maybe_send::{MaybeSend, MaybeSendFuture};
 use core::future::Future;
 use core::pin::Pin;
+use core::time::Duration;
 use futures_util::StreamExt;
 
 #[derive(Debug, thiserror::Error)]
@@ -55,6 +56,13 @@ pub type BodySender = Box<dyn StreamingBodySender>;
 
 pub trait HttpClientCapability: Clone + std::fmt::Debug {
     fn new_client() -> Self;
+
+    /// Construct a client that evicts pooled connections after `idle_timeout`.
+    ///
+    /// Implementations without connection pooling may use [`Self::new_client`].
+    fn new_client_with_connection_pool_idle_timeout(_idle_timeout: Duration) -> Self {
+        Self::new_client()
+    }
 
     fn request(
         &self,

--- a/libdd-common/src/http_common.rs
+++ b/libdd-common/src/http_common.rs
@@ -135,16 +135,6 @@ mod native {
             .build(Connector::default())
     }
 
-    /// Create a pooling hyper client that evicts connections after `idle_timeout`.
-    pub fn new_client_with_connection_pool_idle_timeout(
-        idle_timeout: core::time::Duration,
-    ) -> GenericHttpClient<Connector> {
-        hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::default())
-            .pool_idle_timeout(idle_timeout)
-            .pool_timer(hyper_util::rt::TokioTimer::new())
-            .build(Connector::default())
-    }
-
     pub fn into_response(response: hyper::Response<Incoming>) -> HttpResponse {
         response.map(Body::Incoming)
     }

--- a/libdd-common/src/http_common.rs
+++ b/libdd-common/src/http_common.rs
@@ -135,6 +135,16 @@ mod native {
             .build(Connector::default())
     }
 
+    /// Create a pooling hyper client that evicts connections after `idle_timeout`.
+    pub fn new_client_with_connection_pool_idle_timeout(
+        idle_timeout: core::time::Duration,
+    ) -> GenericHttpClient<Connector> {
+        hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::default())
+            .pool_idle_timeout(idle_timeout)
+            .pool_timer(hyper_util::rt::TokioTimer::new())
+            .build(Connector::default())
+    }
+
     pub fn into_response(response: hyper::Response<Incoming>) -> HttpResponse {
         response.map(Body::Incoming)
     }

--- a/libdd-data-pipeline/src/trace_exporter/mod.rs
+++ b/libdd-data-pipeline/src/trace_exporter/mod.rs
@@ -1369,6 +1369,12 @@ mod tests {
             LOG_CAPTURE.with(|c| c.borrow_mut().clear());
             Self(NativeCapabilities::new_client())
         }
+
+        fn new_without_connection_pooling() -> Self {
+            LOG_CAPTURE.with(|c| c.borrow_mut().clear());
+            Self(NativeCapabilities::new_without_connection_pooling())
+        }
+
         fn request(
             &self,
             req: http::Request<bytes::Bytes>,

--- a/libdd-telemetry/src/worker/http_client.rs
+++ b/libdd-telemetry/src/worker/http_client.rs
@@ -59,11 +59,6 @@ pub fn request_builder(c: &Config) -> anyhow::Result<HttpRequestBuilder> {
             );
             let mut builder =
                 e.to_request_builder(concat!("telemetry/", env!("CARGO_PKG_VERSION")));
-            // Telemetry sends are heartbeat-paced (tens of seconds apart), longer
-            // than the agent's HTTP keep-alive, so pooled connections are typically
-            // half-closed by the next send and EOF on reuse. `Connection: close`
-            // forces a fresh socket per request.
-            builder = Ok(builder?.header(http::header::CONNECTION, "close"));
             if c.debug_enabled {
                 debug!(
                     telemetry.debug_enabled = true,

--- a/libdd-telemetry/src/worker/mod.rs
+++ b/libdd-telemetry/src/worker/mod.rs
@@ -1281,7 +1281,7 @@ impl TelemetryWorkerBuilder {
         let config = self.config;
         let telemetry_heartbeat_interval = config.telemetry_heartbeat_interval;
         let telemetry_extended_heartbeat_interval = config.telemetry_extended_heartbeat_interval;
-        let capabilities = C::new_client();
+        let capabilities = C::new_without_connection_pooling();
 
         let metrics_flush_interval =
             telemetry_heartbeat_interval.min(MetricBuckets::METRICS_FLUSH_INTERVAL);

--- a/libdd-telemetry/src/worker/mod.rs
+++ b/libdd-telemetry/src/worker/mod.rs
@@ -54,6 +54,9 @@ use tracing::debug;
 
 const CONTINUE: ControlFlow<()> = ControlFlow::Continue(());
 const BREAK: ControlFlow<()> = ControlFlow::Break(());
+// Stay below the Agent's 60-second HTTP idle timeout so the client evicts pooled
+// connections before an Agent-side close can race the next telemetry request.
+const HTTP_CLIENT_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(45);
 
 fn time_now() -> f64 {
     time::SystemTime::UNIX_EPOCH
@@ -1281,7 +1284,8 @@ impl TelemetryWorkerBuilder {
         let config = self.config;
         let telemetry_heartbeat_interval = config.telemetry_heartbeat_interval;
         let telemetry_extended_heartbeat_interval = config.telemetry_extended_heartbeat_interval;
-        let capabilities = C::new_client();
+        let capabilities =
+            C::new_client_with_connection_pool_idle_timeout(HTTP_CLIENT_POOL_IDLE_TIMEOUT);
 
         let metrics_flush_interval =
             telemetry_heartbeat_interval.min(MetricBuckets::METRICS_FLUSH_INTERVAL);
@@ -1372,6 +1376,9 @@ impl TelemetryWorkerBuilder {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::Duration;
+
     use crate::config::TelemetryEndpoint;
     use crate::data::Payload;
     use crate::worker::http_client::header::{
@@ -1381,11 +1388,64 @@ mod tests {
         LifecycleAction, TelemetryActions, TelemetryWorker, TelemetryWorkerBuilder,
         TelemetryWorkerFlavor, TelemetryWorkerHandle,
     };
+    use bytes::Bytes;
+    use libdd_capabilities::{HttpClientCapability, HttpError, SleepCapability};
     use libdd_capabilities_impl::NativeCapabilities;
     use tokio::runtime::Runtime;
 
+    static CLIENT_POOL_IDLE_TIMEOUT_SECS: AtomicU64 = AtomicU64::new(0);
+
+    #[derive(Clone, Debug)]
+    struct CapturingCapabilities;
+
+    impl HttpClientCapability for CapturingCapabilities {
+        fn new_client() -> Self {
+            Self
+        }
+
+        fn new_client_with_connection_pool_idle_timeout(idle_timeout: Duration) -> Self {
+            CLIENT_POOL_IDLE_TIMEOUT_SECS.store(idle_timeout.as_secs(), Ordering::Relaxed);
+            Self
+        }
+
+        async fn request(
+            &self,
+            _req: http::Request<Bytes>,
+        ) -> Result<http::Response<Bytes>, HttpError> {
+            panic!("request should not be called while building a worker")
+        }
+    }
+
+    impl SleepCapability for CapturingCapabilities {
+        fn new() -> Self {
+            Self
+        }
+
+        async fn sleep(&self, _duration: Duration) {}
+    }
+
     fn is_send<T: Send>(_: T) {}
     fn is_sync<T: Sync>(_: T) {}
+
+    #[test]
+    fn telemetry_client_pool_idle_timeout_is_45_seconds() {
+        CLIENT_POOL_IDLE_TIMEOUT_SECS.store(0, Ordering::Relaxed);
+        let builder = TelemetryWorkerBuilder::new(
+            "h".into(),
+            "svc".into(),
+            "lang".into(),
+            "1".into(),
+            "tv".into(),
+        );
+        let runtime = Runtime::new().unwrap();
+
+        let _ = builder.build_worker::<CapturingCapabilities>(Some(runtime.handle().clone()));
+
+        assert_eq!(
+            CLIENT_POOL_IDLE_TIMEOUT_SECS.load(Ordering::Relaxed),
+            Duration::from_secs(45).as_secs()
+        );
+    }
 
     #[test]
     fn test_handle_sync_send() {

--- a/libdd-telemetry/src/worker/mod.rs
+++ b/libdd-telemetry/src/worker/mod.rs
@@ -54,9 +54,6 @@ use tracing::debug;
 
 const CONTINUE: ControlFlow<()> = ControlFlow::Continue(());
 const BREAK: ControlFlow<()> = ControlFlow::Break(());
-// Stay below the Agent's 60-second HTTP idle timeout so the client evicts pooled
-// connections before an Agent-side close can race the next telemetry request.
-const HTTP_CLIENT_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(45);
 
 fn time_now() -> f64 {
     time::SystemTime::UNIX_EPOCH
@@ -1284,8 +1281,7 @@ impl TelemetryWorkerBuilder {
         let config = self.config;
         let telemetry_heartbeat_interval = config.telemetry_heartbeat_interval;
         let telemetry_extended_heartbeat_interval = config.telemetry_extended_heartbeat_interval;
-        let capabilities =
-            C::new_client_with_connection_pool_idle_timeout(HTTP_CLIENT_POOL_IDLE_TIMEOUT);
+        let capabilities = C::new_client();
 
         let metrics_flush_interval =
             telemetry_heartbeat_interval.min(MetricBuckets::METRICS_FLUSH_INTERVAL);
@@ -1376,9 +1372,6 @@ impl TelemetryWorkerBuilder {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicU64, Ordering};
-    use std::time::Duration;
-
     use crate::config::TelemetryEndpoint;
     use crate::data::Payload;
     use crate::worker::http_client::header::{
@@ -1388,64 +1381,11 @@ mod tests {
         LifecycleAction, TelemetryActions, TelemetryWorker, TelemetryWorkerBuilder,
         TelemetryWorkerFlavor, TelemetryWorkerHandle,
     };
-    use bytes::Bytes;
-    use libdd_capabilities::{HttpClientCapability, HttpError, SleepCapability};
     use libdd_capabilities_impl::NativeCapabilities;
     use tokio::runtime::Runtime;
 
-    static CLIENT_POOL_IDLE_TIMEOUT_SECS: AtomicU64 = AtomicU64::new(0);
-
-    #[derive(Clone, Debug)]
-    struct CapturingCapabilities;
-
-    impl HttpClientCapability for CapturingCapabilities {
-        fn new_client() -> Self {
-            Self
-        }
-
-        fn new_client_with_connection_pool_idle_timeout(idle_timeout: Duration) -> Self {
-            CLIENT_POOL_IDLE_TIMEOUT_SECS.store(idle_timeout.as_secs(), Ordering::Relaxed);
-            Self
-        }
-
-        async fn request(
-            &self,
-            _req: http::Request<Bytes>,
-        ) -> Result<http::Response<Bytes>, HttpError> {
-            panic!("request should not be called while building a worker")
-        }
-    }
-
-    impl SleepCapability for CapturingCapabilities {
-        fn new() -> Self {
-            Self
-        }
-
-        async fn sleep(&self, _duration: Duration) {}
-    }
-
     fn is_send<T: Send>(_: T) {}
     fn is_sync<T: Sync>(_: T) {}
-
-    #[test]
-    fn telemetry_client_pool_idle_timeout_is_45_seconds() {
-        CLIENT_POOL_IDLE_TIMEOUT_SECS.store(0, Ordering::Relaxed);
-        let builder = TelemetryWorkerBuilder::new(
-            "h".into(),
-            "svc".into(),
-            "lang".into(),
-            "1".into(),
-            "tv".into(),
-        );
-        let runtime = Runtime::new().unwrap();
-
-        let _ = builder.build_worker::<CapturingCapabilities>(Some(runtime.handle().clone()));
-
-        assert_eq!(
-            CLIENT_POOL_IDLE_TIMEOUT_SECS.load(Ordering::Relaxed),
-            Duration::from_secs(45).as_secs()
-        );
-    }
 
     #[test]
     fn test_handle_sync_send() {


### PR DESCRIPTION
Connection is hop-by-hop, but the Agent telemetry proxy currently copies it into a newly constructed Go request without copying the parsed Request.Close state. The forwarded request therefore carries Connection: close while the Agent transport still considers its connection reusable.

An HTTP/1.1 server that receives the close option must close after the response and SHOULD (but need not) repeat the option in that response. If it omits the response option, the Agent can hand the closing connection to a queued telemetry POST, which then fails with EOF or ECONNRESET.

Remove the header to work-around this bug.

See 73f23a2c03be39971c966e444785d63b6fd52e81

See also https://github.com/DataDog/system-tests/pull/7394

BREAKING CHANGE: here to satisfy the fantasy that libdatadog has a stable API; this adds two public functions
