### PR TITLE
fix(sampling): record rate limiter's effective rate on allow, not just drop

### DIFF
--- a/libdd-sampling/src/datadog_sampler.rs
+++ b/libdd-sampling/src/datadog_sampler.rs
@@ -155,10 +155,13 @@ impl DatadogSampler {
 
             if !rule.sample(trace_id) {
                 is_keep = false;
-            } else if !self.rate_limiter.is_allowed() {
-                // Rule kept the span, but the rate limiter dropped it.
-                is_keep = false;
+            } else {
+                // Record the limiter's effective rate whether it allows or drops the trace.
+                let allowed = self.rate_limiter.is_allowed();
                 rl_effective_rate = Some(self.rate_limiter.effective_rate());
+                if !allowed {
+                    is_keep = false;
+                }
             }
         } else {
             let service_key = self.service_key(span);


### PR DESCRIPTION
## What

`DatadogSampler::sample_root` only recorded `rl_effective_rate` (the rate
limiter's effective accept rate, wired as `_dd.limit_psr`) when the rate
limiter *dropped* a trace. It should be recorded whenever the limiter is
consulted, regardless of outcome.

## Why this doesn't follow other tracers

- **dd-trace-rb** (`rule_sampler.rb`, `apply_rule!`): calls
  `rate_limiter.allow?.tap { |allowed| ... set_limiter_metrics(trace,
  rate_limiter.effective_rate) ... }` — the effective rate is set inside the
  `.tap` block unconditionally, for both `allowed == true` and `false`.
- **dd-trace-go** (`span.go`): calls `limiter.AllowOne(now)` and then always
  calls `setMetricLocked(keyRulesSamplerLimiterRate, limiterRate)` right
  after, independent of the allow/drop outcome.

libdatadog: `_dd.limit_psr` was only emitted on
rate-limiter-drop, silently omitting it on allow. This matters for the
Datadog Agent's stats extrapolation (`1/psr`), which needs the tag whenever
the limiter was in play, not just when it rejected the trace.

## Change

`sample_root`: once a rule matches and keeps the trace, always call
`self.rate_limiter.effective_rate()` after `is_allowed()`, whether or not
the limiter allowed it.

## Tests

`cargo test -p libdd-sampling`: 104 lib + 2 doctests pass. fmt and clippy
clean.