### PR TITLE
fix(sidecar): send eof chunk in datagram test

### DIFF
--- a/datadog-sidecar/src/crashtracker.rs
+++ b/datadog-sidecar/src/crashtracker.rs
@@ -299,7 +299,12 @@ mod tests {
         let writer = tokio::task::spawn_blocking(move || {
             let refs: Vec<&[u8]> = chunks.iter().map(|c| c.as_slice()).collect();
             send_datagrams(&a, &refs);
-            // Drop `a` to signal EOF to the reader.
+            // Signal EOF with the protocol's zero-length datagram sentinel
+            // Relying on `drop(a)` alone hangs on
+            // macOS bc closing an AF_UNIX SOCK_DGRAM peer there does not deliver a
+            // readable EOF event, so the reader would never wake
+            let eof: &[u8] = &[];
+            send_datagrams(&a, &[eof]);
             drop(a);
         });
 


### PR DESCRIPTION
# What does this PR do?
`SeqpacketStreamReader`'s EOF contract is: a zero-length datagram signals EOF (or a peer-close error). 

The test, however, signaled EOF only by dropping the writer end of the socket pair:

On Linux, the test uses `SOCK_SEQPACKET`, and closing the peer surfaces to the reader as `recv() == 0` / a reset so eof is detected.

On macOS, `SOCK_SEQPACKET` doesn't exist, so the test falls back to `SOCK_DGRAM`. On Darwin, closing an `AF_UNIX` datagram peer does not deliver a readable EOF event, so tokio's `AsyncFd` sometimes never wakes again and `read_to_end` blocks forever.

This is a race because
Writer closes early (before reader parks) --> the close rides along on an already-pending readable edge so it passes.
but if reader parks first --> no wakeup ever arrives so we hang.

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
