### PR TITLE
chore(libdd-tracer-flare): prepare tracer flare for publishing

### DIFF
--- a/libdd-tracer-flare/Cargo.toml
+++ b/libdd-tracer-flare/Cargo.toml
@@ -6,14 +6,13 @@ rust-version.workspace = true
 edition.workspace = true
 license.workspace = true
 autobenches = false
-publish = false
 authors.workspace = true
 homepage = "https://github.com/DataDog/libdatadog/tree/main/libdd-tracer-flare"
 repository = "https://github.com/DataDog/libdatadog/tree/main/libdd-tracer-flare"
 
 [dependencies]
 anyhow = "1.0"
-libdd-remote-config = { path = "../libdd-remote-config", default-features = false }
+libdd-remote-config = { version = "2.0.0", path = "../libdd-remote-config", default-features = false }
 libdd-common = { version = "5.1.0", path = "../libdd-common" }
 libdd-trace-utils = { version = "9.0.0", path = "../libdd-trace-utils" }
 http = "1"


### PR DESCRIPTION
# What does this PR do?

Prepare libdd-tracer-flare to be published.

# Motivation

Migrate downstream projects to use independent versions.
