### PR TITLE
chore(libdd-http-client): prepare crate to be published

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-http-client"
-version = "38.0.0"
+version = "0.1.0"
 dependencies = [
  "bytes",
  "fastrand",

--- a/libdd-http-client/Cargo.toml
+++ b/libdd-http-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libdd-http-client"
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
@@ -8,7 +8,6 @@ authors.workspace = true
 description = "HTTP client library intended for use by other languages via FFI"
 homepage = "https://github.com/DataDog/libdatadog/tree/main/libdd-http-client"
 repository = "https://github.com/DataDog/libdatadog/tree/main/libdd-http-client"
-publish = false
 
 [lib]
 bench = false


### PR DESCRIPTION
# What does this PR do?

Prepare crate for publication.

# Motivation

Allow downstream projects to use independent versions.

