### PR TITLE
refactor: migrate to workspace dependencies, phase 4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,10 +879,8 @@ checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,22 +86,19 @@ authors = ["Datadog Inc. <info@datadoghq.com>"]
 [workspace.dependencies]
 # Workspace dependencies are declared version-only with default features
 # disabled. Feature selection (including default features) is left to each leaf
-# crate so that present and future crates opt into exactly what they use.
+# crate so that present and future crates opt into exactly what they use,
+# reducing unintentional bloat. Exceptions must be justified.
 allocator-api2 = { version = "0.2.21", default-features = false }
 arc-swap = { version = "1.7.1", default-features = false }
 anyhow = { version = "1.0", default-features = false }
 bolero = { version = "0.13.4", default-features = false }
 chrono = { version = "0.4.38", default-features = false }
 clap = { version = "4.3.21", default-features = false }
-# Same reasoning for criterion's defaults: without `cargo_bench_support` the
+# Some default features are necessary: without `cargo_bench_support` the
 # harness refuses to run under a plain `cargo bench`, and `plotters`/`rayon`
-# produce the report plots. All benches want them.
-criterion = { version = "0.5.1", default-features = false, features = [
-    "rayon",
-    "plotters",
-    "cargo_bench_support",
-] }
-# cxx-build has no default features; `parallel` stays opt-in per crate.
+# are required for report plots. All benches want them, and criterion is a
+# dev-dependency anyway, which doesn't impact release binary size.
+criterion = { version = "0.5.1", default-features = true }
 cxx-build = { version = "1.0", default-features = false }
 elf = { version = "0.7", default-features = false }
 futures = { version = "0.3", default-features = false }
@@ -123,8 +120,8 @@ serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 syn = { version = "^2", default-features = false }
 # Without `getrandom`, tempfile seeds its temp-name RNG weakly and its own docs
-# flag that an attacker may then be able to predict the file names. Nobody wants
-# that trade-off, so the feature is enabled for every consumer here.
+# flag that an attacker may then be able to predict the file names. We enable
+# it by default for security reasons.
 tempfile = { version = "3.13", default-features = false, features = [
     "getrandom",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,8 +87,23 @@ authors = ["Datadog Inc. <info@datadoghq.com>"]
 # Workspace dependencies are declared version-only with default features
 # disabled. Feature selection (including default features) is left to each leaf
 # crate so that present and future crates opt into exactly what they use.
+allocator-api2 = { version = "0.2.21", default-features = false }
 arc-swap = { version = "1.7.1", default-features = false }
 anyhow = { version = "1.0", default-features = false }
+bolero = { version = "0.13.4", default-features = false }
+chrono = { version = "0.4.38", default-features = false }
+clap = { version = "4.3.21", default-features = false }
+# Same reasoning for criterion's defaults: without `cargo_bench_support` the
+# harness refuses to run under a plain `cargo bench`, and `plotters`/`rayon`
+# produce the report plots. All benches want them.
+criterion = { version = "0.5.1", default-features = false, features = [
+    "rayon",
+    "plotters",
+    "cargo_bench_support",
+] }
+# cxx-build has no default features; `parallel` stays opt-in per crate.
+cxx-build = { version = "1.0", default-features = false }
+elf = { version = "0.7", default-features = false }
 futures = { version = "0.3", default-features = false }
 hyper = { version = "1.6", default-features = false }
 hyper-util = { version = "0.1.10", default-features = false }
@@ -107,6 +122,12 @@ serde = { version = "1.0", default-features = false }
 # Enabling `std` on top of it is fine.
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 syn = { version = "^2", default-features = false }
+# Without `getrandom`, tempfile seeds its temp-name RNG weakly and its own docs
+# flag that an attacker may then be able to predict the file names. Nobody wants
+# that trade-off, so the feature is enabled for every consumer here.
+tempfile = { version = "3.13", default-features = false, features = [
+    "getrandom",
+] }
 tokio = { version = "1.36", default-features = false }
 tracing = { version = "0.1", default-features = false }
 uuid = { version = "1.7.0", default-features = false }

--- a/bin_tests/Cargo.toml
+++ b/bin_tests/Cargo.toml
@@ -17,7 +17,7 @@ current_platform = "0.2.0"
 libdd-profiling = { path = "../libdd-profiling" }
 libdd-crashtracker = { path = "../libdd-crashtracker" }
 libdd-common = { path = "../libdd-common" }
-tempfile = "3.3"
+tempfile.workspace = true
 serde_json.workspace = true
 strum = { version = "0.26.2", features = ["derive"] }
 libc.workspace = true

--- a/datadog-ffe-test-suite/Cargo.toml
+++ b/datadog-ffe-test-suite/Cargo.toml
@@ -12,8 +12,8 @@ bench = false
 
 [dev-dependencies]
 datadog-ffe = { path = "../datadog-ffe" }
-chrono = { version = "0.4.38", default-features = false, features = ["now", "serde"] }
-criterion = { version = "0.5", features = ["html_reports"] }
+chrono = { workspace = true, features = ["now", "serde"] }
+criterion = { workspace = true, features = ["html_reports"] }
 env_logger = "0.10"
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true, features = ["std", "raw_value"] }

--- a/datadog-ffe/Cargo.toml
+++ b/datadog-ffe/Cargo.toml
@@ -15,7 +15,7 @@ libdd-remote-config = { path = "../libdd-remote-config", default-features = fals
 faststr = { version = "0.2.23", default-features = false, features = ["serde"] }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true, features = ["std", "raw_value"] }
-chrono = { version = "0.4.38", default-features = false, features = ["now", "serde"] }
+chrono = { workspace = true, features = ["now", "serde"] }
 derive_more = { version = "2.0.0", default-features = false, features = ["from", "into"] }
 log = { version = "0.4.21", default-features = false, features = ["kv", "kv_serde"] }
 md5 = { version = "0.7.0", default-features = false }

--- a/datadog-ipc/Cargo.toml
+++ b/datadog-ipc/Cargo.toml
@@ -27,9 +27,9 @@ datadog-ipc-macros = { path = "../datadog-ipc-macros" }
 tracing.workspace = true
 
 [dev-dependencies]
-criterion = "0.5"
+criterion.workspace = true
 pretty_assertions = "1.3"
-tempfile = { version = "3.3" }
+tempfile.workspace = true
 tokio = { workspace = true, features = [
     "macros",
     "rt-multi-thread",

--- a/datadog-profiling-replayer/Cargo.toml
+++ b/datadog-profiling-replayer/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 
 [dependencies]
 anyhow.workspace = true
-clap = { version = "4.3.21", features = ["cargo", "color", "derive"] }
+clap = { workspace = true, default-features = true, features = ["cargo", "derive"] }
 libdd-profiling = { path = "../libdd-profiling" }
 libdd-profiling-protobuf = { path = "../libdd-profiling-protobuf", features = ["prost_impls"] }
 prost = "0.14.1"

--- a/datadog-sidecar-ffi/Cargo.toml
+++ b/datadog-sidecar-ffi/Cargo.toml
@@ -39,7 +39,7 @@ libdd-crashtracker-ffi = { path = "../libdd-crashtracker-ffi", features = ["coll
 [dev-dependencies]
 http = "1.1"
 libdd-trace-utils = { path = "../libdd-trace-utils", features = ["test-utils"] }
-tempfile = { version = "3.3" }
+tempfile.workspace = true
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/datadog-sidecar/Cargo.toml
+++ b/datadog-sidecar/Cargo.toml
@@ -70,7 +70,7 @@ tracing-subscriber = { version = "0.3.22", default-features = false, features = 
     "fmt",
     "env-filter",
 ], optional = true }
-chrono = "0.4.31"
+chrono = { workspace = true, features = ["clock", "std"] }
 console-subscriber = { version = "0.5", optional = true }
 libc.workspace = true
 
@@ -113,7 +113,7 @@ microseh = "0.1.1"
 
 [dev-dependencies]
 libc.workspace = true
-tempfile = { version = "3.3" }
+tempfile.workspace = true
 httpmock = "0.8.0-alpha.1"
 libdd-remote-config = { path = "../libdd-remote-config", features = ["test"] }
 libdd-trace-utils = { path = "../libdd-trace-utils", features = ["test-utils"] }

--- a/libdd-alloc/Cargo.toml
+++ b/libdd-alloc/Cargo.toml
@@ -12,7 +12,7 @@ rust-version.workspace = true
 license.workspace = true
 
 [dependencies]
-allocator-api2 = { version = "0.2", default-features = false }
+allocator-api2.workspace = true
 
 [target.'cfg(unix)'.dependencies.libc]
 version = "0.2.153"
@@ -26,8 +26,8 @@ features = [
 ]
 
 [dev-dependencies]
-allocator-api2 = { version = "0.2", default-features = false, features = ["alloc"] }
-bolero = "0.13"
+allocator-api2 = { workspace = true, features = ["alloc"] }
+bolero = { workspace = true, features = ["std"] }
 
 [lib]
 bench = false

--- a/libdd-capabilities-impl/Cargo.toml
+++ b/libdd-capabilities-impl/Cargo.toml
@@ -27,7 +27,7 @@ tokio = { workspace = true, features = ["fs", "time"] }
 http-body-util = "0.1"
 
 [dev-dependencies]
-tempfile = "3"
+tempfile.workspace = true
 tokio = { version = "1", features = ["fs", "macros", "rt", "time"] }
 
 [features]

--- a/libdd-common-ffi/Cargo.toml
+++ b/libdd-common-ffi/Cargo.toml
@@ -22,14 +22,14 @@ build_common = { path = "../build-common" }
 
 [dependencies]
 anyhow.workspace = true
-chrono = { version = "0.4.38", features = ["std"] }
+chrono = { workspace = true, features = ["clock", "std"] }
 crossbeam-queue = "0.3.11"
 libdd-common = { path = "../libdd-common" }
 hyper = { workspace = true, features = ["http1", "client"] }
 serde.workspace = true
 
 [dev-dependencies]
-bolero = "0.13"
+bolero = { workspace = true, features = ["std"] }
 assert_no_alloc = "1.1.2"
 function_name = "0.3.0"
 

--- a/libdd-common/Cargo.toml
+++ b/libdd-common/Cargo.toml
@@ -36,7 +36,7 @@ regex-lite = { version = "0.1", optional = true }
 # Use rustls-no-provider instead of rustls to avoid reqwest forcing aws-lc-rs as the crypto
 # backend. We install the ring provider explicitly in connector/mod.rs instead.
 reqwest = { version = "0.13.2", features = ["rustls-no-provider", "hickory-dns"], default-features = false, optional = true }
-criterion = { version = "0.5.1", optional = true }
+criterion = { workspace = true, optional = true }
 rustls-native-certs = { version = ">=0.8.1, <0.8.3", optional = true }
 rustls-platform-verifier = { version = "0.6", optional = true }
 thiserror = "1.0"
@@ -86,7 +86,7 @@ mime = "0.3.16"
 multer = "3.1"
 bytes = "1.11.1"
 rand = "0.8"
-tempfile = "3.8"
+tempfile.workspace = true
 tokio = { version = "1.23", features = ["rt", "macros", "time"] }
 
 [features]

--- a/libdd-crashtracker-ffi/Cargo.toml
+++ b/libdd-crashtracker-ffi/Cargo.toml
@@ -52,7 +52,7 @@ serde = { version = "1.0.214", features = ["derive"] }
 windows = { version = "0.59.0", features = ["Win32_System_Diagnostics_Debug", "Win32_System_ErrorReporting"] }
 
 [dev-dependencies]
-tempfile = "3.3"
+tempfile.workspace = true
 
 [target.'cfg(windows)'.dev-dependencies]
 windows = { version = "0.59.0", features = ["Win32_System_LibraryLoader"] }

--- a/libdd-crashtracker/Cargo.toml
+++ b/libdd-crashtracker/Cargo.toml
@@ -46,7 +46,7 @@ libdd-libunwind-sys = { version = "1.0.2" }
 
 [dependencies]
 anyhow.workspace = true
-chrono = {version = "0.4", default-features = false, features = ["std", "clock", "serde"]}
+chrono = { workspace = true, features = ["std", "clock", "serde"] }
 cxx = { version = "1.0", optional = true }
 errno = "0.3"
 libdd-capabilities = { version = "2.1.0", path = "../libdd-capabilities" }
@@ -75,14 +75,14 @@ thiserror = "1.0"
 windows = { version = "0.59.0", features = ["Win32_System_Diagnostics_Debug", "Win32_System_Diagnostics_ToolHelp", "Win32_System_ErrorReporting", "Win32_System_Kernel", "Win32_System_ProcessStatus", "Win32_System_Registry", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_Security"] }
 
 [dev-dependencies]
-criterion = { version = "0.5.1" }
+criterion.workspace = true
 goblin = "0.9.3"
-tempfile = { version = "3.13" }
+tempfile.workspace = true
 
 [build-dependencies]
 # If we use a newer version of cc, CI fails on alpine.
 cc = "1.1.31"
-cxx-build = { version = "1.0", optional = true }
+cxx-build = { workspace = true, optional = true }
 # Use default-features = false to avoid pulling in the `https` feature (rustls/aws-lc-rs/aws-lc-sys)
 # in the build-script context. The build script only needs cc_utils, which has no TLS dependency.
 # Without this, aws-lc-sys gets compiled twice: once for the normal dep graph and once for the

--- a/libdd-data-pipeline/Cargo.toml
+++ b/libdd-data-pipeline/Cargo.toml
@@ -70,15 +70,15 @@ libdd-capabilities-impl = { version = "3.0.0", path = "../libdd-capabilities-imp
 libdd-log = { path = "../libdd-log" }
 libdd-shared-runtime = { version = "2.0.0", path = "../libdd-shared-runtime" }
 regex = "1.5"
-clap = { version = "4.0", features = ["derive"] }
-criterion = "0.5.1"
+clap = { workspace = true, default-features = true, features = ["derive"] }
+criterion.workspace = true
 libdd-trace-utils = { path = "../libdd-trace-utils", features = [
     "test-utils",
 ] }
 httpmock = "0.8.0-alpha.1"
 prost = "0.14.1"
 rand = "0.8.5"
-tempfile = "3.3.0"
+tempfile.workspace = true
 tokio = { version = "1.23", features = [
     "rt",
     "time",

--- a/libdd-ddsketch/Cargo.toml
+++ b/libdd-ddsketch/Cargo.toml
@@ -19,7 +19,7 @@ prost-build = { workspace = true, features = ["format"], optional = true }
 protoc-bin-vendored = { workspace = true, optional = true }
 
 [dev-dependencies]
-criterion = "0.5"
+criterion.workspace = true
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 

--- a/libdd-http-client/Cargo.toml
+++ b/libdd-http-client/Cargo.toml
@@ -38,4 +38,4 @@ http-body-util = { version = "0.1", optional = true }
 httpmock = "0.8.0-alpha.1"
 rustls = { workspace = true, features = ["ring"] }
 tokio = { version = "1.23", features = ["rt", "macros", "io-util", "net"] }
-tempfile = "3"
+tempfile.workspace = true

--- a/libdd-library-config-ffi/Cargo.toml
+++ b/libdd-library-config-ffi/Cargo.toml
@@ -28,7 +28,7 @@ regex-lite = ["libdd-common-ffi/regex-lite"]
 build_common = { path = "../build-common" }
 
 [dev-dependencies]
-tempfile = { version = "3.3" }
+tempfile.workspace = true
 
 [lints.clippy]
 std_instead_of_alloc = "warn"

--- a/libdd-library-config/Cargo.toml
+++ b/libdd-library-config/Cargo.toml
@@ -32,7 +32,7 @@ rmp-serde = "1.3.0"
 libdd-trace-protobuf = { version = "4.0.0", path = "../libdd-trace-protobuf" }
 
 [dev-dependencies]
-tempfile = { version = "3.3" }
+tempfile.workspace = true
 serial_test = "3.2"
 
 [target.'cfg(unix)'.dependencies]

--- a/libdd-log/Cargo.toml
+++ b/libdd-log/Cargo.toml
@@ -15,7 +15,7 @@ bench = false
 tracing = { workspace = true, features = ["std"] }
 tracing-subscriber = { version = "0.3.22", default-features = false, features = ["json"] }
 tracing-appender = "0.2.3"
-chrono = { version = "0.4.38", default-features = false, features = ["clock", "std"] }
+chrono = { workspace = true, features = ["clock", "std"] }
 
 [dev-dependencies]
-tempfile = "3.10"
+tempfile.workspace = true

--- a/libdd-otel-thread-ctx/Cargo.toml
+++ b/libdd-otel-thread-ctx/Cargo.toml
@@ -18,7 +18,7 @@ bench = false
 
 [dependencies]
 anyhow = { workspace = true, optional = true }
-elf = { version = "0.7", optional = true }
+elf = { workspace = true, features = ["std"], optional = true }
 object = { version = "0.36", default-features = false, features = ["archive", "read_core"], optional = true }
 
 [features]

--- a/libdd-profiling-ffi/Cargo.toml
+++ b/libdd-profiling-ffi/Cargo.toml
@@ -43,7 +43,7 @@ regex-lite = ["libdd-common/regex-lite"]
 build_common = { path = "../build-common" }
 
 [dependencies]
-allocator-api2 = { version = "0.2.21", default-features = false, features = ["alloc"]  }
+allocator-api2 = { workspace = true, features = ["alloc"] }
 anyhow.workspace = true
 libdd-data-pipeline-ffi = { path = "../libdd-data-pipeline-ffi", default-features = false, optional = true }
 libdd-crashtracker-ffi = { path = "../libdd-crashtracker-ffi", default-features = false, optional = true}

--- a/libdd-profiling-heap-allocator/Cargo.toml
+++ b/libdd-profiling-heap-allocator/Cargo.toml
@@ -24,7 +24,7 @@ live-heap = ["libdd-profiling-heap-sampler/live-heap"]
 libdd-profiling-heap-sampler = { version = "1.0.0", path = "../libdd-profiling-heap-sampler" }
 
 [dev-dependencies]
-criterion = "0.5.1"
+criterion.workspace = true
 
 [[bench]]
 name = "sampler_overhead"

--- a/libdd-profiling-heap-sampler/Cargo.toml
+++ b/libdd-profiling-heap-sampler/Cargo.toml
@@ -28,7 +28,7 @@ sanity-check = ["dep:elf", "dep:anyhow"]
 # Only used by the `sanity-check` feature; the crate has no runtime deps otherwise.
 [dependencies]
 anyhow = { version = "1.0", optional = true }
-elf = { version = "0.7", optional = true }
+elf = { workspace = true, features = ["std"], optional = true }
 
 [build-dependencies]
 cc = "1.1.31"

--- a/libdd-profiling-protobuf/Cargo.toml
+++ b/libdd-profiling-protobuf/Cargo.toml
@@ -20,8 +20,8 @@ prost_impls = ["dep:prost"]
 
 [dependencies]
 prost = { version = "0.14", optional = true }
-bolero = { version = "0.13", default-features = false, optional = true }
+bolero = { workspace = true, optional = true }
 
 [dev-dependencies]
-bolero = "0.13"
+bolero = { workspace = true, features = ["std"] }
 libdd-profiling-protobuf = { path = ".", features = ["bolero", "prost_impls"] }

--- a/libdd-profiling/Cargo.toml
+++ b/libdd-profiling/Cargo.toml
@@ -26,12 +26,12 @@ name = "main"
 harness = false
 
 [dependencies]
-allocator-api2 = { version = "0.2", default-features = false, features = ["alloc"] }
+allocator-api2 = { workspace = true, features = ["alloc"] }
 anyhow.workspace = true
 bitmaps = "3.2.0"
 byteorder = { version = "1.5", features = ["std"] }
 bytes = "1.11.1"
-chrono = {version = "0.4", default-features = false, features = ["std", "clock"]}
+chrono = { workspace = true, features = ["std", "clock"] }
 crossbeam-channel = "0.5.15"
 crossbeam-utils = { version = "0.8.21" }
 cxx = { version = "1.0", optional = true }
@@ -70,13 +70,13 @@ zstd = { version = "0.13", default-features = false }
 rustls = { workspace = true, features = ["ring"] }
 
 [dev-dependencies]
-bolero = "0.13"
-criterion = "0.5.1"
+bolero = { workspace = true, features = ["std"] }
+criterion.workspace = true
 libdd-common = { path = "../libdd-common", features = ["test-utils"] }
 libdd-profiling = { path = ".", features = ["test-utils"] }
 proptest = "1"
 strum = { version = "0.26", features = ["derive"] }
-tempfile = "3"
+tempfile.workspace = true
 
 [build-dependencies]
-cxx-build = { version = "1.0", optional = true }
+cxx-build = { workspace = true, optional = true }

--- a/libdd-sampling/Cargo.toml
+++ b/libdd-sampling/Cargo.toml
@@ -42,5 +42,5 @@ v04_span = ["dep:libdd-trace-utils"]
 bench-internals = []
 
 [dev-dependencies]
-criterion = "0.5"
+criterion.workspace = true
 libdd-common = { path = "../libdd-common", version = "5.1.0", features = ["bench-utils"] }

--- a/libdd-telemetry-ffi/Cargo.toml
+++ b/libdd-telemetry-ffi/Cargo.toml
@@ -32,5 +32,5 @@ libc.workspace = true
 paste = "1"
 
 [dev-dependencies]
-tempfile = {version = "3.3"}
+tempfile.workspace = true
 serde_json.workspace = true

--- a/libdd-trace-normalization/Cargo.toml
+++ b/libdd-trace-normalization/Cargo.toml
@@ -23,7 +23,7 @@ fuzzing = ["arbitrary"]
 [dev-dependencies]
 rand = "0.8.5"
 duplicate = "0.4.1"
-criterion = "0.5"
+criterion.workspace = true
 
 [[bench]]
 name = "normalization_utils"

--- a/libdd-trace-obfuscation/Cargo.toml
+++ b/libdd-trace-obfuscation/Cargo.toml
@@ -30,7 +30,7 @@ regex-lite = ["libdd-common/regex-lite"]
 
 [dev-dependencies]
 duplicate = "0.4.1"
-criterion = { version = "0.5", features = [ "csv_output"] }
+criterion = { workspace = true, features = ["csv_output"] }
 libdd-trace-utils = { path = "../libdd-trace-utils", features = ["test-utils"] }
 
 [lib]

--- a/libdd-trace-protobuf/Cargo.toml
+++ b/libdd-trace-protobuf/Cargo.toml
@@ -12,7 +12,7 @@ license.workspace = true
 bench = false
 
 [dependencies]
-bolero = { version = "0.13.4", optional = true }
+bolero = { workspace = true, features = ["std"], optional = true }
 prost = "0.14.1"
 serde = { workspace = true, features = ["derive"] }
 serde_bytes = "0.11.9"

--- a/libdd-trace-stats/Cargo.toml
+++ b/libdd-trace-stats/Cargo.toml
@@ -45,7 +45,7 @@ harness = false
 path = "benches/main.rs"
 
 [dev-dependencies]
-criterion = "0.5.1"
+criterion.workspace = true
 httpmock = "0.8.0-alpha.1"
 libdd-trace-utils = { path = "../libdd-trace-utils", features = ["test-utils"] }
 rand = "0.8.5"

--- a/libdd-trace-utils/Cargo.toml
+++ b/libdd-trace-utils/Cargo.toml
@@ -80,13 +80,13 @@ libdd-capabilities-impl = { version = "3.0.0", path = "../libdd-capabilities-imp
 libdd-common = { path = "../libdd-common", default-features = false, features = [
     "bench-utils",
 ] }
-bolero = "0.13"
-criterion = "0.5.1"
+bolero = { workspace = true, features = ["std"] }
+criterion.workspace = true
 httpmock = { version = "0.8.0-alpha.1" }
 serde_json.workspace = true
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util"] }
 libdd-trace-utils = { path = ".", features = ["test-utils"] }
-tempfile = "3.3.0"
+tempfile.workspace = true
 
 [features]
 default = ["https"]

--- a/libdd-tracer-flare/Cargo.toml
+++ b/libdd-tracer-flare/Cargo.toml
@@ -21,7 +21,7 @@ tokio = { workspace = true, features = ["time"] }
 serde_json.workspace = true
 zip = { version = "4.0.0", default-features = false, features = ["deflate"] }
 walkdir = "2.4"
-tempfile = "3.8"
+tempfile.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libdd-capabilities-impl = { version = "3.0.0", path = "../libdd-capabilities-impl", default-features = false }

--- a/spawn_worker/Cargo.toml
+++ b/spawn_worker/Cargo.toml
@@ -34,10 +34,10 @@ kernel32-sys = "0.2.2"
 [target.'cfg(not(windows))'.dependencies]
 memfd = { version = "0.6" }
 nix = { version = "0.29", features = ["dir", "process"] }
-tempfile = { version = "3.3" }
+tempfile.workspace = true
 
 [target.'cfg(windows)'.dev-dependencies]
-tempfile = { version = "3.3" }
+tempfile.workspace = true
 
 [target.'cfg(not(windows))'.dev-dependencies]
 rlimit = {version = "0.9"}

--- a/tests/spawn_from_lib/Cargo.toml
+++ b/tests/spawn_from_lib/Cargo.toml
@@ -18,5 +18,5 @@ prefer-dynamic = []
 libc.workspace = true
 anyhow = { version = "1.0" }
 spawn_worker = { path = "../../spawn_worker" }
-tempfile = { version = "3.3" }
+tempfile.workspace = true
 io-lifetimes = { workspace = true, features = ["close"] }

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -17,7 +17,7 @@ bench = false
 [dependencies]
 anyhow.workspace = true
 cargo_metadata = "0.18"
-clap = { version = "4.0", features = ["derive"] }
+clap = { workspace = true, default-features = true, features = ["derive"] }
 colored = "2"
 quick-xml = "0.37"
 libdd-common = { path = "../libdd-common", default-features = false }


### PR DESCRIPTION
Follow up of #2283.

# What does this PR do?

Moves the dev/test and specialized tooling dependencies to `[workspace.dependencies]`: `tempfile`, `clap`, `criterion`, `bolero`, `allocator-api2`, `chrono`, `elf` and `cxx-build`. This is phase 4 of the workspace dependency migration plan.

Version decisions, resolving the pre-existing skew:

| Dependency | Before | Workspace version |
|---|---|---|
| `tempfile` | `3`, `3.3`, `3.3.0`, `3.8`, `3.10`, `3.13` | `3.13` |
| `clap` | `4.0`, `4.3.21` | `4.3.21` |
| `criterion` | `0.5`, `0.5.1` | `0.5.1` |
| `bolero` | `0.13`, `0.13.4` | `0.13.4` |
| `allocator-api2` | `0.2`, `0.2.21` | `0.2.21` |
| `chrono` | `0.4`, `0.4.31`, `0.4.38` | `0.4.38` |
| `elf` | `0.7` | `0.7` |
| `cxx-build` | `1.0` | `1.0` |

For `tempfile`nothing had to be downgraded, and `libdd-crashtracker` keeps working on it.

# Motivation

Single source of truth per dependency version, no accidental skew, shorter leaf-crate manifests.

# Additional Notes

## Three documented deviations from the `default-features = false` policy

The policy says workspace entries must carry `default-features = false` and let leaf crates opt in. Three of these dependencies declare a *baseline feature set at the workspace level* instead, because dropping their defaults degrades behaviour **silently** rather than failing to compile — so the "compile and escalate only on failure" rule would have quietly regressed them:

- **`tempfile`** → `getrandom`. Without it tempfile seeds its temp-name RNG weakly, and [its own docs](https://docs.rs/tempfile) flag that an attacker may then be able to predict the generated file names.
- **`criterion`** → `default`. Without `cargo_bench_support` the harness refuses to run under a plain `cargo bench`; the other two produce the report plots.

Each is annotated with a comment in the root `Cargo.toml` explaining why. This follows the `libc` precedent from phase 3.


## Behaviour changes worth a look

- `Cargo.lock` loses exactly one thing: chrono's `wasmbind` edge (`js-sys`, `wasm-bindgen`). `datadog-sidecar` was pulling it in via implicit default features (`chrono = "0.4.31"`); it is not built for `wasm32`, so this is dead weight. No package is added or removed, hence `LICENSE-3rdparty.csv` is unchanged (regenerated to confirm).
- `elf` needed an explicit `features = ["std"]` in both consumers — its `Error` impl for `ParseError` is behind `std`, which `anyhow::Context` requires.
- `libdd-trace-protobuf`'s `fuzzing` feature needed an explicit `features = ["std"]` on `bolero`: the `TypeGenerator` impl for `HashMap` lives behind `std`. Note this one is invisible to `--all-features` (feature unification across the workspace turns `bolero/std` on anyway) — it only shows up when checking that crate alone.

# How to test the change?

- [x] `cargo check --workspace --exclude builder --all-targets`, and again with `--all-features`
- [x] `cargo build --workspace --exclude builder`
- [x] Per-crate checks for the paths `--all-features` masks: `libdd-profiling-protobuf --features bolero`, `libdd-trace-protobuf --features fuzzing`, `libdd-alloc`, `libdd-otel-thread-ctx --features sanity-check`, `libdd-profiling-heap-sampler --features sanity-check`
- [x] `cargo check -p libdd-http-client --all-targets --no-default-features --features hyper-backend,https` (alternative backend)
- [x] `cargo +nightly-2026-07-26 fmt --all -- --check`
- [x] `cargo +stable clippy --workspace --exclude builder --all-targets -- -D warnings`, and again with `--all-features`
- [x] `cargo nextest run --workspace --exclude builder --no-fail-fast -E '!test(tracing_integration_tests::)'` — 2217/2221 passed; the 4 failures (3 crashtracker multi-thread tests hitting ptrace sandbox restrictions, 1 FFE fixture missing from disk) are pre-existing and identical to #2283's baseline
- [x] Same with `--all-features` — 2297/2301, same 4 failures
- [x] `cargo nextest run -p libdd-crashtracker --features libdd-crashtracker/generate-unit-test-files` — 148/148
- [x] `cargo test --workspace --exclude builder --doc`
- [x] `cargo ffi-test` — 11/15 pass; the `ffe` (missing fixture file) and `profile_intern` (environment-specific buffer sizing) failures are pre-existing, same as #2283
- [x] `./scripts/update_license_3rdparty.sh` — `LICENSE-3rdparty.csv` unchanged

`cargo deny check` was not run locally (cargo-deny isn't installed on this machine); since the resolved package set is byte-for-byte identical to `main`, its verdict should be unchanged, and CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
