### PR TITLE
chore(rc)!: add DEBUG product

### DIFF
--- a/libdd-remote-config/src/path.rs
+++ b/libdd-remote-config/src/path.rs
@@ -40,6 +40,7 @@ pub enum RemoteConfigProduct {
     FfeFlags,
     LiveDebugging,
     LiveDebuggingSymbolDb,
+    Debug,
 }
 
 #[derive(Clone)]

--- a/libdd-remote-config/src/path.rs
+++ b/libdd-remote-config/src/path.rs
@@ -36,6 +36,7 @@ pub enum RemoteConfigProduct {
     FfeFlags,
     LiveDebugger,
     LiveDebuggerSymbolDb,
+    Debug,
 }
 
 impl Display for RemoteConfigProduct {
@@ -51,6 +52,7 @@ impl Display for RemoteConfigProduct {
             RemoteConfigProduct::FfeFlags => "FFE_FLAGS",
             RemoteConfigProduct::LiveDebugger => "LIVE_DEBUGGING",
             RemoteConfigProduct::LiveDebuggerSymbolDb => "LIVE_DEBUGGING_SYMBOL_DB",
+            RemoteConfigProduct::Debug => "DEBUG",
         };
         write!(f, "{str}")
     }
@@ -102,6 +104,7 @@ impl RemoteConfigPath {
                 "FFE_FLAGS" => RemoteConfigProduct::FfeFlags,
                 "LIVE_DEBUGGING" => RemoteConfigProduct::LiveDebugger,
                 "LIVE_DEBUGGING_SYMBOL_DB" => RemoteConfigProduct::LiveDebuggerSymbolDb,
+                "DEBUG" => RemoteConfigProduct::Debug,
                 product => anyhow::bail!("Unknown product {}", product),
             },
             config_id: parts[parts.len() - 2],


### PR DESCRIPTION
# What does this PR do?

This PR adds the `DEBUG` product to the list of known Remote Configuration products.

# Motivation

I _need_ this in order to test a new Remote Configuration integration in `dd-trace-py` (see https://github.com/DataDog/dd-trace-py/pull/19357). Because the list of known Remote Configuration products in `dd-trace-py` is defined as a Python enum derived from the native Remote Configuration Product enum defined in `libdatadog`, the only way I can use the  `DEBUG` product in `dd-trace-py` is to add the `DEBUG` product to `libdatadog`.

I don't think this need is a one time thing or specific to me. Anyone trying to add a new integration in a tracing library that uses the native Remote Configuration client would have the same issue. The only way not to need it would be not to use the `libdatadog` client, which isn't the way of the future as far as I can tell.