### PR TITLE
feat!: RegexCapability

### DIFF
--- a/libdd-capabilities-impl/src/lib.rs
+++ b/libdd-capabilities-impl/src/lib.rs
@@ -10,6 +10,7 @@
 pub mod env;
 pub mod file;
 mod http;
+pub mod regex;
 pub mod sleep;
 
 use core::future::Future;
@@ -20,12 +21,14 @@ pub use file::NativeFileCapability;
 pub use http::NativeHttpClient;
 use libdd_capabilities::{
     http::{BodySender, HttpError, ResponseFuture},
+    regex::{Captures, Match, RegexError},
     MaybeSend,
 };
 pub use libdd_capabilities::{
     EnvCapability, EnvError, FileCapability, FileError, FileMetadata, HttpClientCapability,
-    LogWriterCapability, SleepCapability,
+    LogWriterCapability, RegexCapability, SleepCapability,
 };
+pub use regex::NativeRegexCapability;
 pub use sleep::NativeSleepCapability;
 
 /// Bundle struct for native platform capabilities.
@@ -149,5 +152,37 @@ impl FileCapability for NativeCapabilities {
 
     fn exists(&self, path: &str) -> impl Future<Output = Result<bool, FileError>> + MaybeSend {
         self.file.exists(path)
+    }
+}
+
+impl RegexCapability for NativeCapabilities {
+    type Handle = <NativeRegexCapability as RegexCapability>::Handle;
+
+    fn compile(pattern: &str) -> Result<Self::Handle, RegexError> {
+        NativeRegexCapability::compile(pattern)
+    }
+
+    fn is_match(handle: &Self::Handle, haystack: &str) -> bool {
+        NativeRegexCapability::is_match(handle, haystack)
+    }
+
+    fn find(handle: &Self::Handle, haystack: &str) -> Option<Match> {
+        NativeRegexCapability::find(handle, haystack)
+    }
+
+    fn find_all(handle: &Self::Handle, haystack: &str) -> Vec<Match> {
+        NativeRegexCapability::find_all(handle, haystack)
+    }
+
+    fn captures(handle: &Self::Handle, haystack: &str) -> Option<Captures> {
+        NativeRegexCapability::captures(handle, haystack)
+    }
+
+    fn captures_all(handle: &Self::Handle, haystack: &str) -> Vec<Captures> {
+        NativeRegexCapability::captures_all(handle, haystack)
+    }
+
+    fn pattern(handle: &Self::Handle) -> &str {
+        NativeRegexCapability::pattern(handle)
     }
 }

--- a/libdd-capabilities-impl/src/regex.rs
+++ b/libdd-capabilities-impl/src/regex.rs
@@ -1,0 +1,75 @@
+// Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+//! Native regex capability, backed by `libdd_common::regex_engine`.
+//!
+//! Which underlying engine is used (full `regex` vs `regex_lite`) is decided
+//! by the `regex-lite` / `require-regex-full` features on `libdd-common` — this
+//! impl is agnostic.
+
+use libdd_capabilities::regex::{Captures, Match, RegexCapability, RegexError};
+use libdd_common::regex_engine::{Captures as EngineCaptures, Regex};
+
+#[derive(Clone, Debug)]
+pub struct NativeRegexCapability;
+
+impl RegexCapability for NativeRegexCapability {
+    type Handle = Regex;
+
+    fn compile(pattern: &str) -> Result<Self::Handle, RegexError> {
+        Regex::new(pattern).map_err(|e| RegexError::InvalidPattern {
+            pattern: pattern.to_owned(),
+            message: e.to_string(),
+        })
+    }
+
+    fn is_match(handle: &Self::Handle, haystack: &str) -> bool {
+        handle.is_match(haystack)
+    }
+
+    fn find(handle: &Self::Handle, haystack: &str) -> Option<Match> {
+        handle.find(haystack).map(|m| Match {
+            start: m.start(),
+            end: m.end(),
+        })
+    }
+
+    fn find_all(handle: &Self::Handle, haystack: &str) -> Vec<Match> {
+        handle
+            .find_iter(haystack)
+            .map(|m| Match {
+                start: m.start(),
+                end: m.end(),
+            })
+            .collect()
+    }
+
+    fn captures(handle: &Self::Handle, haystack: &str) -> Option<Captures> {
+        handle.captures(haystack).map(engine_captures_to_owned)
+    }
+
+    fn captures_all(handle: &Self::Handle, haystack: &str) -> Vec<Captures> {
+        handle
+            .captures_iter(haystack)
+            .map(engine_captures_to_owned)
+            .collect()
+    }
+
+    fn pattern(handle: &Self::Handle) -> &str {
+        handle.as_str()
+    }
+}
+
+fn engine_captures_to_owned(caps: EngineCaptures<'_>) -> Captures {
+    Captures {
+        groups: caps
+            .iter()
+            .map(|g| {
+                g.map(|m| Match {
+                    start: m.start(),
+                    end: m.end(),
+                })
+            })
+            .collect(),
+    }
+}

--- a/libdd-capabilities/src/lib.rs
+++ b/libdd-capabilities/src/lib.rs
@@ -8,6 +8,7 @@ pub mod file;
 pub mod http;
 pub mod log_output;
 pub mod maybe_send;
+pub mod regex;
 pub mod sleep;
 pub mod spawn;
 
@@ -18,6 +19,7 @@ pub use self::http::{
     StreamingBodySender,
 };
 pub use self::log_output::LogWriterCapability;
+pub use self::regex::{Captures, Match, RegexCapability, RegexError};
 pub use self::sleep::SleepCapability;
 pub use self::spawn::SpawnError;
 pub use ::http::{Request, Response};

--- a/libdd-capabilities/src/regex.rs
+++ b/libdd-capabilities/src/regex.rs
@@ -1,0 +1,60 @@
+// Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+//! Regex capability trait.
+//!
+//! Callers compile a pattern once into an opaque `Handle` and reuse the handle
+//! for every match. Match results are byte offsets into the caller-owned
+//! haystack, so replacement logic (e.g. `regex::Replacer` expansion) can live
+//! entirely in caller code and stay independent of the backing engine.
+
+use crate::MaybeSend;
+
+/// A single non-overlapping match, expressed as **UTF-8 byte offsets** into the
+/// haystack the caller passed in.
+///
+/// Both impls are required to return byte offsets so callers can safely
+/// `&haystack[m.start..m.end]` regardless of the backing engine. The native
+/// impl gets this for free from `regex`; the wasm impl translates JS's UTF-16
+/// code-unit indices to UTF-8 bytes before returning.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Match {
+    pub start: usize,
+    pub end: usize,
+}
+
+/// Captures for a single match. `groups[0]` is always the full match;
+/// `groups[i]` for `i > 0` is the i-th capture group, or `None` if the group
+/// did not participate in this match.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Captures {
+    pub groups: Vec<Option<Match>>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RegexError {
+    #[error("invalid regex pattern `{pattern}`: {message}")]
+    InvalidPattern { pattern: String, message: String },
+}
+
+pub trait RegexCapability {
+    /// Opaque compiled-pattern handle.
+    type Handle: Clone + std::fmt::Debug + MaybeSend + Sync;
+
+    fn compile(pattern: &str) -> Result<Self::Handle, RegexError>;
+
+    fn is_match(handle: &Self::Handle, haystack: &str) -> bool;
+
+    fn find(handle: &Self::Handle, haystack: &str) -> Option<Match>;
+
+    /// All non-overlapping matches, batched.
+    fn find_all(handle: &Self::Handle, haystack: &str) -> Vec<Match>;
+
+    fn captures(handle: &Self::Handle, haystack: &str) -> Option<Captures>;
+
+    /// All non-overlapping matches with their capture groups, batched.
+    fn captures_all(handle: &Self::Handle, haystack: &str) -> Vec<Captures>;
+
+    /// The source pattern the handle was compiled from.
+    fn pattern(handle: &Self::Handle) -> &str;
+}

--- a/libdd-data-pipeline/src/trace_buffer/mod.rs
+++ b/libdd-data-pipeline/src/trace_buffer/mod.rs
@@ -13,7 +13,9 @@ use std::{
     time::{Duration, Instant},
 };
 
-use libdd_capabilities::{HttpClientCapability, LogWriterCapability, MaybeSend, SleepCapability};
+use libdd_capabilities::{
+    HttpClientCapability, LogWriterCapability, MaybeSend, RegexCapability, SleepCapability,
+};
 use libdd_shared_runtime::{SharedRuntime, Worker};
 
 use crate::trace_exporter::{
@@ -645,7 +647,13 @@ pub trait Export<T>: Send + Debug {
 #[derive(Debug)]
 pub struct DefaultExport<C, R>
 where
-    C: HttpClientCapability + SleepCapability + LogWriterCapability + MaybeSend + Sync + 'static,
+    C: HttpClientCapability
+        + SleepCapability
+        + LogWriterCapability
+        + RegexCapability
+        + MaybeSend
+        + Sync
+        + 'static,
     R: SharedRuntime + std::fmt::Debug + Send + Sync + 'static,
 {
     trace_exporter: TraceExporter<C, R>,
@@ -653,7 +661,13 @@ where
 
 impl<C, R> DefaultExport<C, R>
 where
-    C: HttpClientCapability + SleepCapability + LogWriterCapability + MaybeSend + Sync + 'static,
+    C: HttpClientCapability
+        + SleepCapability
+        + LogWriterCapability
+        + RegexCapability
+        + MaybeSend
+        + Sync
+        + 'static,
     R: SharedRuntime + std::fmt::Debug + Send + Sync + 'static,
 {
     pub fn new(trace_exporter: TraceExporter<C, R>) -> Self {
@@ -663,7 +677,13 @@ where
 
 impl<C, R> Export<libdd_trace_utils::span::v04::SpanBytes> for DefaultExport<C, R>
 where
-    C: HttpClientCapability + SleepCapability + LogWriterCapability + MaybeSend + Sync + 'static,
+    C: HttpClientCapability
+        + SleepCapability
+        + LogWriterCapability
+        + RegexCapability
+        + MaybeSend
+        + Sync
+        + 'static,
     R: SharedRuntime + std::fmt::Debug + Send + Sync + 'static,
 {
     fn export_trace_chunks(

--- a/libdd-data-pipeline/src/trace_exporter/builder.rs
+++ b/libdd-data-pipeline/src/trace_exporter/builder.rs
@@ -19,7 +19,9 @@ use crate::trace_exporter::{
     TracerMetadata, INFO_ENDPOINT,
 };
 use arc_swap::{ArcSwap, ArcSwapOption};
-use libdd_capabilities::{HttpClientCapability, LogWriterCapability, MaybeSend, SleepCapability};
+use libdd_capabilities::{
+    HttpClientCapability, LogWriterCapability, MaybeSend, RegexCapability, SleepCapability,
+};
 use libdd_common::{parse_uri, tag, Endpoint};
 use libdd_dogstatsd_client::DogStatsDClient;
 use libdd_shared_runtime::SharedRuntime;
@@ -555,7 +557,13 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
     /// available on wasm — use [`Self::build_async`] there.
     #[cfg(not(target_arch = "wasm32"))]
     pub fn build<
-        C: HttpClientCapability + SleepCapability + LogWriterCapability + MaybeSend + Sync + 'static,
+        C: HttpClientCapability
+            + SleepCapability
+            + LogWriterCapability
+            + RegexCapability
+            + MaybeSend
+            + Sync
+            + 'static,
     >(
         mut self,
     ) -> Result<TraceExporter<C, R>, TraceExporterError>
@@ -583,7 +591,13 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
     /// context. If [`set_shared_runtime`](Self::set_shared_runtime) was not called, a new
     /// runtime is constructed via [`SharedRuntime::new`].
     pub async fn build_async<
-        C: HttpClientCapability + SleepCapability + LogWriterCapability + MaybeSend + Sync + 'static,
+        C: HttpClientCapability
+            + SleepCapability
+            + LogWriterCapability
+            + RegexCapability
+            + MaybeSend
+            + Sync
+            + 'static,
     >(
         self,
     ) -> Result<TraceExporter<C, R>, TraceExporterError> {
@@ -872,6 +886,7 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
             #[cfg(feature = "telemetry")]
             telemetry: ArcSwapOption::from(telemetry_client.map(Arc::new)),
             health_metrics_enabled: self.health_metrics_enabled,
+            trace_filterer: ArcSwap::from_pointee(TraceFilterer::<C>::with_empty_conf()),
             capabilities,
             workers: TraceExporterWorkers {
                 dogstatsd: dogstatsd_handle,
@@ -884,7 +899,6 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
                 .then(AgentResponsePayloadVersion::new),
             otlp_config,
             agentless_config,
-            trace_filterer: ArcSwap::from_pointee(TraceFilterer::with_empty_conf()),
             otlp_stats_enabled,
             log_output,
             restart_after_fork: self.restart_after_fork,

--- a/libdd-data-pipeline/src/trace_exporter/mod.rs
+++ b/libdd-data-pipeline/src/trace_exporter/mod.rs
@@ -40,7 +40,9 @@ use futures::stream::{FuturesUnordered, StreamExt};
 use http::header::HeaderMap;
 use http::uri::PathAndQuery;
 use http::Uri;
-use libdd_capabilities::{HttpClientCapability, LogWriterCapability, MaybeSend, SleepCapability};
+use libdd_capabilities::{
+    HttpClientCapability, LogWriterCapability, MaybeSend, RegexCapability, SleepCapability,
+};
 use libdd_common::tag::Tag;
 use libdd_common::Endpoint;
 use libdd_dogstatsd_client::DogStatsDClient;
@@ -238,7 +240,13 @@ impl From<TraceExporterInputFormat> for DeserInputFormat {
 /// [`libdd_shared_runtime::SharedRuntime`] for guidance on choosing an implementation.
 #[derive(Debug)]
 pub struct TraceExporter<
-    C: HttpClientCapability + SleepCapability + LogWriterCapability + MaybeSend + Sync + 'static,
+    C: HttpClientCapability
+        + SleepCapability
+        + LogWriterCapability
+        + RegexCapability
+        + MaybeSend
+        + Sync
+        + 'static,
     R: SharedRuntime,
 > {
     endpoint: Endpoint,
@@ -272,7 +280,7 @@ pub struct TraceExporter<
     /// When set, APM trace spans are exported directly to the Datadog HTTP intake (agentless)
     /// instead of via the Datadog Agent
     agentless_config: Option<AgentlessTraceConfig>,
-    trace_filterer: ArcSwap<TraceFilterer>,
+    trace_filterer: ArcSwap<TraceFilterer<C>>,
     /// When true, span stats are computed and exported as OTLP metrics. The concentrator is
     /// started at build time, so agent-driven stats (de)activation in `check_agent_info` is
     /// skipped.
@@ -287,7 +295,13 @@ pub struct TraceExporter<
 }
 
 impl<
-        C: HttpClientCapability + SleepCapability + LogWriterCapability + MaybeSend + Sync + 'static,
+        C: HttpClientCapability
+            + SleepCapability
+            + LogWriterCapability
+            + RegexCapability
+            + MaybeSend
+            + Sync
+            + 'static,
         R: SharedRuntime,
     > TraceExporter<C, R>
 {
@@ -463,7 +477,7 @@ impl<
             return;
         }
 
-        self.trace_filterer.store(Arc::new(TraceFilterer::new(
+        self.trace_filterer.store(Arc::new(TraceFilterer::<C>::new(
             &agent_info.info.filter_tags.require,
             &agent_info.info.filter_tags.reject,
             &agent_info.info.filter_tags_regex.require,
@@ -1417,6 +1431,47 @@ mod tests {
         fn write_log_output(&self, bytes: &[u8]) -> std::io::Result<()> {
             LOG_CAPTURE.with(|c| c.borrow_mut().extend_from_slice(bytes));
             Ok(())
+        }
+    }
+
+    impl libdd_capabilities::RegexCapability for CapturingCapabilities {
+        type Handle = <NativeCapabilities as libdd_capabilities::RegexCapability>::Handle;
+
+        fn compile(pattern: &str) -> Result<Self::Handle, libdd_capabilities::regex::RegexError> {
+            NativeCapabilities::compile(pattern)
+        }
+
+        fn is_match(handle: &Self::Handle, haystack: &str) -> bool {
+            NativeCapabilities::is_match(handle, haystack)
+        }
+
+        fn find(handle: &Self::Handle, haystack: &str) -> Option<libdd_capabilities::regex::Match> {
+            NativeCapabilities::find(handle, haystack)
+        }
+
+        fn find_all(
+            handle: &Self::Handle,
+            haystack: &str,
+        ) -> Vec<libdd_capabilities::regex::Match> {
+            NativeCapabilities::find_all(handle, haystack)
+        }
+
+        fn captures(
+            handle: &Self::Handle,
+            haystack: &str,
+        ) -> Option<libdd_capabilities::regex::Captures> {
+            NativeCapabilities::captures(handle, haystack)
+        }
+
+        fn captures_all(
+            handle: &Self::Handle,
+            haystack: &str,
+        ) -> Vec<libdd_capabilities::regex::Captures> {
+            NativeCapabilities::captures_all(handle, haystack)
+        }
+
+        fn pattern(handle: &Self::Handle) -> &str {
+            NativeCapabilities::pattern(handle)
         }
     }
 

--- a/libdd-data-pipeline/src/trace_exporter/stats.rs
+++ b/libdd-data-pipeline/src/trace_exporter/stats.rs
@@ -13,7 +13,7 @@ use super::add_path;
 use super::TracerMetadata;
 use crate::agent_info::schema::AgentInfo;
 use arc_swap::ArcSwap;
-use libdd_capabilities::{HttpClientCapability, MaybeSend, SleepCapability};
+use libdd_capabilities::{HttpClientCapability, MaybeSend, RegexCapability, SleepCapability};
 use libdd_common::Endpoint;
 use libdd_common::MutexExt;
 use libdd_shared_runtime::{SharedRuntime, WorkerHandle};
@@ -43,7 +43,7 @@ pub(crate) const SUPPORTED_OBFUSCATION_VERSION_STR: &str = "1";
 /// Context struct that groups immutable parameters used by stats functions
 pub(crate) struct StatsContext<
     'a,
-    C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static,
+    C: HttpClientCapability + SleepCapability + RegexCapability + MaybeSend + Sync + 'static,
     R: SharedRuntime,
 > {
     pub metadata: &'a TracerMetadata,
@@ -124,7 +124,7 @@ fn get_span_kinds_for_stats(agent_info: &Arc<AgentInfo>) -> Vec<String> {
 ///
 /// Should only be used if the agent enabled stats computation
 pub(crate) fn start_stats_computation<
-    C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static,
+    C: HttpClientCapability + SleepCapability + RegexCapability + MaybeSend + Sync + 'static,
     R: SharedRuntime,
 >(
     ctx: &StatsContext<C, R>,
@@ -153,7 +153,7 @@ pub(crate) fn start_stats_computation<
 
 /// Create stats exporter and worker, start the worker, and update the state
 fn create_and_start_stats_worker<
-    C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static,
+    C: HttpClientCapability + SleepCapability + RegexCapability + MaybeSend + Sync + 'static,
     R: SharedRuntime,
 >(
     ctx: &StatsContext<C, R>,
@@ -212,7 +212,7 @@ pub(crate) async fn stop_stats_computation(client_side_stats: &ArcSwap<StatsComp
 
 /// Handle stats computation when agent changes from disabled to enabled
 pub(crate) fn handle_stats_disabled_by_agent<
-    C: HttpClientCapability + SleepCapability + MaybeSend + Sync + 'static,
+    C: HttpClientCapability + SleepCapability + RegexCapability + MaybeSend + Sync + 'static,
     R: SharedRuntime,
 >(
     ctx: &StatsContext<C, R>,
@@ -321,8 +321,9 @@ fn add_spans_to_stats<T: libdd_trace_utils::span::TraceData>(
 /// will be sent to telemetry.
 pub(crate) fn process_traces_for_stats<
     T: libdd_trace_utils::span::TraceData,
-    #[cfg(feature = "telemetry")] C: libdd_capabilities::HttpClientCapability
+    C: libdd_capabilities::HttpClientCapability
         + libdd_capabilities::SleepCapability
+        + libdd_capabilities::RegexCapability
         + libdd_capabilities::MaybeSend
         + Sync
         + 'static,
@@ -331,7 +332,7 @@ pub(crate) fn process_traces_for_stats<
     header_tags: &mut libdd_trace_utils::trace_utils::TracerHeaderTags,
     client_side_stats: &ArcSwap<StatsComputationStatus>,
     client_computed_top_level: bool,
-    trace_filterer: &TraceFilterer,
+    trace_filterer: &TraceFilterer<C>,
     #[cfg(feature = "telemetry")] telemetry: Option<&crate::telemetry::TelemetryClient<C>>,
 ) {
     let status = client_side_stats.load();

--- a/libdd-trace-utils/src/trace_filter.rs
+++ b/libdd-trace-utils/src/trace_filter.rs
@@ -4,13 +4,13 @@
 //! ignore_resources as published by the agent's /info endpoint).
 use std::borrow::Borrow as _;
 
-use libdd_common::regex_engine::Regex;
+use libdd_capabilities::regex::RegexCapability;
 use libdd_trace_normalization::{normalize_utils, normalizer};
 use tracing::{debug, error};
 
 use crate::span::{self, trace_utils::get_root_span_index, TraceData};
 
-trait TagFilter {
+trait TagFilter<C: RegexCapability> {
     /// Returns true if the given tag value matches the Filterer.
     fn matches_tag_value(&self, value: &str) -> bool;
     // Getter to the key field
@@ -24,24 +24,25 @@ struct TagLiteralFilter {
 }
 
 #[derive(Debug)]
-struct TagRegexFilter {
+struct TagRegexFilter<H> {
     key: String,
-    value: Option<Regex>,
+    value: Option<H>,
 }
 
 /// Applies trace-level filters derived from the agent's `/info` endpoint configuration:
 /// `filter_tags`, `filter_tags_regex`, and `ignore_resources`.
 ///
-/// Filtering is evaluated on the root span of each trace.
-#[derive(Debug, Default)]
-pub struct TraceFilterer {
+/// Filtering is evaluated on the root span of each trace. Regex patterns are compiled once
+/// at construction through the [`RegexCapability`] so per-span filtering never recompiles.
+#[derive(Debug)]
+pub struct TraceFilterer<C: RegexCapability> {
     reject: Vec<TagLiteralFilter>,
-    reject_regex: Vec<TagRegexFilter>,
+    reject_regex: Vec<TagRegexFilter<C::Handle>>,
 
     require: Vec<TagLiteralFilter>,
-    require_regex: Vec<TagRegexFilter>,
+    require_regex: Vec<TagRegexFilter<C::Handle>>,
 
-    ignore_resources: Vec<Regex>,
+    ignore_resources: Vec<C::Handle>,
 }
 
 /// Minimal span interface required by [`TraceFilterer`].
@@ -52,7 +53,7 @@ pub trait Span<'a> {
     fn get_meta(&'a self, key: &str) -> Option<&'a str>;
 }
 
-impl TagFilter for TagLiteralFilter {
+impl<C: RegexCapability> TagFilter<C> for TagLiteralFilter {
     fn matches_tag_value(&self, value: &str) -> bool {
         match &self.value {
             None => true, // No value requirement => Any value is a match
@@ -65,11 +66,11 @@ impl TagFilter for TagLiteralFilter {
     }
 }
 
-impl TagFilter for TagRegexFilter {
+impl<C: RegexCapability> TagFilter<C> for TagRegexFilter<C::Handle> {
     fn matches_tag_value(&self, value: &str) -> bool {
         match &self.value {
             None => true, // No value requirement => Any value is a match
-            Some(pattern) => pattern.is_match(value),
+            Some(handle) => C::is_match(handle, value),
         }
     }
 
@@ -99,7 +100,7 @@ impl<'a, T: TraceData> Span<'a> for span::v04::Span<T> {
     }
 }
 
-impl TraceFilterer {
+impl<C: RegexCapability> TraceFilterer<C> {
     fn compile_literal_filters(filters: &[String]) -> Vec<TagLiteralFilter> {
         let mut tag_regex_filters = Vec::new();
         for filter in filters {
@@ -126,7 +127,7 @@ impl TraceFilterer {
         tag_regex_filters
     }
 
-    fn compile_regex_filters(filters: &[String]) -> Vec<TagRegexFilter> {
+    fn compile_regex_filters(filters: &[String]) -> Vec<TagRegexFilter<C::Handle>> {
         let mut tag_regex_filters = Vec::new();
         for filter in filters {
             let (key, value) = match filter.split_once(":") {
@@ -142,8 +143,8 @@ impl TraceFilterer {
             }
 
             let value = match value {
-                Some(value) => match Regex::new(value) {
-                    Ok(regex) => Some(regex),
+                Some(value) => match C::compile(value) {
+                    Ok(handle) => Some(handle),
                     Err(err) => {
                         error!(
                             ?filter,
@@ -165,11 +166,11 @@ impl TraceFilterer {
         tag_regex_filters
     }
 
-    fn compile_resource_filters(ignore_resources: &[String]) -> Vec<Regex> {
+    fn compile_resource_filters(ignore_resources: &[String]) -> Vec<C::Handle> {
         ignore_resources
             .iter()
             .filter_map(|regex| {
-                Regex::new(regex)
+                C::compile(regex)
                     .inspect_err(|err| {
                         error!(
                             ?regex,
@@ -206,9 +207,16 @@ impl TraceFilterer {
             ignore_resources,
         }
     }
+
     /// Creates a no-op filterer that keeps all traces.
     pub fn with_empty_conf() -> Self {
-        Self::default()
+        Self {
+            reject: Vec::new(),
+            reject_regex: Vec::new(),
+            require: Vec::new(),
+            require_regex: Vec::new(),
+            ignore_resources: Vec::new(),
+        }
     }
 
     /// Removes traces that fail filter checks in-place. Returns the number of traces dropped.
@@ -248,7 +256,7 @@ impl TraceFilterer {
             if self
                 .ignore_resources
                 .iter()
-                .any(|resource_pattern| resource_pattern.is_match(span_resource))
+                .any(|handle| C::is_match(handle, span_resource))
             {
                 return true;
             }
@@ -290,7 +298,7 @@ impl TraceFilterer {
     }
 
     fn check_tag_filter_with_normalization<'a>(
-        filter: &impl TagFilter,
+        filter: &impl TagFilter<C>,
         root_span: &'a impl Span<'a>,
     ) -> bool {
         let Some(value) = root_span.get_meta(filter.key()) else {
@@ -315,8 +323,12 @@ impl TraceFilterer {
 
 #[cfg(test)]
 mod tests {
+    use libdd_capabilities_impl::NativeRegexCapability;
+
     use super::TraceFilterer;
     use crate::span::v04::{SpanBytes, VecMap};
+
+    type Filterer = TraceFilterer<NativeRegexCapability>;
     // ---- helpers ----
 
     fn span_with(resource: &'static str, meta: &[(&'static str, &'static str)]) -> SpanBytes {
@@ -343,24 +355,24 @@ mod tests {
         values.iter().map(|&s| s.to_owned()).collect()
     }
 
-    fn require_str(tags: &[&str]) -> TraceFilterer {
-        TraceFilterer::new(&map_to_owned(tags), &[], &[], &[], &[])
+    fn require_str(tags: &[&str]) -> Filterer {
+        Filterer::new(&map_to_owned(tags), &[], &[], &[], &[])
     }
 
-    fn reject_str(tags: &[&str]) -> TraceFilterer {
-        TraceFilterer::new(&[], &map_to_owned(tags), &[], &[], &[])
+    fn reject_str(tags: &[&str]) -> Filterer {
+        Filterer::new(&[], &map_to_owned(tags), &[], &[], &[])
     }
 
-    fn require_regex(tags: &[&str]) -> TraceFilterer {
-        TraceFilterer::new(&[], &[], &map_to_owned(tags), &[], &[])
+    fn require_regex(tags: &[&str]) -> Filterer {
+        Filterer::new(&[], &[], &map_to_owned(tags), &[], &[])
     }
 
-    fn reject_regex(tags: &[&str]) -> TraceFilterer {
-        TraceFilterer::new(&[], &[], &[], &map_to_owned(tags), &[])
+    fn reject_regex(tags: &[&str]) -> Filterer {
+        Filterer::new(&[], &[], &[], &map_to_owned(tags), &[])
     }
 
-    fn ignore_resources(patterns: &[&str]) -> TraceFilterer {
-        TraceFilterer::new(&[], &[], &[], &[], &map_to_owned(patterns))
+    fn ignore_resources(patterns: &[&str]) -> Filterer {
+        Filterer::new(&[], &[], &[], &[], &map_to_owned(patterns))
     }
 
     // ---- reject (TagStringFilter) ----
@@ -581,7 +593,7 @@ mod tests {
 
     #[test]
     fn no_filters_keeps_all_traces() {
-        let f = TraceFilterer::new(&[], &[], &[], &[], &[]);
+        let f = Filterer::new(&[], &[], &[], &[], &[]);
         let mut traces = vec![
             vec![span_with("r1", &[])],
             vec![span_with("r2", &[("env", "prod")])],


### PR DESCRIPTION
# What does this PR do?

Add RegexCapability, so that regex in libdatadog can be handled by implementer of another platform.

# Motivation

regex was a huge part of the wasm package of libdatadog-nodejs. Forwarding the RegexRequests to the efficient JS' RexExp leads to no Regex in the package, but still lot more efficient than `regex-lite`.

# Additional Notes

- 

# How to test the change?

- 