### PR TITLE
fix(crashtracking): check fields and exclude uuid for `has_data`

### DIFF
--- a/libdd-crashtracker/src/crash_info/builder.rs
+++ b/libdd-crashtracker/src/crash_info/builder.rs
@@ -195,8 +195,10 @@ impl CrashInfoBuilder {
     /// when the builder is created, so it is excluded: comparing the whole struct
     /// against `Self::default()` would always differ on it and always report data
     pub fn has_data(&self) -> bool {
-        let mut blank = Self::default();
-        blank.uuid = self.uuid;
+        let blank = Self {
+            uuid: self.uuid,
+            ..Self::default()
+        };
 
         self != &blank
     }

--- a/libdd-crashtracker/src/crash_info/builder.rs
+++ b/libdd-crashtracker/src/crash_info/builder.rs
@@ -191,8 +191,14 @@ impl CrashInfoBuilder {
         })
     }
 
+    /// True if the builder received anything at all. The `uuid` is generated
+    /// when the builder is created, so it is excluded: comparing the whole struct
+    /// against `Self::default()` would always differ on it and always report data
     pub fn has_data(&self) -> bool {
-        *self != Self::default()
+        let mut blank = Self::default();
+        blank.uuid = self.uuid;
+
+        self != &blank
     }
 
     pub fn new() -> Self {
@@ -475,6 +481,28 @@ mod tests {
 
         let crash_ping = builder.build_crash_ping().unwrap();
         assert!(crash_ping.message().contains(&test_message));
+    }
+
+    #[test]
+    fn test_has_data_empty() {
+        // A fresh builder has a freshly generated uuid, which must not count as
+        // received data.
+        assert!(!CrashInfoBuilder::new().has_data());
+    }
+
+    #[test]
+    fn test_has_data_after_setting() {
+        let mut builder = CrashInfoBuilder::new();
+        builder.with_kind(ErrorKind::Panic).unwrap();
+        assert!(builder.has_data());
+
+        let mut builder = CrashInfoBuilder::new();
+        builder.with_metadata(Metadata::test_instance(1)).unwrap();
+        assert!(builder.has_data());
+
+        let mut builder = CrashInfoBuilder::new();
+        builder.with_incomplete(false).unwrap();
+        assert!(builder.has_data());
     }
 
     #[test]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.87.0"
-components = ["rustfmt", "clippy", "rust-analyzer"]
+components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.87.0"
-components = ["rustfmt", "clippy"]
+components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"


### PR DESCRIPTION
# What does this PR do?

Excludes `uuid` field from `CrashInfoBuilder` when checking for `has_data`

# Motivation

Previously, the `has_data` check would compare the whole struct against `Self::default()`. However, uuid is generated when the builder is created, so this would always return true

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
