### PR TITLE
refactor(rc)!: make conversion from RemoteConfigProduct back and forth generally available

### DIFF
--- a/datadog-live-debugger/src/remote_config.rs
+++ b/datadog-live-debugger/src/remote_config.rs
@@ -5,7 +5,7 @@ use crate::probe_defs::LiveDebuggingData;
 use libdd_remote_config::{ParseError, RemoteConfigContent, RemoteConfigProduct};
 
 impl RemoteConfigContent for LiveDebuggingData {
-    const PRODUCT: RemoteConfigProduct = RemoteConfigProduct::LiveDebugger;
+    const PRODUCT: RemoteConfigProduct = RemoteConfigProduct::LiveDebugging;
 
     fn parse(data: &[u8]) -> Result<Self, ParseError> {
         crate::parse_json::parse(&String::from_utf8_lossy(data))

--- a/datadog-sidecar/src/shm_remote_config.rs
+++ b/datadog-sidecar/src/shm_remote_config.rs
@@ -187,7 +187,7 @@ impl<N: NotifyTarget + 'static> FileStorage for ConfigFileStorage<N> {
     ) -> anyhow::Result<Arc<StoredShmFile>> {
         Ok(Arc::new(StoredShmFile {
             handle: Mutex::new(Some(store_shm(version, &path, file)?)),
-            limiter: if path.product == RemoteConfigProduct::LiveDebugger {
+            limiter: if path.product == RemoteConfigProduct::LiveDebugging {
                 Some(SHM_LIMITER.lock_or_panic().alloc())
             } else {
                 None
@@ -320,9 +320,9 @@ impl<N: NotifyTarget + 'static> MultiTargetHandlers<N, Self, NativeCapabilities>
                 let now_enabled =
                     dynamic_instrumentation_is_enabled(writer.dynamic_instrumentation, info);
                 if was_enabled && !now_enabled {
-                    fetcher.unforce_product(target, RemoteConfigProduct::LiveDebugger);
+                    fetcher.unforce_product(target, RemoteConfigProduct::LiveDebugging);
                 } else if !was_enabled && now_enabled {
-                    fetcher.force_product(target, RemoteConfigProduct::LiveDebugger);
+                    fetcher.force_product(target, RemoteConfigProduct::LiveDebugging);
                 }
             }
         }
@@ -411,7 +411,7 @@ impl<N: NotifyTarget + 'static> Drop for ShmRemoteConfigsGuard<N> {
                         freshly_disabled = true;
                     }
                     if Some(false) != apm_config_dynamic_instrumentation && freshly_disabled {
-                        fetcher.unforce_product(&self.target, RemoteConfigProduct::LiveDebugger);
+                        fetcher.unforce_product(&self.target, RemoteConfigProduct::LiveDebugging);
                     }
                     remove
                 };
@@ -528,7 +528,7 @@ impl<N: NotifyTarget + 'static> ShmRemoteConfigs<N> {
                 };
                 if freshly_enabled {
                     self.0
-                        .force_product(&target, RemoteConfigProduct::LiveDebugger);
+                        .force_product(&target, RemoteConfigProduct::LiveDebugging);
                 }
             }
         }
@@ -826,7 +826,7 @@ mod tests {
 
     static PATH_LIVE_DEBUGGER: LazyLock<RemoteConfigPath> = LazyLock::new(|| RemoteConfigPath {
         source: RemoteConfigSource::Employee,
-        product: RemoteConfigProduct::LiveDebugger,
+        product: RemoteConfigProduct::LiveDebugging,
         config_id: "ld-1".to_string(),
         name: "config".to_string(),
     });
@@ -1116,7 +1116,7 @@ mod tests {
             assert_eq!(value.config_id, PATH_LIVE_DEBUGGER.config_id);
             assert_eq!(
                 value.product,
-                RemoteConfigProduct::LiveDebugger,
+                RemoteConfigProduct::LiveDebugging,
                 "must be parsed as LiveDebugger, not skipped"
             );
             let data = value.data.as_ref().expect("LiveDebugger must parse");

--- a/libdd-ffe/src/telemetry/flagevaluation.rs
+++ b/libdd-ffe/src/telemetry/flagevaluation.rs
@@ -1536,6 +1536,7 @@ mod tests {
         assert!(coalescer.finish_flush_cycle());
     }
 
+    #[cfg_attr(miri, ignore)] // large cap-boundary fixture is prohibitively slow under Miri
     #[test]
     fn coalescer_degrades_after_per_flag_cap() {
         let coalescer = FlagEvaluationEvpCoalescer::<String>::default();

--- a/libdd-remote-config/src/fetch/test_server.rs
+++ b/libdd-remote-config/src/fetch/test_server.rs
@@ -229,7 +229,7 @@ impl RemoteConfigServer {
             },
             products: vec![
                 RemoteConfigProduct::ApmTracing,
-                RemoteConfigProduct::LiveDebugger,
+                RemoteConfigProduct::LiveDebugging,
             ],
             capabilities: vec![RemoteConfigCapabilities::ApmTracingCustomTags],
         }

--- a/libdd-remote-config/src/path.rs
+++ b/libdd-remote-config/src/path.rs
@@ -4,6 +4,7 @@
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use std::hash::Hash;
+use std::str::FromStr;
 use std::sync::Arc;
 
 #[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]
@@ -24,36 +25,21 @@ pub enum RemoteConfigSource {
     Deserialize,
     strum_macros::EnumIter,
     strum_macros::IntoStaticStr,
+    strum_macros::Display,
+    strum_macros::EnumString,
 )]
+#[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 pub enum RemoteConfigProduct {
     AgentConfig,
     AgentTask,
     ApmTracing,
     Asm,
     AsmData,
-    AsmDD,
+    AsmDd,
     AsmFeatures,
     FfeFlags,
-    LiveDebugger,
-    LiveDebuggerSymbolDb,
-}
-
-impl Display for RemoteConfigProduct {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let str = match self {
-            RemoteConfigProduct::AgentConfig => "AGENT_CONFIG",
-            RemoteConfigProduct::AgentTask => "AGENT_TASK",
-            RemoteConfigProduct::ApmTracing => "APM_TRACING",
-            RemoteConfigProduct::Asm => "ASM",
-            RemoteConfigProduct::AsmData => "ASM_DATA",
-            RemoteConfigProduct::AsmDD => "ASM_DD",
-            RemoteConfigProduct::AsmFeatures => "ASM_FEATURES",
-            RemoteConfigProduct::FfeFlags => "FFE_FLAGS",
-            RemoteConfigProduct::LiveDebugger => "LIVE_DEBUGGING",
-            RemoteConfigProduct::LiveDebuggerSymbolDb => "LIVE_DEBUGGING_SYMBOL_DB",
-        };
-        write!(f, "{str}")
-    }
+    LiveDebugging,
+    LiveDebuggingSymbolDb,
 }
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
@@ -91,19 +77,8 @@ impl RemoteConfigPath {
                 }
                 source => anyhow::bail!("Unknown source {}", source),
             },
-            product: match parts[parts.len() - 3] {
-                "AGENT_CONFIG" => RemoteConfigProduct::AgentConfig,
-                "AGENT_TASK" => RemoteConfigProduct::AgentTask,
-                "APM_TRACING" => RemoteConfigProduct::ApmTracing,
-                "ASM" => RemoteConfigProduct::Asm,
-                "ASM_DATA" => RemoteConfigProduct::AsmData,
-                "ASM_DD" => RemoteConfigProduct::AsmDD,
-                "ASM_FEATURES" => RemoteConfigProduct::AsmFeatures,
-                "FFE_FLAGS" => RemoteConfigProduct::FfeFlags,
-                "LIVE_DEBUGGING" => RemoteConfigProduct::LiveDebugger,
-                "LIVE_DEBUGGING_SYMBOL_DB" => RemoteConfigProduct::LiveDebuggerSymbolDb,
-                product => anyhow::bail!("Unknown product {}", product),
-            },
+            product: RemoteConfigProduct::from_str(parts[parts.len() - 3])
+                .map_err(|_| anyhow::anyhow!("Unknown product {}", parts[parts.len() - 3]))?,
             config_id: parts[parts.len() - 2],
             name: parts[parts.len() - 1],
         })

--- a/libdd-telemetry/src/worker/metric_ring.rs
+++ b/libdd-telemetry/src/worker/metric_ring.rs
@@ -242,6 +242,7 @@ mod tests {
         assert_eq!(sum, (0..n).map(|i| i as f64).sum::<f64>());
     }
 
+    #[cfg_attr(miri, ignore)] // very slow
     #[test]
     fn multi_producer_batch_drain_loses_nothing() {
         let ring = Arc::new(MetricRing::new());

--- a/libdd-trace-utils/src/trace_filter.rs
+++ b/libdd-trace-utils/src/trace_filter.rs
@@ -461,6 +461,7 @@ mod tests {
 
     // ---- require_regex (TagRegexFilter – literal key, regex value) ----
 
+    #[cfg_attr(miri, ignore)] // regex compilation is prohibitively slow under Miri
     #[test]
     fn require_regex_value_match_keeps() {
         let mut traces = one_trace(span_with("r", &[("env", "production")]));


### PR DESCRIPTION
In wasm we need to shuffle these around via string repr, hence simply use strum to expose this.

Renaming the enum values to be more canonical.