### PR TITLE
chore: release v40.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,7 +715,7 @@ checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "build_common"
-version = "39.0.0"
+version = "40.0.0"
 dependencies = [
  "cbindgen",
  "serde",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "builder"
-version = "39.0.0"
+version = "40.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-replayer"
-version = "39.0.0"
+version = "40.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2793,7 +2793,7 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libdd-agent-client"
-version = "39.0.0"
+version = "40.0.0"
 dependencies = [
  "bytes",
  "flate2",
@@ -2892,7 +2892,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-common-ffi"
-version = "39.0.0"
+version = "40.0.0"
 dependencies = [
  "anyhow",
  "assert_no_alloc",
@@ -2947,7 +2947,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-crashtracker-ffi"
-version = "39.0.0"
+version = "40.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -3013,7 +3013,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-data-pipeline-ffi"
-version = "39.0.0"
+version = "40.0.0"
 dependencies = [
  "build_common",
  "httpmock",
@@ -3043,7 +3043,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-ddsketch-ffi"
-version = "39.0.0"
+version = "40.0.0"
 dependencies = [
  "build_common",
  "libdd-common-ffi",
@@ -3102,7 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-ffe-test-suite"
-version = "39.0.0"
+version = "40.0.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -3192,7 +3192,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-log-ffi"
-version = "39.0.0"
+version = "40.0.0"
 dependencies = [
  "build_common",
  "libdd-common-ffi",
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-profiling-heap-gotter-ffi"
-version = "39.0.0"
+version = "40.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -3408,7 +3408,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-shared-runtime-ffi"
-version = "39.0.0"
+version = "40.0.0"
 dependencies = [
  "build_common",
  "libdd-shared-runtime",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-telemetry-ffi"
-version = "39.0.0"
+version = "40.0.0"
 dependencies = [
  "build_common",
  "function_name",
@@ -5731,7 +5731,7 @@ dependencies = [
 
 [[package]]
 name = "symbolizer-ffi"
-version = "39.0.0"
+version = "40.0.0"
 dependencies = [
  "blazesym-c",
  "build_common",
@@ -6179,7 +6179,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "39.0.0"
+version = "40.0.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.87.0"
 edition = "2021"
-version = "39.0.0"
+version = "40.0.0"
 license = "Apache-2.0"
 authors = ["Datadog Inc. <info@datadoghq.com>"]
 


### PR DESCRIPTION
Bump for inclusion of telemetry changes in python.