### PR TITLE
test: skip/shorten slow miri jobs

### DIFF
--- a/builder/src/features.rs
+++ b/builder/src/features.rs
@@ -139,6 +139,7 @@ mod tests {
 
     /// APMSP-3830 was the feature being present for some builds and absent for others, so
     /// cover every combination a project can ask for, not just the one we release.
+    #[cfg_attr(miri, ignore)] // exhaustive feature combinations are prohibitively slow under Miri
     #[test]
     fn catch_panic_survives_every_module_combination() {
         for bits in 0..(1u32 << MODULE_SETTERS.len()) {
@@ -152,6 +153,7 @@ mod tests {
     }
 
     /// The converse: not asking for it never sneaks it in, whatever else is selected.
+    #[cfg_attr(miri, ignore)] // exhaustive feature combinations are prohibitively slow under Miri
     #[test]
     fn catch_panic_is_never_implied_by_another_feature() {
         for bits in 0..(1u32 << MODULE_SETTERS.len()) {
@@ -208,6 +210,7 @@ mod tests {
 
     /// Nothing is inherited under `--no-default-features`, so still-needed defaults must be
     /// listed explicitly.
+    #[cfg_attr(miri, ignore)] // exhaustive feature combinations are prohibitively slow under Miri
     #[test]
     fn always_lists_features_that_no_longer_come_from_defaults() {
         for bits in 0..(1u32 << MODULE_SETTERS.len()) {
@@ -244,6 +247,7 @@ mod tests {
         assert_eq!(features, vec!["cbindgen", "ddcommon-ffi"]);
     }
 
+    #[cfg_attr(miri, ignore)] // exhaustive feature combinations are prohibitively slow under Miri
     #[test]
     fn emitted_list_has_no_duplicates() {
         for bits in 0..(1u32 << MODULE_SETTERS.len()) {
@@ -302,6 +306,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)] // exhaustive feature combinations are prohibitively slow under Miri
     #[test]
     fn every_containment_capable_sub_crate_is_fanned_out() {
         let root = workspace_root();

--- a/datadog-live-debugger/src/sender.rs
+++ b/datadog-live-debugger/src/sender.rs
@@ -863,6 +863,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)] // stalled async request cancellation is prohibitively slow under Miri
     #[tokio::test]
     async fn test_dropping_payload_sender_aborts_in_flight_request() {
         let cancelled = Arc::new(AtomicBool::new(false));

--- a/libdd-crashtracker/src/receiver/debug_logger.rs
+++ b/libdd-crashtracker/src/receiver/debug_logger.rs
@@ -154,6 +154,7 @@ impl DebugLogger {
 mod tests {
     use super::*;
 
+    #[cfg_attr(miri, ignore)] // HTTP uploader construction is prohibitively slow under Miri
     #[test]
     fn test_debug_logger_usable_without_config_or_metadata() {
         // The receiver must be able to report problems before (or without) the
@@ -163,6 +164,7 @@ mod tests {
         assert!(logger.uploader.is_some());
     }
 
+    #[cfg_attr(miri, ignore)] // HTTP uploader construction is prohibitively slow under Miri
     #[test]
     fn test_debug_logger_rebuilds_as_blocks_arrive() {
         let mut logger = DebugLogger::new(None, None);

--- a/libdd-ffe/src/telemetry/flagevaluation/sender.rs
+++ b/libdd-ffe/src/telemetry/flagevaluation/sender.rs
@@ -447,6 +447,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)] // hanging HTTP timeout is prohibitively slow under Miri
     #[tokio::test]
     async fn timeout_returns_without_waiting_for_http_response() {
         let ep = Endpoint {

--- a/libdd-profiling/src/profiles/collections/parallel/string_set.rs
+++ b/libdd-profiling/src/profiles/collections/parallel/string_set.rs
@@ -265,7 +265,7 @@ mod tests {
 
         // Share the set across threads using try_clone (which clones the internal Arc)
         let num_threads = 4;
-        let operations_per_thread = 50;
+        let operations_per_thread = if cfg!(miri) { 10 } else { 50 };
 
         // Keep a clone of the original set for final verification
         let original_set = set.try_clone().unwrap();


### PR DESCRIPTION
# What does this PR do?

This either skips or shortens some miri jobs.

# Motivation

These specific jobs were summarized as SLOW, meaning they individually took over 1 minute.

# Additional Notes

Most of them exercise no direct unsafe miri code. Then one I shortened does, which is why I shortened it instead of skipping it.

# How to test the change?

As usual, e.g. to run just the affected crates:
  - `cargo test -p libdd-profiling -p libdd-ffe -p libdd-crashtracker -p datadog-live-debugger`
  - `cargo +nightly miri nextest run -p libdd-profiling -p libdd-ffe -p libdd-crashtracker -p datadog-live-debugger` on Linux (portable atomic does not seem to work on macOS due to missing atomic for 128 bit types).