### PR TITLE
fix(ffe): report rejected flags as parse errors

### DIFF
--- a/libdd-ffe-ffi/src/assignment.rs
+++ b/libdd-ffe-ffi/src/assignment.rs
@@ -370,7 +370,6 @@ impl From<&ResolutionDetails> for Reason {
             Ok(assignment) => assignment.reason.into(),
             Err(EvaluationError::FlagDisabled) => Reason::Disabled,
             Err(EvaluationError::DefaultAllocationNull) => Reason::Default,
-            Err(EvaluationError::FlagConfigurationInvalid) => Reason::Default,
             Err(_) => Reason::Error,
         }
     }
@@ -409,7 +408,7 @@ impl From<&EvaluationError> for ErrorCode {
             EvaluationError::TypeMismatch { .. } => ErrorCode::TypeMismatch,
             EvaluationError::TargetingKeyMissing => ErrorCode::TargetingKeyMissing,
             EvaluationError::ConfigurationParseError => ErrorCode::ParseError,
-            EvaluationError::FlagConfigurationInvalid => ErrorCode::Ok,
+            EvaluationError::FlagConfigurationInvalid => ErrorCode::ParseError,
             EvaluationError::ConfigurationMissing => ErrorCode::ProviderNotReady,
             EvaluationError::FlagUnrecognizedOrDisabled => ErrorCode::FlagNotFound,
             EvaluationError::FlagDisabled => ErrorCode::Ok,
@@ -485,4 +484,17 @@ pub unsafe extern "C" fn ddog_ffe_assignnment_get_flag_metadata(
 pub unsafe extern "C" fn ddog_ffe_assignment_drop(assignment: *mut Handle<ResolutionDetails>) {
     // SAFETY: the caller must ensure that assignment is valid
     unsafe { Handle::free(assignment) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejected_flag_is_exposed_as_parse_error() {
+        let details = ResolutionDetails::from(EvaluationError::FlagConfigurationInvalid);
+
+        assert!(matches!(Reason::from(&details), Reason::Error));
+        assert_eq!(ErrorCode::from(&details), ErrorCode::ParseError);
+    }
 }

--- a/libdd-ffe-test-suite/tests/canonical_fixtures.rs
+++ b/libdd-ffe-test-suite/tests/canonical_fixtures.rs
@@ -125,21 +125,19 @@ fn reason_from_assignment(reason: AssignmentReason) -> &'static str {
 fn reason_from_error(err: &EvaluationError) -> &'static str {
     match err {
         EvaluationError::FlagDisabled => "DISABLED",
-        EvaluationError::DefaultAllocationNull | EvaluationError::FlagConfigurationInvalid => {
-            "DEFAULT"
-        }
+        EvaluationError::DefaultAllocationNull => "DEFAULT",
         _ => "ERROR",
     }
 }
 
 fn error_code_from_error(err: &EvaluationError) -> Option<&'static str> {
     match err {
-        EvaluationError::FlagDisabled
-        | EvaluationError::DefaultAllocationNull
-        | EvaluationError::FlagConfigurationInvalid => None,
+        EvaluationError::FlagDisabled | EvaluationError::DefaultAllocationNull => None,
         EvaluationError::TypeMismatch { .. } => Some("TYPE_MISMATCH"),
         EvaluationError::TargetingKeyMissing => Some("TARGETING_KEY_MISSING"),
-        EvaluationError::ConfigurationParseError => Some("PARSE_ERROR"),
+        EvaluationError::ConfigurationParseError | EvaluationError::FlagConfigurationInvalid => {
+            Some("PARSE_ERROR")
+        }
         EvaluationError::ConfigurationMissing => Some("PROVIDER_NOT_READY"),
         EvaluationError::FlagUnrecognizedOrDisabled => Some("FLAG_NOT_FOUND"),
         EvaluationError::Internal(_) => Some("GENERAL"),

--- a/libdd-ffe/src/rules_based/error.rs
+++ b/libdd-ffe/src/rules_based/error.rs
@@ -33,8 +33,10 @@ pub enum EvaluationError {
     ConfigurationParseError,
 
     /// A requested flag exists in the configuration payload, but its per-flag configuration is
-    /// invalid or unsupported by this SDK. The SDK should return the caller default and expose
-    /// this as a parse error for that flag without invalidating the rest of the configuration.
+    /// invalid or unsupported by this SDK. Failures encountered while compiling an individual
+    /// flag are converted to `FlagConfigurationInvalid` at the per-flag ingestion boundary. The
+    /// SDK should return the caller default and expose this as a parse error for that flag without
+    /// invalidating the rest of the configuration.
     #[error("flag configuration is invalid or unsupported")]
     FlagConfigurationInvalid,
 

--- a/libdd-ffe/src/rules_based/error.rs
+++ b/libdd-ffe/src/rules_based/error.rs
@@ -33,7 +33,8 @@ pub enum EvaluationError {
     ConfigurationParseError,
 
     /// A requested flag exists in the configuration payload, but its per-flag configuration is
-    /// invalid or unsupported by this SDK. The SDK should return the caller default for that flag.
+    /// invalid or unsupported by this SDK. The SDK should return the caller default and expose
+    /// this as a parse error for that flag without invalidating the rest of the configuration.
     #[error("flag configuration is invalid or unsupported")]
     FlagConfigurationInvalid,
 

--- a/libdd-ffe/src/rules_based/eval/eval_assignment.rs
+++ b/libdd-ffe/src/rules_based/eval/eval_assignment.rs
@@ -176,6 +176,32 @@ impl Allocation {
     }
 }
 
+impl Split {
+    /// Return `true` if `targeting_key` matches the given split.
+    ///
+    /// To match a split, subject must match all underlying shards.
+    fn matches(&self, targeting_key: Option<&str>) -> Result<bool, EvaluationError> {
+        if self.shards.is_empty() {
+            return Ok(true);
+        }
+
+        let Some(targeting_key) = targeting_key else {
+            return Err(EvaluationError::TargetingKeyMissing);
+        };
+
+        Ok(self.shards.iter().all(|shard| shard.matches(targeting_key)))
+    }
+}
+
+impl Shard {
+    /// Return `true` if `targeting_key` matches the given shard.
+    fn matches(&self, targeting_key: &str) -> bool {
+        let h = self.sharder.shard(&[targeting_key]);
+
+        self.ranges.iter().any(|range| range.contains(h))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::{collections::HashMap, sync::Arc};
@@ -241,31 +267,5 @@ mod tests {
             AssignmentValue::String(ref value) if value.as_str() == "valid"
         ));
         assert_eq!(assignment.reason, AssignmentReason::Static);
-    }
-}
-
-impl Split {
-    /// Return `true` if `targeting_key` matches the given split.
-    ///
-    /// To match a split, subject must match all underlying shards.
-    fn matches(&self, targeting_key: Option<&str>) -> Result<bool, EvaluationError> {
-        if self.shards.is_empty() {
-            return Ok(true);
-        }
-
-        let Some(targeting_key) = targeting_key else {
-            return Err(EvaluationError::TargetingKeyMissing);
-        };
-
-        Ok(self.shards.iter().all(|shard| shard.matches(targeting_key)))
-    }
-}
-
-impl Shard {
-    /// Return `true` if `targeting_key` matches the given shard.
-    fn matches(&self, targeting_key: &str) -> bool {
-        let h = self.sharder.shard(&[targeting_key]);
-
-        self.ranges.iter().any(|range| range.contains(h))
     }
 }

--- a/libdd-ffe/src/rules_based/eval/eval_assignment.rs
+++ b/libdd-ffe/src/rules_based/eval/eval_assignment.rs
@@ -176,6 +176,74 @@ impl Allocation {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, sync::Arc};
+
+    use super::*;
+    use crate::rules_based::{AssignmentReason, AssignmentValue, UniversalFlagConfig};
+
+    #[test]
+    fn invalid_flag_does_not_poison_valid_neighbor() {
+        let config = UniversalFlagConfig::from_json(
+            br#"
+            {
+              "createdAt": "2026-08-11T00:00:00Z",
+              "environment": {"name": "test"},
+              "flags": {
+                "invalid-regex": {
+                  "key": "invalid-regex",
+                  "enabled": true,
+                  "variationType": "STRING",
+                  "variations": {"trap": {"key": "trap", "value": "trap"}},
+                  "allocations": [{
+                    "key": "invalid",
+                    "rules": [{"conditions": [{
+                      "attribute": "email",
+                      "operator": "MATCHES",
+                      "value": "[invalid"
+                    }]}],
+                    "splits": [{"variationKey": "trap", "shards": []}]
+                  }]
+                },
+                "valid": {
+                  "key": "valid",
+                  "enabled": true,
+                  "variationType": "STRING",
+                  "variations": {"on": {"key": "on", "value": "valid"}},
+                  "allocations": [{
+                    "key": "static",
+                    "splits": [{"variationKey": "on", "shards": []}]
+                  }]
+                }
+              }
+            }
+            "#
+            .to_vec(),
+        )
+        .unwrap();
+        let config = Configuration::from_server_response(config);
+        let context = EvaluationContext::new(None, Arc::new(HashMap::new()));
+        let now = chrono::Utc::now();
+
+        assert_eq!(
+            config
+                .eval_flag("invalid-regex", &context, ExpectedFlagType::String, now)
+                .unwrap_err(),
+            EvaluationError::FlagConfigurationInvalid
+        );
+
+        let assignment = config
+            .eval_flag("valid", &context, ExpectedFlagType::String, now)
+            .unwrap();
+        assert!(matches!(
+            assignment.value,
+            AssignmentValue::String(ref value) if value.as_str() == "valid"
+        ));
+        assert_eq!(assignment.reason, AssignmentReason::Static);
+    }
+}
+
 impl Split {
     /// Return `true` if `targeting_key` matches the given split.
     ///

--- a/libdd-ffe/src/rules_based/eval/eval_rules.rs
+++ b/libdd-ffe/src/rules_based/eval/eval_rules.rs
@@ -67,7 +67,7 @@ impl ConditionCheck {
             } => {
                 let attr_str = attribute?.as_str()?;
                 let attr_version = semver::Version::parse(attr_str.as_ref()).ok()?;
-                let ordering = attr_version.cmp(comparand);
+                let ordering = attr_version.cmp_precedence(comparand);
                 match operator {
                     SemverComparisonOperator::Eq => ordering.is_eq(),
                     SemverComparisonOperator::Neq => !ordering.is_eq(),
@@ -315,6 +315,7 @@ mod tests {
             comparand: semver("1.2.3"),
         };
         assert!(check.eval(Some(&"1.2.3".into())));
+        assert!(check.eval(Some(&"1.2.3+build.42".into())));
         assert!(!check.eval(Some(&"1.2.4".into())));
         assert!(!check.eval(Some(&"1.2.2".into())));
         assert!(!check.eval(None));
@@ -327,6 +328,7 @@ mod tests {
             comparand: semver("1.2.3"),
         };
         assert!(!check.eval(Some(&"1.2.3".into())));
+        assert!(!check.eval(Some(&"1.2.3+build.42".into())));
         assert!(check.eval(Some(&"1.2.4".into())));
         assert!(!check.eval(None));
     }

--- a/libdd-ffe/src/rules_based/ufc/models.rs
+++ b/libdd-ffe/src/rules_based/ufc/models.rs
@@ -167,8 +167,8 @@ pub(crate) enum ConditionCheck {
     },
     Regex {
         expected_match: bool,
-        // As regex is supplied by user, we allow regex parse failure to not fail parsing and
-        // evaluation. Invalid regexes are simply ignored.
+        // Compile user-supplied regexes during ingestion so a failure rejects only the containing
+        // flag before evaluation.
         regex: Regex,
     },
     Membership {


### PR DESCRIPTION
## Motivation

Malformed per-flag UFC configuration is already isolated during ingestion: libdatadog stores a rejection error for that key while compiling valid neighboring flags normally. The FFI translation incorrectly exposed that rejection as a normal DEFAULT result with no error code, hiding a configuration bug from callers.

This implements the contract merged in [DataDog/ffe-system-test-data#26](https://github.com/DataDog/ffe-system-test-data/pull/26): evaluating a rejected key returns the caller default with ERROR / PARSE_ERROR, while valid neighboring flags remain usable.

## Changes

- Map FlagConfigurationInvalid to the FFI ERROR reason and PARSE_ERROR error code.
- Add regression coverage proving an invalid regex flag does not poison a valid neighboring flag.
- Bump the canonical fixture submodule to the revision merged in [DataDog/ffe-system-test-data#26](https://github.com/DataDog/ffe-system-test-data/pull/26).
- Update the canonical adapter to expect PARSE_ERROR for rejected keys.
- Compare semantic versions by precedence so build metadata does not change equality or ordering.
- Correct the regex-ingestion documentation to match the parser behavior.

## Decisions

- Keep validation in libdatadog so the same Rust regex and UFC parsers used for evaluation own rejection decisions.
- Retain only the per-key rejection error in the compiled configuration, not the malformed flag object.
- Preserve FLAG_NOT_FOUND for keys absent from the configuration.
- Use SemVer precedence comparisons, which ignore build metadata as required by the specification.

## Validation

- [x] cargo test -p libdd-ffe
- [x] cargo test -p libdd-ffe-ffi rejected_flag_is_exposed_as_parse_error
- [x] cargo test -p libdd-ffe-test-suite --test canonical_fixtures
- [x] git diff --check