### PR TITLE
fix(ffe): report malformed flags as parse errors

### DIFF
--- a/libdd-ffe-ffi/src/assignment.rs
+++ b/libdd-ffe-ffi/src/assignment.rs
@@ -370,7 +370,7 @@ impl From<&ResolutionDetails> for Reason {
             Ok(assignment) => assignment.reason.into(),
             Err(EvaluationError::FlagDisabled) => Reason::Disabled,
             Err(EvaluationError::DefaultAllocationNull) => Reason::Default,
-            Err(EvaluationError::FlagConfigurationInvalid) => Reason::Default,
+            Err(EvaluationError::FlagConfigurationInvalid) => Reason::Error,
             Err(_) => Reason::Error,
         }
     }
@@ -409,7 +409,7 @@ impl From<&EvaluationError> for ErrorCode {
             EvaluationError::TypeMismatch { .. } => ErrorCode::TypeMismatch,
             EvaluationError::TargetingKeyMissing => ErrorCode::TargetingKeyMissing,
             EvaluationError::ConfigurationParseError => ErrorCode::ParseError,
-            EvaluationError::FlagConfigurationInvalid => ErrorCode::Ok,
+            EvaluationError::FlagConfigurationInvalid => ErrorCode::ParseError,
             EvaluationError::ConfigurationMissing => ErrorCode::ProviderNotReady,
             EvaluationError::FlagUnrecognizedOrDisabled => ErrorCode::FlagNotFound,
             EvaluationError::FlagDisabled => ErrorCode::Ok,
@@ -485,4 +485,25 @@ pub unsafe extern "C" fn ddog_ffe_assignnment_get_flag_metadata(
 pub unsafe extern "C" fn ddog_ffe_assignment_drop(assignment: *mut Handle<ResolutionDetails>) {
     // SAFETY: the caller must ensure that assignment is valid
     unsafe { Handle::free(assignment) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_flag_configuration_reports_parse_error() {
+        let details = ResolutionDetails::from(EvaluationError::FlagConfigurationInvalid);
+
+        assert!(matches!(Reason::from(&details), Reason::Error));
+        assert_eq!(ErrorCode::from(&details), ErrorCode::ParseError);
+    }
+
+    #[test]
+    fn unrecognized_flag_remains_flag_not_found() {
+        let details = ResolutionDetails::from(EvaluationError::FlagUnrecognizedOrDisabled);
+
+        assert!(matches!(Reason::from(&details), Reason::Error));
+        assert_eq!(ErrorCode::from(&details), ErrorCode::FlagNotFound);
+    }
 }

--- a/libdd-ffe-test-suite/tests/canonical_fixtures.rs
+++ b/libdd-ffe-test-suite/tests/canonical_fixtures.rs
@@ -125,18 +125,15 @@ fn reason_from_assignment(reason: AssignmentReason) -> &'static str {
 fn reason_from_error(err: &EvaluationError) -> &'static str {
     match err {
         EvaluationError::FlagDisabled => "DISABLED",
-        EvaluationError::DefaultAllocationNull | EvaluationError::FlagConfigurationInvalid => {
-            "DEFAULT"
-        }
+        EvaluationError::DefaultAllocationNull => "DEFAULT",
         _ => "ERROR",
     }
 }
 
 fn error_code_from_error(err: &EvaluationError) -> Option<&'static str> {
     match err {
-        EvaluationError::FlagDisabled
-        | EvaluationError::DefaultAllocationNull
-        | EvaluationError::FlagConfigurationInvalid => None,
+        EvaluationError::FlagDisabled | EvaluationError::DefaultAllocationNull => None,
+        EvaluationError::FlagConfigurationInvalid => Some("PARSE_ERROR"),
         EvaluationError::TypeMismatch { .. } => Some("TYPE_MISMATCH"),
         EvaluationError::TargetingKeyMissing => Some("TARGETING_KEY_MISSING"),
         EvaluationError::ConfigurationParseError => Some("PARSE_ERROR"),

--- a/libdd-ffe/src/rules_based/eval/eval_rules.rs
+++ b/libdd-ffe/src/rules_based/eval/eval_rules.rs
@@ -67,7 +67,7 @@ impl ConditionCheck {
             } => {
                 let attr_str = attribute?.as_str()?;
                 let attr_version = semver::Version::parse(attr_str.as_ref()).ok()?;
-                let ordering = attr_version.cmp(comparand);
+                let ordering = attr_version.cmp_precedence(comparand);
                 match operator {
                     SemverComparisonOperator::Eq => ordering.is_eq(),
                     SemverComparisonOperator::Neq => !ordering.is_eq(),
@@ -384,6 +384,15 @@ mod tests {
         assert!(check.eval(Some(&"1.0.0-alpha".into())));
         assert!(check.eval(Some(&"1.0.0-beta.1".into())));
         assert!(!check.eval(Some(&"1.0.0".into())));
+    }
+
+    #[test]
+    fn semver_build_metadata_does_not_affect_precedence() {
+        let check = ConditionCheck::SemverComparison {
+            operator: SemverComparisonOperator::Eq,
+            comparand: semver("1.0.0"),
+        };
+        assert!(check.eval(Some(&"1.0.0+build.42".into())));
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

Ruby, PHP, and Python share libdatadog's FFE evaluator. The updated canonical corpus requires malformed flag keys to report parse errors without blocking valid siblings, and exposes a SemVer precedence bug for build metadata.

## Changes

- bump `ffe-system-test-data` to `ea8b5cc5ce335109f11f3efbc5fd608f98a3ca54`
- expose the existing per-flag invalid-configuration sentinel as `ERROR/PARSE_ERROR` through the FFI
- keep unrecognized flags on `ERROR/FLAG_NOT_FOUND`
- compare SemVer values by precedence so build metadata is ignored
- add focused FFI and SemVer regressions and update the canonical harness

## Decisions

- retain `FlagConfigurationInvalid` as the per-flag sentinel; reserve `ConfigurationParseError` for whole-payload failures
- keep independent flag compilation and immutable full-map replacement as the isolation boundary
- put shared behavior here instead of duplicating evaluator logic in Ruby, PHP, and Python
- keep the separate regex-fixture proposal in ffe-system-test-data#21 out of scope

## Validation

- `cargo test -p libdd-ffe -p libdd-ffe-ffi -p libdd-ffe-test-suite --no-fail-fast`
- `cargo +nightly-2026-07-26 fmt --all -- --check`
- `cargo +stable clippy -p libdd-ffe -p libdd-ffe-ffi -p libdd-ffe-test-suite --all-targets -- -D warnings`
- `cargo ffi-test` built the release FFI artifacts and 14 example targets before an intentional stop during unrelated examples
- `git diff --check`