### PR TITLE
feat(profiling): replace weight with per-allocation unbiased byte …

### DIFF
--- a/libdd-profiling-heap-gotter/src/hooks.rs
+++ b/libdd-profiling-heap-gotter/src/hooks.rs
@@ -154,8 +154,9 @@ pub unsafe extern "C" fn gotter_calloc(nmemb: usize, size: usize) -> *mut c_void
     // single (1, req.size) allocation when sampling kicks in, so the
     // underlying allocator zeroes everything we hand back. Unsampled
     // path keeps the user's (nmemb, size) verbatim.
-    // `req.weight == 0` is `!dd_alloc_req_is_sampled(req)`, inlined here to avoid a cross-FFI call.
-    let raw = if req.weight == 0 {
+    // `req.weighted_bytes == 0` is `!dd_alloc_req_is_sampled(req)`, inlined here to avoid a
+    // cross-FFI call.
+    let raw = if req.weighted_bytes == 0 {
         real(nmemb, size)
     } else {
         real(1, req.size)
@@ -277,6 +278,6 @@ fn _types_anchor() -> dd_alloc_req_t {
         size: 0,
         user_size: 0,
         alignment: 0,
-        weight: 0,
+        weighted_bytes: 0,
     }
 }

--- a/libdd-profiling-heap-sampler/README.md
+++ b/libdd-profiling-heap-sampler/README.md
@@ -54,7 +54,7 @@ They are responsible for deciding whether or not to sample, and storing the info
 
 The actual USDTs emitted are:
 
-* `ddheap:alloc(void *user, uint64_t size, uint64_t weight)` — fired on sampled allocations; `user` is the user-visible pointer, `size` in bytes, `weight` is the unbiased size estimator (`nsamples * interval`)
+* `ddheap:alloc(void *user, uint64_t size, uint64_t weighted_bytes)` — fired on sampled allocations; `user` is the user-visible pointer, `size` is the application-requested allocation size in bytes, `weighted_bytes` is the estimated allocated bytes represented by this sampled allocation computed as `size / (1 - exp(-size / interval))` where `interval` is the mean sampling distance. Small allocations have weighted_bytes close to one sampling interval; large allocations have weighted_bytes close to their actual size.
 * `ddheap:free(void *ptr)` — fired when a previously-sampled allocation is freed
 * `ddheap:mmap` - TODO 
 * `ddheap:munmap` - TODO

--- a/libdd-profiling-heap-sampler/include/datadog/heap/allocation_created.h
+++ b/libdd-profiling-heap-sampler/include/datadog/heap/allocation_created.h
@@ -5,7 +5,7 @@
  *
  * Call dd_allocation_created() immediately after the underlying allocator
  * returns. On the common (unsampled) fast path this is a single branch on
- * req.weight and an immediate return of the raw pointer. On the sampled slow
+ * req.weighted_bytes and an immediate return of the raw pointer. On the sampled slow
  * path it applies the architecture-specific sample flag to the raw pointer,
  * emits the ddheap:alloc USDT, and closes the reentry guard that was opened
  * by the paired dd_allocation_requested() call.

--- a/libdd-profiling-heap-sampler/include/datadog/heap/allocation_requested.h
+++ b/libdd-profiling-heap-sampler/include/datadog/heap/allocation_requested.h
@@ -19,9 +19,12 @@
  *                the profiler via the ddheap:alloc USDT.
  *   - alignment: passed through so dd_allocation_created can place the
  *                user pointer correctly relative to the raw pointer.
- *   - weight:    0 if not sampled; otherwise the unbiased size
- *                estimator (nsamples * interval) to attribute to this
- *                allocation.
+ *   - weighted_bytes: 0 if not sampled; otherwise the estimated allocated
+ *                bytes represented by this sampled allocation, computed
+ *                from the allocation size and its probability of being
+ *                sampled under Poisson sampling:
+ *                  p = 1 - exp(-size / interval)
+ *                  weighted_bytes = size / p
  *
  * Always pair with dd_allocation_created(), even if the allocator fails.
  */
@@ -53,9 +56,11 @@
  *               dd_allocation_requested; carried through so
  *               dd_allocation_created can place the user pointer
  *               correctly relative to the raw pointer.
- *   weight    - 0 if this allocation was not sampled; otherwise the
- *               unbiased size estimator (nsamples * interval) for
- *               aggregated reporting.
+ *   weighted_bytes
+ *             - 0 if this allocation was not sampled; otherwise the
+ *               estimated allocated bytes represented by this sampled
+ *               allocation, computed as size / (1 - exp(-size/interval))
+ *               where interval is the mean sampling distance in bytes.
  *
  * 32 bytes on 64-bit targets, cache-line-friendly.
  */
@@ -63,19 +68,19 @@ typedef struct {
     size_t   size;
     size_t   user_size;
     size_t   alignment;
-    uint64_t weight;
+    uint64_t weighted_bytes;
 } dd_alloc_req_t;
 
 /*
- * True if this request was sampled (weight > 0). Both the C fast path
- * (allocation_created.h) and callers that branch on sampled-ness (e.g.
- * gotter's calloc hook) should use this instead of comparing `weight == 0`
- * directly, so there is one named predicate rather than the same
- * comparison repeated in C and Rust.
+ * True if this request was sampled (weighted_bytes > 0). Both the C fast
+ * path (allocation_created.h) and callers that branch on sampled-ness
+ * (e.g. gotter's calloc hook) should use this instead of comparing
+ * `weighted_bytes == 0` directly, so there is one named predicate rather
+ * than the same comparison repeated in C and Rust.
  */
 static inline __attribute__((always_inline))
 bool dd_alloc_req_is_sampled(dd_alloc_req_t req) {
-    return req.weight != 0;
+    return req.weighted_bytes != 0;
 }
 
 /* Slow path for an allocation request. This is only taken when we think we
@@ -130,5 +135,16 @@ dd_alloc_req_t dd_allocation_requested(size_t size, size_t alignment) {
     // concerned about the cost of the function call.
     return dd_allocation_requested_slow(tl, size, alignment);
 }
+
+/*
+ * Test-only: expose the per-allocation weighted-bytes calculation so unit
+ * tests can exercise it deterministically. Computes:
+ *
+ *     p = 1 - exp(-size / interval)
+ *     weighted_bytes = size / p
+ *
+ * Returns 0 when size == 0 or interval == 0.
+ */
+uint64_t dd_test_allocation_weight(uint64_t size, uint64_t interval);
 
 #endif

--- a/libdd-profiling-heap-sampler/include/datadog/heap/probes.h
+++ b/libdd-profiling-heap-sampler/include/datadog/heap/probes.h
@@ -32,11 +32,13 @@
 
 /*
  * Emits the `ddheap:alloc` USDT.
- *   user   - user-visible allocation pointer
- *   size   - allocation size in bytes
- *   weight - unbiased size estimator (nsamples * interval)
+ *   user          - user-visible allocation pointer
+ *   size          - application-requested allocation size in bytes
+ *   weighted_bytes - estimated allocated bytes represented by this sampled
+ *                   allocation, computed as size / (1 - exp(-size / interval))
+ *                   where interval is the mean sampling distance.
  */
-void dd_probe_alloc(void *user, uint64_t size, uint64_t weight);
+void dd_probe_alloc(void *user, uint64_t size, uint64_t weighted_bytes);
 
 /*
  * Emits the `ddheap:free` USDT.

--- a/libdd-profiling-heap-sampler/src/allocation_created.c
+++ b/libdd-profiling-heap-sampler/src/allocation_created.c
@@ -10,7 +10,7 @@
 
 /*
  * Slow path for dd_allocation_created. We only arrive here when the paired
- * dd_allocation_requested_slow decided to sample (req.weight > 0).
+ * dd_allocation_requested_slow decided to sample (req.weighted_bytes > 0).
  *
  * Applies the architecture-specific sample flag to raw (tagging the pointer
  * on arm64, writing a header magic word on x86-64) to produce the
@@ -45,7 +45,7 @@ void *dd_allocation_created_slow(void *raw, dd_alloc_req_t req) {
         /* Report the application-requested size, not the sampler-bumped
          * size (`req.size`), so heap-size distributions in the profiler
          * aren't skewed by per-sample overhead. */
-        dd_probe_alloc(user, (uint64_t)req.user_size, req.weight);
+        dd_probe_alloc(user, (uint64_t)req.user_size, req.weighted_bytes);
     }
 
     /* Always close the reentry guard, even on allocation failure (raw == NULL),

--- a/libdd-profiling-heap-sampler/src/allocation_requested.c
+++ b/libdd-profiling-heap-sampler/src/allocation_requested.c
@@ -34,23 +34,27 @@ static uint64_t next_interval(uint32_t *rng, uint64_t mean) {
 }
 
 /*
- * Called when remaining_bytes has crossed zero, meaning at least one sample
- * is owed. Draws fresh intervals until the counter is negative again, counting
- * how many samples fired. Returns nsamples * interval as the unbiased weight
- * estimator to attribute to this allocation. A sampling_interval of 0 is the
- * documented "do not sample this thread" value and returns 0 immediately.
+ * Called when remaining_bytes has crossed zero, meaning at least one sampling
+ * point lies within this allocation. Draws fresh intervals until the counter
+ * is negative again, advancing the point process through the entire allocation
+ * so that remaining_bytes represents the distance to the next sample after
+ * this allocation. Returns true if this allocation was sampled, false
+ * otherwise.
+ *
+ * A sampling_interval of 0 is the documented "do not sample this thread"
+ * value and returns false immediately.
  *
  * On the very first call for a thread, remaining_bytes_initialized is false
  * and we draw the initial interval from scratch. If that interval exceeds the
- * accumulated byte credit the counter goes back negative and we return 0,
+ * accumulated byte credit the counter goes back negative and we return false,
  * meaning no sample this time. This is normal and happens at most once per thread.
  *
  * Note: remaining_bytes has already been incremented by `size` in the inline
  * fast path; we arrive here because that increment pushed it to zero or above.
  */
-static uint64_t sample(dd_tl_state_t *tl) {
+static bool sample(dd_tl_state_t *tl) {
     uint64_t interval = tl->sampling_interval;
-    if (interval == 0) return 0;
+    if (interval == 0) return false;
 
     if (!tl->remaining_bytes_initialized) {
         /* First allocation on this thread: draw the initial interval and
@@ -59,24 +63,59 @@ static uint64_t sample(dd_tl_state_t *tl) {
          * enough to cover the first interval. */
         tl->remaining_bytes -= (int64_t)next_interval(&tl->rng, interval);
         tl->remaining_bytes_initialized = true;
-        if (tl->remaining_bytes < 0) return 0;
+        if (tl->remaining_bytes < 0) return false;
     }
 
-    /* remaining_bytes is >= 0, meaning we've crossed one full interval
-     * boundary. Integer-divide to find how many full intervals fit in the
-     * current credit (usually 1, but can be more for very large allocations),
-     * then keep drawing until we're back in the red. Each iteration is one
-     * additional sample. */
-    size_t nsamples = (size_t)tl->remaining_bytes / interval;
+    /* remaining_bytes is >= 0, meaning we've crossed at least one full
+     * interval boundary. Use integer division to skip over all the full
+     * intervals that fit in the current credit (an optimization for very
+     * large allocations), then keep drawing until we're back in the red.
+     * This preserves the invariant that after processing an allocation,
+     * remaining_bytes is exactly equivalent to advancing through every
+     * sampling point individually. */
     tl->remaining_bytes %= (int64_t)interval;
     do {
         tl->remaining_bytes -= (int64_t)next_interval(&tl->rng, interval);
-        ++nsamples;
     } while (tl->remaining_bytes >= 0);
 
-    /* Weight is the unbiased estimator: each sample represents `interval`
-     * bytes on average, so nsamples * interval gives the expected total. */
-    return (uint64_t)nsamples * interval;
+    return true;
+}
+
+/*
+ * Computes the per-allocation unbiased byte weight for a sampled allocation.
+ *
+ * For Poisson/random-interval sampling with mean interval R, the probability
+ * that an allocation of size S is sampled is:
+ *
+ *     p = 1 - exp(-S / R)
+ *
+ * The unbiased estimator for total allocated bytes represented by this sample
+ * is:
+ *
+ *     weight = S / p
+ *
+ * Properties:
+ *   - Small allocations (S << R): weight ~= R (one sampling interval)
+ *   - Large allocations (S >> R): weight ~= S (allocation is almost certain
+ *     to be sampled, so it represents only itself)
+ *   - S == R: weight ~= 1.582 * R
+ *
+ * Uses expm1 for numerical stability when S is small relative to R.
+ */
+static uint64_t allocation_weight(uint64_t size, uint64_t interval) {
+    if (size == 0 || interval == 0) {
+        return 0;
+    }
+
+    double p = -expm1(-(double)size / (double)interval);
+    double w = (double)size / p;
+
+    /* Clamp to UINT64_MAX on overflow; round to nearest integer. */
+    if (w >= (double)UINT64_MAX) {
+        return UINT64_MAX;
+    }
+
+    return (uint64_t)(w + 0.5);
 }
 
 /*
@@ -85,10 +124,11 @@ static uint64_t sample(dd_tl_state_t *tl) {
  * decision, and returns the allocation request the caller should forward to
  * the real allocator.
  *
- * If sample() returns 0 (first-interval miss on a fresh thread) the guard is
- * closed here and a no-sample result is returned. Otherwise the guard stays
- * open until dd_allocation_created_slow closes it, keeping any allocations
- * triggered during the slow path from re-entering the sampler.
+ * If sample() returns false (first-interval miss on a fresh thread, or
+ * interval == 0) the guard is closed here and a no-sample result is returned.
+ * Otherwise the guard stays open until dd_allocation_created_slow closes it,
+ * keeping any allocations triggered during the slow path from re-entering
+ * the sampler.
  *
  * (ddprof: AllocationTracker::track_allocation / next_sample_interval)
  */
@@ -131,11 +171,26 @@ dd_alloc_req_t dd_allocation_requested_slow(dd_tl_state_t *tl, size_t size,
 
     /* Save / restore errno: sample() reaches log(), which may set it. */
     int saved_errno = errno;
-    uint64_t weight = sample(tl);
+    bool sampled = sample(tl);
     errno = saved_errno;
-    if (weight == 0) {
+    if (!sampled) {
         /* First-interval miss: no sample this time. Close the guard now since
          * dd_allocation_created_slow won't be called on the sampled path. */
+        tl->reentry_guard = false;
+        dd_alloc_req_t out = { size, size, alignment, 0 };
+        return out;
+    }
+
+    /* Compute the per-allocation unbiased weighted bytes from the
+     * application-requested size and the sampling interval.
+     *
+     * Zero-size allocations: allocation_weight(0, interval) returns 0,
+     * and weighted_bytes==0 means "unsampled" to downstream code. Treat
+     * them as unsampled to avoid leaving the reentry guard open (since
+     * dd_allocation_created short-circuits when weighted_bytes==0 and
+     * would never close it). */
+    uint64_t weighted_bytes = allocation_weight((uint64_t)size, tl->sampling_interval);
+    if (weighted_bytes == 0) {
         tl->reentry_guard = false;
         dd_alloc_req_t out = { size, size, alignment, 0 };
         return out;
@@ -146,7 +201,7 @@ dd_alloc_req_t dd_allocation_requested_slow(dd_tl_state_t *tl, size_t size,
         /* Alignment too large or arithmetic overflow: pass through as
          * an unsampled allocation rather than corrupt the request. The
          * guard must be closed here since dd_allocation_created_slow
-         * won't be reached (weight == 0 fast-path in the header). */
+         * won't be reached (weighted_bytes == 0 fast-path in the header). */
         tl->reentry_guard = false;
         dd_alloc_req_t out = { size, size, alignment, 0 };
         return out;
@@ -156,7 +211,16 @@ dd_alloc_req_t dd_allocation_requested_slow(dd_tl_state_t *tl, size_t size,
         .size      = bumped,
         .user_size = size,
         .alignment = alignment,
-        .weight    = weight,
+        .weighted_bytes = weighted_bytes,
     };
     return out;
+}
+
+/*
+ * Test-only: expose the allocation_weight helper so unit tests can exercise
+ * the weight calculation deterministically without depending on random
+ * sampling. Not part of the public API.
+ */
+uint64_t dd_test_allocation_weight(uint64_t size, uint64_t interval) {
+    return allocation_weight(size, interval);
 }

--- a/libdd-profiling-heap-sampler/src/generated/bindings.rs
+++ b/libdd-profiling-heap-sampler/src/generated/bindings.rs
@@ -51,7 +51,7 @@ unsafe extern "C" {
     pub fn dd_tl_state_get_or_init() -> *mut dd_tl_state_t;
 }
 unsafe extern "C" {
-    pub fn dd_probe_alloc(user: *mut ::std::os::raw::c_void, size: u64, weight: u64);
+    pub fn dd_probe_alloc(user: *mut ::std::os::raw::c_void, size: u64, weighted_bytes: u64);
 }
 unsafe extern "C" {
     pub fn dd_probe_free(ptr: *mut ::std::os::raw::c_void);
@@ -68,7 +68,7 @@ pub struct dd_alloc_req_t {
     pub size: usize,
     pub user_size: usize,
     pub alignment: usize,
-    pub weight: u64,
+    pub weighted_bytes: u64,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
@@ -80,8 +80,8 @@ const _: () = {
         [::std::mem::offset_of!(dd_alloc_req_t, user_size) - 8usize];
     ["Offset of field: dd_alloc_req_t::alignment"]
         [::std::mem::offset_of!(dd_alloc_req_t, alignment) - 16usize];
-    ["Offset of field: dd_alloc_req_t::weight"]
-        [::std::mem::offset_of!(dd_alloc_req_t, weight) - 24usize];
+    ["Offset of field: dd_alloc_req_t::weighted_bytes"]
+        [::std::mem::offset_of!(dd_alloc_req_t, weighted_bytes) - 24usize];
 };
 unsafe extern "C" {
     #[link_name = "dd_alloc_req_is_sampled__extern"]
@@ -97,6 +97,9 @@ unsafe extern "C" {
 unsafe extern "C" {
     #[link_name = "dd_allocation_requested__extern"]
     pub fn dd_allocation_requested(size: usize, alignment: usize) -> dd_alloc_req_t;
+}
+unsafe extern "C" {
+    pub fn dd_test_allocation_weight(size: u64, interval: u64) -> u64;
 }
 unsafe extern "C" {
     pub fn dd_allocation_created_slow(

--- a/libdd-profiling-heap-sampler/src/lib.rs
+++ b/libdd-profiling-heap-sampler/src/lib.rs
@@ -203,7 +203,7 @@ mod tests {
             assert!(dd_tl_state_get().is_null());
             let req = dd_allocation_requested(1, 1);
             assert_eq!(req.size, 1);
-            assert_eq!(req.weight, 0);
+            assert_eq!(req.weighted_bytes, 0);
             // Semaphore is inactive (no profiler), so TLS is never touched.
             assert!(dd_tl_state_get().is_null());
         })
@@ -219,14 +219,14 @@ mod tests {
                 size: 64,
                 user_size: 64,
                 alignment: 8,
-                weight: 0,
+                weighted_bytes: 0,
             };
             assert_eq!(dd_allocation_created(fake, req), fake);
         }
     }
 
     // With live-heap tracking compiled out, even a "sampled" allocation
-    // (weight > 0) is never flagged: the created pointer is the raw pointer
+    // (weighted_bytes > 0) is never flagged: the created pointer is the raw pointer
     // unchanged. The alloc USDT still fires (allocation profiling), but
     // there is no tag/header, so no matching free is expected.
     #[cfg(not(feature = "live-heap"))]
@@ -238,7 +238,7 @@ mod tests {
                 size: 64,
                 user_size: 64,
                 alignment: 8,
-                weight: 5,
+                weighted_bytes: 5,
             };
             assert_eq!(dd_allocation_created(fake, req), fake);
         }
@@ -292,7 +292,7 @@ mod tests {
         assert_eq!(req.size, 64);
         assert_eq!(req.user_size, 64);
         assert_eq!(req.alignment, 8);
-        assert_eq!(req.weight, 0);
+        assert_eq!(req.weighted_bytes, 0);
         assert!(!tl.reentry_guard);
     }
 
@@ -404,5 +404,206 @@ mod tests {
         })
         .join()
         .unwrap();
+    }
+}
+
+// Tests for the per-allocation unbiased byte weight calculation.
+// These exercise the allocation_weight helper deterministically via the
+// dd_test_allocation_weight C test entry point.
+#[cfg(all(test, target_os = "linux", not(miri)))]
+mod weight_tests {
+    use super::*;
+
+    extern "C" {
+        fn dd_test_allocation_weight(size: u64, interval: u64) -> u64;
+    }
+
+    fn weight(size: u64, interval: u64) -> u64 {
+        unsafe { dd_test_allocation_weight(size, interval) }
+    }
+
+    /// Helper: compute expected weight with f64 precision for comparison.
+    fn expected_weight(size: f64, interval: f64) -> f64 {
+        let p = -(-size / interval).exp_m1();
+        size / p
+    }
+
+    // Small allocation: size = 64, interval = 512 KiB.
+    // The weight should be approximately one sampling interval (~512 KiB)
+    // because the allocation is so small relative to the interval that each
+    // sample represents roughly `interval` bytes.
+    #[test]
+    fn small_allocation_weight_approximately_one_interval() {
+        let interval: u64 = 512 * 1024;
+        let size: u64 = 64;
+        let w = weight(size, interval);
+
+        // For very small S/R, weight ~= R * (1 + S/(2R) + ...)
+        // With size=64, interval=512K: weight should be very close to interval.
+        let tolerance = interval / 100; // 1% tolerance
+        assert!(
+            w > interval - tolerance && w < interval + tolerance,
+            "small allocation weight {w} should be approximately interval {interval}"
+        );
+    }
+
+    // Allocation at the sampling interval: size == interval.
+    // weight should be approximately interval / (1 - exp(-1)) ~= 1.582 * interval.
+    #[test]
+    fn allocation_at_interval_weight() {
+        let interval: u64 = 512 * 1024;
+        let size: u64 = interval;
+        let w = weight(size, interval);
+
+        let expected = expected_weight(size as f64, interval as f64);
+        let tolerance = (expected * 0.001) as u64; // 0.1% tolerance
+        assert!(
+            (w as f64 - expected).abs() < tolerance as f64,
+            "interval-sized allocation weight {w} should be ~{expected:.0} \
+             (1.582 * interval = {})",
+            (1.582 * interval as f64) as u64
+        );
+    }
+
+    // Large allocation: size = 8 * interval.
+    // The allocation is almost certain to be sampled (p ~= 1), so weight
+    // should be very close to the actual size.
+    #[test]
+    fn large_allocation_weight_close_to_size() {
+        let interval: u64 = 512 * 1024;
+        let size: u64 = 8 * interval;
+        let w = weight(size, interval);
+
+        // p = 1 - exp(-8) ~= 0.99966; weight ~= size / 0.99966 ~= size * 1.0003
+        let tolerance = size / 1000; // 0.1% tolerance
+        assert!(
+            (w as i64 - size as i64).unsigned_abs() < tolerance,
+            "large allocation weight {w} should be close to size {size} \
+             (diff = {})",
+            (w as i64 - size as i64).abs()
+        );
+    }
+
+    // Monotonic large-allocation behavior: as size grows much larger than
+    // the interval, weight/size should approach 1.
+    #[test]
+    fn large_allocation_weight_over_size_approaches_one() {
+        let interval: u64 = 512 * 1024;
+        let mut prev_ratio = f64::MAX;
+        for multiplier in [4u64, 8, 16, 32, 64] {
+            let size = multiplier * interval;
+            let w = weight(size, interval);
+            let ratio = w as f64 / size as f64;
+            // At 4x interval: 1/(1-exp(-4)) ~= 1.0187, so use 2% tolerance.
+            assert!(
+                (ratio - 1.0).abs() < 0.02,
+                "size={size} ({}x interval): weight/size = {ratio:.6}, expected ~1.0",
+                multiplier
+            );
+            // Verify monotonic (non-increasing) convergence toward 1.0.
+            assert!(
+                ratio <= prev_ratio,
+                "ratio should not increase as size grows: {ratio:.6} > {prev_ratio:.6}"
+            );
+            prev_ratio = ratio;
+        }
+    }
+
+    // Disabled sampling: interval == 0 should always return weight 0.
+    #[test]
+    fn zero_interval_returns_zero_weight() {
+        assert_eq!(weight(64, 0), 0);
+        assert_eq!(weight(1024, 0), 0);
+        assert_eq!(weight(0, 0), 0);
+    }
+
+    // Zero-size allocation: should return weight 0.
+    #[test]
+    fn zero_size_returns_zero_weight() {
+        assert_eq!(weight(0, 512 * 1024), 0);
+    }
+
+    // Verify the slow path produces the new weight semantics.
+    // Set up a thread-local state that will immediately sample, then check
+    // that the returned weight matches allocation_weight(size, interval).
+    #[test]
+    fn slow_path_produces_correct_weight() {
+        let interval: u64 = 512 * 1024;
+        let size: usize = 256;
+
+        let mut tl = dd_tl_state_t {
+            sampling_interval: interval,
+            remaining_bytes: 0, // will trigger sampling
+            remaining_bytes_initialized: true,
+            initialized: true,
+            reentry_guard: false,
+            rng: 42,
+        };
+
+        let req = unsafe { dd_allocation_requested_slow(&mut tl, size, 8) };
+
+        // The allocation was sampled, so weighted_bytes > 0.
+        assert!(
+            req.weighted_bytes > 0,
+            "sampled allocation must have weighted_bytes > 0"
+        );
+
+        // weighted_bytes should match the deterministic allocation_weight calculation.
+        let expected = weight(size as u64, interval);
+        assert_eq!(
+            req.weighted_bytes,
+            expected,
+            "slow path weighted_bytes {w} != allocation_weight({size}, {interval}) = {expected}",
+            w = req.weighted_bytes
+        );
+
+        // The reentry guard should still be open (waiting for created).
+        assert!(tl.reentry_guard);
+    }
+
+    // Statistical regression: perform many allocations of a fixed size and
+    // verify that the sum of weights converges to the actual total bytes.
+    // Uses a deterministic seed via the LCG so this is not flaky.
+    #[test]
+    fn statistical_weight_sum_converges_to_total_bytes() {
+        let interval: u64 = 512 * 1024;
+        let alloc_size: usize = 128;
+        let num_allocations: usize = 200_000;
+
+        let mut tl = dd_tl_state_t {
+            sampling_interval: interval,
+            remaining_bytes: -(interval as i64), // start cold
+            remaining_bytes_initialized: true,
+            initialized: true,
+            reentry_guard: false,
+            rng: 12345,
+        };
+
+        let total_allocated = (alloc_size as u64) * (num_allocations as u64);
+        let mut weight_sum: u64 = 0;
+
+        for _ in 0..num_allocations {
+            // Simulate the fast-path counter increment.
+            tl.remaining_bytes += alloc_size as i64;
+            if tl.remaining_bytes >= 0 {
+                // Would enter slow path.
+                tl.reentry_guard = false;
+                let req = unsafe { dd_allocation_requested_slow(&mut tl, alloc_size, 8) };
+                weight_sum += req.weighted_bytes;
+                // Close the reentry guard as dd_allocation_created_slow would.
+                tl.reentry_guard = false;
+            }
+        }
+
+        // The sum of weights should be within 10% of total allocated bytes.
+        // With 200K allocations of 128 bytes = ~24.4 MiB total, and interval
+        // of 512 KiB, we expect roughly 48 samples. The statistical error
+        // for a Poisson process should be well within 10%.
+        let ratio = weight_sum as f64 / total_allocated as f64;
+        assert!(
+            (ratio - 1.0).abs() < 0.10,
+            "weight_sum/total_allocated = {ratio:.4} (weight_sum={weight_sum}, \
+             total={total_allocated}), expected within 10% of 1.0"
+        );
     }
 }

--- a/libdd-profiling-heap-sampler/src/probes.c
+++ b/libdd-profiling-heap-sampler/src/probes.c
@@ -30,9 +30,9 @@
 USDT_DEFINE_SEMA(ddheap_alloc);
 
 /* Save / restore errno: an attached USDT consumer may perturb it. */
-void dd_probe_alloc(void *user, uint64_t size, uint64_t weight) {
+void dd_probe_alloc(void *user, uint64_t size, uint64_t weighted_bytes) {
     int saved_errno = errno;
-    USDT_WITH_EXPLICIT_SEMA(ddheap_alloc, ddheap, alloc, user, size, weight);
+    USDT_WITH_EXPLICIT_SEMA(ddheap_alloc, ddheap, alloc, user, size, weighted_bytes);
     errno = saved_errno;
 }
 


### PR DESCRIPTION
### What

 Redefines weight in the ddheap:alloc USDT from nsamples * sampling_interval to a proper per-allocation unbiased byte estimator. Matches [proposed changes to design](https://github.com/open-telemetry/opentelemetry-ebpf-profiler/pull/1743). 

 ### Why

 nsamples * sampling_interval is a coarse measure that counts how many sampling-interval boundaries an allocation crosses, then multiplies by the interval. This has two problems:

 1. Excessive variance for large allocations. A 4 MiB allocation with a 512 KiB interval might cross 7 or 9 boundaries depending on where the random sampling points fall, producing a weight of 3.5-4.5 MiB instead of
    consistently ~4 MiB. The allocation is virtually certain to be sampled, so its weight should be close to its actual size.
 2. Size-bias distortion. Downstream consumers that count alloc_objects = 1 per emitted event systematically overstate large-allocation stacks relative to small ones, since large allocations are more likely to be sampled.

 The new weight enables consumers to derive both unbiased byte totals (alloc_space = weight) and unbiased object counts (alloc_objects = weight / size) from a single value.

 This brings the sampler in line with [jemalloc's approach to correcting sampling bias https://github.com/jemalloc/jemalloc/blob/dev/doc_internal/PROFILING_INTERNALS.md), which the design already references as the model for the in-process sampler.

 ### Changes

 - weight semantics: now the unbiased estimate of allocated bytes represented by this sampled allocation, computed from its inclusion probability under Poisson sampling: p = 1 - exp(-size / interval), weight = size / p.
   Uses expm1 for numerical stability.
 - sample() return type: changed from uint64_t (nsamples * interval) to bool (was this allocation sampled?). The nsamples counter is removed; the sampling loop now only advances remaining_bytes state.
 - Weight calculation on slow path only: allocation_weight() is called after the sampling decision, so no floating-point work is added to the unsampled fast path.
 - Zero-size allocations: treated as unsampled (weight = 0) to preserve the weight == 0 means "not sampled" invariant and avoid leaving the reentry guard open.
 - Documentation: all references to nsamples * interval updated across headers, comments, and README.
 - Tests: focused deterministic tests for weight at small/interval/large sizes, monotonic convergence, edge cases, and a statistical regression test verifying sum(weights) ≈ total_allocated.

