### PR TITLE
chore: release v41.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,7 +715,7 @@ checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "build_common"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "cbindgen",
  "serde",
@@ -724,7 +724,7 @@ dependencies = [
 
 [[package]]
 name = "builder"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "datadog-profiling-replayer"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2793,7 +2793,7 @@ checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libdd-agent-client"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "bytes",
  "flate2",
@@ -2893,7 +2893,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-common-ffi"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "assert_no_alloc",
@@ -2948,7 +2948,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-crashtracker-ffi"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -3014,7 +3014,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-data-pipeline-ffi"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "build_common",
  "httpmock",
@@ -3044,7 +3044,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-ddsketch-ffi"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "build_common",
  "libdd-common-ffi",
@@ -3109,7 +3109,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-ffe-test-suite"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "chrono",
  "criterion",
@@ -3200,7 +3200,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-log-ffi"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "build_common",
  "libdd-common-ffi",
@@ -3322,7 +3322,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-profiling-heap-gotter-ffi"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "build_common",
@@ -3416,7 +3416,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-shared-runtime-ffi"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "build_common",
  "libdd-shared-runtime",
@@ -3458,7 +3458,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-telemetry-ffi"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "build_common",
  "function_name",
@@ -5741,7 +5741,7 @@ dependencies = [
 
 [[package]]
 name = "symbolizer-ffi"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "blazesym-c",
  "build_common",
@@ -6189,7 +6189,7 @@ dependencies = [
 
 [[package]]
 name = "tools"
-version = "40.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ resolver = "2"
 [workspace.package]
 rust-version = "1.87.0"
 edition = "2021"
-version = "40.0.0"
+version = "41.0.0"
 license = "Apache-2.0"
 authors = ["Datadog Inc. <info@datadoghq.com>"]
 


### PR DESCRIPTION
Prepare the `v41.0.0` release by bumping the workspace version and regenerating the lockfile.