### PR TITLE
refactor: migrate HTTP & networking deps to workspace level (phase 4bis)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2176,11 +2176,11 @@ dependencies = [
 
 [[package]]
 name = "headers"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes",
  "headers-core",
  "http 1.1.0",
@@ -5561,9 +5561,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,9 +106,9 @@ clap = { version = "4.3.21", default-features = false }
 criterion = { version = "0.5.1", default-features = true }
 cxx-build = { version = "1.0", default-features = false }
 elf = { version = "0.7", default-features = false }
+fastrand = { version = "2", default-features = false }
 # flate2 without a backend feature is unusable (no compression backend at all).
 # `rust_backend` (pure Rust, no C dependency) is the baseline we want everywhere.
-fastrand = { version = "2", default-features = false }
 flate2 = { version = "1.0", default-features = false, features = ["rust_backend"] }
 futures = { version = "0.3", default-features = false }
 http = { version = "1.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,9 @@ authors = ["Datadog Inc. <info@datadoghq.com>"]
 allocator-api2 = { version = "0.2.21", default-features = false }
 arc-swap = { version = "1.7.1", default-features = false }
 anyhow = { version = "1.0", default-features = false }
+base64 = { version = "0.22", default-features = false }
 bolero = { version = "0.13.4", default-features = false }
+bytes = { version = "1.11", default-features = false }
 chrono = { version = "0.4.38", default-features = false }
 clap = { version = "4.3.21", default-features = false }
 # Some default features are necessary: without `cargo_bench_support` the
@@ -104,7 +106,18 @@ clap = { version = "4.3.21", default-features = false }
 criterion = { version = "0.5.1", default-features = true }
 cxx-build = { version = "1.0", default-features = false }
 elf = { version = "0.7", default-features = false }
+# flate2 without a backend feature is unusable (no compression backend at all).
+# `rust_backend` (pure Rust, no C dependency) is the baseline we want everywhere.
+fastrand = { version = "2", default-features = false }
+flate2 = { version = "1.0", default-features = false, features = ["rust_backend"] }
 futures = { version = "0.3", default-features = false }
+http = { version = "1.1", default-features = false }
+http-body-util = { version = "0.1", default-features = false }
+# httpmock 0.8.0-alpha.1 does not compile without the `cookies` feature: its
+# own `readers.rs` calls `req.cookies()` unconditionally while that method is
+# gated behind `cookies`. Keep it as a baseline at the workspace level.
+httpmock = { version = "0.8.0-alpha.1", default-features = false, features = ["cookies"] }
+httparse = { version = "1.9", default-features = false }
 hyper = { version = "1.6", default-features = false }
 hyper-util = { version = "0.1.10", default-features = false }
 io-lifetimes = { version = "1.0", default-features = false }
@@ -113,14 +126,21 @@ io-lifetimes = { version = "1.0", default-features = false }
 # `no-std` environment is not the recommended way, and that this possibility
 # will be gone in future versions). We enable it by default for everyone.
 libc = { version = "0.2", default-features = true }
+mime = { version = "0.3.16", default-features = false }
+once_cell = { version = "1.18", default-features = false }
+percent-encoding = { version = "2.1", default-features = false }
 prost-build = { version = "0.14.1", default-features = false }
 protoc-bin-vendored = { version = "3.0.0", default-features = false }
+regex = { version = "1.5", default-features = false }
+reqwest = { version = "0.13", default-features = false }
 rustls = { version = "0.23", default-features = false }
+rustls-platform-verifier = { version = "0.6", default-features = false }
 serde = { version = "1.0", default-features = false }
 # serde_json requires at least one of `std` or `alloc`. We set `alloc` here as
 # the minimal working baseline, and to avoid repeating alloc everywhere.
 # Enabling `std` on top of it is fine.
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
+sha2 = { version = "0.10", default-features = false }
 syn = { version = "^2", default-features = false }
 # Without `getrandom`, tempfile seeds its temp-name RNG weakly and its own docs
 # flag that an attacker may then be able to predict the file names. We enable
@@ -131,6 +151,7 @@ tempfile = { version = "3.13", default-features = false, features = [
 tokio = { version = "1.36", default-features = false }
 tracing = { version = "0.1", default-features = false }
 uuid = { version = "1.7.0", default-features = false }
+zstd = { version = "0.13", default-features = false }
 
 [profile.dev]
 debug = 2 # full debug info

--- a/bin_tests/Cargo.toml
+++ b/bin_tests/Cargo.toml
@@ -11,7 +11,7 @@ build = "build.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-once_cell = "1.18"
+once_cell = { workspace = true, features = ["std"] }
 anyhow = "1.0"
 current_platform = "0.2.0"
 libdd-profiling = { path = "../libdd-profiling" }

--- a/datadog-live-debugger-ffi/Cargo.toml
+++ b/datadog-live-debugger-ffi/Cargo.toml
@@ -15,7 +15,7 @@ bench = false
 datadog-live-debugger = { path = "../datadog-live-debugger" }
 libdd-common = { path = "../libdd-common" }
 libdd-common-ffi = { path = "../libdd-common-ffi", default-features = false }
-percent-encoding = "2.1"
+percent-encoding = { workspace = true, features = ["std"] }
 uuid = { workspace = true, features = ["v4", "std"] }
 serde_json.workspace = true
 tokio = "1.36.0"

--- a/datadog-live-debugger/Cargo.toml
+++ b/datadog-live-debugger/Cargo.toml
@@ -11,11 +11,11 @@ libdd-remote-config = { path = "../libdd-remote-config", default-features = fals
 libdd-common = { path = "../libdd-common" }
 libdd-data-pipeline = { path = "../libdd-data-pipeline" }
 libdd-capabilities = { path = "../libdd-capabilities" }
-"http" = "1"
-bytes =  "1.11.1"
+"http" = { workspace = true, features = ["std"] }
+bytes = { workspace = true, features = ["std"] }
 futures.workspace = true
 
-percent-encoding = "2.1"
+percent-encoding = { workspace = true, features = ["std"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 sys-info = { version = "0.9.0" }

--- a/datadog-sidecar-ffi/Cargo.toml
+++ b/datadog-sidecar-ffi/Cargo.toml
@@ -37,7 +37,7 @@ libdd-crashtracker = { path = "../libdd-crashtracker", default-features = false,
 libdd-crashtracker-ffi = { path = "../libdd-crashtracker-ffi", features = ["collector", "collector_windows"] }
 
 [dev-dependencies]
-http = "1.1"
+http = { workspace = true, features = ["std"] }
 libdd-trace-utils = { path = "../libdd-trace-utils", features = ["test-utils"] }
 tempfile.workspace = true
 

--- a/datadog-sidecar/Cargo.toml
+++ b/datadog-sidecar/Cargo.toml
@@ -36,8 +36,8 @@ libdd-tinybytes = { path = "../libdd-tinybytes" }
 
 futures.workspace = true
 manual_future = "0.1.1"
-http = "1.1"
-http-body-util = "0.1"
+http = { workspace = true, features = ["std"] }
+http-body-util.workspace = true
 
 libdd-ipc = { path = "../libdd-ipc", features = ["tiny-bytes"] }
 libdd-ipc-macros = { path = "../libdd-ipc-macros" }
@@ -48,10 +48,10 @@ serde = { version = "1.0", features = ["derive", "rc"] }
 serde_with = "3.6.0"
 bincode = { version = "1.3.3" }
 serde_json.workspace = true
-base64 = "0.22.1"
+base64 = { workspace = true, features = ["std"] }
 spawn_worker = { path = "../spawn_worker" }
 zwohash = "0.1.2"
-sha2 = "0.10"
+sha2 = { workspace = true, features = ["std"] }
 tokio = { version = "1.49.0", features = [
     "fs",
     "sync",
@@ -115,7 +115,7 @@ microseh = "0.1.1"
 [dev-dependencies]
 libc.workspace = true
 tempfile.workspace = true
-httpmock = "0.8.0-alpha.1"
+httpmock.workspace = true
 libdd-remote-config = { path = "../libdd-remote-config", features = ["test"] }
 libdd-trace-utils = { path = "../libdd-trace-utils", features = ["test-utils"] }
 

--- a/libdd-agent-client/Cargo.toml
+++ b/libdd-agent-client/Cargo.toml
@@ -23,8 +23,8 @@ reqwest-backend = ["libdd-http-client/reqwest-backend"]
 hyper-backend = ["libdd-http-client/hyper-backend"]
 
 [dependencies]
-bytes = "1.4"
-flate2 = "1"
+bytes = { workspace = true, features = ["std"] }
+flate2.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 thiserror = "2"
@@ -34,7 +34,7 @@ libdd-common = { version = "5.2", path = "../libdd-common", default-features = f
 tracing.workspace = true
 
 [dev-dependencies]
-httpmock = "0.8.0-alpha.1"
+httpmock.workspace = true
 rustls = { workspace = true, features = ["ring"] }
 serial_test = "3.2"
 tokio = { version = "1.23", features = ["rt", "macros"] }

--- a/libdd-capabilities-impl/Cargo.toml
+++ b/libdd-capabilities-impl/Cargo.toml
@@ -17,14 +17,14 @@ bench = false
 
 [dependencies]
 anyhow.workspace = true
-bytes = "1"
-http = "1"
+bytes = { workspace = true, features = ["std"] }
+http = { workspace = true, features = ["std"] }
 libdd-capabilities = { path = "../libdd-capabilities", version = "3.0.0" }
 libdd-common = { path = "../libdd-common", version = "5.2.0", default-features = false, features = ["http-client"] }
 tokio = { workspace = true, features = ["fs", "time"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-http-body-util = "0.1"
+http-body-util.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/libdd-capabilities/Cargo.toml
+++ b/libdd-capabilities/Cargo.toml
@@ -16,8 +16,8 @@ crate-type = ["lib"]
 bench = false
 
 [dependencies]
-http = "1"
-bytes = "1.11.1"
+http = { workspace = true, features = ["std"] }
+bytes = { workspace = true, features = ["std"] }
 anyhow = "1.0"
 thiserror = "1.0"
 futures-channel = { version = "0.3", default-features = false, features = ["std"] }

--- a/libdd-common/Cargo.toml
+++ b/libdd-common/Cargo.toml
@@ -21,24 +21,24 @@ futures = { workspace = true, features = ["alloc", "executor"] }
 futures-core = { version = "0.3.0", default-features = false }
 futures-util = { version = "0.3.0", default-features = false }
 hex = "0.4"
-httparse = { version = "1.9", optional = true }
-http = "1"
-mime = { version = "0.3.16", optional = true }
+httparse = { workspace = true, features = ["std"], optional = true }
+http = { workspace = true, features = ["std"] }
+mime = { workspace = true, optional = true }
 multer = { version = "3.1", optional = true }
-bytes = { version = "1.11.1" }
+bytes = { workspace = true, features = ["std"] }
 pin-project = "1"
 rand = { version = "0.8", optional = true }
-regex = "1.5"
+regex = { workspace = true, features = ["std", "unicode", "perf"] }
 regex-lite = { version = "0.1", optional = true }
 # Use hickory-dns instead of the default system DNS resolver to avoid fork safety issues.
 # The default resolver can hold locks or other global state that can cause deadlocks
 # or corruption when the process forks (e.g., in PHP-FPM or other forking environments).
 # Use rustls-no-provider instead of rustls to avoid reqwest forcing aws-lc-rs as the crypto
 # backend. We install the ring provider explicitly in connector/mod.rs instead.
-reqwest = { version = "0.13.2", features = ["rustls-no-provider", "hickory-dns"], default-features = false, optional = true }
+reqwest = { workspace = true, features = ["rustls-no-provider", "hickory-dns"], optional = true }
 criterion = { workspace = true, optional = true }
 rustls-native-certs = { version = ">=0.8.1, <0.8.3", optional = true }
-rustls-platform-verifier = { version = "0.6", optional = true }
+rustls-platform-verifier = { workspace = true, optional = true }
 thiserror = "1.0"
 tokio-rustls = { version = "0.26", default-features = false, optional = true }
 serde = { workspace = true, default-features = true, features = ["derive"] }
@@ -60,7 +60,7 @@ rustls-webpki = { version = ">=0.103.13", optional = true }
 hyper = { workspace = true, features = ["http1", "client"], optional = true }
 hyper-util = { workspace = true, features = ["http1", "client", "client-legacy"], optional = true }
 http-body = { version = "1.0", optional = true }
-http-body-util = { version = "0.1", optional = true }
+http-body-util = {workspace = true, optional = true }
 tower-service = { version = "0.3", optional = true }
 cc = "1.1.31"
 pin-project = "1"
@@ -81,11 +81,11 @@ features = [
 nix = { version = "0.29", features = ["process"] }
 
 [dev-dependencies]
-bytes = "1.11.1"
-httparse = "1.9"
+bytes = { workspace = true, features = ["std"] }
+httparse = { workspace = true, features = ["std"] }
 indexmap = "2.11"
 maplit = "1.0"
-mime = "0.3.16"
+mime.workspace = true
 multer = "3.1"
 proptest = "1"
 rand = "0.8"

--- a/libdd-crashtracker/Cargo.toml
+++ b/libdd-crashtracker/Cargo.toml
@@ -54,7 +54,7 @@ libdd-capabilities = { version = "3.0.0", path = "../libdd-capabilities" }
 libdd-capabilities-impl = { version = "4.0.0", path = "../libdd-capabilities-impl" }
 libdd-common = { version = "5.2.0", path = "../libdd-common" }
 libdd-telemetry = { version = "7.0.0", path = "../libdd-telemetry" }
-http = "1.1"
+http = { workspace = true, features = ["std"] }
 libc.workspace = true
 nix = { version = "0.29", features = ["poll", "signal", "socket"] }
 num-derive = "0.4.2"

--- a/libdd-data-pipeline-ffi/Cargo.toml
+++ b/libdd-data-pipeline-ffi/Cargo.toml
@@ -31,7 +31,7 @@ stats-obfuscation = ["libdd-data-pipeline/stats-obfuscation"]
 build_common = { path = "../build-common" }
 
 [dev-dependencies]
-httpmock = "0.8.0-alpha.1"
+httpmock.workspace = true
 rmp-serde = "1.3.0"
 libdd-trace-utils = { path = "../libdd-trace-utils" }
 

--- a/libdd-data-pipeline/Cargo.toml
+++ b/libdd-data-pipeline/Cargo.toml
@@ -95,14 +95,10 @@ tokio = { version = "1.23", features = [
     "test-util",
 ], default-features = false }
 duplicate = "2.0.1"
-<<<<<<< HEAD
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 h2 = "0.4"
-zstd = { version = "0.13", default-features = false }
-=======
 zstd.workspace = true
->>>>>>> 1e4b95586 (refactor: migrate HTTP & networking deps to workspace level (phase 5))
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 zrip = { version = "=0.6.0", default-features = false, features = ["alloc"] }

--- a/libdd-data-pipeline/Cargo.toml
+++ b/libdd-data-pipeline/Cargo.toml
@@ -15,14 +15,14 @@ autobenches = false
 arc-swap.workspace = true
 anyhow.workspace = true
 async-trait = "0.1"
-http = "1"
-http-body-util = "0.1"
+http = { workspace = true, features = ["std"] }
+http-body-util.workspace = true
 tracing.workspace = true
 rmp-serde = "1.3.0"
 serde.workspace = true
 serde_json.workspace = true
-bytes = "1.11.1"
-sha2 = "0.10"
+bytes = { workspace = true, features = ["std"] }
+sha2 = { workspace = true, features = ["std"] }
 either = "1.13.0"
 futures = { workspace = true, features = ["alloc"] }
 tokio = { workspace = true, features = [
@@ -79,13 +79,13 @@ path = "benches/trace_buffer.rs"
 libdd-capabilities-impl = { version = "4.0.0", path = "../libdd-capabilities-impl" }
 libdd-log = { path = "../libdd-log" }
 libdd-shared-runtime = { version = "3.0.0", path = "../libdd-shared-runtime" }
-regex = "1.5"
+regex = { workspace = true, features = ["std", "unicode", "perf"] }
 clap = { workspace = true, default-features = true, features = ["derive"] }
 criterion.workspace = true
 libdd-trace-utils = { path = "../libdd-trace-utils", features = [
     "test-utils",
 ] }
-httpmock = "0.8.0-alpha.1"
+httpmock.workspace = true
 prost = "0.14.1"
 rand = "0.8.5"
 tempfile.workspace = true
@@ -95,10 +95,14 @@ tokio = { version = "1.23", features = [
     "test-util",
 ], default-features = false }
 duplicate = "2.0.1"
+<<<<<<< HEAD
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 h2 = "0.4"
 zstd = { version = "0.13", default-features = false }
+=======
+zstd.workspace = true
+>>>>>>> 1e4b95586 (refactor: migrate HTTP & networking deps to workspace level (phase 5))
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 zrip = { version = "=0.6.0", default-features = false, features = ["alloc"] }

--- a/libdd-dogstatsd-client/Cargo.toml
+++ b/libdd-dogstatsd-client/Cargo.toml
@@ -17,7 +17,7 @@ cadence = "1.3.0"
 serde = { workspace = true, features = ["derive", "rc"] }
 tracing.workspace = true
 anyhow.workspace = true
-http = "1.1"
+http = { workspace = true, features = ["std"] }
 libdd-shared-runtime = { version = "3.0.0", path = "../libdd-shared-runtime", default-features = false, optional = true }
 tokio = { version = "1.23", features = ["sync"], optional = true }
 async-trait = { version = "0.1", optional = true }

--- a/libdd-ffe/Cargo.toml
+++ b/libdd-ffe/Cargo.toml
@@ -23,7 +23,7 @@ log = { version = "0.4.21", default-features = false, features = ["kv", "kv_serd
 md5 = { version = "0.7.0", default-features = false }
 libdd-common = { version = "5.2.0", path = "../libdd-common", default-features = false, features = ["require-regex-full"] }
 libdd-capabilities = { path = "../libdd-capabilities", version = "3.0.0", optional = true }
-http = { version = "1.1", optional = true }
+http = { workspace = true, features = ["std"], optional = true }
 tokio = { version = "1.49.0", features = ["time"], optional = true }
 semver = "1.0"
 serde-bool = { version = "0.1.3", default-features = false }
@@ -40,7 +40,7 @@ pyo3 = { version = "0.28", optional = true, default-features = false, features =
 # round-trip test, which guards against `skip_serializing_if` reintroducing the
 # worker→sidecar IPC field-misalignment bug (bincode is non-self-describing).
 bincode = { version = "1.3.3" }
-httpmock = "0.8.0-alpha.1"
+httpmock.workspace = true
 libdd-capabilities-impl = { path = "../libdd-capabilities-impl" }
 
 [features]

--- a/libdd-http-client/Cargo.toml
+++ b/libdd-http-client/Cargo.toml
@@ -30,20 +30,20 @@ hyper-proxy = ["hyper-backend", "libdd-common?/hyper-proxy"]
 fips = ["dep:reqwest", "reqwest?/rustls-no-provider", "dep:rustls", "rustls?/aws-lc-rs", "libdd-common?/fips"]
 
 [dependencies]
-bytes = "1.4"
+bytes = { workspace = true, features = ["std"] }
 thiserror = "2"
-fastrand = "2"
+fastrand = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["rt", "time"] }
-reqwest = { version = "0.13", default-features = false, optional = true }
+reqwest = { workspace = true, optional = true }
 rustls = { workspace = true, optional = true }
 libdd-common = { version = "5.2.0", path = "../libdd-common", default-features = false, optional = true }
 hyper = { workspace = true, optional = true, features = ["http1", "client"] }
 hyper-util = { workspace = true, optional = true, features = ["http1", "client", "client-legacy"] }
-http-body-util = { version = "0.1", optional = true }
+http-body-util = { workspace = true, optional = true }
 
 
 [dev-dependencies]
-httpmock = "0.8.0-alpha.1"
+httpmock.workspace = true
 rustls = { workspace = true, features = ["ring"] }
 tokio = { version = "1.23", features = ["rt", "macros", "io-util", "net"] }
 tempfile.workspace = true

--- a/libdd-profiling-ffi/Cargo.toml
+++ b/libdd-profiling-ffi/Cargo.toml
@@ -81,7 +81,7 @@ libdd-ddsketch-ffi = { path = "../libdd-ddsketch-ffi", default-features = false,
 libdd-log-ffi = { path = "../libdd-log-ffi", default-features = false, optional = true }
 function_name = "0.3.0"
 futures.workspace = true
-http-body-util = "0.1"
+http-body-util.workspace = true
 hyper = { workspace = true, features = ["http1", "client"] }
 libc.workspace = true
 serde_json.workspace = true

--- a/libdd-profiling/Cargo.toml
+++ b/libdd-profiling/Cargo.toml
@@ -30,21 +30,21 @@ allocator-api2 = { workspace = true, features = ["alloc"] }
 anyhow.workspace = true
 bitmaps = "3.2.0"
 byteorder = { version = "1.5", features = ["std"] }
-bytes = "1.11.1"
+bytes = { workspace = true, features = ["std"] }
 chrono = { workspace = true, features = ["std", "clock"] }
 crossbeam-channel = "0.5.15"
 crossbeam-utils = { version = "0.8.21" }
 cxx = { version = "1.0", optional = true }
 futures.workspace = true
 hashbrown = { version = "0.16", default-features = false }
-http = "1.1"
-http-body-util = "0.1"
-httparse = "1.9"
+http = { workspace = true, features = ["std"] }
+http-body-util.workspace = true
+httparse = { workspace = true, features = ["std"] }
 indexmap = "2.11"
 libdd-alloc = { version = "1.0.0", path = "../libdd-alloc" }
 libdd-common = { version = "5.2.0", path = "../libdd-common", default-features = false, features = ["reqwest", "test-utils"] }
 libdd-profiling-protobuf = { version = "2.0.0", path = "../libdd-profiling-protobuf", features = ["prost_impls"] }
-mime = "0.3.16"
+mime.workspace = true
 parking_lot = { version = "0.12", default-features = false }
 prost = "0.14.1"
 rand = "0.8"
@@ -55,8 +55,8 @@ rand = "0.8"
 # or corruption when the process forks (e.g., in PHP-FPM or other forking environments).
 # Use rustls-no-provider instead of rustls to avoid reqwest forcing aws-lc-rs as the crypto
 # backend. We install the ring provider explicitly via tls.rs / libdd-common instead.
-reqwest = { version = "0.13.2", features = ["multipart", "rustls-no-provider", "hickory-dns"], default-features = false}
-rustls-platform-verifier = "0.6"
+reqwest = { workspace = true, features = ["multipart", "rustls-no-provider", "hickory-dns"] }
+rustls-platform-verifier.workspace = true
 rustc-hash = { version = "2.1", default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
@@ -69,7 +69,7 @@ tokio-util = { version = "0.7.1", default-features = false }
 rustls = { workspace = true, features = ["ring"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-zstd = { version = "0.13", default-features = false }
+zstd.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 zrip = { version = "=0.6.0", default-features = false, features = ["frame"] }

--- a/libdd-remote-config/Cargo.toml
+++ b/libdd-remote-config/Cargo.toml
@@ -47,18 +47,15 @@ test = ["hyper/server", "hyper-util"]
 
 [dependencies]
 anyhow.workspace = true
-bytes = { version = "1", optional = true }
+bytes = { workspace = true, features = ["std"], optional = true }
 libdd-common = { path = "../libdd-common", version = "5.2.0", default-features = false }
 libdd-capabilities = { path = "../libdd-capabilities", version = "3.0.0" }
 libdd-trace-protobuf = { path = "../libdd-trace-protobuf", version = "5.0.0", optional = true }
-hyper = { workspace = true, optional = true, default-features = false, features = [
-    "http1",
-    "client",
-] }
-http-body-util = { version = "0.1", optional = true }
-http = { version = "1.1", optional = true }
-base64 = { version = "0.22.1", optional = true }
-sha2 = { version = "0.10", optional = true }
+hyper = { workspace = true, optional = true, features = ["http1", "client"] }
+http-body-util = { workspace = true, optional = true }
+http = { workspace = true, features = ["std"], optional = true }
+base64 = { workspace = true, features = ["std"], optional = true }
+sha2 = { workspace = true, features = ["std"], optional = true }
 getrandom = { version = "0.2", optional = true }
 uuid = { workspace = true, features = ["std"], optional = true }
 futures-util = { version = "0.3", optional = true }

--- a/libdd-telemetry/Cargo.toml
+++ b/libdd-telemetry/Cargo.toml
@@ -20,9 +20,9 @@ fips = ["libdd-common/fips", "libdd-shared-runtime/fips"]
 [dependencies]
 anyhow.workspace = true
 async-trait = "0.1"
-base64 = "0.22"
+base64 = { workspace = true, features = ["std"] }
 futures.workspace = true
-http = "1"
+http = { workspace = true, features = ["std"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 strum = { version = "0.26", default-features = false }
@@ -32,7 +32,7 @@ tokio-util = { version = "0.7", features = ["codec"] }
 tracing.workspace = true
 uuid = { workspace = true, features = ["v4", "std"] }
 hashbrown = "0.15"
-bytes = "1.4"
+bytes = { workspace = true, features = ["std"] }
 libdd-capabilities = { version = "3.0.0", path = "../libdd-capabilities" }
 libdd-common = { version = "5.2.0", path = "../libdd-common", default-features = false }
 libdd-shared-runtime = { version = "3.0.0", path = "../libdd-shared-runtime", default-features = false }
@@ -57,4 +57,4 @@ tracing-subscriber = "0.3.22"
 tokio = { version = "1.23", features = ["sync", "io-util", "rt-multi-thread"] }
 libdd-capabilities-impl = { path = "../libdd-capabilities-impl" }
 libdd-common = { path = "../libdd-common", features = ["test-utils"] }
-httpmock = "0.8.0-alpha.1"
+httpmock.workspace = true

--- a/libdd-tinybytes/Cargo.toml
+++ b/libdd-tinybytes/Cargo.toml
@@ -12,7 +12,7 @@ license.workspace = true
 bench = false
 
 [dev-dependencies]
-once_cell = "1.8"
+once_cell = { workspace = true, features = ["std"] }
 pretty_assertions = "1.3"
 proptest = {version = "1.5", features = ["std"], default-features = false}
 test-case = "2.2"

--- a/libdd-trace-obfuscation/Cargo.toml
+++ b/libdd-trace-obfuscation/Cargo.toml
@@ -15,7 +15,7 @@ authors.workspace = true
 anyhow.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
-percent-encoding = "2.1"
+percent-encoding = { workspace = true, features = ["std"] }
 log = "0.4"
 fluent-uri = "0.4.1"
 libdd-trace-protobuf = { version = "5.0.0", path = "../libdd-trace-protobuf" }

--- a/libdd-trace-stats/Cargo.toml
+++ b/libdd-trace-stats/Cargo.toml
@@ -22,7 +22,7 @@ libdd-trace-protobuf = { version = "5.0.0", path = "../libdd-trace-protobuf" }
 libdd-trace-obfuscation = { version = "7.0.0", path = "../libdd-trace-obfuscation", default-features = false }
 libdd-trace-utils = { version = "11.0.0", path = "../libdd-trace-utils", default-features = false }
 hashbrown = { version = "0.15" }
-http = "1.1"
+http = { workspace = true, features = ["std"] }
 rmp-serde = "1.3.0"
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["macros", "time"] }
@@ -46,7 +46,7 @@ path = "benches/main.rs"
 
 [dev-dependencies]
 criterion.workspace = true
-httpmock = "0.8.0-alpha.1"
+httpmock.workspace = true
 libdd-trace-utils = { path = "../libdd-trace-utils", features = ["test-utils"] }
 rand = "0.8.5"
 tokio = { version = "1.23", features = ["rt-multi-thread", "macros", "test-util", "time"], default-features = false }

--- a/libdd-trace-utils/Cargo.toml
+++ b/libdd-trace-utils/Cargo.toml
@@ -69,7 +69,7 @@ urlencoding = { version = "2.1.3", optional = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libdd-capabilities-impl = { version = "4.0.0", path = "../libdd-capabilities-impl", default-features = false, optional = true }
 tokio = { version = "1", features = ["time"], optional = true }
-zstd.workspace = true
+zstd = {workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/libdd-trace-utils/Cargo.toml
+++ b/libdd-trace-utils/Cargo.toml
@@ -25,13 +25,13 @@ required-features = ["bench-internals"]
 
 [dependencies]
 anyhow.workspace = true
-base64 = "0.22"
+base64 = { workspace = true, features = ["std"] }
 hex = "0.4"
 itoa = "1.0"
 hyper = { workspace = true, optional = true, features = ["http1", "client"] }
-"http" = "1"
+"http" = { workspace = true, features = ["std"] }
 "http-body" = "1"
-http-body-util = "0.1"
+http-body-util.workspace = true
 serde = { workspace = true, features = ["derive"] }
 prost = "0.14.1"
 rmp-serde = "1.3.0"
@@ -40,7 +40,7 @@ serde_json = { workspace = true, features = ["std"] }
 serde-transcode = "1.1"
 futures.workspace = true
 rand = "0.8.5"
-bytes = "1.11.1"
+bytes = { workspace = true, features = ["std"] }
 rmpv = { version = "1.3.0", default-features = false }
 rmp = { version = "0.8.14", default-features = false }
 rustc-hash = "2.1.1"
@@ -57,19 +57,19 @@ indexmap = "2.11"
 thin-vec = "0.2"
 
 # Compression feature
-flate2 = { version = "1.0", optional = true }
+flate2 = { workspace = true, optional = true }
 
 # test-utils feature
 cargo_metadata = { version = "0.18.1", optional = true }
 # Dependency of cargo metadata, but 0.1.8 requires too new of a rust version.
 cargo-platform = { version = "=0.1.7", optional = true }
-httpmock = { version = "0.8.0-alpha.1", optional = true }
+httpmock = { workspace = true, optional = true }
 urlencoding = { version = "2.1.3", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libdd-capabilities-impl = { version = "4.0.0", path = "../libdd-capabilities-impl", default-features = false, optional = true }
 tokio = { version = "1", features = ["time"], optional = true }
-zstd = { version = "0.13.3", default-features = false, optional = true }
+zstd.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
@@ -82,7 +82,7 @@ libdd-common = { path = "../libdd-common", default-features = false, features = 
 ] }
 bolero = { workspace = true, features = ["std"] }
 criterion.workspace = true
-httpmock = { version = "0.8.0-alpha.1" }
+httpmock.workspace = true
 serde_json.workspace = true
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util"] }
 libdd-trace-utils = { path = ".", features = ["test-utils"] }

--- a/libdd-tracer-flare/Cargo.toml
+++ b/libdd-tracer-flare/Cargo.toml
@@ -15,8 +15,8 @@ anyhow = "1.0"
 libdd-remote-config = { version = "4.0.0", path = "../libdd-remote-config", default-features = false }
 libdd-common = { version = "5.2.0", path = "../libdd-common" }
 libdd-trace-utils = { version = "11.0.0", path = "../libdd-trace-utils" }
-http = "1"
-bytes = "1.11.1"
+http = { workspace = true, features = ["std"] }
+bytes = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["time"] }
 serde_json.workspace = true
 zip = { version = "4.0.0", default-features = false, features = ["deflate"] }
@@ -31,7 +31,7 @@ bench = false
 
 [dev-dependencies]
 libdd-remote-config = { path = "../libdd-remote-config", features = ["test"] }
-httpmock = "0.8.0-alpha.1"
+httpmock.workspace = true
 libdd-trace-utils = { path = "../libdd-trace-utils", features = ["test-utils"] }
 tokio = { version = "1.36.0", features = ["time", "macros", "rt"] }
 

--- a/spawn_worker/Cargo.toml
+++ b/spawn_worker/Cargo.toml
@@ -10,7 +10,7 @@ bench = false
 [dependencies]
 anyhow.workspace = true
 io-lifetimes = { workspace = true, features = ["close"] }
-fastrand = "2.0.1"
+fastrand = { workspace = true, features = ["std"] }
 libc.workspace = true
 
 [build-dependencies]


### PR DESCRIPTION
# What does this PR do?

Moves the HTTP & networking dependencies to `[workspace.dependencies]`:
`http`, `bytes`, `http-body-util`, `httpmock`, `reqwest`, `httparse`,
`mime`, `sha2`, `base64`, `percent-encoding`, `rustls-platform-verifier`,
`flate2`, `zstd`, `fastrand`, `once_cell` and `regex`. This is an additional phase before phase 5 of the original plan.

All workspace entries are version-only with `default-features = false`; each
leaf crate opts into exactly the features it needs (mostly `std`). Two
documented exceptions where the no-default-features build is unusable:

- `flate2` needs a compression backend; `rust_backend` (pure Rust, no C
  dependency) is the baseline.
- `httpmock` 0.8.0-alpha.1 does not compile with `default-features = false`:
  its own `readers.rs` calls `req.cookies()` unconditionally while that
  method is gated behind the `cookies` feature (upstream alpha bug).

# Motivation

Single source of truth per dependency version, no accidental skew, shorter
leaf-crate manifests.

# Additional Notes

- `Cargo.lock` only bumps `headers` 0.4.0 -> 0.4.1 and `sha1` 0.10.6 ->
  0.10.7 (transitive of httpmock's `cookies` feature).
- Dev-only duplicates (`serial_test`, `proptest`, `duplicate`,
  `pretty_assertions`) are left for a later step.

# How to test the change?

- `cargo check --workspace`
- `cargo nextest run` on the affected crates
- `cargo ffi-test`
