### PR TITLE
fix(ffe): align semantic version evaluation errors

### DIFF
--- a/libdd-ffe-ffi/src/assignment.rs
+++ b/libdd-ffe-ffi/src/assignment.rs
@@ -369,7 +369,9 @@ impl From<&ResolutionDetails> for Reason {
         match value.as_ref() {
             Ok(assignment) => assignment.reason.into(),
             Err(EvaluationError::FlagDisabled) => Reason::Disabled,
-            Err(EvaluationError::DefaultAllocationNull) => Reason::Default,
+            Err(
+                EvaluationError::DefaultAllocationNull | EvaluationError::FlagConfigurationInvalid,
+            ) => Reason::Default,
             Err(_) => Reason::Error,
         }
     }
@@ -408,7 +410,7 @@ impl From<&EvaluationError> for ErrorCode {
             EvaluationError::TypeMismatch { .. } => ErrorCode::TypeMismatch,
             EvaluationError::TargetingKeyMissing => ErrorCode::TargetingKeyMissing,
             EvaluationError::ConfigurationParseError => ErrorCode::ParseError,
-            EvaluationError::FlagConfigurationInvalid => ErrorCode::ParseError,
+            EvaluationError::FlagConfigurationInvalid => ErrorCode::Ok,
             EvaluationError::ConfigurationMissing => ErrorCode::ProviderNotReady,
             EvaluationError::FlagUnrecognizedOrDisabled => ErrorCode::FlagNotFound,
             EvaluationError::FlagDisabled => ErrorCode::Ok,
@@ -491,10 +493,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn rejected_flag_is_exposed_as_parse_error() {
+    fn rejected_flag_returns_default_without_error() {
         let details = ResolutionDetails::from(EvaluationError::FlagConfigurationInvalid);
 
-        assert!(matches!(Reason::from(&details), Reason::Error));
-        assert_eq!(ErrorCode::from(&details), ErrorCode::ParseError);
+        assert!(matches!(Reason::from(&details), Reason::Default));
+        assert_eq!(ErrorCode::from(&details), ErrorCode::Ok);
     }
 }

--- a/libdd-ffe-test-suite/tests/canonical_fixtures.rs
+++ b/libdd-ffe-test-suite/tests/canonical_fixtures.rs
@@ -125,7 +125,9 @@ fn reason_from_assignment(reason: AssignmentReason) -> &'static str {
 fn reason_from_error(err: &EvaluationError) -> &'static str {
     match err {
         EvaluationError::FlagDisabled => "DISABLED",
-        EvaluationError::DefaultAllocationNull => "DEFAULT",
+        EvaluationError::DefaultAllocationNull | EvaluationError::FlagConfigurationInvalid => {
+            "DEFAULT"
+        }
         _ => "ERROR",
     }
 }
@@ -135,9 +137,8 @@ fn error_code_from_error(err: &EvaluationError) -> Option<&'static str> {
         EvaluationError::FlagDisabled | EvaluationError::DefaultAllocationNull => None,
         EvaluationError::TypeMismatch { .. } => Some("TYPE_MISMATCH"),
         EvaluationError::TargetingKeyMissing => Some("TARGETING_KEY_MISSING"),
-        EvaluationError::ConfigurationParseError | EvaluationError::FlagConfigurationInvalid => {
-            Some("PARSE_ERROR")
-        }
+        EvaluationError::ConfigurationParseError => Some("PARSE_ERROR"),
+        EvaluationError::FlagConfigurationInvalid => None,
         EvaluationError::ConfigurationMissing => Some("PROVIDER_NOT_READY"),
         EvaluationError::FlagUnrecognizedOrDisabled => Some("FLAG_NOT_FOUND"),
         EvaluationError::Internal(_) => Some("GENERAL"),

--- a/libdd-ffe/src/rules_based/error.rs
+++ b/libdd-ffe/src/rules_based/error.rs
@@ -33,10 +33,9 @@ pub enum EvaluationError {
     ConfigurationParseError,
 
     /// A requested flag exists in the configuration payload, but its per-flag configuration is
-    /// invalid or unsupported by this SDK. Failures encountered while compiling an individual
-    /// flag are converted to `FlagConfigurationInvalid` at the per-flag ingestion boundary. The
-    /// SDK should return the caller default and expose this as a parse error for that flag without
-    /// invalidating the rest of the configuration.
+    /// invalid or unsupported by this SDK. The SDK should return the caller default without
+    /// invalidating the rest of the configuration. Invalid semantic version comparands use
+    /// `ConfigurationParseError` instead, as required by the feature flag evaluation contract.
     #[error("flag configuration is invalid or unsupported")]
     FlagConfigurationInvalid,
 

--- a/libdd-ffe/src/rules_based/eval/eval_assignment.rs
+++ b/libdd-ffe/src/rules_based/eval/eval_assignment.rs
@@ -232,6 +232,21 @@ mod tests {
                     "splits": [{"variationKey": "trap", "shards": []}]
                   }]
                 },
+                "invalid-semver": {
+                  "key": "invalid-semver",
+                  "enabled": true,
+                  "variationType": "STRING",
+                  "variations": {"trap": {"key": "trap", "value": "trap"}},
+                  "allocations": [{
+                    "key": "invalid",
+                    "rules": [{"conditions": [{
+                      "attribute": "version",
+                      "operator": "SEMVER_EQ",
+                      "value": "18446744073709551616.0.0"
+                    }]}],
+                    "splits": [{"variationKey": "trap", "shards": []}]
+                  }]
+                },
                 "valid": {
                   "key": "valid",
                   "enabled": true,
@@ -257,6 +272,13 @@ mod tests {
                 .eval_flag("invalid-regex", &context, ExpectedFlagType::String, now)
                 .unwrap_err(),
             EvaluationError::FlagConfigurationInvalid
+        );
+
+        assert_eq!(
+            config
+                .eval_flag("invalid-semver", &context, ExpectedFlagType::String, now)
+                .unwrap_err(),
+            EvaluationError::ConfigurationParseError
         );
 
         let assignment = config

--- a/libdd-ffe/src/rules_based/eval/eval_rules.rs
+++ b/libdd-ffe/src/rules_based/eval/eval_rules.rs
@@ -77,6 +77,7 @@ impl ConditionCheck {
                     SemverComparisonOperator::Gte => ordering.is_ge(),
                 }
             }
+            ConditionCheck::InvalidSemverComparand { .. } => return None,
         };
 
         Some(result)

--- a/libdd-ffe/src/rules_based/ufc/compiled_flag_config.rs
+++ b/libdd-ffe/src/rules_based/ufc/compiled_flag_config.rs
@@ -87,8 +87,7 @@ impl From<UniversalFlagConfigWire> for CompiledFlagsConfig {
                     key,
                     Option::from(flag)
                         .ok_or(EvaluationError::FlagConfigurationInvalid)
-                        .and_then(compile_flag)
-                        .map_err(per_flag_config_error),
+                        .and_then(compile_flag),
                 )
             })
             .collect();
@@ -98,13 +97,6 @@ impl From<UniversalFlagConfigWire> for CompiledFlagsConfig {
             environment: config.environment,
             flags,
         }
-    }
-}
-
-fn per_flag_config_error(err: EvaluationError) -> EvaluationError {
-    match err {
-        EvaluationError::ConfigurationParseError => EvaluationError::FlagConfigurationInvalid,
-        err => err,
     }
 }
 
@@ -118,7 +110,7 @@ fn compile_flag(flag: FlagWire) -> Result<Flag, EvaluationError> {
         .into_values()
         .map(|variation| {
             let assignment_value = AssignmentValue::from_wire(flag.variation_type, variation.value)
-                .ok_or(EvaluationError::ConfigurationParseError)?;
+                .ok_or(EvaluationError::FlagConfigurationInvalid)?;
 
             Ok((variation.key, assignment_value))
         })
@@ -140,6 +132,19 @@ fn compile_allocation(
     allocation: AllocationWire,
     variation_values: &HashMap<Str, AssignmentValue>,
 ) -> Result<Allocation, EvaluationError> {
+    let rules = allocation.rules.unwrap_or_default();
+    let has_invalid_semver_comparand = rules.iter().any(|rule| {
+        rule.conditions.iter().any(|condition| {
+            matches!(
+                &condition.check,
+                super::ConditionCheck::InvalidSemverComparand { .. }
+            )
+        })
+    });
+    if has_invalid_semver_comparand {
+        return Err(EvaluationError::ConfigurationParseError);
+    }
+
     let splits = allocation
         .splits
         .into_iter()
@@ -149,7 +154,7 @@ fn compile_allocation(
         key: allocation.key,
         start_at: allocation.start_at,
         end_at: allocation.end_at,
-        rules: allocation.rules.unwrap_or_default(),
+        rules,
         splits,
         do_log: allocation.do_log,
     })
@@ -173,7 +178,7 @@ fn compile_split(
     let result = variation_values
         .get(&split.variation_key)
         .cloned()
-        .ok_or(EvaluationError::ConfigurationParseError)?;
+        .ok_or(EvaluationError::FlagConfigurationInvalid)?;
 
     Ok(Split {
         shards,

--- a/libdd-ffe/src/rules_based/ufc/models.rs
+++ b/libdd-ffe/src/rules_based/ufc/models.rs
@@ -182,6 +182,10 @@ pub(crate) enum ConditionCheck {
         operator: SemverComparisonOperator,
         comparand: semver::Version,
     },
+    InvalidSemverComparand {
+        operator: SemverComparisonOperator,
+        value: ConditionValue,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -277,6 +281,7 @@ impl From<Condition> for ConditionWire {
                     comparand.to_string().as_str(),
                 ))),
             ),
+            ConditionCheck::InvalidSemverComparand { operator, value } => (operator.into(), value),
         };
         ConditionWire {
             attribute: condition.attribute,
@@ -394,26 +399,35 @@ impl TryFrom<ConditionWire> for Condition {
                     ConditionOperator::SemverGte => SemverComparisonOperator::Gte,
                     _ => unreachable!(),
                 };
-                let semver_string = match condition.value.singleton() {
-                    Some(SingleConditionValue::String(s)) => s,
+                match condition.value.singleton() {
+                    Some(SingleConditionValue::String(semver_string)) => {
+                        match semver::Version::parse(&semver_string) {
+                            Ok(comparand) => ConditionCheck::SemverComparison {
+                                operator,
+                                comparand,
+                            },
+                            Err(err) => {
+                                log::warn!(
+                                    "failed to parse condition: invalid semver {:?}: {err:?}",
+                                    semver_string
+                                );
+                                ConditionCheck::InvalidSemverComparand {
+                                    operator,
+                                    value: condition.value,
+                                }
+                            }
+                        }
+                    }
                     _ => {
                         log::warn!(
                             "failed to parse condition: {:?} condition with non-string condition value",
                             condition.operator
                         );
-                        return Err(EvaluationError::ConfigurationParseError);
+                        ConditionCheck::InvalidSemverComparand {
+                            operator,
+                            value: condition.value,
+                        }
                     }
-                };
-                let comparand = semver::Version::parse(&semver_string).map_err(|err| {
-                    log::warn!(
-                        "failed to parse condition: invalid semver {:?}: {err:?}",
-                        semver_string
-                    );
-                    EvaluationError::ConfigurationParseError
-                })?;
-                ConditionCheck::SemverComparison {
-                    operator,
-                    comparand,
                 }
             }
         };


### PR DESCRIPTION
## Summary

- Align FFE semantic-version evaluation error mapping across the Rust and FFI layers.
- Update the canonical fixture Gitlink to `aaa97e44bb19c9cee7ae079995ddbcc864c6b702`.
- Run the canonical fixture suite against both semantic-version fixture files: comparison and validation (22 cases total: 13 + 9).

## Validation

- [x] `cargo check -p libdd-ffe -p libdd-ffe-ffi -p libdd-ffe-test-suite`
- [x] `cargo +nightly-2026-07-26 fmt --all -- --check`
- [x] `cargo +stable clippy -p libdd-ffe -p libdd-ffe-ffi -p libdd-ffe-test-suite --all-targets -- -D warnings`
- [x] `cargo nextest run -p libdd-ffe -p libdd-ffe-ffi -p libdd-ffe-test-suite` — 59 passed, 0 skipped
- [ ] `cargo ffi-test` — repeatable unrelated macOS `crashtracking` failure: expected crash signal but got killed by signal 5; all other examples passed, including `ffe`
- [x] `cargo ffi-test --filter ffe` — passed

`cargo-nextest` was installed with the repository-pinned version `0.9.96` because it was not initially available.

The full FFI gate is required because `libdd-ffe-ffi` changed. The focused FFE example passes; the repeatable `crashtracking` failure needs release-owner waiver before merge if it cannot be fixed independently.
