### PR TITLE
perf(trace-exporter): forward encoded v0.4 payloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3539,6 +3539,7 @@ dependencies = [
  "criterion",
  "duplicate 0.4.1",
  "fluent-uri",
+ "libdd-capabilities",
  "libdd-common",
  "libdd-trace-protobuf",
  "libdd-trace-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3529,6 +3529,7 @@ dependencies = [
  "duplicate 0.4.1",
  "libdd-trace-protobuf",
  "rand 0.8.5",
+ "web-time",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3542,7 +3542,6 @@ dependencies = [
  "libdd-common",
  "libdd-trace-protobuf",
  "libdd-trace-utils",
- "log",
  "percent-encoding",
  "serde",
  "serde_json",

--- a/libdd-data-pipeline/Cargo.toml
+++ b/libdd-data-pipeline/Cargo.toml
@@ -65,6 +65,10 @@ name = "trace_buffer"
 harness = false
 path = "benches/trace_buffer.rs"
 
+[[example]]
+name = "send-traces-agentless"
+required-features = ["agentless"]
+
 [dev-dependencies]
 libdd-capabilities-impl = { version = "4.0.0", path = "../libdd-capabilities-impl" }
 libdd-log = { path = "../libdd-log" }
@@ -89,6 +93,7 @@ zstd = { version = "0.13", default-features = false }
 
 [features]
 default = ["https", "telemetry"]
+agentless = ["dep:libdd-trace-obfuscation"]
 telemetry = ["libdd-telemetry", "libdd-trace-stats/telemetry"]
 https = [
     "libdd-common/https",
@@ -100,7 +105,7 @@ https = [
     "libdd-dogstatsd-client/https",
 ]
 stats-obfuscation = [
-    "libdd-trace-obfuscation",
+    "dep:libdd-trace-obfuscation",
     "libdd-trace-stats/stats-obfuscation"
 ]
 fips = [

--- a/libdd-data-pipeline/README.md
+++ b/libdd-data-pipeline/README.md
@@ -43,6 +43,15 @@ configure the communication.
 
 See [`trace_exporter.rs`](src/trace_exporter.rs).
 
+### Agentless trace export
+
+Enable the `agentless` Cargo feature to send traces directly to the Datadog HTTP intake. Agentless
+setup requires an explicit `ObfuscationConfig`; the exporter normalizes and obfuscates every span
+before encoding the request as JSON. `ObfuscationConfig::new()` reads the standard Datadog
+obfuscation environment variables and rejects invalid replacement rules.
+
+See [`send-traces-agentless.rs`](examples/send-traces-agentless.rs) for a complete setup.
+
 ## Integrating the TraceExporter in the tracers
 ### \[WIP\]Importing a binary into an existing project
 In case you want to use a binary to hook C-like functions in your language we will provide a crate to build such binary.

--- a/libdd-data-pipeline/examples/send-traces-agentless.rs
+++ b/libdd-data-pipeline/examples/send-traces-agentless.rs
@@ -14,7 +14,7 @@
 use clap::Parser;
 use libdd_capabilities_impl::NativeCapabilities;
 use libdd_data_pipeline::trace_exporter::{
-    TraceExporter, TraceExporterInputFormat, TraceExporterOutputFormat,
+    ObfuscationConfig, TraceExporter, TraceExporterInputFormat, TraceExporterOutputFormat,
 };
 use libdd_log::logger::{
     logger_configure_std, logger_set_log_level, LogEventLevel, StdConfig, StdTarget,
@@ -79,6 +79,8 @@ fn main() {
         .unwrap_or_else(|| format!("https://public-trace-http-intake.logs.{site}/v1/input"));
 
     let shared_runtime = Arc::new(ForkSafeRuntime::new().expect("Failed to create runtime"));
+    let obfuscation =
+        ObfuscationConfig::new().expect("Failed to configure agentless trace obfuscation");
 
     let mut builder = TraceExporter::<NativeCapabilities, _>::builder();
     builder
@@ -92,7 +94,7 @@ fn main() {
         .set_input_format(TraceExporterInputFormat::V04)
         .set_output_format(TraceExporterOutputFormat::V04)
         .set_shared_runtime(shared_runtime.clone())
-        .set_agentless_endpoint(&intake_url, &api_key);
+        .set_agentless_endpoint(&intake_url, &api_key, obfuscation);
 
     let exporter = builder
         .build::<NativeCapabilities>()

--- a/libdd-data-pipeline/src/agentless/config.rs
+++ b/libdd-data-pipeline/src/agentless/config.rs
@@ -5,10 +5,11 @@
 
 use std::{fmt::Debug, time::Duration};
 
+use libdd_trace_obfuscation::obfuscation_config::ObfuscationConfig;
+
 pub const DEFAULT_AGENTLESS_TIMEOUT: Duration = Duration::from_secs(15);
 
-///Agentless trace exporter configuration.
-#[derive(Clone)]
+/// Agentless trace exporter configuration.
 pub struct AgentlessTraceConfig {
     /// Full URL to POST traces to (e.g.
     /// `https://public-trace-http-intake.logs.datadoghq.com/v1/input`).
@@ -17,6 +18,8 @@ pub struct AgentlessTraceConfig {
     pub api_key: String,
     /// Request timeout.
     pub timeout: Duration,
+    /// Span normalization and obfuscation settings.
+    pub obfuscation: ObfuscationConfig,
 }
 
 impl Debug for AgentlessTraceConfig {

--- a/libdd-data-pipeline/src/agentless/mod.rs
+++ b/libdd-data-pipeline/src/agentless/mod.rs
@@ -12,8 +12,9 @@
 //!
 //! - **Transport**: `POST` to the public HTTP trace intake (default `https://public-trace-http-intake.logs.{DD_SITE}/v1/input`,
 //!   or a custom URL) using `dd-api-key` auth, instead of msgpack to the local agent's
-//!   `/v0.4/traces`. The host language resolves the URL from `DD_SITE` and supplies the API key;
-//!   the exporter reads no environment variables.
+//!   `/v0.4/traces`. The host language resolves the URL from `DD_SITE` and supplies the API key.
+//! - **Processing**: spans are normalized and obfuscated with the configuration supplied by the
+//!   host before they leave the process.
 //! - **Encoding**: JSON (see [`libdd_trace_utils::agentless_encoder`]) instead of msgpack v04. See
 //!   that module for the payload-shape differences.
 //! - **Retries**: up to 2 retries with exponential backoff starting at 1 s and no cap (the agent
@@ -25,6 +26,7 @@
 
 pub(crate) mod config;
 pub(crate) mod exporter;
+pub(crate) mod obfuscation;
 
 pub use config::AgentlessTraceConfig;
 pub use exporter::send_agentless_traces_http;

--- a/libdd-data-pipeline/src/agentless/obfuscation.rs
+++ b/libdd-data-pipeline/src/agentless/obfuscation.rs
@@ -1,0 +1,342 @@
+// Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+use std::borrow::Borrow;
+use std::collections::HashMap;
+
+use anyhow::{ensure, Context};
+use libdd_tinybytes::{Bytes, BytesString};
+use libdd_trace_normalization::normalizer::normalize_trace;
+use libdd_trace_obfuscation::obfuscate::obfuscate_span;
+use libdd_trace_obfuscation::obfuscation_config::ObfuscationConfig;
+use libdd_trace_protobuf::pb;
+use libdd_trace_utils::span::v04::{
+    AttributeAnyValue, AttributeAnyValueBytes, AttributeArrayValue, AttributeArrayValueBytes, Span,
+    SpanBytes, SpanEvent, SpanEventBytes, SpanLink, SpanLinkBytes, VecMap,
+};
+use libdd_trace_utils::span::TraceData;
+use libdd_trace_utils::trace_utils::{compute_top_level_span, update_tracer_top_level};
+
+pub(crate) fn normalize_and_obfuscate<T: TraceData>(
+    traces: Vec<Vec<Span<T>>>,
+    config: &ObfuscationConfig,
+    client_computed_top_level: bool,
+) -> anyhow::Result<Vec<Vec<SpanBytes>>> {
+    let mut output = Vec::with_capacity(traces.len());
+
+    for trace in traces {
+        output.push(process_trace(trace, config, client_computed_top_level)?);
+    }
+
+    Ok(output)
+}
+
+fn process_trace<T: TraceData>(
+    trace: Vec<Span<T>>,
+    config: &ObfuscationConfig,
+    client_computed_top_level: bool,
+) -> anyhow::Result<Vec<SpanBytes>> {
+    let trace_id = trace
+        .first()
+        .context("cannot normalize an empty agentless trace")?
+        .trace_id;
+    ensure!(
+        trace.iter().all(|span| span.trace_id == trace_id),
+        "agentless trace contains spans with different trace IDs"
+    );
+
+    let mut spans: Vec<_> = trace.into_iter().map(into_protobuf_span::<T>).collect();
+
+    normalize_trace(&mut spans).context("failed to normalize agentless trace")?;
+    if client_computed_top_level {
+        for span in &mut spans {
+            update_tracer_top_level(span);
+        }
+    } else {
+        compute_top_level_span(&mut spans);
+    }
+    for span in &mut spans {
+        obfuscate_span(span, config);
+    }
+
+    spans.into_iter().map(from_protobuf_span).collect()
+}
+
+fn into_protobuf_span<T: TraceData>(span: Span<T>) -> pb::Span {
+    let Span {
+        service,
+        name,
+        resource,
+        r#type,
+        trace_id,
+        span_id,
+        parent_id,
+        start,
+        duration,
+        error,
+        meta,
+        metrics,
+        meta_struct,
+        span_links,
+        span_events,
+    } = span;
+
+    let mut meta = own_text_map::<T>(meta);
+    let trace_id_high = (trace_id >> 64) as u64;
+    if trace_id_high != 0 && !meta.contains_key("_dd.p.tid") {
+        meta.insert("_dd.p.tid".to_owned(), format!("{trace_id_high:016x}"));
+    }
+
+    pb::Span {
+        service: own_string(service),
+        name: own_string(name),
+        resource: own_string(resource),
+        trace_id: trace_id as u64,
+        span_id,
+        parent_id,
+        start,
+        duration,
+        error,
+        meta,
+        metrics: own_map::<T>(metrics),
+        r#type: own_string(r#type),
+        meta_struct: own_byte_map::<T>(meta_struct),
+        span_links: span_links
+            .into_iter()
+            .map(into_protobuf_link::<T>)
+            .collect(),
+        span_events: span_events
+            .into_iter()
+            .map(into_protobuf_event::<T>)
+            .collect(),
+    }
+}
+
+fn from_protobuf_span(span: pb::Span) -> anyhow::Result<SpanBytes> {
+    Ok(SpanBytes {
+        service: span.service.into(),
+        name: span.name.into(),
+        resource: span.resource.into(),
+        r#type: span.r#type.into(),
+        trace_id: u128::from(span.trace_id),
+        span_id: span.span_id,
+        parent_id: span.parent_id,
+        start: span.start,
+        duration: span.duration,
+        error: span.error,
+        meta: span
+            .meta
+            .into_iter()
+            .map(|(key, value)| (key.into(), value.into()))
+            .collect(),
+        metrics: span
+            .metrics
+            .into_iter()
+            .map(|(key, value)| (key.into(), value))
+            .collect(),
+        meta_struct: span
+            .meta_struct
+            .into_iter()
+            .map(|(key, value)| (key.into(), Bytes::from_underlying(value)))
+            .collect(),
+        span_links: span
+            .span_links
+            .into_iter()
+            .map(from_protobuf_link)
+            .collect(),
+        span_events: span
+            .span_events
+            .into_iter()
+            .map(from_protobuf_event)
+            .collect::<anyhow::Result<_>>()?,
+    })
+}
+
+fn own_string<T: Borrow<str>>(value: T) -> String {
+    value.borrow().to_owned()
+}
+
+fn own_text_map<T: TraceData>(map: VecMap<T::Text, T::Text>) -> HashMap<String, String> {
+    let mut output = HashMap::with_capacity(map.len());
+    for (key, value) in map {
+        output.insert(own_string(key), own_string(value));
+    }
+    output
+}
+
+fn own_map<T: TraceData>(map: VecMap<T::Text, f64>) -> HashMap<String, f64> {
+    map.into_iter()
+        .map(|(key, value)| (own_string(key), value))
+        .collect()
+}
+
+fn own_byte_map<T: TraceData>(map: VecMap<T::Text, T::Bytes>) -> HashMap<String, Vec<u8>> {
+    map.into_iter()
+        .map(|(key, value)| (own_string(key), value.borrow().to_vec()))
+        .collect()
+}
+
+fn into_protobuf_link<T: TraceData>(link: SpanLink<T>) -> pb::SpanLink {
+    pb::SpanLink {
+        trace_id: link.trace_id,
+        trace_id_high: link.trace_id_high,
+        span_id: link.span_id,
+        attributes: link
+            .attributes
+            .into_iter()
+            .map(|(key, value)| (own_string(key), own_string(value)))
+            .collect(),
+        tracestate: own_string(link.tracestate),
+        flags: link.flags,
+    }
+}
+
+fn from_protobuf_link(link: pb::SpanLink) -> SpanLinkBytes {
+    SpanLink {
+        trace_id: link.trace_id,
+        trace_id_high: link.trace_id_high,
+        span_id: link.span_id,
+        attributes: link
+            .attributes
+            .into_iter()
+            .map(|(key, value)| (BytesString::from(key), BytesString::from(value)))
+            .collect(),
+        tracestate: link.tracestate.into(),
+        flags: link.flags,
+    }
+}
+
+fn into_protobuf_event<T: TraceData>(event: SpanEvent<T>) -> pb::SpanEvent {
+    pb::SpanEvent {
+        time_unix_nano: event.time_unix_nano,
+        name: own_string(event.name),
+        attributes: event
+            .attributes
+            .into_iter()
+            .map(|(key, value)| (own_string(key), into_protobuf_attribute(value)))
+            .collect(),
+    }
+}
+
+fn into_protobuf_attribute<T: TraceData>(value: AttributeAnyValue<T>) -> pb::AttributeAnyValue {
+    match value {
+        AttributeAnyValue::SingleValue(value) => into_protobuf_scalar::<T>(value),
+        AttributeAnyValue::Array(values) => pb::AttributeAnyValue {
+            r#type: pb::attribute_any_value::AttributeAnyValueType::ArrayValue as i32,
+            array_value: Some(pb::AttributeArray {
+                values: values
+                    .into_iter()
+                    .map(into_protobuf_array_scalar::<T>)
+                    .collect(),
+            }),
+            ..Default::default()
+        },
+    }
+}
+
+fn into_protobuf_scalar<T: TraceData>(value: AttributeArrayValue<T>) -> pb::AttributeAnyValue {
+    match value {
+        AttributeArrayValue::String(value) => pb::AttributeAnyValue {
+            r#type: pb::attribute_any_value::AttributeAnyValueType::StringValue as i32,
+            string_value: own_string(value),
+            ..Default::default()
+        },
+        AttributeArrayValue::Boolean(value) => pb::AttributeAnyValue {
+            r#type: pb::attribute_any_value::AttributeAnyValueType::BoolValue as i32,
+            bool_value: value,
+            ..Default::default()
+        },
+        AttributeArrayValue::Integer(value) => pb::AttributeAnyValue {
+            r#type: pb::attribute_any_value::AttributeAnyValueType::IntValue as i32,
+            int_value: value,
+            ..Default::default()
+        },
+        AttributeArrayValue::Double(value) => pb::AttributeAnyValue {
+            r#type: pb::attribute_any_value::AttributeAnyValueType::DoubleValue as i32,
+            double_value: value,
+            ..Default::default()
+        },
+    }
+}
+
+fn into_protobuf_array_scalar<T: TraceData>(
+    value: AttributeArrayValue<T>,
+) -> pb::AttributeArrayValue {
+    match value {
+        AttributeArrayValue::String(value) => pb::AttributeArrayValue {
+            r#type: pb::attribute_array_value::AttributeArrayValueType::StringValue as i32,
+            string_value: own_string(value),
+            ..Default::default()
+        },
+        AttributeArrayValue::Boolean(value) => pb::AttributeArrayValue {
+            r#type: pb::attribute_array_value::AttributeArrayValueType::BoolValue as i32,
+            bool_value: value,
+            ..Default::default()
+        },
+        AttributeArrayValue::Integer(value) => pb::AttributeArrayValue {
+            r#type: pb::attribute_array_value::AttributeArrayValueType::IntValue as i32,
+            int_value: value,
+            ..Default::default()
+        },
+        AttributeArrayValue::Double(value) => pb::AttributeArrayValue {
+            r#type: pb::attribute_array_value::AttributeArrayValueType::DoubleValue as i32,
+            double_value: value,
+            ..Default::default()
+        },
+    }
+}
+
+fn from_protobuf_event(event: pb::SpanEvent) -> anyhow::Result<SpanEventBytes> {
+    Ok(SpanEventBytes {
+        time_unix_nano: event.time_unix_nano,
+        name: event.name.into(),
+        attributes: event
+            .attributes
+            .into_iter()
+            .map(|(key, value)| Ok((key.into(), from_protobuf_attribute(value)?)))
+            .collect::<anyhow::Result<_>>()?,
+    })
+}
+
+fn from_protobuf_attribute(value: pb::AttributeAnyValue) -> anyhow::Result<AttributeAnyValueBytes> {
+    use pb::attribute_any_value::AttributeAnyValueType;
+
+    Ok(match value.r#type() {
+        AttributeAnyValueType::StringValue => {
+            AttributeAnyValue::SingleValue(AttributeArrayValue::String(value.string_value.into()))
+        }
+        AttributeAnyValueType::BoolValue => {
+            AttributeAnyValue::SingleValue(AttributeArrayValue::Boolean(value.bool_value))
+        }
+        AttributeAnyValueType::IntValue => {
+            AttributeAnyValue::SingleValue(AttributeArrayValue::Integer(value.int_value))
+        }
+        AttributeAnyValueType::DoubleValue => {
+            AttributeAnyValue::SingleValue(AttributeArrayValue::Double(value.double_value))
+        }
+        AttributeAnyValueType::ArrayValue => AttributeAnyValue::Array(
+            value
+                .array_value
+                .context("agentless span event array is missing its values")?
+                .values
+                .into_iter()
+                .map(from_protobuf_array_scalar)
+                .collect::<anyhow::Result<_>>()?,
+        ),
+    })
+}
+
+fn from_protobuf_array_scalar(
+    value: pb::AttributeArrayValue,
+) -> anyhow::Result<AttributeArrayValueBytes> {
+    use pb::attribute_array_value::AttributeArrayValueType;
+
+    match value.r#type() {
+        AttributeArrayValueType::StringValue => {
+            Ok(AttributeArrayValue::String(value.string_value.into()))
+        }
+        AttributeArrayValueType::BoolValue => Ok(AttributeArrayValue::Boolean(value.bool_value)),
+        AttributeArrayValueType::IntValue => Ok(AttributeArrayValue::Integer(value.int_value)),
+        AttributeArrayValueType::DoubleValue => Ok(AttributeArrayValue::Double(value.double_value)),
+    }
+}

--- a/libdd-data-pipeline/src/agentless/obfuscation.rs
+++ b/libdd-data-pipeline/src/agentless/obfuscation.rs
@@ -5,14 +5,12 @@ use std::borrow::Borrow;
 use std::collections::HashMap;
 
 use anyhow::{ensure, Context};
-use libdd_tinybytes::{Bytes, BytesString};
 use libdd_trace_normalization::normalizer::normalize_trace;
 use libdd_trace_obfuscation::obfuscate::obfuscate_span;
 use libdd_trace_obfuscation::obfuscation_config::ObfuscationConfig;
 use libdd_trace_protobuf::pb;
 use libdd_trace_utils::span::v04::{
-    AttributeAnyValue, AttributeAnyValueBytes, AttributeArrayValue, AttributeArrayValueBytes, Span,
-    SpanBytes, SpanEvent, SpanEventBytes, SpanLink, SpanLinkBytes, VecMap,
+    AttributeAnyValue, AttributeArrayValue, Span, SpanEvent, SpanLink, VecMap,
 };
 use libdd_trace_utils::span::TraceData;
 use libdd_trace_utils::trace_utils::{compute_top_level_span, update_tracer_top_level};
@@ -21,7 +19,7 @@ pub(crate) fn normalize_and_obfuscate<T: TraceData>(
     traces: Vec<Vec<Span<T>>>,
     config: &ObfuscationConfig,
     client_computed_top_level: bool,
-) -> anyhow::Result<Vec<Vec<SpanBytes>>> {
+) -> anyhow::Result<Vec<Vec<pb::Span>>> {
     let mut output = Vec::with_capacity(traces.len());
 
     for trace in traces {
@@ -35,7 +33,7 @@ fn process_trace<T: TraceData>(
     trace: Vec<Span<T>>,
     config: &ObfuscationConfig,
     client_computed_top_level: bool,
-) -> anyhow::Result<Vec<SpanBytes>> {
+) -> anyhow::Result<Vec<pb::Span>> {
     let trace_id = trace
         .first()
         .context("cannot normalize an empty agentless trace")?
@@ -59,7 +57,7 @@ fn process_trace<T: TraceData>(
         obfuscate_span(span, config);
     }
 
-    spans.into_iter().map(from_protobuf_span).collect()
+    Ok(spans)
 }
 
 fn into_protobuf_span<T: TraceData>(span: Span<T>) -> pb::Span {
@@ -112,46 +110,6 @@ fn into_protobuf_span<T: TraceData>(span: Span<T>) -> pb::Span {
     }
 }
 
-fn from_protobuf_span(span: pb::Span) -> anyhow::Result<SpanBytes> {
-    Ok(SpanBytes {
-        service: span.service.into(),
-        name: span.name.into(),
-        resource: span.resource.into(),
-        r#type: span.r#type.into(),
-        trace_id: u128::from(span.trace_id),
-        span_id: span.span_id,
-        parent_id: span.parent_id,
-        start: span.start,
-        duration: span.duration,
-        error: span.error,
-        meta: span
-            .meta
-            .into_iter()
-            .map(|(key, value)| (key.into(), value.into()))
-            .collect(),
-        metrics: span
-            .metrics
-            .into_iter()
-            .map(|(key, value)| (key.into(), value))
-            .collect(),
-        meta_struct: span
-            .meta_struct
-            .into_iter()
-            .map(|(key, value)| (key.into(), Bytes::from_underlying(value)))
-            .collect(),
-        span_links: span
-            .span_links
-            .into_iter()
-            .map(from_protobuf_link)
-            .collect(),
-        span_events: span
-            .span_events
-            .into_iter()
-            .map(from_protobuf_event)
-            .collect::<anyhow::Result<_>>()?,
-    })
-}
-
 fn own_string<T: Borrow<str>>(value: T) -> String {
     value.borrow().to_owned()
 }
@@ -187,21 +145,6 @@ fn into_protobuf_link<T: TraceData>(link: SpanLink<T>) -> pb::SpanLink {
             .map(|(key, value)| (own_string(key), own_string(value)))
             .collect(),
         tracestate: own_string(link.tracestate),
-        flags: link.flags,
-    }
-}
-
-fn from_protobuf_link(link: pb::SpanLink) -> SpanLinkBytes {
-    SpanLink {
-        trace_id: link.trace_id,
-        trace_id_high: link.trace_id_high,
-        span_id: link.span_id,
-        attributes: link
-            .attributes
-            .into_iter()
-            .map(|(key, value)| (BytesString::from(key), BytesString::from(value)))
-            .collect(),
-        tracestate: link.tracestate.into(),
         flags: link.flags,
     }
 }
@@ -283,60 +226,5 @@ fn into_protobuf_array_scalar<T: TraceData>(
             double_value: value,
             ..Default::default()
         },
-    }
-}
-
-fn from_protobuf_event(event: pb::SpanEvent) -> anyhow::Result<SpanEventBytes> {
-    Ok(SpanEventBytes {
-        time_unix_nano: event.time_unix_nano,
-        name: event.name.into(),
-        attributes: event
-            .attributes
-            .into_iter()
-            .map(|(key, value)| Ok((key.into(), from_protobuf_attribute(value)?)))
-            .collect::<anyhow::Result<_>>()?,
-    })
-}
-
-fn from_protobuf_attribute(value: pb::AttributeAnyValue) -> anyhow::Result<AttributeAnyValueBytes> {
-    use pb::attribute_any_value::AttributeAnyValueType;
-
-    Ok(match value.r#type() {
-        AttributeAnyValueType::StringValue => {
-            AttributeAnyValue::SingleValue(AttributeArrayValue::String(value.string_value.into()))
-        }
-        AttributeAnyValueType::BoolValue => {
-            AttributeAnyValue::SingleValue(AttributeArrayValue::Boolean(value.bool_value))
-        }
-        AttributeAnyValueType::IntValue => {
-            AttributeAnyValue::SingleValue(AttributeArrayValue::Integer(value.int_value))
-        }
-        AttributeAnyValueType::DoubleValue => {
-            AttributeAnyValue::SingleValue(AttributeArrayValue::Double(value.double_value))
-        }
-        AttributeAnyValueType::ArrayValue => AttributeAnyValue::Array(
-            value
-                .array_value
-                .context("agentless span event array is missing its values")?
-                .values
-                .into_iter()
-                .map(from_protobuf_array_scalar)
-                .collect::<anyhow::Result<_>>()?,
-        ),
-    })
-}
-
-fn from_protobuf_array_scalar(
-    value: pb::AttributeArrayValue,
-) -> anyhow::Result<AttributeArrayValueBytes> {
-    use pb::attribute_array_value::AttributeArrayValueType;
-
-    match value.r#type() {
-        AttributeArrayValueType::StringValue => {
-            Ok(AttributeArrayValue::String(value.string_value.into()))
-        }
-        AttributeArrayValueType::BoolValue => Ok(AttributeArrayValue::Boolean(value.bool_value)),
-        AttributeArrayValueType::IntValue => Ok(AttributeArrayValue::Integer(value.int_value)),
-        AttributeArrayValueType::DoubleValue => Ok(AttributeArrayValue::Double(value.double_value)),
     }
 }

--- a/libdd-data-pipeline/src/lib.rs
+++ b/libdd-data-pipeline/src/lib.rs
@@ -12,6 +12,7 @@
 //! in different languages.
 
 pub mod agent_info;
+#[cfg(feature = "agentless")]
 pub(crate) mod agentless;
 mod health_metrics;
 pub(crate) mod otlp;

--- a/libdd-data-pipeline/src/trace_exporter/builder.rs
+++ b/libdd-data-pipeline/src/trace_exporter/builder.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::agent_info::AgentInfoFetcher;
+#[cfg(feature = "agentless")]
 use crate::agentless::config::{AgentlessTraceConfig, DEFAULT_AGENTLESS_TIMEOUT};
 use crate::otlp::config::{OtlpProtocol, DEFAULT_OTLP_TIMEOUT};
 use crate::otlp::{OtlpMetricsConfig, OtlpResourceInfo, OtlpTraceConfig};
@@ -10,15 +11,20 @@ use crate::telemetry::TelemetryClientBuilder;
 use crate::trace_exporter::agent_response::AgentResponsePayloadVersion;
 use crate::trace_exporter::error::BuilderErrorKind;
 use crate::trace_exporter::log_writer::DEFAULT_LOG_MAX_LINE_SIZE;
+#[cfg(feature = "agentless")]
+use crate::trace_exporter::ObfuscationConfig;
 #[cfg(feature = "telemetry")]
 use crate::trace_exporter::TelemetryConfig;
+#[cfg(feature = "telemetry")]
+use crate::trace_exporter::TelemetryInstrumentationSessions;
 use crate::trace_exporter::TraceExporterWorkers;
 use crate::trace_exporter::{
-    add_path, StatsComputationStatus, TelemetryInstrumentationSessions, TraceExporter,
-    TraceExporterError, TraceExporterInputFormat, TraceExporterOutputFormat, TraceSerializer,
-    TracerMetadata, INFO_ENDPOINT,
+    add_path, StatsComputationStatus, TraceExporter, TraceExporterError, TraceExporterInputFormat,
+    TraceExporterOutputFormat, TraceSerializer, TracerMetadata, INFO_ENDPOINT,
 };
-use arc_swap::{ArcSwap, ArcSwapOption};
+use arc_swap::ArcSwap;
+#[cfg(feature = "telemetry")]
+use arc_swap::ArcSwapOption;
 use libdd_capabilities::{HttpClientCapability, LogWriterCapability, MaybeSend, SleepCapability};
 use libdd_common::{parse_uri, tag, Endpoint};
 use libdd_dogstatsd_client::DogStatsDClient;
@@ -92,9 +98,14 @@ pub struct TraceExporterBuilder<R: SharedRuntime> {
     connection_timeout: Option<u64>,
     otlp_endpoint: Option<String>,
     otlp_headers: Vec<(String, String)>,
+    #[cfg(feature = "agentless")]
     agentless_endpoint: Option<String>,
+    #[cfg(feature = "agentless")]
     agentless_api_key: Option<String>,
+    #[cfg(feature = "agentless")]
     agentless_timeout: Option<Duration>,
+    #[cfg(feature = "agentless")]
+    agentless_obfuscation: Option<ObfuscationConfig>,
     otlp_protocol: OtlpProtocol,
     otlp_metrics_endpoint: Option<String>,
     otlp_metrics_headers: Vec<(String, String)>,
@@ -172,9 +183,14 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
             otlp_metrics_headers: Vec::new(),
             otel_trace_semantics_enabled: false,
             runtime_id: None,
+            #[cfg(feature = "agentless")]
             agentless_endpoint: None,
+            #[cfg(feature = "agentless")]
             agentless_api_key: None,
+            #[cfg(feature = "agentless")]
             agentless_timeout: None,
+            #[cfg(feature = "agentless")]
+            agentless_obfuscation: None,
             output_to_log: false,
             log_max_line_size: None,
             restart_after_fork: true,
@@ -474,23 +490,32 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
 
     /// Enables agentless APM trace export and sets the intake URL and API key.
     ///
-    /// When set, APM trace spans are sent directly to the Datadog HTTP intake in JSON format
-    /// (`POST /v1/input`) instead of through the Datadog Agent. The host language is responsible
-    /// for resolving the endpoint URL (default
+    /// When set, APM trace spans are normalized, obfuscated, and sent directly to the Datadog HTTP
+    /// intake in JSON format (`POST /v1/input`) instead of through the Datadog Agent. The host
+    /// language is responsible for resolving the endpoint URL (default
     /// `https://public-trace-http-intake.logs.{DD_SITE}` or a custom override) and the API key
-    /// from its configuration. This crate does not read environment variables.
+    /// from its configuration. The exporter does not resolve these values from the environment.
     ///
     /// Agentless trace export is mutually exclusive with both OTLP trace export
     /// ([`Self::set_otlp_endpoint`]) and a configured agent URL ([`Self::set_url`]);
     /// combining either with this method causes [`Self::build`]/[`Self::build_async`]
     /// to return [`BuilderErrorKind::InvalidConfiguration`].
-    /// the output format is ignored in agentless mode; payloads are always
-    /// JSON
+    /// The output format is ignored in agentless mode; payloads are always JSON.
     ///
-    /// Example: `set_agentless_endpoint("https://public-trace-http-intake.logs.datadoghq.com/v1/input", "<api-key>")`
-    pub fn set_agentless_endpoint(&mut self, url: &str, api_key: &str) -> &mut Self {
+    /// [`ObfuscationConfig::new`] reads the standard Datadog obfuscation environment variables.
+    /// Callers that already own configuration can construct the value directly instead.
+    ///
+    /// The `send-traces-agentless` crate example shows complete setup.
+    #[cfg(feature = "agentless")]
+    pub fn set_agentless_endpoint(
+        &mut self,
+        url: &str,
+        api_key: &str,
+        obfuscation: ObfuscationConfig,
+    ) -> &mut Self {
         self.agentless_endpoint = Some(url.to_owned());
         self.agentless_api_key = Some(api_key.to_owned());
+        self.agentless_obfuscation = Some(obfuscation);
         self
     }
 
@@ -499,6 +524,7 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
     /// Defaults to 15 seconds when not set. Calling this method without also calling
     /// [`Self::set_agentless_endpoint`] causes [`Self::build`]/[`Self::build_async`] to
     /// return [`BuilderErrorKind::InvalidConfiguration`].
+    #[cfg(feature = "agentless")]
     pub fn set_agentless_timeout(&mut self, timeout: Duration) -> &mut Self {
         self.agentless_timeout = Some(timeout);
         self
@@ -646,7 +672,10 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
 
         // Agentless mode has no Datadog Agent to poll, so we skip
         // starting the `/info` fetcher
+        #[cfg(feature = "agentless")]
         let agentless_enabled = self.agentless_endpoint.is_some();
+        #[cfg(not(feature = "agentless"))]
+        let agentless_enabled = false;
         let info_endpoint = Endpoint::from_url(add_path(&agent_url, INFO_ENDPOINT));
         let (info_fetcher, info_response_observer) =
             AgentInfoFetcher::<C>::new(info_endpoint, Duration::from_secs(5 * 60));
@@ -735,18 +764,20 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
         // rules are enforced by `validate_export_targets` above, so we can just move the
         // fields out here.
         let otlp_endpoint = self.otlp_endpoint;
-        let agentless_endpoint = self.agentless_endpoint;
-        let agentless_api_key = self.agentless_api_key;
-
-        let agentless_config = match (agentless_endpoint, agentless_api_key) {
-            (Some(url), Some(api_key)) => Some(AgentlessTraceConfig {
+        #[cfg(feature = "agentless")]
+        let agentless_config = match (
+            self.agentless_endpoint,
+            self.agentless_api_key,
+            self.agentless_obfuscation,
+        ) {
+            (Some(url), Some(api_key), Some(obfuscation)) => Some(AgentlessTraceConfig {
                 endpoint_url: url,
                 api_key,
                 timeout: self.agentless_timeout.unwrap_or(DEFAULT_AGENTLESS_TIMEOUT),
+                obfuscation,
             }),
             _ => None,
         };
-
         let otlp_timeout = self
             .connection_timeout
             .map(Duration::from_millis)
@@ -897,6 +928,7 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
                 .agent_rates_payload_version_enabled
                 .then(AgentResponsePayloadVersion::new),
             otlp_config,
+            #[cfg(feature = "agentless")]
             agentless_config,
             trace_filterer: ArcSwap::from_pointee(TraceFilterer::with_empty_conf()),
             otlp_stats_enabled,
@@ -922,7 +954,10 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
     /// agent endpoints (info, stats) even when trace payloads are routed to OTLP.
     fn validate_export_targets(&self) -> Result<(), TraceExporterError> {
         let otlp_set = self.otlp_endpoint.is_some();
+        #[cfg(feature = "agentless")]
         let agentless_set = self.agentless_endpoint.is_some();
+        #[cfg(not(feature = "agentless"))]
+        let agentless_set = false;
         let agent_url_set = self.url.is_some();
         let log_output_set = self.output_to_log;
 
@@ -959,6 +994,7 @@ impl<R: SharedRuntime> TraceExporterBuilder<R> {
             ));
         }
 
+        #[cfg(feature = "agentless")]
         if !agentless_set && self.agentless_timeout.is_some() {
             return Err(TraceExporterError::Builder(
                 BuilderErrorKind::InvalidConfiguration(
@@ -1164,6 +1200,7 @@ mod tests {
         ));
     }
 
+    #[cfg(feature = "agentless")]
     fn assert_invalid_config(
         result: Result<TraceExporter<NativeCapabilities, ForkSafeRuntime>, TraceExporterError>,
     ) -> String {
@@ -1175,6 +1212,7 @@ mod tests {
     }
 
     #[cfg_attr(miri, ignore)]
+    #[cfg(feature = "agentless")]
     #[test]
     fn test_otlp_and_agentless_rejected() {
         let mut builder = TraceExporterBuilder::default();
@@ -1183,6 +1221,7 @@ mod tests {
             .set_agentless_endpoint(
                 "https://public-trace-http-intake.logs.datadoghq.com/v1/input",
                 "api-key",
+                ObfuscationConfig::default(),
             );
         let msg = assert_invalid_config(builder.build::<NativeCapabilities>());
         assert!(
@@ -1192,6 +1231,7 @@ mod tests {
     }
 
     #[cfg_attr(miri, ignore)]
+    #[cfg(feature = "agentless")]
     #[test]
     fn test_agentless_and_agent_url_rejected() {
         let mut builder = TraceExporterBuilder::default();
@@ -1200,6 +1240,7 @@ mod tests {
             .set_agentless_endpoint(
                 "https://public-trace-http-intake.logs.datadoghq.com/v1/input",
                 "api-key",
+                ObfuscationConfig::default(),
             );
         let msg = assert_invalid_config(builder.build::<NativeCapabilities>());
         assert!(
@@ -1209,6 +1250,7 @@ mod tests {
     }
 
     #[cfg_attr(miri, ignore)]
+    #[cfg(feature = "agentless")]
     #[test]
     fn test_agentless_timeout_without_endpoint_rejected() {
         let mut builder = TraceExporterBuilder::default();
@@ -1221,6 +1263,7 @@ mod tests {
     }
 
     #[cfg(feature = "telemetry")]
+    #[cfg(feature = "agentless")]
     #[cfg_attr(miri, ignore)]
     #[test]
     fn test_agentless_skips_info_fetcher_and_telemetry() {
@@ -1229,6 +1272,7 @@ mod tests {
             .set_agentless_endpoint(
                 "https://public-trace-http-intake.logs.datadoghq.com/v1/input",
                 "api-key",
+                ObfuscationConfig::default(),
             )
             .enable_telemetry(TelemetryConfig {
                 heartbeat: 1000,
@@ -1242,7 +1286,7 @@ mod tests {
         // Telemetry talks to the agent base URL and is also skipped.
         assert!(exporter.workers.telemetry.is_none());
         assert!(exporter.telemetry.load().is_none());
-        // Sanity: the agentless transport is actually configured.
+        assert!(!exporter.should_check_agent_info());
         assert!(exporter.agentless_config.is_some());
     }
 

--- a/libdd-data-pipeline/src/trace_exporter/mod.rs
+++ b/libdd-data-pipeline/src/trace_exporter/mod.rs
@@ -52,6 +52,8 @@ use libdd_shared_runtime::BlockingRuntime;
 use libdd_shared_runtime::{SharedRuntime, WorkerHandle};
 #[cfg(feature = "telemetry")]
 use libdd_telemetry::worker::TelemetryWorkerHandle;
+#[cfg(feature = "agentless")]
+use libdd_trace_utils::agentless_encoder::encode_protobuf_payload;
 use libdd_trace_utils::msgpack_decoder;
 use libdd_trace_utils::send_with_retry::{
     send_with_retry, CompressionStrategy, RetryStrategy, SendWithRetryError, SendWithRetryResult,
@@ -747,11 +749,7 @@ impl<
                     ))
                 })?;
         let trace_count = traces.len();
-        let json_body = libdd_trace_utils::agentless_encoder::encode_payload(
-            &traces,
-            &self.metadata,
-        )
-        .map_err(|e| {
+        let json_body = encode_protobuf_payload(&traces, &self.metadata).map_err(|e| {
             error!("Agentless JSON serialization error: {e}");
             TraceExporterError::Internal(InternalErrorKind::InvalidWorkerState(e.to_string()))
         })?;

--- a/libdd-data-pipeline/src/trace_exporter/mod.rs
+++ b/libdd-data-pipeline/src/trace_exporter/mod.rs
@@ -53,7 +53,10 @@ use libdd_trace_utils::msgpack_decoder;
 use libdd_trace_utils::send_with_retry::{
     send_with_retry, CompressionStrategy, RetryStrategy, SendWithRetryError, SendWithRetryResult,
 };
-use libdd_trace_utils::span::{v04::Span, TraceData};
+use libdd_trace_utils::span::{
+    v04::{Span, SpanSlice},
+    TraceData,
+};
 use libdd_trace_utils::trace_utils::TracerHeaderTags;
 use std::io;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -402,19 +405,33 @@ impl<
             self.check_agent_info().await;
         }
 
-        let format: DeserInputFormat = self.input_format.into();
+        let traces = self.deserialize_traces(data, self.input_format.into())?;
 
+        let res = self.send_trace_chunks_inner(traces).await?;
+        if matches!(&res, AgentResponse::Changed { body } if body.is_empty()) {
+            return Err(TraceExporterError::Agent(
+                error::AgentErrorKind::EmptyResponse,
+            ));
+        }
+        Ok(res)
+    }
+
+    fn deserialize_traces<'a>(
+        &self,
+        data: &'a [u8],
+        format: DeserInputFormat,
+    ) -> Result<Vec<Vec<SpanSlice<'a>>>, TraceExporterError> {
         let (traces, _) = match format {
             DeserInputFormat::V04 => msgpack_decoder::v04::from_slice(data),
             DeserInputFormat::V05 => msgpack_decoder::v05::from_slice(data),
         }
-        .map_err(|e| {
-            error!("Error deserializing trace from request body: {e}");
+        .map_err(|error| {
+            error!("Error deserializing trace from request body: {error}");
             self.emit_metric(
                 HealthMetric::Count(health_metrics::DESERIALIZE_TRACES_ERRORS, 1),
                 None,
             );
-            TraceExporterError::Deserialization(e)
+            TraceExporterError::Deserialization(error)
         })?;
         debug!(
             trace_count = traces.len(),
@@ -424,14 +441,53 @@ impl<
             HealthMetric::Count(health_metrics::DESERIALIZE_TRACES, traces.len() as i64),
             None,
         );
+        Ok(traces)
+    }
 
-        let res = self.send_trace_chunks_inner(traces).await?;
-        if matches!(&res, AgentResponse::Changed { body } if body.is_empty()) {
-            return Err(TraceExporterError::Agent(
-                error::AgentErrorKind::EmptyResponse,
-            ));
+    /// Send an already encoded v0.4 trace payload.
+    ///
+    /// The payload is forwarded without decoding when the exporter can preserve it exactly.
+    /// Configurations that consume or transform spans use the regular decoded path instead.
+    /// `chunk_count` must match the number of trace chunks in `data`.
+    pub async fn send_v04_payload_async(
+        &self,
+        data: Vec<u8>,
+        chunk_count: usize,
+    ) -> Result<AgentResponse, TraceExporterError> {
+        if self.log_output.is_none() {
+            self.check_agent_info().await;
         }
-        Ok(res)
+
+        if !self.can_forward_v04_payload() {
+            let traces = self.deserialize_traces(&data, DeserInputFormat::V04)?;
+            return self.send_trace_chunks_inner(traces).await;
+        }
+
+        let header_tags: TracerHeaderTags = self.metadata.borrow().into();
+        let headers = self.serializer.build_traces_headers(
+            header_tags,
+            chunk_count,
+            self.agent_payload_response_version.as_ref(),
+        );
+        let endpoint = Endpoint {
+            url: TraceExporterOutputFormat::V04.add_path(&self.endpoint.url),
+            ..self.endpoint.clone()
+        };
+
+        self.send_traces_with_telemetry(&endpoint, data, headers, chunk_count)
+            .await
+    }
+
+    fn can_forward_v04_payload(&self) -> bool {
+        self.output_format == TraceExporterOutputFormat::V04
+            && self.log_output.is_none()
+            && self.agentless_config.is_none()
+            && self.otlp_config.is_none()
+            && matches!(
+                &**self.client_side_stats.status.load(),
+                StatsComputationStatus::Disabled
+            )
+            && self.trace_filterer.load().is_empty()
     }
 
     /// Check if agent info state has changed
@@ -1371,6 +1427,75 @@ mod tests {
         }
 
         builder.build::<NativeCapabilities>().unwrap()
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_send_v04_payload_forwards_bytes_without_reserializing() {
+        let fake_agent = MockServer::start();
+        let traces = vec![vec![SpanBytes {
+            name: BytesString::from_slice(b"raw-payload").unwrap(),
+            ..Default::default()
+        }]];
+        let data = msgpack_encoder::v04::to_vec_from_v04(&traces);
+        let expected = data.clone();
+        let mock_traces = fake_agent.mock(move |when, then| {
+            when.method(POST)
+                .path(V04_TRACES_ENDPOINT)
+                .header("x-datadog-trace-count", "1")
+                .is_true(move |request| request.body_ref() == expected.as_slice());
+            then.status(200).body("{}");
+        });
+        let exporter = build_test_exporter(
+            fake_agent.url("/"),
+            None,
+            TraceExporterInputFormat::V04,
+            TraceExporterOutputFormat::V04,
+            false,
+            false,
+        );
+
+        exporter
+            .shared_runtime
+            .block_on(exporter.send_v04_payload_async(data, 1))
+            .unwrap()
+            .unwrap();
+
+        mock_traces.assert_calls(1);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_send_v04_payload_decodes_when_output_requires_transformation() {
+        let fake_agent = MockServer::start();
+        let traces = vec![vec![SpanBytes {
+            name: BytesString::from_slice(b"transformed-payload").unwrap(),
+            ..Default::default()
+        }]];
+        let data = msgpack_encoder::v04::to_vec_from_v04(&traces);
+        let original = data.clone();
+        let mock_traces = fake_agent.mock(move |when, then| {
+            when.method(POST)
+                .path(V05_TRACES_ENDPOINT)
+                .is_true(move |request| request.body_ref() != original.as_slice());
+            then.status(200).body("{}");
+        });
+        let exporter = build_test_exporter(
+            fake_agent.url("/"),
+            None,
+            TraceExporterInputFormat::V04,
+            TraceExporterOutputFormat::V05,
+            false,
+            false,
+        );
+
+        exporter
+            .shared_runtime
+            .block_on(exporter.send_v04_payload_async(data, 1))
+            .unwrap()
+            .unwrap();
+
+        mock_traces.assert_calls(1);
     }
 
     // Capturing capabilities: delegate HTTP/sleep to the native impls, but capture

--- a/libdd-data-pipeline/src/trace_exporter/mod.rs
+++ b/libdd-data-pipeline/src/trace_exporter/mod.rs
@@ -18,6 +18,9 @@ use self::metrics::MetricsEmitter;
 use self::stats::StatsComputationStatus;
 use self::trace_serializer::TraceSerializer;
 use crate::agent_info::ResponseObserver;
+#[cfg(feature = "agentless")]
+use crate::agentless::obfuscation::normalize_and_obfuscate;
+#[cfg(feature = "agentless")]
 use crate::agentless::{send_agentless_traces_http, AgentlessTraceConfig};
 use crate::otlp::{map_traces_to_otlp, send_otlp_traces_http, OtlpResourceInfo, OtlpTraceConfig};
 #[cfg(feature = "telemetry")]
@@ -75,6 +78,7 @@ const V1_TRACES_ENDPOINT: &str = "/v1.0/traces";
 ///
 /// Includes the API key, content-type, trace count, `Datadog-Meta-*` tracer headers,
 /// and entity headers (container-id / entity-id / external-env) when available.
+#[cfg(feature = "agentless")]
 fn build_agentless_headers(
     metadata: &TracerMetadata,
     api_key: &str,
@@ -188,6 +192,8 @@ fn add_path(url: &Uri, path: &str) -> Uri {
     Uri::from_parts(parts).unwrap()
 }
 
+#[cfg(feature = "agentless")]
+pub use libdd_trace_obfuscation::obfuscation_config::ObfuscationConfig;
 pub use libdd_trace_utils::tracer_metadata::TracerMetadata;
 
 /// Handles for the background workers owned by a [`TraceExporter`].
@@ -274,6 +280,7 @@ pub struct TraceExporter<
     otlp_config: Option<OtlpTraceConfig>,
     /// When set, APM trace spans are exported directly to the Datadog HTTP intake (agentless)
     /// instead of via the Datadog Agent
+    #[cfg(feature = "agentless")]
     agentless_config: Option<AgentlessTraceConfig>,
     trace_filterer: ArcSwap<TraceFilterer>,
     /// When true, span stats are computed and exported as OTLP metrics. The concentrator is
@@ -400,8 +407,7 @@ impl<
     /// `data` must be encoded per the `input_format` given to the builder.
     /// [`Self::send`] is the sync facade over this method.
     pub async fn send_async(&self, data: &[u8]) -> Result<AgentResponse, TraceExporterError> {
-        // In log-export mode there is no agent to negotiate with; skip the poll.
-        if self.log_output.is_none() {
+        if self.should_check_agent_info() {
             self.check_agent_info().await;
         }
 
@@ -454,7 +460,7 @@ impl<
         data: Vec<u8>,
         chunk_count: usize,
     ) -> Result<AgentResponse, TraceExporterError> {
-        if self.log_output.is_none() {
+        if self.should_check_agent_info() {
             self.check_agent_info().await;
         }
 
@@ -479,15 +485,33 @@ impl<
     }
 
     fn can_forward_v04_payload(&self) -> bool {
+        #[cfg(feature = "agentless")]
+        let agentless_disabled = self.agentless_config.is_none();
+        #[cfg(not(feature = "agentless"))]
+        let agentless_disabled = true;
+
         self.output_format == TraceExporterOutputFormat::V04
             && self.log_output.is_none()
-            && self.agentless_config.is_none()
+            && agentless_disabled
             && self.otlp_config.is_none()
             && matches!(
                 &**self.client_side_stats.status.load(),
                 StatsComputationStatus::Disabled
             )
             && self.trace_filterer.load().is_empty()
+    }
+
+    fn should_check_agent_info(&self) -> bool {
+        if self.log_output.is_some() {
+            return false;
+        }
+
+        #[cfg(feature = "agentless")]
+        if self.agentless_config.is_some() {
+            return false;
+        }
+
+        true
     }
 
     /// Check if agent info state has changed
@@ -701,19 +725,27 @@ impl<
         &self,
         trace_chunks: Vec<Vec<Span<T>>>,
     ) -> Result<AgentResponse, TraceExporterError> {
-        // In log-export mode there is no agent to negotiate with; skip the poll.
-        if self.log_output.is_none() {
+        if self.should_check_agent_info() {
             self.check_agent_info().await;
         }
         self.send_trace_chunks_inner(trace_chunks).await
     }
 
     /// Sends trace chunks to the Datadog agentless intake (`/v1/input`) as JSON.
+    #[cfg(feature = "agentless")]
     async fn send_agentless_traces_inner<T: TraceData>(
         &self,
         traces: Vec<Vec<Span<T>>>,
         config: &AgentlessTraceConfig,
     ) -> Result<AgentResponse, TraceExporterError> {
+        let traces =
+            normalize_and_obfuscate(traces, &config.obfuscation, self.client_computed_top_level)
+                .map_err(|error| {
+                    error!("Agentless trace normalization or obfuscation error: {error}");
+                    TraceExporterError::Internal(InternalErrorKind::InvalidWorkerState(
+                        error.to_string(),
+                    ))
+                })?;
         let trace_count = traces.len();
         let json_body = libdd_trace_utils::agentless_encoder::encode_payload(
             &traces,
@@ -857,19 +889,12 @@ impl<
             return self.send_trace_chunks_to_log(&traces, max_line_size);
         }
 
-        let mut header_tags: TracerHeaderTags = self.metadata.borrow().into();
-
+        #[cfg(feature = "agentless")]
         if let Some(ref config) = self.agentless_config {
-            // For agentless we want to tag top level spans, but not perform
-            // stats aggregation or span drops
-            if !self.client_computed_top_level {
-                for chunk in traces.iter_mut() {
-                    libdd_trace_utils::span::trace_utils::compute_top_level_span(chunk);
-                }
-            }
-
             return self.send_agentless_traces_inner(traces, config).await;
         }
+
+        let mut header_tags: TracerHeaderTags = self.metadata.borrow().into();
 
         // Process stats computation and drop non-sampled (p0) chunks.
         // This must run before the OTLP path so that unsampled spans are not exported.
@@ -1187,10 +1212,22 @@ mod tests {
     use httpmock::MockServer;
     use libdd_capabilities_impl::NativeCapabilities;
     use libdd_shared_runtime::ForkSafeRuntime;
+    #[cfg(feature = "agentless")]
+    use libdd_tinybytes::Bytes;
     use libdd_tinybytes::BytesString;
+    #[cfg(feature = "agentless")]
+    use libdd_trace_obfuscation::obfuscation_config::{CreditCardConfig, HttpConfig, RedisConfig};
+    #[cfg(feature = "agentless")]
+    use libdd_trace_obfuscation::replacer::parse_rules_from_string;
     use libdd_trace_utils::msgpack_encoder;
     use libdd_trace_utils::span::v04::SpanBytes;
+    #[cfg(feature = "agentless")]
+    use libdd_trace_utils::span::v04::{AttributeAnyValue, AttributeArrayValue, SpanEvent, VecMap};
+    #[cfg(feature = "agentless")]
+    use std::collections::HashMap;
     use std::net;
+    #[cfg(feature = "agentless")]
+    use std::sync::{Arc, Mutex};
 
     #[test]
     fn test_from_tracer_tags_to_tracer_header_tags() {
@@ -2359,6 +2396,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "agentless")]
     #[cfg_attr(miri, ignore)]
     fn test_agentless_export_via_builder() {
         let server = MockServer::start();
@@ -2382,7 +2420,7 @@ mod tests {
             .set_language("nodejs")
             .set_language_version("v20.11.0")
             .set_language_interpreter("v8")
-            .set_agentless_endpoint(&intake_url, "test-api-key")
+            .set_agentless_endpoint(&intake_url, "test-api-key", ObfuscationConfig::default())
             .set_input_format(TraceExporterInputFormat::V04)
             .set_output_format(TraceExporterOutputFormat::V04);
         let exporter = builder.build::<NativeCapabilities>().unwrap();
@@ -2400,7 +2438,10 @@ mod tests {
             ..Default::default()
         }]];
         let data = msgpack_encoder::v04::to_vec_from_v04(&traces);
-        let result = exporter.send(data.as_ref());
+        let result = exporter
+            .shared_runtime
+            .block_on(exporter.send_v04_payload_async(data, 1))
+            .unwrap();
 
         assert!(
             result.is_ok(),
@@ -2413,6 +2454,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "agentless")]
     #[cfg_attr(miri, ignore)]
     fn test_agentless_export_body_shape() {
         let server = MockServer::start();
@@ -2455,11 +2497,14 @@ mod tests {
             .set_language("nodejs")
             .set_language_version("v20.11.0")
             .set_language_interpreter("v8")
-            .set_agentless_endpoint(&intake_url, "k")
+            .set_client_computed_top_level()
+            .set_agentless_endpoint(&intake_url, "k", ObfuscationConfig::default())
             .set_input_format(TraceExporterInputFormat::V04)
             .set_output_format(TraceExporterOutputFormat::V04);
         let exporter = builder.build::<NativeCapabilities>().unwrap();
 
+        let mut metrics = VecMap::new();
+        metrics.insert("_dd.top_level".into(), 1.0);
         let traces: Vec<Vec<SpanBytes>> = vec![vec![SpanBytes {
             name: BytesString::from_slice(b"op").unwrap(),
             service: BytesString::from_static("svc"),
@@ -2469,11 +2514,294 @@ mod tests {
             parent_id: 0,
             start: 0,
             duration: 1,
+            metrics,
             ..Default::default()
         }]];
         let data = msgpack_encoder::v04::to_vec_from_v04(&traces);
         exporter.send(data.as_ref()).unwrap();
         mock_intake.assert();
+    }
+
+    #[test]
+    #[cfg(feature = "agentless")]
+    #[cfg_attr(miri, ignore)]
+    fn test_agentless_export_normalizes_and_obfuscates_before_sending() {
+        let server = MockServer::start();
+        let received_body = Arc::new(Mutex::new(None));
+        let body_capture = received_body.clone();
+        let mock_intake = server.mock(move |when, then| {
+            when.method(POST).path("/v1/input").is_true(move |request| {
+                #[cfg(feature = "compression")]
+                let body = zstd::decode_all(request.body_ref()).unwrap();
+                #[cfg(not(feature = "compression"))]
+                let body = request.body_vec();
+                *body_capture.lock().unwrap() = Some(body);
+                true
+            });
+            then.status(200).body("");
+        });
+
+        let obfuscation = ObfuscationConfig {
+            tag_replace_rules: Some(
+                parse_rules_from_string(
+                    r#"[{"name":"custom.tag","pattern":"(/foo/bar/).*","repl":"${1}extra"}]"#,
+                )
+                .unwrap(),
+            ),
+            http: HttpConfig {
+                remove_query_string: true,
+                remove_paths_with_digits: true,
+            },
+            redis: RedisConfig {
+                enabled: true,
+                remove_all_args: false,
+            },
+            credit_cards: CreditCardConfig {
+                enabled: true,
+                luhn: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let intake_url = format!("{}/v1/input", server.url("/").trim_end_matches('/'));
+        let mut builder = TraceExporterBuilder::default();
+        builder
+            .set_hostname("host")
+            .set_language("nodejs")
+            .set_agentless_endpoint(&intake_url, "api-key", obfuscation)
+            .set_input_format(TraceExporterInputFormat::V04)
+            .set_output_format(TraceExporterOutputFormat::V04);
+        let exporter = builder.build::<NativeCapabilities>().unwrap();
+
+        let trace_id = 0x1234;
+        let mut web_meta = VecMap::new();
+        web_meta.insert(
+            "http.url".into(),
+            "http://example.com/users/123?token=secret".into(),
+        );
+        web_meta.insert("card.number".into(), "4111111111111111".into());
+        web_meta.insert("custom.tag".into(), "/foo/bar/private".into());
+        web_meta.insert("_dd.p.tid".into(), "abcdef0123456789".into());
+        let mut meta_struct = VecMap::new();
+        meta_struct.insert(
+            "_dd.appsec.json".into(),
+            Bytes::from(
+                rmp_serde::to_vec_named(&serde_json::json!({
+                    "rule_id": "crs-913-110",
+                    "category": "sqli"
+                }))
+                .unwrap(),
+            ),
+        );
+        let web = SpanBytes {
+            service: "".into(),
+            name: "".into(),
+            resource: "".into(),
+            r#type: "web".into(),
+            trace_id,
+            span_id: 1,
+            start: 1_700_000_000_000_000_000,
+            duration: 1_000_000,
+            meta: web_meta,
+            meta_struct,
+            span_events: vec![SpanEvent {
+                time_unix_nano: 1_700_000_000_000_000_000,
+                name: "payment".into(),
+                attributes: HashMap::from([(
+                    "payment.card".into(),
+                    AttributeAnyValue::SingleValue(AttributeArrayValue::String(
+                        "4111111111111111".into(),
+                    )),
+                )]),
+            }],
+            ..Default::default()
+        };
+        let sql = SpanBytes {
+            service: "database".into(),
+            name: "sql.query".into(),
+            resource: "SELECT * FROM users WHERE id = 42".into(),
+            r#type: "sql".into(),
+            trace_id,
+            span_id: 2,
+            parent_id: 1,
+            start: 1_700_000_000_001_000_000,
+            duration: 1_000_000,
+            ..Default::default()
+        };
+        let mut redis_meta = VecMap::new();
+        redis_meta.insert(
+            "redis.raw_command".into(),
+            "GEOADD key longitude latitude member".into(),
+        );
+        let redis = SpanBytes {
+            service: "redis".into(),
+            name: "redis.command".into(),
+            resource: "GEOADD key longitude latitude member".into(),
+            r#type: "redis".into(),
+            trace_id,
+            span_id: 3,
+            parent_id: 1,
+            start: 1_700_000_000_002_000_000,
+            duration: 1_000_000,
+            meta: redis_meta,
+            ..Default::default()
+        };
+        let normalized_parent = SpanBytes {
+            service: "bad&service".into(),
+            name: "normalized.parent".into(),
+            resource: "parent".into(),
+            r#type: "normalized-parent".into(),
+            trace_id,
+            span_id: 4,
+            parent_id: 1,
+            start: 1_700_000_000_003_000_000,
+            duration: 1_000_000,
+            ..Default::default()
+        };
+        let normalized_child = SpanBytes {
+            service: "bad$service".into(),
+            name: "normalized.child".into(),
+            resource: "child".into(),
+            r#type: "normalized-child".into(),
+            trace_id,
+            span_id: 5,
+            parent_id: 4,
+            start: 1_700_000_000_004_000_000,
+            duration: 1_000_000,
+            ..Default::default()
+        };
+
+        let data = msgpack_encoder::v04::to_vec_from_v04(&[vec![
+            web,
+            sql,
+            redis,
+            normalized_parent,
+            normalized_child,
+        ]]);
+        exporter.send(data.as_ref()).unwrap();
+        mock_intake.assert_calls(1);
+
+        let body = received_body.lock().unwrap().take().unwrap();
+        let body_text = std::str::from_utf8(&body).unwrap();
+        assert!(!body_text.contains("token=secret"));
+        assert!(!body_text.contains("4111111111111111"));
+        assert!(!body_text.contains("id = 42"));
+        assert!(!body_text.contains("longitude latitude member"));
+        assert!(!body_text.contains("/foo/bar/private"));
+
+        let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let spans = payload["traces"][0]["spans"].as_array().unwrap();
+        let web = spans.iter().find(|span| span["type"] == "web").unwrap();
+        assert_eq!(web["service"], "unnamed-service");
+        assert_eq!(web["name"], "unnamed_operation");
+        assert_eq!(web["resource"], "unnamed_operation");
+        assert_eq!(web["meta"]["http.url"], "http://example.com/users/??");
+        assert_eq!(web["meta"]["card.number"], "?");
+        assert_eq!(web["meta"]["custom.tag"], "/foo/bar/extra");
+        assert_eq!(web["meta"]["_dd.p.tid"], "abcdef0123456789");
+        assert_eq!(
+            web["meta_struct"]["_dd.appsec.json"],
+            serde_json::json!({
+                "rule_id": "crs-913-110",
+                "category": "sqli"
+            })
+        );
+        let events: serde_json::Value =
+            serde_json::from_str(web["meta"]["events"].as_str().unwrap()).unwrap();
+        assert_eq!(events[0]["attributes"]["payment.card"], "?");
+
+        let sql = spans.iter().find(|span| span["type"] == "sql").unwrap();
+        assert_eq!(sql["resource"], "SELECT * FROM users WHERE id = ?");
+        assert_eq!(sql["meta"]["sql.query"], sql["resource"]);
+
+        let redis = spans.iter().find(|span| span["type"] == "redis").unwrap();
+        assert_eq!(redis["resource"], "GEOADD");
+        assert_eq!(
+            redis["meta"]["redis.raw_command"],
+            "GEOADD key longitude latitude ?"
+        );
+
+        let normalized_parent = spans
+            .iter()
+            .find(|span| span["type"] == "normalized-parent")
+            .unwrap();
+        assert_eq!(normalized_parent["service"], "bad_service");
+        assert_eq!(normalized_parent["metrics"]["_top_level"], 1.0);
+
+        let normalized_child = spans
+            .iter()
+            .find(|span| span["type"] == "normalized-child")
+            .unwrap();
+        assert_eq!(normalized_child["service"], "bad_service");
+        assert!(normalized_child["metrics"]["_top_level"].is_null());
+
+        let trace_id = (u128::from(0x123456789abcdef0_u64) << 64) | 0x5678;
+        let traces = vec![vec![SpanBytes {
+            service: "service".into(),
+            name: "operation".into(),
+            resource: "resource".into(),
+            trace_id,
+            span_id: 6,
+            start: 1_700_000_000_005_000_000,
+            duration: 1_000_000,
+            ..Default::default()
+        }]];
+        exporter
+            .shared_runtime
+            .block_on(exporter.send_trace_chunks_async(traces))
+            .unwrap()
+            .unwrap();
+        mock_intake.assert_calls(2);
+
+        let body = received_body.lock().unwrap().take().unwrap();
+        let payload: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let span = &payload["traces"][0]["spans"][0];
+        assert_eq!(span["trace_id"], "0000000000005678");
+        assert_eq!(span["meta"]["_dd.p.tid"], "123456789abcdef0");
+    }
+
+    #[test]
+    #[cfg(feature = "agentless")]
+    #[cfg_attr(miri, ignore)]
+    fn test_agentless_rejects_invalid_traces_before_sending() {
+        let server = MockServer::start();
+        let mock_intake = server.mock(|when, then| {
+            when.method(POST).path("/v1/input");
+            then.status(200).body("");
+        });
+        let intake_url = format!("{}/v1/input", server.url("/").trim_end_matches('/'));
+        let mut builder = TraceExporterBuilder::default();
+        builder
+            .set_agentless_endpoint(&intake_url, "api-key", ObfuscationConfig::default())
+            .set_input_format(TraceExporterInputFormat::V04)
+            .set_output_format(TraceExporterOutputFormat::V04);
+        let exporter = builder.build::<NativeCapabilities>().unwrap();
+
+        let valid_span = |trace_id, span_id| SpanBytes {
+            service: "service".into(),
+            name: "operation".into(),
+            resource: "resource".into(),
+            trace_id,
+            span_id,
+            start: 1_700_000_000_000_000_000,
+            duration: 1_000_000,
+            ..Default::default()
+        };
+        let cases = [
+            ("empty trace", vec![vec![]]),
+            (
+                "different trace IDs",
+                vec![vec![valid_span(1, 1), valid_span(2, 2)]],
+            ),
+            ("zero trace ID", vec![vec![valid_span(0, 1)]]),
+            ("zero span ID", vec![vec![valid_span(1, 0)]]),
+        ];
+
+        for (name, traces) in cases {
+            let data = msgpack_encoder::v04::to_vec_from_v04(&traces);
+            assert!(exporter.send(data.as_ref()).is_err(), "{name} was accepted");
+        }
+        mock_intake.assert_calls(0);
     }
 }
 

--- a/libdd-data-pipeline/src/trace_exporter/trace_serializer.rs
+++ b/libdd-data-pipeline/src/trace_exporter/trace_serializer.rs
@@ -96,7 +96,7 @@ impl TraceSerializer {
     }
 
     /// Build HTTP headers for traces request
-    fn build_traces_headers(
+    pub(super) fn build_traces_headers(
         &self,
         header_tags: TracerHeaderTags,
         chunk_count: usize,

--- a/libdd-trace-normalization/Cargo.toml
+++ b/libdd-trace-normalization/Cargo.toml
@@ -16,6 +16,7 @@ bench = false
 anyhow.workspace = true
 libdd-trace-protobuf = { version = "4.0.1", path = "../libdd-trace-protobuf" }
 arbitrary = { version = "1.3", features = ["derive"], optional = true }
+web-time = "1"
 
 [features]
 fuzzing = ["arbitrary"]

--- a/libdd-trace-normalization/src/normalize_utils.rs
+++ b/libdd-trace-normalization/src/normalize_utils.rs
@@ -1,7 +1,7 @@
 // Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::SystemTime;
+use web_time::SystemTime;
 
 // MAX_TYPE_LEN the maximum size for a span type
 pub(crate) const MAX_TYPE_LEN: usize = 100;

--- a/libdd-trace-normalization/src/normalizer.rs
+++ b/libdd-trace-normalization/src/normalizer.rs
@@ -115,7 +115,7 @@ mod tests {
     use libdd_trace_protobuf::pb;
     use rand::Rng;
     use std::collections::HashMap;
-    use std::time::SystemTime;
+    use web_time::SystemTime;
 
     fn new_test_span() -> pb::Span {
         let mut rng = rand::thread_rng();

--- a/libdd-trace-obfuscation/Cargo.toml
+++ b/libdd-trace-obfuscation/Cargo.toml
@@ -17,6 +17,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
 percent-encoding = "2.1"
 fluent-uri = "0.4.1"
+libdd-capabilities = { version = "3.0.0", path = "../libdd-capabilities" }
 libdd-trace-protobuf = { version = "4.0.1", path = "../libdd-trace-protobuf" }
 libdd-trace-utils = { version = "10.1.0", path = "../libdd-trace-utils", default-features = false }
 libdd-common = { version = "5.2.0", path = "../libdd-common", default-features = false }
@@ -30,7 +31,6 @@ regex-lite = ["libdd-common/regex-lite"]
 [dev-dependencies]
 duplicate = "0.4.1"
 criterion = { workspace = true, features = ["csv_output"] }
-libdd-common = { path = "../libdd-common", features = ["test-utils"], default-features = false }
 libdd-trace-utils = { path = "../libdd-trace-utils", features = ["test-utils"] }
 
 [lib]

--- a/libdd-trace-obfuscation/Cargo.toml
+++ b/libdd-trace-obfuscation/Cargo.toml
@@ -16,7 +16,6 @@ anyhow.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
 percent-encoding = "2.1"
-log = "0.4"
 fluent-uri = "0.4.1"
 libdd-trace-protobuf = { version = "4.0.1", path = "../libdd-trace-protobuf" }
 libdd-trace-utils = { version = "10.1.0", path = "../libdd-trace-utils", default-features = false }
@@ -31,6 +30,7 @@ regex-lite = ["libdd-common/regex-lite"]
 [dev-dependencies]
 duplicate = "0.4.1"
 criterion = { workspace = true, features = ["csv_output"] }
+libdd-common = { path = "../libdd-common", features = ["test-utils"], default-features = false }
 libdd-trace-utils = { path = "../libdd-trace-utils", features = ["test-utils"] }
 
 [lib]

--- a/libdd-trace-obfuscation/README.md
+++ b/libdd-trace-obfuscation/README.md
@@ -14,3 +14,9 @@ This crate provides trace obfuscation functionality, implementing the same obfus
 - Stack traces
 
 For more details on trace obfuscation, see the [Datadog documentation](https://docs.datadoghq.com/tracing/configure_data_security/?tab=net#trace-obfuscation).
+
+## Configuration
+
+`ObfuscationConfig::new()` reads the process environment. Embedded runtimes can use
+`ObfuscationConfig::from_env()` with an `EnvCapability` implementation to apply the same option
+names, defaults, and replacement-rule validation through their platform environment provider.

--- a/libdd-trace-obfuscation/src/obfuscation_config.rs
+++ b/libdd-trace-obfuscation/src/obfuscation_config.rs
@@ -4,7 +4,7 @@
 use serde::Deserialize;
 use std::{collections::HashSet, env};
 
-use libdd_common::config::parse_env;
+use libdd_capabilities::env::EnvCapability;
 
 use crate::{
     replacer::{self, ReplaceRule},
@@ -106,21 +106,35 @@ impl ObfuscationConfig {
     ///
     /// Returns an error if one of the regular expressions used by the config cannot be compiled.
     pub fn new() -> Result<Self, Box<dyn core::error::Error>> {
-        let tag_replace_rules: Option<Vec<ReplaceRule>> = match env::var("DD_APM_REPLACE_TAGS") {
-            Ok(replace_rules) => Some(replacer::parse_rules_from_string(&replace_rules)?),
-            Err(_) => None,
-        };
-        let http_remove_query_string =
-            parse_env::bool("DD_APM_OBFUSCATION_HTTP_REMOVE_QUERY_STRING").unwrap_or(false);
-        let http_remove_path_digits =
-            parse_env::bool("DD_APM_OBFUSCATION_HTTP_REMOVE_PATHS_WITH_DIGITS").unwrap_or(false);
-        let obfuscation_redis_enabled =
-            parse_env::bool("DD_APM_OBFUSCATION_REDIS_ENABLED").unwrap_or(false);
-        let obfuscation_redis_remove_all_args =
-            parse_env::bool("DD_APM_OBFUSCATION_REDIS_REMOVE_ALL_ARGS").unwrap_or(false);
+        Self::from_getter(|name| Ok::<_, env::VarError>(env::var(name).ok()))
+    }
 
-        let obfuscate_memcached =
-            parse_env::bool("DD_APM_OBFUSCATION_MEMCACHED_ENABLED").unwrap_or(false);
+    /// Builds the obfuscation config from a platform environment capability.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when an environment value cannot be read or a replacement rule is invalid.
+    pub fn from_env<C: EnvCapability>(source: &C) -> Result<Self, Box<dyn core::error::Error>> {
+        Self::from_getter(|name| source.get(name))
+    }
+
+    fn from_getter<F, E>(mut get: F) -> Result<Self, Box<dyn core::error::Error>>
+    where
+        F: FnMut(&str) -> Result<Option<String>, E>,
+        E: core::error::Error + 'static,
+    {
+        let tag_replace_rules = get("DD_APM_REPLACE_TAGS")?
+            .map(|rules| replacer::parse_rules_from_string(&rules))
+            .transpose()?;
+        let http_remove_query_string =
+            enabled(get("DD_APM_OBFUSCATION_HTTP_REMOVE_QUERY_STRING")?.as_deref());
+        let http_remove_path_digits =
+            enabled(get("DD_APM_OBFUSCATION_HTTP_REMOVE_PATHS_WITH_DIGITS")?.as_deref());
+        let obfuscation_redis_enabled =
+            enabled(get("DD_APM_OBFUSCATION_REDIS_ENABLED")?.as_deref());
+        let obfuscation_redis_remove_all_args =
+            enabled(get("DD_APM_OBFUSCATION_REDIS_REMOVE_ALL_ARGS")?.as_deref());
+        let obfuscate_memcached = enabled(get("DD_APM_OBFUSCATION_MEMCACHED_ENABLED")?.as_deref());
 
         Ok(Self {
             tag_replace_rules,
@@ -146,24 +160,98 @@ impl ObfuscationConfig {
     }
 }
 
+fn enabled(value: Option<&str>) -> bool {
+    matches!(value, Some("true" | "1"))
+}
+
 #[cfg(test)]
 mod tests {
-    use std::sync::Mutex;
+    use std::collections::HashMap;
 
-    use libdd_common::test_utils::EnvGuard;
+    use libdd_capabilities::env::{EnvCapability, EnvError};
 
     use super::ObfuscationConfig;
 
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
+    #[derive(Clone, Debug, Default)]
+    struct TestEnv(HashMap<String, String>);
+
+    impl EnvCapability for TestEnv {
+        fn new() -> Self {
+            Self::default()
+        }
+
+        fn get(&self, name: &str) -> Result<Option<String>, EnvError> {
+            Ok(self.0.get(name).cloned())
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct BrokenEnv;
+
+    impl EnvCapability for BrokenEnv {
+        fn new() -> Self {
+            Self
+        }
+
+        fn get(&self, _name: &str) -> Result<Option<String>, EnvError> {
+            Err(EnvError::Io(anyhow::anyhow!("environment unavailable")))
+        }
+    }
+
+    #[test]
+    fn reads_from_environment_capability() {
+        let source = TestEnv(HashMap::from([
+            (
+                "DD_APM_REPLACE_TAGS".to_owned(),
+                r#"[{"name":"custom.tag","pattern":"secret","repl":"?"}]"#.to_owned(),
+            ),
+            (
+                "DD_APM_OBFUSCATION_HTTP_REMOVE_QUERY_STRING".to_owned(),
+                "true".to_owned(),
+            ),
+            (
+                "DD_APM_OBFUSCATION_HTTP_REMOVE_PATHS_WITH_DIGITS".to_owned(),
+                "1".to_owned(),
+            ),
+            (
+                "DD_APM_OBFUSCATION_REDIS_ENABLED".to_owned(),
+                "true".to_owned(),
+            ),
+            (
+                "DD_APM_OBFUSCATION_REDIS_REMOVE_ALL_ARGS".to_owned(),
+                "1".to_owned(),
+            ),
+            (
+                "DD_APM_OBFUSCATION_MEMCACHED_ENABLED".to_owned(),
+                "true".to_owned(),
+            ),
+        ]));
+
+        let config = ObfuscationConfig::from_env(&source).unwrap();
+
+        assert_eq!(config.tag_replace_rules.unwrap().len(), 1);
+        assert!(config.http.remove_query_string);
+        assert!(config.http.remove_paths_with_digits);
+        assert!(config.redis.enabled);
+        assert!(config.redis.remove_all_args);
+        assert!(config.memcached.enabled);
+        assert!(config.memcached.keep_command);
+    }
 
     #[test]
     fn rejects_invalid_replacement_rules() {
-        let _lock = ENV_LOCK.lock().unwrap();
-        let _replace_tags = EnvGuard::set(
-            "DD_APM_REPLACE_TAGS",
-            r#"[{"name":"custom.tag","pattern":"[","repl":"?"}]"#,
-        );
+        let source = TestEnv(HashMap::from([(
+            "DD_APM_REPLACE_TAGS".to_owned(),
+            r#"[{"name":"custom.tag","pattern":"[","repl":"?"}]"#.to_owned(),
+        )]));
 
-        assert!(ObfuscationConfig::new().is_err());
+        assert!(ObfuscationConfig::from_env(&source).is_err());
+    }
+
+    #[test]
+    fn propagates_environment_errors() {
+        let error = ObfuscationConfig::from_env(&BrokenEnv).unwrap_err();
+
+        assert_eq!(error.to_string(), "IO error: environment unavailable");
     }
 }

--- a/libdd-trace-obfuscation/src/obfuscation_config.rs
+++ b/libdd-trace-obfuscation/src/obfuscation_config.rs
@@ -1,7 +1,6 @@
 // Copyright 2023-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use log::{debug, error};
 use serde::Deserialize;
 use std::{collections::HashSet, env};
 
@@ -108,16 +107,7 @@ impl ObfuscationConfig {
     /// Returns an error if one of the regular expressions used by the config cannot be compiled.
     pub fn new() -> Result<Self, Box<dyn core::error::Error>> {
         let tag_replace_rules: Option<Vec<ReplaceRule>> = match env::var("DD_APM_REPLACE_TAGS") {
-            Ok(replace_rules_str) => match replacer::parse_rules_from_string(&replace_rules_str) {
-                Ok(res) => {
-                    debug!("Successfully parsed DD_APM_REPLACE_TAGS: {res:?}");
-                    Some(res)
-                }
-                Err(e) => {
-                    error!("Failed to parse DD_APM_REPLACE_TAGS: {e}");
-                    None
-                }
-            },
+            Ok(replace_rules) => Some(replacer::parse_rules_from_string(&replace_rules)?),
             Err(_) => None,
         };
         let http_remove_query_string =
@@ -153,5 +143,27 @@ impl ObfuscationConfig {
             },
             ..Default::default()
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use libdd_common::test_utils::EnvGuard;
+
+    use super::ObfuscationConfig;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn rejects_invalid_replacement_rules() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        let _replace_tags = EnvGuard::set(
+            "DD_APM_REPLACE_TAGS",
+            r#"[{"name":"custom.tag","pattern":"[","repl":"?"}]"#,
+        );
+
+        assert!(ObfuscationConfig::new().is_err());
     }
 }

--- a/libdd-trace-utils/src/agentless_encoder/mod.rs
+++ b/libdd-trace-utils/src/agentless_encoder/mod.rs
@@ -13,6 +13,7 @@
 //!   inlined on each trace instead of being carried in request headers. Hostname is always emitted
 //! - **IDs**: `trace_id`, `span_id`, `parent_id` are lowercase hex strings (16 chars; 32 for
 //!   span-link trace IDs)
+//! - **Time**: span `start` is whole seconds since Unix epoch; `duration` remains nanoseconds
 //! - **128-bit trace IDs**: only the low 64 bits go into `trace_id`; the `_dd.p.tid` meta tag
 //!   carries upper 64 bits
 //! - **Span links / events**: not top-level fields. They are JSON-stringified into
@@ -525,7 +526,7 @@ fn encode_span<T: AgentlessSpan, S: Serializer>(
     )?;
     map.serialize_entry("service", service_str)?;
     map.serialize_entry("error", &span.error())?;
-    map.serialize_entry("start", &span.start().max(0))?;
+    map.serialize_entry("start", &(span.start().max(0) / 1_000_000_000))?;
     map.serialize_entry("duration", &span.duration())?;
 
     let type_str = span.span_type();

--- a/libdd-trace-utils/src/agentless_encoder/mod.rs
+++ b/libdd-trace-utils/src/agentless_encoder/mod.rs
@@ -3,8 +3,8 @@
 
 //! Agentless APM JSON encoder.
 //!
-//! Encodes Datadog v04 trace chunks to the JSON body
-//! accepted by the Datadog HTTP trace intake (`POST /v1/input`).
+//! Encodes Datadog v04 trace chunks or normalized protobuf spans to the JSON body accepted by the
+//! Datadog HTTP trace intake (`POST /v1/input`).
 //!
 //! ## Differences from the regular agent (msgpack v04) encoding
 //!
@@ -29,8 +29,9 @@
 use crate::span::v04::{AttributeAnyValue, AttributeArrayValue, Span, SpanEvent, SpanLink};
 use crate::span::{TraceData, SPAN_LINK_FLAGS_SET_SENTINEL};
 use crate::tracer_metadata::TracerMetadata;
+use libdd_trace_protobuf::pb;
 use serde::{
-    ser::{SerializeMap, SerializeSeq},
+    ser::{Error as _, SerializeMap, SerializeSeq},
     Serializer,
 };
 use std::borrow::Borrow;
@@ -85,11 +86,340 @@ macro_rules! ser_fn {
     }
 }
 
+trait AgentlessSpan {
+    type Event: AgentlessSpanEvent;
+    type Link: AgentlessSpanLink;
+
+    fn service(&self) -> &str;
+    fn name(&self) -> &str;
+    fn resource(&self) -> &str;
+    fn span_type(&self) -> &str;
+    fn trace_id(&self) -> u64;
+    fn trace_id_high(&self) -> u64;
+    fn span_id(&self) -> u64;
+    fn parent_id(&self) -> u64;
+    fn start(&self) -> i64;
+    fn duration(&self) -> i64;
+    fn error(&self) -> i32;
+    fn meta(&self) -> impl Iterator<Item = (&str, &str)>;
+    fn metrics(&self) -> impl Iterator<Item = (&str, f64)>;
+    fn meta_struct(&self) -> impl Iterator<Item = (&str, &[u8])>;
+    fn meta_struct_is_empty(&self) -> bool;
+    fn span_links(&self) -> &[Self::Link];
+    fn span_events(&self) -> &[Self::Event];
+}
+
+impl<T: TraceData> AgentlessSpan for Span<T> {
+    type Event = SpanEvent<T>;
+    type Link = SpanLink<T>;
+
+    fn service(&self) -> &str {
+        self.service.borrow()
+    }
+
+    fn name(&self) -> &str {
+        self.name.borrow()
+    }
+
+    fn resource(&self) -> &str {
+        self.resource.borrow()
+    }
+
+    fn span_type(&self) -> &str {
+        self.r#type.borrow()
+    }
+
+    fn trace_id(&self) -> u64 {
+        self.trace_id as u64
+    }
+
+    fn trace_id_high(&self) -> u64 {
+        (self.trace_id >> 64) as u64
+    }
+
+    fn span_id(&self) -> u64 {
+        self.span_id
+    }
+
+    fn parent_id(&self) -> u64 {
+        self.parent_id
+    }
+
+    fn start(&self) -> i64 {
+        self.start
+    }
+
+    fn duration(&self) -> i64 {
+        self.duration
+    }
+
+    fn error(&self) -> i32 {
+        self.error
+    }
+
+    fn meta(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.meta
+            .iter()
+            .map(|(key, value)| (key.borrow(), value.borrow()))
+    }
+
+    fn metrics(&self) -> impl Iterator<Item = (&str, f64)> {
+        self.metrics
+            .iter()
+            .map(|(key, value)| (key.borrow(), *value))
+    }
+
+    fn meta_struct(&self) -> impl Iterator<Item = (&str, &[u8])> {
+        self.meta_struct
+            .iter()
+            .map(|(key, value)| (key.borrow(), value.borrow()))
+    }
+
+    fn meta_struct_is_empty(&self) -> bool {
+        self.meta_struct.is_empty()
+    }
+
+    fn span_links(&self) -> &[Self::Link] {
+        &self.span_links
+    }
+
+    fn span_events(&self) -> &[Self::Event] {
+        &self.span_events
+    }
+}
+
+impl AgentlessSpan for pb::Span {
+    type Event = pb::SpanEvent;
+    type Link = pb::SpanLink;
+
+    fn service(&self) -> &str {
+        &self.service
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn resource(&self) -> &str {
+        &self.resource
+    }
+
+    fn span_type(&self) -> &str {
+        &self.r#type
+    }
+
+    fn trace_id(&self) -> u64 {
+        self.trace_id
+    }
+
+    fn trace_id_high(&self) -> u64 {
+        0
+    }
+
+    fn span_id(&self) -> u64 {
+        self.span_id
+    }
+
+    fn parent_id(&self) -> u64 {
+        self.parent_id
+    }
+
+    fn start(&self) -> i64 {
+        self.start
+    }
+
+    fn duration(&self) -> i64 {
+        self.duration
+    }
+
+    fn error(&self) -> i32 {
+        self.error
+    }
+
+    fn meta(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.meta
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str()))
+    }
+
+    fn metrics(&self) -> impl Iterator<Item = (&str, f64)> {
+        self.metrics
+            .iter()
+            .map(|(key, value)| (key.as_str(), *value))
+    }
+
+    fn meta_struct(&self) -> impl Iterator<Item = (&str, &[u8])> {
+        self.meta_struct
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_slice()))
+    }
+
+    fn meta_struct_is_empty(&self) -> bool {
+        self.meta_struct.is_empty()
+    }
+
+    fn span_links(&self) -> &[Self::Link] {
+        &self.span_links
+    }
+
+    fn span_events(&self) -> &[Self::Event] {
+        &self.span_events
+    }
+}
+
+trait AgentlessSpanLink {
+    fn trace_id(&self) -> u64;
+    fn trace_id_high(&self) -> u64;
+    fn span_id(&self) -> u64;
+    fn attributes(&self) -> impl Iterator<Item = (&str, &str)>;
+    fn attributes_len(&self) -> usize;
+    fn tracestate(&self) -> &str;
+    fn flags(&self) -> u32;
+}
+
+impl<T: TraceData> AgentlessSpanLink for SpanLink<T> {
+    fn trace_id(&self) -> u64 {
+        self.trace_id
+    }
+
+    fn trace_id_high(&self) -> u64 {
+        self.trace_id_high
+    }
+
+    fn span_id(&self) -> u64 {
+        self.span_id
+    }
+
+    fn attributes(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.attributes
+            .iter()
+            .map(|(key, value)| (key.borrow(), value.borrow()))
+    }
+
+    fn attributes_len(&self) -> usize {
+        self.attributes.len()
+    }
+
+    fn tracestate(&self) -> &str {
+        self.tracestate.borrow()
+    }
+
+    fn flags(&self) -> u32 {
+        self.flags
+    }
+}
+
+impl AgentlessSpanLink for pb::SpanLink {
+    fn trace_id(&self) -> u64 {
+        self.trace_id
+    }
+
+    fn trace_id_high(&self) -> u64 {
+        self.trace_id_high
+    }
+
+    fn span_id(&self) -> u64 {
+        self.span_id
+    }
+
+    fn attributes(&self) -> impl Iterator<Item = (&str, &str)> {
+        self.attributes
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str()))
+    }
+
+    fn attributes_len(&self) -> usize {
+        self.attributes.len()
+    }
+
+    fn tracestate(&self) -> &str {
+        &self.tracestate
+    }
+
+    fn flags(&self) -> u32 {
+        self.flags
+    }
+}
+
+trait AgentlessSpanEvent {
+    type Attribute: AgentlessAttribute;
+
+    fn time_unix_nano(&self) -> u64;
+    fn name(&self) -> &str;
+    fn attributes(&self) -> impl Iterator<Item = (&str, &Self::Attribute)>;
+    fn attributes_len(&self) -> usize;
+}
+
+impl<T: TraceData> AgentlessSpanEvent for SpanEvent<T> {
+    type Attribute = AttributeAnyValue<T>;
+
+    fn time_unix_nano(&self) -> u64 {
+        self.time_unix_nano
+    }
+
+    fn name(&self) -> &str {
+        self.name.borrow()
+    }
+
+    fn attributes(&self) -> impl Iterator<Item = (&str, &Self::Attribute)> {
+        self.attributes
+            .iter()
+            .map(|(key, value)| (key.borrow(), value))
+    }
+
+    fn attributes_len(&self) -> usize {
+        self.attributes.len()
+    }
+}
+
+impl AgentlessSpanEvent for pb::SpanEvent {
+    type Attribute = pb::AttributeAnyValue;
+
+    fn time_unix_nano(&self) -> u64 {
+        self.time_unix_nano
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn attributes(&self) -> impl Iterator<Item = (&str, &Self::Attribute)> {
+        self.attributes
+            .iter()
+            .map(|(key, value)| (key.as_str(), value))
+    }
+
+    fn attributes_len(&self) -> usize {
+        self.attributes.len()
+    }
+}
+
+trait AgentlessAttribute {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error>;
+}
+
 /// Encode the given `traces` to the agentless JSON payload (`/v1/input` body).
 ///
 /// Returns the serialized JSON bytes on success.
 pub fn encode_payload<T: TraceData>(
     traces: &[Vec<Span<T>>],
+    metadata: &TracerMetadata,
+) -> Result<Vec<u8>, serde_json::Error> {
+    encode_payload_inner(traces, metadata)
+}
+
+/// Encode normalized protobuf spans to the agentless JSON payload (`/v1/input` body).
+///
+/// Returns the serialized JSON bytes on success.
+pub fn encode_protobuf_payload(
+    traces: &[Vec<pb::Span>],
+    metadata: &TracerMetadata,
+) -> Result<Vec<u8>, serde_json::Error> {
+    encode_payload_inner(traces, metadata)
+}
+
+fn encode_payload_inner<T: AgentlessSpan>(
+    traces: &[Vec<T>],
     metadata: &TracerMetadata,
 ) -> Result<Vec<u8>, serde_json::Error> {
     let mut bytes = Vec::new();
@@ -98,10 +428,10 @@ pub fn encode_payload<T: TraceData>(
     let mut map_ser = serializer.serialize_map(Some(1))?;
     map_ser.serialize_entry(
         "traces",
-        &ser_fn!(<T: TraceData> |ser, traces: &'a [Vec<Span<T>>], metadata: &'a TracerMetadata| {
+        &ser_fn!(<T: AgentlessSpan> |ser, traces: &'a [Vec<T>], metadata: &'a TracerMetadata| {
             let mut traces_serializer = ser.serialize_seq(Some(traces.len()))?;
             for chunk in traces {
-                traces_serializer.serialize_element(&ser_fn!(<T: TraceData> |ser, chunk: &'a Vec<Span<T>>, metadata: &'a TracerMetadata| {
+                traces_serializer.serialize_element(&ser_fn!(<T: AgentlessSpan> |ser, chunk: &'a Vec<T>, metadata: &'a TracerMetadata| {
                     encode_trace(ser, chunk, metadata)
                 }))?;
             }
@@ -112,9 +442,9 @@ pub fn encode_payload<T: TraceData>(
     Ok(bytes)
 }
 
-fn encode_trace<T: TraceData, S: Serializer>(
+fn encode_trace<T: AgentlessSpan, S: Serializer>(
     ser: S,
-    chunk: &[Span<T>],
+    chunk: &[T],
     metadata: &TracerMetadata,
 ) -> Result<S::Ok, S::Error> {
     let mut map = ser.serialize_map(None)?;
@@ -142,11 +472,11 @@ fn encode_trace<T: TraceData, S: Serializer>(
 
     map.serialize_entry(
         "spans",
-        &ser_fn!(<T: TraceData> |ser, chunk: &'a [Span<T>]| {
+        &ser_fn!(<T: AgentlessSpan> |ser, chunk: &'a [T]| {
             let mut seq = ser.serialize_seq(Some(chunk.len()))?;
             for (i, span) in chunk.iter().enumerate() {
                 let is_first = i == 0;
-                seq.serialize_element(&ser_fn!(<T: TraceData> |ser, span: &'a Span<T>, is_first: bool| {
+                seq.serialize_element(&ser_fn!(<T: AgentlessSpan> |ser, span: &'a T, is_first: bool| {
                     encode_span(ser, span, is_first)
                 }))?;
             }
@@ -157,37 +487,33 @@ fn encode_trace<T: TraceData, S: Serializer>(
     map.end()
 }
 
-fn encode_span<T: TraceData, S: Serializer>(
+fn encode_span<T: AgentlessSpan, S: Serializer>(
     ser: S,
-    span: &Span<T>,
+    span: &T,
     is_first_in_trace: bool,
 ) -> Result<S::Ok, S::Error> {
     let mut map = ser.serialize_map(None)?;
 
-    let trace_id = span.trace_id;
+    let trace_id = span.trace_id();
     map.serialize_entry(
         "trace_id",
-        &ser_fn!(|ser, trace_id: u128| {
-            ser.collect_str(&format_args!("{:016x}", trace_id as u64))
-        }),
+        &ser_fn!(|ser, trace_id: u64| { ser.collect_str(&format_args!("{trace_id:016x}")) }),
     )?;
-    let span_id = span.span_id;
+    let span_id = span.span_id();
     map.serialize_entry(
         "span_id",
-        &ser_fn!(|ser, span_id: u64| { ser.collect_str(&format_args!("{:016x}", span_id as u64)) }),
+        &ser_fn!(|ser, span_id: u64| { ser.collect_str(&format_args!("{span_id:016x}")) }),
     )?;
-    let parent_id = span.parent_id;
+    let parent_id = span.parent_id();
     map.serialize_entry(
         "parent_id",
-        &ser_fn!(|ser, parent_id: u64| {
-            ser.collect_str(&format_args!("{:016x}", parent_id as u64))
-        }),
+        &ser_fn!(|ser, parent_id: u64| { ser.collect_str(&format_args!("{parent_id:016x}")) }),
     )?;
 
     // Resource defaults to name when empty.
-    let name_str: &str = span.name.borrow();
-    let resource_str: &str = span.resource.borrow();
-    let service_str: &str = span.service.borrow();
+    let name_str = span.name();
+    let resource_str = span.resource();
+    let service_str = span.service();
     map.serialize_entry("name", name_str)?;
     map.serialize_entry(
         "resource",
@@ -198,27 +524,26 @@ fn encode_span<T: TraceData, S: Serializer>(
         },
     )?;
     map.serialize_entry("service", service_str)?;
-    map.serialize_entry("error", &span.error)?;
-    map.serialize_entry("start", &span.start.max(0))?;
-    map.serialize_entry("duration", &span.duration)?;
+    map.serialize_entry("error", &span.error())?;
+    map.serialize_entry("start", &span.start().max(0))?;
+    map.serialize_entry("duration", &span.duration())?;
 
-    let type_str: &str = span.r#type.borrow();
+    let type_str = span.span_type();
     if !type_str.is_empty() {
         map.serialize_entry("type", type_str)?;
     }
 
     map.serialize_entry(
         "meta",
-        &ser_fn!(<T: TraceData> |ser, span: &'a Span<T>, is_first_in_trace: bool| {
-            let upper_bits = (span.trace_id >> 64) as u64;
+        &ser_fn!(<T: AgentlessSpan> |ser, span: &'a T, is_first_in_trace: bool| {
+            let upper_bits = span.trace_id_high();
             let mut p_tid_seen = false;
             let mut span_links_seen = false;
             let mut events_seen = false;
             let mut compute_stats_seen = false;
 
             let mut meta = ser.serialize_map(None)?;
-            for (k, v) in span.meta.iter() {
-                let key: &str = k.borrow();
+            for (key, value) in span.meta() {
                 match key {
                     "_dd.p.tid" => p_tid_seen = true,
                     "_dd.span_links" => span_links_seen = true,
@@ -226,8 +551,7 @@ fn encode_span<T: TraceData, S: Serializer>(
                     "_dd.compute_stats"=> compute_stats_seen = true,
                     _ => {}
                 };
-                let val: &str = v.borrow();
-                meta.serialize_entry(key, val)?;
+                meta.serialize_entry(key, value)?;
             }
             if !p_tid_seen && upper_bits != 0 {
                 meta.serialize_entry(
@@ -237,13 +561,13 @@ fn encode_span<T: TraceData, S: Serializer>(
                     }),
                 )?;
             }
-            if !span_links_seen && !span.span_links.is_empty() {
-                if let Some(s) = serialize_span_links(&span.span_links) {
+            if !span_links_seen && !span.span_links().is_empty() {
+                if let Some(s) = serialize_span_links(span.span_links()) {
                     meta.serialize_entry("_dd.span_links", &s)?;
                 }
             }
-            if !events_seen && !span.span_events.is_empty() {
-                if let Some(s) = serialize_span_events(&span.span_events) {
+            if !events_seen && !span.span_events().is_empty() {
+                if let Some(s) = serialize_span_events(span.span_events()) {
                     meta.serialize_entry("events", &s)?;
                 }
             }
@@ -256,40 +580,36 @@ fn encode_span<T: TraceData, S: Serializer>(
 
     map.serialize_entry(
         "metrics",
-        &ser_fn!(<T: TraceData> |ser, span: &'a Span<T>| {
+        &ser_fn!(<T: AgentlessSpan> |ser, span: &'a T| {
             let mut metrics = ser.serialize_map(None)?;
             let mut trace_root_seen = false;
-            for (k, v) in span.metrics.iter() {
-                let key: &str = k.borrow();
+            for (key, value) in span.metrics() {
                 // serde_json refuses to serialize NaN/Inf; drop them silently.
-                if v.is_finite() {
+                if value.is_finite() {
                     match key {
                         "_trace_root" => trace_root_seen = true,
                         "_top_level" => {
-                            metrics.serialize_entry(key, &(*v as u32))?;
+                            metrics.serialize_entry(key, &(value as u32))?;
                             continue
                         },
                         _ => {},
                     }
-                    metrics.serialize_entry(key, v)?
+                    metrics.serialize_entry(key, &value)?
                 }
             }
-            if !trace_root_seen && span.parent_id == 0 {
+            if !trace_root_seen && span.parent_id() == 0 {
                 metrics.serialize_entry("_trace_root", &1u32)?;
             }
             metrics.end()
         }),
     )?;
 
-    if !span.meta_struct.is_empty() {
+    if !span.meta_struct_is_empty() {
         map.serialize_entry(
             "meta_struct",
-            &ser_fn!(<T: TraceData> |ser, span: &'a Span<T>| {
+            &ser_fn!(<T: AgentlessSpan> |ser, span: &'a T| {
                 let mut ms = ser.serialize_map(None)?;
-                for (k, v) in span.meta_struct.iter() {
-                    let key: &str = k.borrow();
-                    let bytes: &[u8] = v.borrow();
-
+                for (key, bytes) in span.meta_struct() {
                     // abort whole payload on malformed entry
                     ms.serialize_entry(key, &MsgpackAsJson(bytes))?;
                 }
@@ -305,11 +625,11 @@ fn encode_span<T: TraceData, S: Serializer>(
 /// Returns `None` if serialization fails. The result is truncated to
 /// [`MAX_META_VALUE_LEN`] characters with a trailing `"..."` if it would
 /// otherwise exceed that limit.
-fn serialize_span_links<T: TraceData>(links: &[SpanLink<T>]) -> Option<String> {
-    let s = serde_json::to_string(&ser_fn!(<T: TraceData> |ser, links: &'a [SpanLink<T>]| {
+fn serialize_span_links<T: AgentlessSpanLink>(links: &[T]) -> Option<String> {
+    let s = serde_json::to_string(&ser_fn!(<T: AgentlessSpanLink> |ser, links: &'a [T]| {
         let mut seq = ser.serialize_seq(Some(links.len()))?;
         for link in links {
-            seq.serialize_element(&ser_fn!(<T: TraceData> |ser, link: &'a SpanLink<T>| {
+            seq.serialize_element(&ser_fn!(<T: AgentlessSpanLink> |ser, link: &'a T| {
                 encode_span_link(ser, link)
             }))?;
         }
@@ -319,23 +639,21 @@ fn serialize_span_links<T: TraceData>(links: &[SpanLink<T>]) -> Option<String> {
     Some(truncate_with_ellipsis(s, MAX_META_VALUE_LEN))
 }
 
-fn encode_span_link<T: TraceData, S: Serializer>(
+fn encode_span_link<T: AgentlessSpanLink, S: Serializer>(
     ser: S,
-    link: &SpanLink<T>,
+    link: &T,
 ) -> Result<S::Ok, S::Error> {
     let mut map = ser.serialize_map(None)?;
-    let trace_id_128: u128 = ((link.trace_id_high as u128) << 64) | (link.trace_id as u128);
+    let trace_id_128: u128 = ((link.trace_id_high() as u128) << 64) | (link.trace_id() as u128);
     map.serialize_entry("trace_id", &format!("{:032x}", trace_id_128))?;
-    map.serialize_entry("span_id", &format!("{:016x}", link.span_id))?;
-    if !link.attributes.is_empty() {
+    map.serialize_entry("span_id", &format!("{:016x}", link.span_id()))?;
+    if link.attributes_len() != 0 {
         map.serialize_entry(
             "attributes",
-            &ser_fn!(<T: TraceData> |ser, link: &'a SpanLink<T>| {
-                let mut attrs = ser.serialize_map(Some(link.attributes.len()))?;
-                for (k, v) in link.attributes.iter() {
-                    let key: &str = k.borrow();
-                    let val: &str = v.borrow();
-                    attrs.serialize_entry(key, val)?;
+            &ser_fn!(<T: AgentlessSpanLink> |ser, link: &'a T| {
+                let mut attrs = ser.serialize_map(Some(link.attributes_len()))?;
+                for (key, value) in link.attributes() {
+                    attrs.serialize_entry(key, value)?;
                 }
                 attrs.end()
             }),
@@ -344,13 +662,13 @@ fn encode_span_link<T: TraceData, S: Serializer>(
     // When `flags` is 0, no sampling decision exists, so omit the field. Before emission,
     // mask off the internal "explicitly set" sentinel (bit 31), because this JSON field uses
     // the same `_dd.span_links` key that the v0.5 encoder produces and must match its output.
-    if link.flags != 0 {
+    if link.flags() != 0 {
         map.serialize_entry(
             "flags",
-            &((link.flags & !SPAN_LINK_FLAGS_SET_SENTINEL) as u64),
+            &((link.flags() & !SPAN_LINK_FLAGS_SET_SENTINEL) as u64),
         )?;
     }
-    let tracestate: &str = link.tracestate.borrow();
+    let tracestate = link.tracestate();
     if !tracestate.is_empty() {
         map.serialize_entry("tracestate", tracestate)?;
     }
@@ -358,11 +676,11 @@ fn encode_span_link<T: TraceData, S: Serializer>(
 }
 
 /// Serialize span events to a JSON string suitable for `meta['events']`.
-fn serialize_span_events<T: TraceData>(events: &[SpanEvent<T>]) -> Option<String> {
-    let s = serde_json::to_string(&ser_fn!(<T: TraceData> |ser, events: &'a [SpanEvent<T>]| {
+fn serialize_span_events<T: AgentlessSpanEvent>(events: &[T]) -> Option<String> {
+    let s = serde_json::to_string(&ser_fn!(<T: AgentlessSpanEvent> |ser, events: &'a [T]| {
         let mut seq = ser.serialize_seq(Some(events.len()))?;
         for event in events {
-            seq.serialize_element(&ser_fn!(<T: TraceData> |ser, event: &'a SpanEvent<T>| {
+            seq.serialize_element(&ser_fn!(<T: AgentlessSpanEvent> |ser, event: &'a T| {
                 encode_span_event(ser, event)
             }))?;
         }
@@ -372,34 +690,21 @@ fn serialize_span_events<T: TraceData>(events: &[SpanEvent<T>]) -> Option<String
     Some(truncate_with_ellipsis(s, MAX_META_VALUE_LEN))
 }
 
-fn encode_span_event<T: TraceData, S: Serializer>(
+fn encode_span_event<T: AgentlessSpanEvent, S: Serializer>(
     ser: S,
-    event: &SpanEvent<T>,
+    event: &T,
 ) -> Result<S::Ok, S::Error> {
     let mut map = ser.serialize_map(None)?;
-    let name: &str = event.name.borrow();
-    map.serialize_entry("name", name)?;
-    map.serialize_entry("time_unix_nano", &event.time_unix_nano)?;
-    if !event.attributes.is_empty() {
+    map.serialize_entry("name", event.name())?;
+    map.serialize_entry("time_unix_nano", &event.time_unix_nano())?;
+    if event.attributes_len() != 0 {
         map.serialize_entry(
             "attributes",
-            &ser_fn!(<T: TraceData> |ser, event: &'a SpanEvent<T>| {
-                let mut attrs = ser.serialize_map(Some(event.attributes.len()))?;
-                for (k, v) in event.attributes.iter() {
-                    let key: &str = k.borrow();
-                    attrs.serialize_entry(key, &ser_fn!(<T: TraceData> |ser, v: &'a AttributeAnyValue<T> | {
-                        match v {
-                            AttributeAnyValue::SingleValue(v) => serialize_scalar(ser, v),
-                            AttributeAnyValue::Array(values) => {
-                                let mut seq = ser.serialize_seq(Some(values.len()))?;
-                                for v in values {
-                                    seq.serialize_element(&ser_fn!(<T: TraceData> |ser, v: &'a AttributeArrayValue<T>| {
-                                        serialize_scalar(ser, v)
-                                    }))?;
-                                }
-                                seq.end()
-                            }
-                        }
+            &ser_fn!(<T: AgentlessSpanEvent> |ser, event: &'a T| {
+                let mut attrs = ser.serialize_map(Some(event.attributes_len()))?;
+                for (key, value) in event.attributes() {
+                    attrs.serialize_entry(key, &ser_fn!(<A: AgentlessAttribute> |ser, value: &'a A| {
+                        value.serialize(ser)
                     }))?;
                 }
                 attrs.end()
@@ -409,25 +714,87 @@ fn encode_span_event<T: TraceData, S: Serializer>(
     map.end()
 }
 
-fn serialize_scalar<S: serde::Serializer, T: TraceData>(
-    ser: S,
-    s: &AttributeArrayValue<T>,
-) -> Result<S::Ok, S::Error> {
-    match s {
-        AttributeArrayValue::String(s) => {
-            let s: &str = s.borrow();
-            ser.serialize_str(s)
-        }
-        AttributeArrayValue::Boolean(b) => ser.serialize_bool(*b),
-        AttributeArrayValue::Integer(i) => ser.serialize_i64(*i),
-        AttributeArrayValue::Double(d) => {
-            if d.is_finite() {
-                ser.serialize_f64(*d)
-            } else {
-                // NaN/Inf become JSON null.
-                ser.serialize_unit()
+impl<T: TraceData> AgentlessAttribute for AttributeAnyValue<T> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            AttributeAnyValue::SingleValue(value) => serialize_scalar(serializer, value),
+            AttributeAnyValue::Array(values) => {
+                let mut sequence = serializer.serialize_seq(Some(values.len()))?;
+                for value in values {
+                    sequence.serialize_element(
+                        &ser_fn!(<T: TraceData> |ser, value: &'a AttributeArrayValue<T>| {
+                            serialize_scalar(ser, value)
+                        }),
+                    )?;
+                }
+                sequence.end()
             }
         }
+    }
+}
+
+impl AgentlessAttribute for pb::AttributeAnyValue {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use pb::attribute_any_value::AttributeAnyValueType;
+
+        match self.r#type() {
+            AttributeAnyValueType::StringValue => serializer.serialize_str(&self.string_value),
+            AttributeAnyValueType::BoolValue => serializer.serialize_bool(self.bool_value),
+            AttributeAnyValueType::IntValue => serializer.serialize_i64(self.int_value),
+            AttributeAnyValueType::DoubleValue => serialize_f64(serializer, self.double_value),
+            AttributeAnyValueType::ArrayValue => {
+                let values = self.array_value.as_ref().ok_or_else(|| {
+                    S::Error::custom("agentless span event array is missing its values")
+                })?;
+                let mut sequence = serializer.serialize_seq(Some(values.values.len()))?;
+                for value in &values.values {
+                    sequence.serialize_element(&ser_fn!(
+                        |ser, value: &'a pb::AttributeArrayValue| {
+                            serialize_protobuf_scalar(ser, value)
+                        }
+                    ))?;
+                }
+                sequence.end()
+            }
+        }
+    }
+}
+
+fn serialize_scalar<S: Serializer, T: TraceData>(
+    serializer: S,
+    value: &AttributeArrayValue<T>,
+) -> Result<S::Ok, S::Error> {
+    match value {
+        AttributeArrayValue::String(value) => {
+            let value: &str = value.borrow();
+            serializer.serialize_str(value)
+        }
+        AttributeArrayValue::Boolean(value) => serializer.serialize_bool(*value),
+        AttributeArrayValue::Integer(value) => serializer.serialize_i64(*value),
+        AttributeArrayValue::Double(value) => serialize_f64(serializer, *value),
+    }
+}
+
+fn serialize_protobuf_scalar<S: Serializer>(
+    serializer: S,
+    value: &pb::AttributeArrayValue,
+) -> Result<S::Ok, S::Error> {
+    use pb::attribute_array_value::AttributeArrayValueType;
+
+    match value.r#type() {
+        AttributeArrayValueType::StringValue => serializer.serialize_str(&value.string_value),
+        AttributeArrayValueType::BoolValue => serializer.serialize_bool(value.bool_value),
+        AttributeArrayValueType::IntValue => serializer.serialize_i64(value.int_value),
+        AttributeArrayValueType::DoubleValue => serialize_f64(serializer, value.double_value),
+    }
+}
+
+fn serialize_f64<S: Serializer>(serializer: S, value: f64) -> Result<S::Ok, S::Error> {
+    if value.is_finite() {
+        serializer.serialize_f64(value)
+    } else {
+        // NaN/Inf become JSON null.
+        serializer.serialize_unit()
     }
 }
 

--- a/libdd-trace-utils/src/agentless_encoder/mod.rs
+++ b/libdd-trace-utils/src/agentless_encoder/mod.rs
@@ -24,7 +24,7 @@
 //!   `metrics["_trace_root"]=1` where applicable.
 //! - **Non-finite metrics** (NaN/Inf) are dropped (JSON can't represent them).
 //!
-//! TODO: span normalization (service/name/resource/type truncation + defaults)
+//! The trace exporter normalizes and obfuscates spans before calling this encoder.
 
 use crate::span::v04::{AttributeAnyValue, AttributeArrayValue, Span, SpanEvent, SpanLink};
 use crate::span::{TraceData, SPAN_LINK_FLAGS_SET_SENTINEL};

--- a/libdd-trace-utils/src/agentless_encoder/tests.rs
+++ b/libdd-trace-utils/src/agentless_encoder/tests.rs
@@ -1,11 +1,12 @@
 // Copyright 2024-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use super::encode_payload;
+use super::{encode_payload, encode_protobuf_payload};
 use crate::span::v04::{AttributeAnyValue, AttributeArrayValue, Span, SpanEvent, SpanLink, VecMap};
 use crate::span::BytesData;
 use crate::tracer_metadata::TracerMetadata;
 use libdd_tinybytes::{Bytes, BytesString};
+use libdd_trace_protobuf::pb;
 use serde_json::Value;
 use std::collections::HashMap;
 
@@ -28,6 +29,185 @@ fn base_metadata() -> TracerMetadata {
 
 fn json_from_bytes(b: &[u8]) -> Value {
     serde_json::from_slice(b).expect("payload must be valid JSON")
+}
+
+#[cfg_attr(miri, ignore)] // serde_json/rmp_serde overhead is prohibitively slow under Miri
+#[test]
+fn protobuf_spans_match_v04_spans() {
+    let trace_id_high = 0x0011_2233_4455_6677_u64;
+    let trace_id = 0x8899_aabb_ccdd_eeff_u64;
+    let meta_struct =
+        rmp_serde::to_vec_named(&serde_json::json!({ "rule_id": "crs-913-110" })).unwrap();
+    let span_link = SpanLink::<BytesData> {
+        trace_id: 0x9abc_def0_1234_5678,
+        trace_id_high: 0x0011_2233_4455_6677,
+        span_id: 0xfeed_face_dead_beef,
+        attributes: HashMap::from([(bs("link.name"), bs("scheduled_by"))]),
+        flags: 1,
+        tracestate: bs("dd=s:1"),
+    };
+    let span_event = SpanEvent::<BytesData> {
+        time_unix_nano: 1_700_000_000_000_000_000,
+        name: bs("exception"),
+        attributes: HashMap::from([
+            (
+                bs("exception.message"),
+                AttributeAnyValue::SingleValue(AttributeArrayValue::String(bs("timeout"))),
+            ),
+            (
+                bs("bool"),
+                AttributeAnyValue::SingleValue(AttributeArrayValue::Boolean(true)),
+            ),
+            (
+                bs("int"),
+                AttributeAnyValue::SingleValue(AttributeArrayValue::Integer(42)),
+            ),
+            (
+                bs("double"),
+                AttributeAnyValue::SingleValue(AttributeArrayValue::Double(1.5)),
+            ),
+            (
+                bs("array"),
+                AttributeAnyValue::Array(vec![
+                    AttributeArrayValue::String(bs("value")),
+                    AttributeArrayValue::Boolean(false),
+                    AttributeArrayValue::Integer(7),
+                    AttributeArrayValue::Double(2.5),
+                ]),
+            ),
+        ]),
+    };
+    let span: Span<BytesData> = Span {
+        service: bs("svc"),
+        name: bs("op"),
+        resource: bs("res"),
+        r#type: bs("web"),
+        trace_id: ((trace_id_high as u128) << 64) | trace_id as u128,
+        span_id: 1,
+        parent_id: 0,
+        start: 2_500_000_000,
+        duration: 1_000_000,
+        error: 1,
+        meta: VecMap::from_iter([("some.tag".into(), "kept".into())]),
+        metrics: VecMap::from_iter([("_top_level".into(), 1.0)]),
+        meta_struct: VecMap::from_iter([(
+            "_dd.appsec.json".into(),
+            Bytes::from(meta_struct.clone()),
+        )]),
+        span_links: vec![span_link],
+        span_events: vec![span_event],
+    };
+    let protobuf_span = pb::Span {
+        service: "svc".to_string(),
+        name: "op".to_string(),
+        resource: "res".to_string(),
+        r#type: "web".to_string(),
+        trace_id,
+        span_id: 1,
+        parent_id: 0,
+        start: 2_500_000_000,
+        duration: 1_000_000,
+        error: 1,
+        meta: HashMap::from([
+            ("some.tag".to_string(), "kept".to_string()),
+            ("_dd.p.tid".to_string(), format!("{trace_id_high:016x}")),
+        ]),
+        metrics: HashMap::from([("_top_level".to_string(), 1.0)]),
+        meta_struct: HashMap::from([("_dd.appsec.json".to_string(), meta_struct)]),
+        span_links: vec![pb::SpanLink {
+            trace_id: 0x9abc_def0_1234_5678,
+            trace_id_high: 0x0011_2233_4455_6677,
+            span_id: 0xfeed_face_dead_beef,
+            attributes: HashMap::from([("link.name".to_string(), "scheduled_by".to_string())]),
+            flags: 1,
+            tracestate: "dd=s:1".to_string(),
+        }],
+        span_events: vec![pb::SpanEvent {
+            time_unix_nano: 1_700_000_000_000_000_000,
+            name: "exception".to_string(),
+            attributes: HashMap::from([
+                (
+                    "exception.message".to_string(),
+                    pb::AttributeAnyValue {
+                        r#type: pb::attribute_any_value::AttributeAnyValueType::StringValue as i32,
+                        string_value: "timeout".to_string(),
+                        ..Default::default()
+                    },
+                ),
+                (
+                    "bool".to_string(),
+                    pb::AttributeAnyValue {
+                        r#type: pb::attribute_any_value::AttributeAnyValueType::BoolValue as i32,
+                        bool_value: true,
+                        ..Default::default()
+                    },
+                ),
+                (
+                    "int".to_string(),
+                    pb::AttributeAnyValue {
+                        r#type: pb::attribute_any_value::AttributeAnyValueType::IntValue as i32,
+                        int_value: 42,
+                        ..Default::default()
+                    },
+                ),
+                (
+                    "double".to_string(),
+                    pb::AttributeAnyValue {
+                        r#type: pb::attribute_any_value::AttributeAnyValueType::DoubleValue as i32,
+                        double_value: 1.5,
+                        ..Default::default()
+                    },
+                ),
+                (
+                    "array".to_string(),
+                    pb::AttributeAnyValue {
+                        r#type: pb::attribute_any_value::AttributeAnyValueType::ArrayValue as i32,
+                        array_value: Some(pb::AttributeArray {
+                            values: vec![
+                                pb::AttributeArrayValue {
+                                    r#type: pb::attribute_array_value::AttributeArrayValueType::StringValue as i32,
+                                    string_value: "value".to_string(),
+                                    ..Default::default()
+                                },
+                                pb::AttributeArrayValue {
+                                    r#type: pb::attribute_array_value::AttributeArrayValueType::BoolValue as i32,
+                                    bool_value: false,
+                                    ..Default::default()
+                                },
+                                pb::AttributeArrayValue {
+                                    r#type: pb::attribute_array_value::AttributeArrayValueType::IntValue as i32,
+                                    int_value: 7,
+                                    ..Default::default()
+                                },
+                                pb::AttributeArrayValue {
+                                    r#type: pb::attribute_array_value::AttributeArrayValueType::DoubleValue as i32,
+                                    double_value: 2.5,
+                                    ..Default::default()
+                                },
+                            ],
+                        }),
+                        ..Default::default()
+                    },
+                ),
+            ]),
+        }],
+    };
+
+    let mut v04 = json_from_bytes(&encode_payload(&[vec![span]], &base_metadata()).unwrap());
+    let mut protobuf = json_from_bytes(
+        &encode_protobuf_payload(&[vec![protobuf_span]], &base_metadata()).unwrap(),
+    );
+    for payload in [&mut v04, &mut protobuf] {
+        let meta = payload["traces"][0]["spans"][0]["meta"]
+            .as_object_mut()
+            .unwrap();
+        for key in ["_dd.span_links", "events"] {
+            let nested = serde_json::from_str(meta[key].as_str().unwrap()).unwrap();
+            meta.insert(key.to_string(), nested);
+        }
+    }
+
+    assert_eq!(protobuf, v04);
 }
 
 #[cfg_attr(miri, ignore)] // serde_json/rmp_serde overhead is prohibitively slow under Miri

--- a/libdd-trace-utils/src/agentless_encoder/tests.rs
+++ b/libdd-trace-utils/src/agentless_encoder/tests.rs
@@ -250,7 +250,7 @@ fn top_level_payload_shape_and_metadata() {
     assert_eq!(s["resource"], "res");
     assert_eq!(s["service"], "svc");
     assert_eq!(s["error"], 0);
-    assert_eq!(s["start"], 2_500_000_000_i64);
+    assert_eq!(s["start"], 2_i64);
     assert_eq!(s["duration"], 1_000_000);
 
     // Root span gets `_trace_root`, top-level (no parent), and first span gets
@@ -260,6 +260,28 @@ fn top_level_payload_shape_and_metadata() {
     assert_eq!(metrics["_top_level"], 1);
     let meta = s["meta"].as_object().unwrap();
     assert_eq!(meta["_dd.compute_stats"], "1");
+}
+
+#[cfg_attr(miri, ignore)] // serde_json/rmp_serde overhead is prohibitively slow under Miri
+#[test]
+fn span_start_is_encoded_in_whole_seconds() {
+    let spans = [-1, 999_999_999, 1_000_000_000]
+        .into_iter()
+        .enumerate()
+        .map(|(index, start)| Span::<BytesData> {
+            trace_id: 1,
+            span_id: index as u64 + 1,
+            start,
+            ..Default::default()
+        })
+        .collect();
+    let bytes = encode_payload(&[spans], &base_metadata()).unwrap();
+    let value = json_from_bytes(&bytes);
+    let spans = value["traces"][0]["spans"].as_array().unwrap();
+
+    assert_eq!(spans[0]["start"], 0);
+    assert_eq!(spans[1]["start"], 0);
+    assert_eq!(spans[2]["start"], 1);
 }
 
 #[cfg_attr(miri, ignore)] // serde_json/rmp_serde overhead is prohibitively slow under Miri

--- a/libdd-trace-utils/src/trace_filter.rs
+++ b/libdd-trace-utils/src/trace_filter.rs
@@ -162,6 +162,15 @@ impl<'a, T: TraceData> Span<'a> for ChunkSpanView<'a, T> {
 }
 
 impl TraceFilterer {
+    /// Returns whether this filter has no active trace rules.
+    pub fn is_empty(&self) -> bool {
+        self.reject.is_empty()
+            && self.reject_regex.is_empty()
+            && self.require.is_empty()
+            && self.require_regex.is_empty()
+            && self.ignore_resources.is_empty()
+    }
+
     fn compile_literal_filters(filters: &[String]) -> Vec<TagLiteralFilter> {
         let mut tag_regex_filters = Vec::new();
         for filter in filters {
@@ -491,6 +500,16 @@ mod tests {
 
     fn ignore_resources(patterns: &[&str]) -> TraceFilterer {
         TraceFilterer::new(&[], &[], &[], &[], &map_to_owned(patterns))
+    }
+
+    #[test]
+    fn is_empty_tracks_all_filter_types() {
+        assert!(TraceFilterer::default().is_empty());
+        assert!(!require_str(&["env:prod"]).is_empty());
+        assert!(!reject_str(&["env:prod"]).is_empty());
+        assert!(!require_regex(&["env:^prod$"]).is_empty());
+        assert!(!reject_regex(&["env:^prod$"]).is_empty());
+        assert!(!ignore_resources(&["health"]).is_empty());
     }
 
     // ---- reject (TagStringFilter) ----

--- a/libdd-trace-utils/src/trace_utils.rs
+++ b/libdd-trace-utils/src/trace_utils.rs
@@ -484,7 +484,8 @@ pub fn set_serverless_root_span_tags(
     }
 }
 
-fn update_tracer_top_level(span: &mut pb::Span) {
+/// Converts the tracer's top-level marker into the marker expected by intake.
+pub fn update_tracer_top_level(span: &mut pb::Span) {
     if span.metrics.contains_key(TRACER_TOP_LEVEL_KEY) {
         span.metrics.insert(TOP_LEVEL_KEY.to_string(), 1.0);
     }

--- a/libdd-trace-utils/src/trace_utils.rs
+++ b/libdd-trace-utils/src/trace_utils.rs
@@ -420,26 +420,30 @@ pub fn get_root_span_index(trace: &[pb::Span]) -> anyhow::Result<usize> {
 ///   - OR its parent belongs to another service (in that case it's a "local root" being the highest
 ///     ancestor of other spans belonging to this service and attached to it).
 pub fn compute_top_level_span(trace: &mut [pb::Span]) {
-    let mut span_id_to_service: HashMap<u64, String> = HashMap::new();
-    for span in trace.iter() {
-        span_id_to_service.insert(span.span_id, span.service.clone());
-    }
-    for span in trace.iter_mut() {
-        if span.parent_id == 0 {
+    if trace.len() == 1 {
+        let span = &mut trace[0];
+        if span.parent_id == 0 || span.parent_id != span.span_id {
             set_top_level_span(span);
-            continue;
         }
-        match span_id_to_service.get(&span.parent_id) {
-            Some(parent_span_service) => {
-                if !parent_span_service.eq(&span.service) {
-                    // parent is not in the same service
-                    set_top_level_span(span)
-                }
+        return;
+    }
+
+    let mut span_id_to_index = HashMap::with_capacity(trace.len());
+    for (index, span) in trace.iter().enumerate() {
+        span_id_to_index.insert(span.span_id, index);
+    }
+    for index in 0..trace.len() {
+        let parent_id = trace[index].parent_id;
+        let is_top_level = if parent_id == 0 {
+            true
+        } else {
+            match span_id_to_index.get(&parent_id) {
+                Some(parent_index) => trace[*parent_index].service != trace[index].service,
+                None => true,
             }
-            None => {
-                // span has no parent in chunk
-                set_top_level_span(span)
-            }
+        };
+        if is_top_level {
+            set_top_level_span(&mut trace[index]);
         }
     }
 }
@@ -1125,6 +1129,21 @@ mod tests {
             })
             .collect();
         assert_eq!(spans_marked_as_top_level, [1, 4, 5])
+    }
+
+    #[test]
+    fn test_compute_top_level_for_short_traces() {
+        let mut empty = [];
+        compute_top_level_span(&mut empty);
+        assert!(empty.is_empty());
+
+        let mut trace = [create_test_span(123, 1, 42, 1, false)];
+        compute_top_level_span(&mut trace);
+        assert!(has_top_level(&trace[0]));
+
+        let mut self_parented = [create_test_span(123, 1, 1, 1, false)];
+        compute_top_level_span(&mut self_parented);
+        assert!(!has_top_level(&self_parented[0]));
     }
 
     #[test]


### PR DESCRIPTION
Already-finalized v0.4 payloads currently pay for a full decode and serialization before agent transport. This forwards them unchanged when no configured consumer needs span objects.

Stats, trace filters, alternate formats, log output, agentless export, and OTLP keep the decoded path.
