### PR TITLE
fix: bump libdd trace stats internal dep

### DIFF
--- a/libdd-ipc/Cargo.toml
+++ b/libdd-ipc/Cargo.toml
@@ -20,7 +20,7 @@ page_size = "0.6.0"
 memfd = { version = "0.6" }
 serde = { workspace = true, features = ["derive"] }
 libc.workspace = true
-libdd-tinybytes = { path = "../libdd-tinybytes", optional = true }
+libdd-tinybytes = { path = "../libdd-tinybytes", version = "1.1.2", optional = true }
 
 
 libdd-common = { version = "5.2.0", path = "../libdd-common" }

--- a/libdd-ipc/Cargo.toml
+++ b/libdd-ipc/Cargo.toml
@@ -26,7 +26,7 @@ libdd-tinybytes = { path = "../libdd-tinybytes", optional = true }
 libdd-common = { version = "5.2.0", path = "../libdd-common" }
 libdd-ddsketch = { version = "1.1.0", path = "../libdd-ddsketch" }
 libdd-trace-protobuf = { version = "4.0.1", path = "../libdd-trace-protobuf" }
-libdd-trace-stats = { version = "6.0.0", path = "../libdd-trace-stats" }
+libdd-trace-stats = { version = "7.0.0", path = "../libdd-trace-stats" }
 libdd-ipc-macros = { version = "0.0.1", path = "../libdd-ipc-macros" }
 tracing.workspace = true
 


### PR DESCRIPTION
# Motivation 

libdd-trace-stats was bumped, but the dependencies in the workspace were not

