### PR TITLE
fix(crashtracking): remove remote symbol lookup libunwind

### DIFF
--- a/docs/RFCs/0015-crashtracker-all-thread-collection.md
+++ b/docs/RFCs/0015-crashtracker-all-thread-collection.md
@@ -24,8 +24,9 @@ as a crash on one thread caused by state corruption on another.
 
 ## Goals
 
-- **Collect all thread stacks near crash time** with function names,
-  IPs, and SPs for every active thread in the process
+- **Collect all thread stacks near crash time** with IPs and SPs for
+  every active thread in the process, and with function names when
+  `StacktraceCollection::EnabledWithSymbolsInReceiver` is configured
 - **Preserve signal-handler safety:** No thread enumeration, ptrace, or
   heap allocation in the signal handler
 - **Bounded resource usage:** Configurable caps on thread count and time
@@ -50,16 +51,26 @@ as a crash on one thread caused by state corruption on another.
 | `collect_all_threads` | `bool` | `false` | Enable multi-thread collection. |
 | `max_threads` | `usize` | `256` | Maximum number of background threads to collect. |
 | `timeout` | `Duration` | receiver timeout | Time budget for the entire receiver phase (shared with other post-processing). |
+| `resolve_frames` | `StacktraceCollection` | `Disabled` | Where — and whether — symbols are resolved. |
 
 When `collect_all_threads` is `false`, only the crashing thread's stack
 trace is collected and the receiver does not attempt ptrace.
 
+`collect_all_threads` and `resolve_frames` are independent. Thread
+collection is gated solely on the former, so enabling it with
+`resolve_frames` set to anything other than
+`EnabledWithSymbolsInReceiver` yields thread stacks that are never
+symbolized. Conversely, `resolve_frames = Disabled` combined with
+`collect_all_threads` populates `error.threads` while leaving
+`error.stack` empty, because the crashing thread's unwind happens in the
+collector child and the thread walk happens in the receiver.
+
 ## Design
 
-### Two-Phase, Two-Process Architecture (Linux)
+### Three-Process Architecture (Linux)
 
-Multi-thread collection is split across three actors (crashing process, fork, receiver) to maintain
-signal-handler safety:
+Multi-thread collection is split across three processes (crashing
+process, collector child, receiver) to maintain signal-handler safety:
 
 ### Phase 1: Signal Handler (Async-Signal-Safe)
 
@@ -81,7 +92,8 @@ alive as a ptrace target) until the receiver signals completion.
 After fork, the collector child:
 
 1. Unwinds the **crashing thread only** using the kernel-saved
-   `ucontext`:
+   `ucontext`, unless `resolve_frames` is `Disabled`, in which case no
+   stack is emitted at all:
    - **Linux:** `unw_init_local2(cursor, ucontext, UNW_INIT_SIGNAL_FRAME)`
      seeded from the saved CPU state at the moment of the crash. The
      signal-frame flag (`1`) is required so that libunwind knows the
@@ -91,10 +103,27 @@ After fork, the collector child:
      Then `unw_step()`/`unw_get_reg()` loop up to 512 frames.
    - **macOS:** Frame-pointer walk from `__ss.__pc`/`__rip` and
      `__ss.__rbp`/`__fp`, validated against pthread stack bounds
+
+   Every frame carries `ip`, and on Linux also `sp` and `fp`. `dladdr`
+   is called unconditionally on both platforms for
+   `module_base_address` and `symbol_address`; it is async-signal-safe
+   enough here because it only reads the dynamic loader's internal
+   tables. On Linux a `function` name is added only under
+   `EnabledWithInprocessSymbols`, via `unw_get_proc_name()`; on macOS
+   `dladdr`'s `dli_sname` is used as the name for every mode that emits
+   a stack.
 2. Emits `ProcInfo` containing parent PID and crashing TID
    (`SYS_gettid` on Linux)
-3. Emits `/proc/self/maps` contents for later symbolization
+3. Emits `/proc/self/maps` contents, which are attached to the report as
+   a file. Symbolization does not read this attachment; the receiver
+   reads the live `/proc/{pid}/maps` instead.
 4. Streams all data to the receiver over the pipe/socket
+
+For an unhandled exception reported through `report_unhandled_exception`
+there is no `ucontext` and no native unwind in the collector child. The
+runtime-supplied stack is written to `error.stack` verbatim, and the
+native view of every thread — the reporting thread included — comes from
+the receiver's ptrace walk.
 
 ### Phase 3: Receiver — Thread Collection
 
@@ -104,25 +133,46 @@ background thread collection if `collect_all_threads()` is enabled:
 #### 3a. Thread Enumeration
 
 The receiver MUST enumerate threads by reading
-`/proc/{parent_pid}/task/`. Each entry is a numeric TID. The crashing
-TID (from `ProcInfo`) is filtered out since its stack is already in
-`error.stack`.
+`/proc/{parent_pid}/task/`. Each entry is a numeric TID.
+
+The crashing TID (from `ProcInfo`) is **included**, and MUST be
+processed first so that the `max_threads` cap can never drop it. It
+appears in `error.threads` marked `crashed: true`, giving consumers a
+uniform native view of every thread. For a signal crash this means the
+crashing thread is represented twice: `error.stack` holds the unwind
+seeded from the kernel-saved `ucontext`, while its `error.threads` entry
+holds the ptrace walk taken with the thread parked inside the signal
+handler.
 
 #### 3b. Thread Suspension via Ptrace
 
 For each thread (up to `max_threads`), the receiver:
 
-1. **Attaches** with `PTRACE_SEIZE(tid, PTRACE_O_TRACESYSGOOD)` —
-   unlike `PTRACE_ATTACH`, this does not deliver SIGSTOP
+1. **Attaches** with `PTRACE_SEIZE(tid)` (no options)
 2. **Interrupts** with `PTRACE_INTERRUPT(tid)` — causes the thread to
    enter a ptrace-stop without a signal
-3. **Waits** with `waitpid(tid, WNOHANG | __WALL)` in a polling loop
-   with a per-thread timeout (50 ms)
+3. **Waits** with `waitpid(tid, WNOHANG | __WALL)` in a 2 ms polling
+   loop, bounded by a per-thread stop timeout of 200 ms (itself capped
+   by the overall budget)
+4. **Confirms registers are committed** by polling
+   `PTRACE_PEEKUSER` for a non-zero instruction pointer. On older
+   kernels `waitpid` can report the stop before register state is
+   readable, which would otherwise yield an empty stack. `EIO` means the
+   architecture does not support the probe and the check is skipped;
+   libunwind uses `PTRACE_GETREGSET`, which works regardless
 
 The use of `PTRACE_SEIZE` + `PTRACE_INTERRUPT` rather than
 `PTRACE_ATTACH` + `SIGSTOP` is deliberate: it avoids delivering
 user-visible signals to threads and does not interact with the target's
 signal handlers.
+
+Attachment is retried up to three times with exponential backoff
+(10 ms, 20 ms, 40 ms) on timeout, and each attempt gets a fresh
+per-thread budget. A capture that succeeds but yields zero frames is
+also retried, since a running thread with a confirmed non-zero IP should
+always produce at least one frame. `EPERM` (Yama denial or a missing
+`PR_SET_PTRACER`) and `ESRCH` (thread already exited) are permanent and
+are not retried.
 
 #### 3c. Remote Stack Unwinding
 
@@ -131,11 +181,41 @@ While a thread is ptrace-stopped, the receiver unwinds its stack:
 1. A single `unw_create_addr_space(&_UPT_accessors)` is created once
    and shared across all threads (DWARF `.eh_frame` cache reuse)
 2. Per thread: `_UPT_create(tid)` → `unw_init_remote(cursor, space,
-   upt_info)` → `unw_step()` loop collecting IP and SP per frame
-3. If `StacktraceCollection::EnabledWithSymbolsInReceiver` is
-   configured, `unw_get_proc_name_remote()` resolves function names
-   during the unwind
-4. `_UPT_destroy(upt_info)` releases per-thread state
+   upt_info)` → `unw_step_remote()` loop collecting IP and SP per frame,
+   up to 512 frames
+3. `_UPT_destroy(upt_info)` releases per-thread state
+
+Only instruction and stack pointers are collected during the unwind.
+Under `StacktraceCollection::EnabledWithSymbolsInReceiver` the receiver
+is the single place that resolves symbols, and it does so for every
+thread — the crashing one included — via blazesym in
+`CrashInfo::enrich_callstacks`. libunwind's remote symbol lookup
+(`unw_get_proc_name_remote()`) MUST NOT be used: it can segfault the
+receiver, which costs the entire crash report rather than a single
+function name.
+
+`enrich_callstacks` has two phases and shares one `Symbolizer` between
+them:
+
+1. **Normalize.** Each frame's absolute IP is translated into a file
+   `path` plus `relative_address` by reading `/proc/{pid}/maps`. Opening
+   a mapped file also registers an `ElfResolver` with the symbolizer,
+   keyed by that path.
+2. **Resolve.** A frame carrying `path` and `relative_address` is
+   symbolized through `Source::Elf` with `Input::VirtOffset`, which
+   reuses the resolver registered in phase 1. Frames lacking either fall
+   back to `Source::Process` with `Input::AbsAddr`.
+
+Resolution therefore reads on-disk binaries and does not depend on the
+crashing process. Normalization does depend on it, and a frame that
+fails to normalize has no path to resolve against and stays
+unsymbolized.
+
+The crashing process is alive for both phases on the normal path: it
+blocks in `wait_for_pollhup` on the socket while the receiver holds the
+stream through symbolization and upload. That wait is bounded by the
+collector's time budget, so a receiver that overruns it can find the
+process gone.
 
 #### 3d. Thread Metadata
 
@@ -150,9 +230,15 @@ After unwinding, `PTRACE_DETACH(tid)` releases the thread. The receiver
 MUST detach all threads before signaling completion to the parent,
 regardless of errors during unwinding.
 
+Detach is best-effort: a failure is not allowed to discard an otherwise
+good stack trace, and `ESRCH` is treated as success because the thread
+has already exited. Any pending `waitpid` event is drained afterwards so
+the kernel fully releases the thread; without that, a rapid re-attach
+can fail with `EPERM` under CPU pressure.
+
 ### Windows Implementation
 
-Windows does not use the two-process model. In the WER
+Windows does not use the multi-process model. In the WER
 `exception_event_callback`:
 
 1. **Enumerate:** `CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, pid)` +
@@ -174,19 +260,41 @@ forked collector child. Multi-thread collection is not implemented.
 
 ### Output Format
 
-Non-crashing threads appear in `error.threads[]` (see RFC 0011 v1.7+):
+On Linux every collected thread appears in `error.threads[]` (see RFC
+0011 v1.7+), including the crashing one, which is marked `crashed:
+true`. On Windows the crashing thread is placed in `error.stack` and
+only the others become `ThreadData` entries.
+
+`format` is always the `StackTrace` format string, `"Datadog
+Crashtracker 1.0"`, regardless of how the frames were captured.
+
+The `function`, `path`, `relative_address`, and `build_id` fields below
+are present only under `EnabledWithSymbolsInReceiver`; in the other
+modes thread frames carry `ip` and `sp` alone.
 
 ```json
 {
   "error": {
-    "stack": { "...crashing thread..." },
+    "stack": { "...crashing thread, unwound from ucontext..." },
     "threads": [
+      {
+        "crashed": true,
+        "name": "main",
+        "state": "S",
+        "stack": {
+          "format": "Datadog Crashtracker 1.0",
+          "frames": [
+            { "ip": "0x55a3f2c05678", "sp": "0x7ffd1c002a40", "function": "faulting_fn" }
+          ],
+          "incomplete": false
+        }
+      },
       {
         "crashed": false,
         "name": "worker-pool-3",
         "state": "S",
         "stack": {
-          "format": "libunwind-ptrace",
+          "format": "Datadog Crashtracker 1.0",
           "frames": [
             { "ip": "0x7f2a1b3c4d50", "sp": "0x7f2a0c001e80", "function": "pthread_cond_wait" },
             { "ip": "0x55a3f2c01234", "sp": "0x7f2a0c001ec0", "function": "worker_loop" }
@@ -218,9 +326,11 @@ pub struct CapturedThreadContext {
 
 ### Ptrace Permission Scoping
 
-On Linux, the signal handler calls `prctl(PR_SET_PTRACER, receiver_pid)`
-to grant ptrace permission **only** to the receiver process. This is the
-minimum privilege needed.
+On Linux, both crash entry points — the signal handler and
+`report_unhandled_exception` — call `prctl(PR_SET_PTRACER,
+receiver_pid)` to grant ptrace permission **only** to the receiver
+process. This is the minimum privilege needed. The grant is made only
+when `collect_all_threads` is enabled.
 
 ### Sidecar Mode Verification
 
@@ -242,10 +352,11 @@ Collection is **best-effort**. The receiver uses the remaining time
 budget after parsing the crash stream from stdin. Collection stops early
 if:
 
-- The per-thread timeout (50 ms waitpid polling) expires for a given
-  thread — that thread is skipped
+- The per-thread stop timeout (200 ms of waitpid polling) expires for a
+  given thread across all three attempts — that thread is skipped
 - The overall time budget is exhausted
-- `max_threads` is reached
+- `max_threads` is reached. The crashing thread is collected first and
+  so is never the one dropped
 
 When collection is cut short, the receiver:
 - Emits all threads that were successfully collected

--- a/libdd-crashtracker/src/crash_info/stacktrace.rs
+++ b/libdd-crashtracker/src/crash_info/stacktrace.rs
@@ -6,7 +6,10 @@ use crate::CachedElfResolvers;
 #[cfg(unix)]
 use blazesym::{
     normalize::Normalizer,
-    symbolize::{source::Source, Input, Symbolized, Symbolizer, TranslateFileOffset},
+    symbolize::{
+        source::{Elf, Source},
+        Input, Sym, Symbolized, Symbolizer, TranslateFileOffset,
+    },
     Pid,
 };
 
@@ -211,19 +214,43 @@ impl StackFrame {
         Ok(())
     }
 
+    /// Resolve the frame's function name, and file/line when debug info is
+    /// available.
+    ///
+    /// When `normalize_ip` has already run, this symbolizes against the
+    /// normalized ELF file rather than `src`. Reading the binary directly
+    /// avoids `/proc/<pid>/maps`, which the process source needs, so names are
+    /// still resolved after the crashing process has exited. That matters for a
+    /// sidecar receiver, which outlives the process it collects from and would
+    /// otherwise produce reports with no symbols at all.
+    ///
+    /// Falls back to `src` for frames that were never normalized.
     pub fn resolve_names(&mut self, src: &Source, symbolizer: &Symbolizer) -> anyhow::Result<()> {
+        let elf_input = match (&self.path, &self.relative_address) {
+            (Some(path), Some(relative_address)) => {
+                let virt_offset =
+                    u64::from_str_radix(relative_address.trim_start_matches("0x"), 16)?;
+                Some((Source::Elf(Elf::new(path.as_str())), virt_offset))
+            }
+            _ => None,
+        };
+
+        if let Some((elf_src, virt_offset)) = elf_input {
+            if let Symbolized::Sym(s) =
+                symbolizer.symbolize_single(&elf_src, Input::VirtOffset(virt_offset))?
+            {
+                self.set_symbol(s);
+                return Ok(());
+            }
+        }
+
         if let Some(ip) = &self.ip {
             let ip = ip.trim_start_matches("0x");
             let ip = u64::from_str_radix(ip, 16)?;
             let input = Input::AbsAddr(ip);
             match symbolizer.symbolize_single(src, input)? {
                 Symbolized::Sym(s) => {
-                    if let Some(c) = s.code_info {
-                        self.column = c.column.map(u32::from);
-                        self.file = Some(c.to_path().display().to_string());
-                        self.line = c.line;
-                    }
-                    self.function = Some(s.name.into_owned());
+                    self.set_symbol(s);
                 }
                 Symbolized::Unknown(reason) => {
                     anyhow::bail!("Couldn't symbolize {ip}: {reason}");
@@ -231,6 +258,15 @@ impl StackFrame {
             }
         }
         Ok(())
+    }
+
+    fn set_symbol(&mut self, sym: Sym<'_>) {
+        if let Some(c) = sym.code_info {
+            self.column = c.column.map(u32::from);
+            self.file = Some(c.to_path().display().to_string());
+            self.line = c.line;
+        }
+        self.function = Some(sym.name.into_owned());
     }
 }
 

--- a/libdd-crashtracker/src/receiver/ptrace_collector.rs
+++ b/libdd-crashtracker/src/receiver/ptrace_collector.rs
@@ -16,7 +16,6 @@
 //!    - unw_create_addr_space()         create address space with ptrace accessors
 //!    - unw_init_remote()               initialize remote cursor
 //!    - unw_step_remote() loop          walk frames
-//!    - unw_get_proc_name_remote()      resolve symbol names
 //!    - _UPT_destroy() + cleanup        clean up
 //! 4. Detach from the thread via PTRACE_DETACH
 //!
@@ -32,8 +31,8 @@ use std::time::{Duration, Instant};
 
 use libdd_libunwind_sys::{
     _UPT_accessors, _UPT_create, _UPT_destroy, unw_create_addr_space, unw_destroy_addr_space,
-    unw_get_proc_name_remote, unw_get_reg_remote, unw_init_remote, unw_step_remote, UnwAddrSpaceT,
-    UnwCursor, UnwWord, UNW_REG_IP, UNW_REG_SP,
+    unw_get_reg_remote, unw_init_remote, unw_step_remote, UnwAddrSpaceT, UnwCursor, UnwWord,
+    UNW_REG_IP, UNW_REG_SP,
 };
 
 use crate::crash_info::{StackFrame, StackTrace};
@@ -290,11 +289,12 @@ fn create_addr_space() -> Option<UnwAddrSpaceT> {
 ///
 /// `addr_space` is a pre-created address space shared across threads; this
 /// function does *not* destroy it.
-fn unwind_remote_thread(
-    tid: libc::pid_t,
-    addr_space: UnwAddrSpaceT,
-    resolve_frames: crate::StacktraceCollection,
-) -> StackTrace {
+///
+/// Only instruction and stack pointers are collected here. Under
+/// `StacktraceCollection::EnabledWithSymbolsInReceiver` the receiver is the
+/// single place that resolves symbols, and blazesym in `CrashInfo::enrich_callstacks`
+/// will symbolize the frames.
+fn unwind_remote_thread(tid: libc::pid_t, addr_space: UnwAddrSpaceT) -> StackTrace {
     // SAFETY: _UPT_create allocates a ptrace unwinding context for the given tid.
     // The thread must already be stopped via ptrace for this to succeed.
     let upt_info = unsafe { _UPT_create(tid) };
@@ -323,7 +323,7 @@ fn unwind_remote_thread(
         }
         let _ = unsafe { unw_get_reg_remote(&mut cursor, UNW_REG_SP, &mut sp) };
 
-        let mut frame = StackFrame {
+        let frame = StackFrame {
             ip: Some(format!("0x{:x}", ip)),
             sp: Some(format!("0x{:x}", sp)),
             module_base_address: None,
@@ -341,28 +341,6 @@ fn unwind_remote_thread(
             mangled_name: None,
             comments: vec![],
         };
-
-        // Resolve the function name if in process symbol resolution is enabled.
-        if resolve_frames == crate::StacktraceCollection::EnabledWithSymbolsInReceiver {
-            let mut name_buf = [0 as libc::c_char; 256];
-            let mut offset: UnwWord = 0;
-            // SAFETY: cursor is valid; unw_get_proc_name_remote reads symbol info via ptrace
-            if unsafe {
-                unw_get_proc_name_remote(
-                    &mut cursor,
-                    name_buf.as_mut_ptr().cast(),
-                    name_buf.len(),
-                    &mut offset,
-                )
-            } == 0
-            {
-                // SAFETY: libunwind wrote a null-terminated string into name_buf
-                let name = unsafe { std::ffi::CStr::from_ptr(name_buf.as_ptr()) };
-                if let Ok(s) = name.to_str() {
-                    frame.function = Some(s.to_string());
-                }
-            }
-        }
 
         frames.push(frame);
 
@@ -387,13 +365,12 @@ fn unwind_remote_thread(
 /// `stop_deadline` bounds how long we poll for the thread to enter ptrace-stop.
 pub fn capture_thread_context(
     tid: libc::pid_t,
-    resolve_frames: crate::StacktraceCollection,
     addr_space: UnwAddrSpaceT,
     stop_deadline: Instant,
 ) -> Result<CapturedThreadContext, PtraceError> {
     attach_thread(tid, stop_deadline)?;
 
-    let stack_trace = unwind_remote_thread(tid, addr_space, resolve_frames);
+    let stack_trace = unwind_remote_thread(tid, addr_space);
 
     // Best-effort detach: if this fails the thread stays in ptrace-stop, but the
     // receiver exiting will clean it up. Don't discard a good stack trace over it.
@@ -434,14 +411,13 @@ fn is_transient_ptrace_error(err: &PtraceError) -> bool {
 /// transient issue.
 fn capture_with_retry(
     tid: libc::pid_t,
-    resolve_frames: crate::StacktraceCollection,
     addr_space: UnwAddrSpaceT,
     overall_deadline: Instant,
 ) -> Option<CapturedThreadContext> {
     for attempt in 0..=MAX_RETRIES {
         let thread_deadline = (Instant::now() + STOP_TIMEOUT_PER_THREAD).min(overall_deadline);
 
-        match capture_thread_context(tid, resolve_frames, addr_space, thread_deadline) {
+        match capture_thread_context(tid, addr_space, thread_deadline) {
             Ok(ctx) if !ctx.stack_trace.frames.is_empty() => return Some(ctx),
             Ok(_) => {}                                      // 0 frames -- retry
             Err(ref e) if is_transient_ptrace_error(e) => {} // ETIMEDOUT -- retry
@@ -486,7 +462,6 @@ pub fn stream_thread_contexts<F>(
     crashing_tid: libc::pid_t,
     max_threads: usize,
     timeout: Duration,
-    resolve_frames: crate::StacktraceCollection,
     mut callback: F,
 ) -> Result<bool, PtraceError>
 where
@@ -507,8 +482,7 @@ where
 
     // Process the crashing thread first so it is never dropped by the cap.
     if crashing_tid != 0 && tids.contains(&crashing_tid) {
-        let context =
-            capture_with_retry(crashing_tid, resolve_frames, addr_space, overall_deadline);
+        let context = capture_with_retry(crashing_tid, addr_space, overall_deadline);
         callback(crashing_tid, context.as_ref());
         processed += 1;
     }
@@ -521,7 +495,7 @@ where
             break;
         }
 
-        let context = capture_with_retry(tid, resolve_frames, addr_space, overall_deadline);
+        let context = capture_with_retry(tid, addr_space, overall_deadline);
         callback(tid, context.as_ref());
         processed += 1;
     }
@@ -603,12 +577,7 @@ mod tests {
             handle.join().unwrap();
             return;
         };
-        match capture_thread_context(
-            tid,
-            crate::StacktraceCollection::Disabled,
-            addr_space,
-            Instant::now() + Duration::from_secs(5),
-        ) {
+        match capture_thread_context(tid, addr_space, Instant::now() + Duration::from_secs(5)) {
             Err(e) => eprintln!("skipping ptrace test (ptrace unavailable): {e}"),
             Ok(ctx) => assert!(
                 !ctx.stack_trace.frames.is_empty(),
@@ -642,7 +611,6 @@ mod tests {
             current_tid(),
             2,
             Duration::from_secs(5),
-            crate::StacktraceCollection::Disabled,
             |_tid, _ctx| collected += 1,
         );
 
@@ -675,7 +643,6 @@ mod tests {
             self_tid,
             64,
             Duration::from_secs(5),
-            crate::StacktraceCollection::Disabled,
             |tid, _ctx| {
                 if tid == worker_tid {
                     seen_worker = true;

--- a/libdd-crashtracker/src/receiver/receive_report.rs
+++ b/libdd-crashtracker/src/receiver/receive_report.rs
@@ -533,7 +533,6 @@ fn collect_and_add_thread_contexts(
         crashing_tid,
         config.max_threads(),
         budget,
-        config.resolve_frames(),
         |tid, captured_context| {
             let (name, state) = read_thread_stat(parent_pid, tid);
             let name = name.unwrap_or_else(|| tid.to_string());


### PR DESCRIPTION
# What does this PR do?

The receiver called `unw_get_proc_name_remote()` on every frame of every remote thread, walking the target's ELF symbol tables over ptrace. That call can segfault, and since the report is only uploaded after thread collection finishes,
a fault cost the entire report, which we noticed with 
[Representative receiver crash and matching events in Datadog Logs](https://app.datadoghq.com/logs?query=service%3Ainstrumentation-telemetry-data%2A%20%28%40tags.severity%3Acrash%20OR%20severity%3Acrash%20OR%20signum%3A%2A%20OR%20%40error.is_crash%3Atrue%29%20%40lib_language%3A%2A%20%40tracer_version%3A%2A%20-%40tags.crash_runtime%3Atrue%20%40org_id%3A%2A%20%40error.stack.frames.function%3A_Ux86_64_get_proc_name&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice&event=AwAAAaAN2Q4H5mHhTgAAABhBYUFOMlE0SEFBQW83Ukt0YlUxRkxBQVIAAAAkMDFhMDBkZGYtOTZkNC00YWU3LWFhN2UtMzNhMjYwYzQxZTIxAAIv6g&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=time%2Cdesc&viz=stream&from_ts=1786334400000&to_ts=1786939199999&live=false)
- Drop the lookup. The ptrace walk now collects IPs and SPs only.
- Resolve symbols in `StackFrame::resolve_names` using `Source::Elf` + `Input::VirtOffset` when a frame has `path` and `relative_address`, falling back to `Source::Process` otherwise. `enrich_callstacks` already registers `ElfResolver`s under during normalization, which resolution previously ignored. 
- RFC 15 also had a lot of outdated information, which is updated with this PR to match the actual implementation


# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
