### PR TITLE
feat(ci): test binaries less heavy and less link time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ on:
     - cron: '0 6 * * *'
 env:
   CARGO_TERM_COLOR: always
+  CARGO_PROFILE_TEST_DEBUG: line-tables-only
 
 jobs:
   setup:


### PR DESCRIPTION
# What does this PR do?

Test binaries inherit [profile.dev] debug = 2 (full debug info) from root Cargo.toml.

# Motivation

This dominated Windows link/PDB time and cached target size

# Additional Notes

`line-tables-only` keeps file/line info for backtraces and llvm-cov.

# How to test the change?

On the first commit of this PR, it took 38min, which is pretty much in line with before the change, but cache needed rebuilding, [I pushed an empty commit and it took **less than 20 minutes**](https://github.com/DataDog/libdatadog/actions/runs/32380142984/job/96461469191), it might be a fluke, I'll do another empty commit, but it might be really big improvement for not much.

Apparently though, having a warm cache is pretty hard, and the 10gb repo limit is exceeded and cache evicted extremely quickly. Once caching is done by sccache, we would have the full upside of this, and it could have a real impact