### PR TITLE
fix(crashtracker): hold the collector connection open through symbolization

### DIFF
--- a/docs/RFCs/0015-crashtracker-all-thread-collection.md
+++ b/docs/RFCs/0015-crashtracker-all-thread-collection.md
@@ -231,24 +231,28 @@ The process source needs `/proc/{pid}` to exist. The ELF retry reads the
 binary from disk and needs nothing from the live process, which is what
 keeps function names available once the process is gone.
 
-Whether that matters depends on how the receiver was reached:
+Normalization still depends on that process, since it reads
+`/proc/{pid}/maps`, and a frame that fails to normalize has no ELF
+location to retry against and stays unsymbolized. The ELF retry
+therefore does not by itself make symbolization independent of the
+crashing process; it only covers the second phase.
 
-- **Unix-socket sidecar** (`async_receiver_entry_point_unix_listener` and
-  `async_receiver_entry_point_unix_socket`): the crashing process is
-  released *before* symbolization. `receive_report_from_stream` owns the
-  `UnixStream` and drops it on return, delivering the POLLHUP the crashing
-  process is waiting on in `wait_for_pollhup`. Thread collection happens
-  inside that function, so unwinding sees a live process, but both
-  symbolization phases race the process's teardown.
-- **Fork/exec receiver** (`receiver_entry_point_stdin`): the stream wraps
-  `tokio::io::stdin()`, and dropping that handle does not close fd 0. The
-  peer therefore stays open until the receiver process exits, after
-  symbolization and upload, so the crashing process is still available
-  throughout.
+The crashing process blocks in `wait_for_pollhup` until the receiver
+closes the collector connection, so the receiver controls how long it
+stays alive. `receiver_entry_point` therefore owns the stream and
+borrows it to `receive_report_from_stream`, holding it open across both
+symbolization phases and closing it only afterwards. Normalization is
+consequently guaranteed a live process rather than racing its teardown.
 
-Normalization reads `/proc/{pid}/maps` and so depends on that process.
-A frame that fails to normalize has no ELF location to retry against and
-stays unsymbolized.
+The close MUST happen before the upload. Nothing after symbolization
+reads from the crashing process, and leaving the connection open through
+a network round-trip to a slow or unreachable endpoint would extend the
+pause the crashing application sees by that latency.
+
+This ordering only binds the Unix-socket sidecar path, where the stream
+is the socket itself. Under `receiver_entry_point_stdin` the stream
+wraps `tokio::io::stdin()`; dropping that handle does not close fd 0, so
+the peer stays open until the receiver process exits regardless.
 
 Symbolization failure MUST NOT cost the report. A frame that resolves
 through neither source keeps its `ip`, `sp`, and whatever normalization

--- a/libdd-crashtracker/src/receiver/entry_points.rs
+++ b/libdd-crashtracker/src/receiver/entry_points.rs
@@ -105,14 +105,21 @@ pub fn get_receiver_unix_socket(socket_path: impl AsRef<str>) -> anyhow::Result<
 /// description.
 pub(crate) async fn receiver_entry_point(
     timeout: Duration,
-    stream: impl AsyncBufReadExt + std::marker::Unpin,
+    mut stream: impl AsyncBufReadExt + std::marker::Unpin,
 ) -> anyhow::Result<()> {
-    if let Some((config, mut crash_info)) = receive_report_from_stream(timeout, stream).await? {
+    if let Some((config, mut crash_info)) = receive_report_from_stream(timeout, &mut stream).await?
+    {
+        // Symbolization reads /proc/<pid>/maps, and the crashing process is
+        // waiting on POLLHUP from this connection to terminate. Hold it open
+        // until the report is symbolized, then release the process before the
+        // upload so a slow endpoint does not extend the crash pause.
         if let Err(e) = resolve_frames(&config, &mut crash_info) {
             crash_info
                 .log_messages
                 .push(format!("Error resolving frames: {e}"));
         }
+        drop(stream);
+
         if config.demangle_names() {
             if let Err(e) = crash_info.demangle_names() {
                 crash_info

--- a/libdd-crashtracker/src/receiver/mod.rs
+++ b/libdd-crashtracker/src/receiver/mod.rs
@@ -25,7 +25,7 @@ mod tests {
     use crate::shared::constants::*;
     use crate::{CrashtrackerConfiguration, ErrorKind};
     use std::time::Duration;
-    use tokio::io::{AsyncWriteExt, BufReader};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt, BufReader};
     use tokio::net::UnixStream;
 
     async fn to_socket(
@@ -40,6 +40,19 @@ mod tests {
 
     async fn send_report(delay: Duration, mut stream: UnixStream) -> anyhow::Result<()> {
         let sender = &mut stream;
+        send_report_prelude(sender).await?;
+        tokio::time::sleep(delay).await;
+        to_socket(sender, DD_CRASHTRACK_DONE).await?;
+        Ok(())
+    }
+
+    async fn send_report_lines(sender: &mut UnixStream) -> anyhow::Result<()> {
+        send_report_prelude(sender).await?;
+        to_socket(sender, DD_CRASHTRACK_DONE).await?;
+        Ok(())
+    }
+
+    async fn send_report_prelude(sender: &mut UnixStream) -> anyhow::Result<()> {
         to_socket(sender, DD_CRASHTRACK_BEGIN_SIGINFO).await?;
         to_socket(
             sender,
@@ -67,8 +80,6 @@ mod tests {
             .build()?;
         to_socket(sender, serde_json::to_string(&config)?).await?;
         to_socket(sender, DD_CRASHTRACK_END_CONFIG).await?;
-        tokio::time::sleep(delay).await;
-        to_socket(sender, DD_CRASHTRACK_DONE).await?;
         Ok(())
     }
 
@@ -77,10 +88,10 @@ mod tests {
     async fn test_receive_report_short_timeout() -> anyhow::Result<()> {
         let (sender, receiver) = tokio::net::UnixStream::pair()?;
 
-        let join_handle1 = tokio::spawn(receive_report_from_stream(
-            Duration::from_secs(1),
-            BufReader::new(receiver),
-        ));
+        let join_handle1 = tokio::spawn(async move {
+            let mut stream = BufReader::new(receiver);
+            receive_report_from_stream(Duration::from_secs(1), &mut stream).await
+        });
         let join_handle2 = tokio::spawn(send_report(Duration::from_secs(2), sender));
 
         let crash_report = join_handle1.await??;
@@ -96,16 +107,47 @@ mod tests {
     async fn test_receive_report_long_timeout() -> anyhow::Result<()> {
         let (sender, receiver) = tokio::net::UnixStream::pair()?;
 
-        let join_handle1 = tokio::spawn(receive_report_from_stream(
-            Duration::from_secs(2),
-            BufReader::new(receiver),
-        ));
+        let join_handle1 = tokio::spawn(async move {
+            let mut stream = BufReader::new(receiver);
+            receive_report_from_stream(Duration::from_secs(2), &mut stream).await
+        });
         let join_handle2 = tokio::spawn(send_report(Duration::from_secs(1), sender));
 
         let crash_report = join_handle1.await??;
         let (_config, crashinfo) = crash_report.expect("Expect a report");
         assert!(crashinfo.incomplete);
         join_handle2.await??;
+        Ok(())
+    }
+
+    /// The collector blocks on this connection until it sees a hangup, and the crashing
+    /// process is torn down as soon as it unblocks. Normalization and symbolization read
+    /// `/proc/<pid>/maps` and the process' mapped files, so returning the report must not
+    /// close the connection: the caller has to keep it open until symbolization is done.
+    #[tokio::test]
+    #[cfg_attr(miri, ignore)]
+    async fn test_receive_report_keeps_collector_connection_open() -> anyhow::Result<()> {
+        let (mut sender, receiver) = tokio::net::UnixStream::pair()?;
+
+        // The whole report fits in the socket buffer, so it can be written up front and
+        // the receiver can be driven from this task while the sender end stays owned here.
+        send_report_lines(&mut sender).await?;
+
+        let mut stream = BufReader::new(receiver);
+        let crash_report = receive_report_from_stream(Duration::from_secs(5), &mut stream).await?;
+        assert!(crash_report.is_some(), "Expect a report");
+
+        let mut buf = [0u8; 1];
+        let hangup = tokio::time::timeout(Duration::from_millis(200), sender.read(&mut buf)).await;
+        assert!(
+            hangup.is_err(),
+            "receive_report_from_stream released the crashing process before symbolization"
+        );
+
+        // Dropping the receiving end is what releases the collector.
+        drop(stream);
+        let n = tokio::time::timeout(Duration::from_secs(5), sender.read(&mut buf)).await??;
+        assert_eq!(n, 0, "Expected a hangup once the receiver drops the stream");
         Ok(())
     }
 }

--- a/libdd-crashtracker/src/receiver/receive_report.rs
+++ b/libdd-crashtracker/src/receiver/receive_report.rs
@@ -324,9 +324,14 @@ fn process_line(
 ///    Some(CrashInfo)
 /// 2. `stdin` closes without a crash report (i.e. if the parent terminated normally). In this case
 ///    we return "None".
+///
+/// Borrows `stream` rather than consuming it. The crashing process blocks on
+/// POLLHUP from this connection, so closing it here would release that process
+/// before the caller has symbolized the report, and symbolization reads
+/// `/proc/<pid>/maps`. The caller decides when to close.
 pub(crate) async fn receive_report_from_stream(
     timeout: Duration,
-    stream: impl AsyncBufReadExt + std::marker::Unpin,
+    stream: &mut (impl AsyncBufReadExt + std::marker::Unpin),
 ) -> anyhow::Result<Option<(CrashtrackerConfiguration, CrashInfo)>> {
     let mut builder = CrashInfoBuilder::new();
     let mut stdin_state = StdinState::Waiting;
@@ -671,10 +676,10 @@ mod tests {
         // Close without sending anything, as a parent that exited normally does.
         drop(sender);
 
-        let report =
-            receive_report_from_stream(Duration::from_secs(1), tokio::io::BufReader::new(receiver))
-                .await
-                .unwrap();
+        let mut stream = tokio::io::BufReader::new(receiver);
+        let report = receive_report_from_stream(Duration::from_secs(1), &mut stream)
+            .await
+            .unwrap();
         assert!(report.is_none());
 
         let request = server.await.unwrap();


### PR DESCRIPTION
[PROF-15799](https://datadoghq.atlassian.net/jira/software/c/projects/PROF/boards/11?selectedIssue=PROF-15799)

# What does this PR do?

The crashing process blocks in `wait_for_pollhup` until the receiver closes the collector connection. `receive_report_from_stream` owned that stream and dropped it on return, so the process was released *before* symbolization ran.

Symbolization's normalization phase reads `/proc/<pid>/maps`, so it can race the crashing process's teardown. When it lost, normalization failed, and a frame that fails to normalize has no ELF location to retry against it

`receive_report_from_stream` now borrows the stream instead of consuming it. `receiver_entry_point` owns it, holds it open across symbolization, and drops it immediately after.

Only the Unix-socket sidecar path is affected. Under `receiver_entry_point_stdin` the stream wraps `tokio::io::stdin()`, and dropping that handle never closed fd 0.


`test_receive_report_keeps_collector_connection_open` asserts the peer sees no hangup after the report is returned, and does see one once the receiver drops the stream. Verified it fails against the old ownership model.

Ran the sidecar bin_test 1000 times and no failures -- it failed ~8% of the time before.

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.


[PROF-15799]: https://datadoghq.atlassian.net/browse/PROF-15799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ