### PR TITLE
feat: keep the same compilation flags so that build can be reused

### DIFF
--- a/.github/workflows/test-ffi.yml
+++ b/.github/workflows/test-ffi.yml
@@ -173,6 +173,8 @@ jobs:
       - name: "(Windows) Run FFI examples"
         shell: bash
         if: matrix.platform == 'windows-latest'
+        env:
+          RUSTFLAGS: "${{ matrix.flags }}"
         run: |
           cargo ffi-test
       - name: "Test building CXX bindings - Crashinfo (Unix)"


### PR DESCRIPTION
Set RUSTFLAGS: "${{ matrix.flags }}" on the (Windows) Run FFI examples step in libdatadog's .github/workflows/test-ffi.yml, matching the flag set on the preceding Generate profiling FFI step. Without it, the differing RUSTFLAGS invalidates Cargo's fingerprint and forces a full fat-LTO rebuild, it was also silently testing a non-crt-static build.