### PR TITLE
chore: use full commit sha for rust-toolchain action

### DIFF
--- a/.github/workflows/cargo-deny-bans.yml
+++ b/.github/workflows/cargo-deny-bans.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
       with:
         cache-targets: true
-    - uses: dtolnay/rust-toolchain@stable
+    - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c #stable
     - uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7 # 2.3.1
       with:
         tool: cargo-deny

--- a/.github/workflows/pr-metadata-docs-and-deps.yml
+++ b/.github/workflows/pr-metadata-docs-and-deps.yml
@@ -107,7 +107,7 @@ jobs:
     - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
       with:
         cache-targets: true
-    - uses: dtolnay/rust-toolchain@stable
+    - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c #stable
     - name: Check missing docs
       id: missing-docs
       run: |
@@ -278,7 +278,7 @@ jobs:
     - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
       with:
         cache-targets: true
-    - uses: dtolnay/rust-toolchain@stable
+    - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c #stabled
     - uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7 # 2.3.1
       with:
         tool: cargo-deny

--- a/.github/workflows/release-proposal-dispatch.yml
+++ b/.github/workflows/release-proposal-dispatch.yml
@@ -207,12 +207,12 @@ jobs:
       - uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
         with:
           cache-targets: true
-      - uses: dtolnay/rust-toolchain@nightly
+      - uses: dtolnay/rust-toolchain@7c8d7d138f5c09cef361f8214cf96882cd029cdb #nightly
         with:
           toolchain: ${{ steps.nightly-version.outputs.version }}
       - name: Link nightly toolchain for cargo-public-api
         run: ln -sf ~/.rustup/toolchains/${{ steps.nightly-version.outputs.version }}-x86_64-unknown-linux-gnu ~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c #stable
         with:
           toolchain: ${{ env.RUSTUP_TOOLCHAIN }}
       - uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7 # 2.3.1

--- a/.github/workflows/release-proposal-test.yml
+++ b/.github/workflows/release-proposal-test.yml
@@ -35,7 +35,7 @@ jobs:
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
         run: ./scripts/exclude-from-green-ci.sh
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c #stable
         with:
           toolchain: 1.92.0
 
@@ -158,7 +158,7 @@ jobs:
           fetch-depth: 0
           repository: DataDog/dd-trace-rs
           ref: ${{ matrix.version }}
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c #stable
         with:
           toolchain: 1.92.0
 


### PR DESCRIPTION
# What does this PR do?

Use full commit sha commits for dtolnay/rust-toolchain action