### PR TITLE
feat: thin lto for non consuming artifacts

### DIFF
--- a/.github/workflows/test-ffi.yml
+++ b/.github/workflows/test-ffi.yml
@@ -67,10 +67,13 @@ jobs:
         include:
           - platform: "ubuntu-latest"
             flags: "-C relocation-model=pic"
+            profile: "release-ci"
           - platform: "macos-15"
             flags: "-C relocation-model=pic"
+            profile: "release"
           - platform: "windows-latest"
             flags: "-C target-feature=+crt-static"
+            profile: "release-ci"
     steps:
       - name: Checkout sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
@@ -122,13 +125,11 @@ jobs:
         shell: bash
         env:
           RUSTFLAGS: "${{ matrix.flags }}"
-          CARGO_PROFILE_RELEASE_LTO: "thin"
-          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
         run: |
           if [[ "${{ matrix.platform }}" == "windows-latest" ]]; then
               git config --global core.longpaths true
           fi
-          cargo run --bin release --release -- --out $LIBDD_OUTPUT_FOLDER
+          cargo run --bin release --profile ${{ matrix.profile }} -- --profile ${{ matrix.profile }} --out $LIBDD_OUTPUT_FOLDER
       - name: 'Publish libdatadog'
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # 4.6.1
         if: success() || failure()

--- a/.github/workflows/test-ffi.yml
+++ b/.github/workflows/test-ffi.yml
@@ -122,6 +122,8 @@ jobs:
         shell: bash
         env:
           RUSTFLAGS: "${{ matrix.flags }}"
+          CARGO_PROFILE_RELEASE_LTO: "thin"
+          CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "16"
         run: |
           if [[ "${{ matrix.platform }}" == "windows-latest" ]]; then
               git config --global core.longpaths true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,6 +162,15 @@ debug = "line-tables-only"
 lto = true
 opt-level = "s"            # optimize for size
 
+# CI-only verification profile. Same shape as `release`, but ThinLTO and 16
+# codegen units so builds that exist purely to prove the tree compiles are not
+# paying for fat LTO's single-threaded codegen. Anything actually shipped stays
+# on [profile.release].
+[profile.release-ci]
+inherits = "release"
+lto = "thin"
+codegen-units = 16
+
 [profile.bench]
 codegen-units = 1
 debug = false

--- a/builder/src/bin/release.rs
+++ b/builder/src/bin/release.rs
@@ -18,6 +18,7 @@ use builder::utils::project_root;
 struct ReleaseArgs {
     pub out_dir: Option<String>,
     pub target: Option<String>,
+    pub profile: Option<String>,
 }
 
 impl From<pico_args::Arguments> for ReleaseArgs {
@@ -25,6 +26,7 @@ impl From<pico_args::Arguments> for ReleaseArgs {
         let release_args = ReleaseArgs {
             out_dir: args.value_from_str("--out").ok(),
             target: args.value_from_str("--target").ok(),
+            profile: args.value_from_str("--profile").ok(),
         };
 
         args.finish();
@@ -40,7 +42,10 @@ pub fn main() {
         ..
     } = determine_paths();
 
-    let profile = env::var("PROFILE").unwrap();
+    let profile = args
+        .profile
+        .clone()
+        .unwrap_or_else(|| env::var("PROFILE").unwrap());
     let version = env::var("CARGO_PKG_VERSION").unwrap();
     let host = env::var("TARGET").unwrap();
     let out_dir = if let Some(out) = args.out_dir {

--- a/builder/src/profiling.rs
+++ b/builder/src/profiling.rs
@@ -143,8 +143,12 @@ impl Module for Profiling {
             &self.arch,
         ];
 
-        if self.profile.as_ref() == "release" {
-            cargo_args.push("--release");
+        match self.profile.as_ref() {
+            "debug" | "dev" => {}
+            profile => {
+                cargo_args.push("--profile");
+                cargo_args.push(profile);
+            }
         }
 
         // Parse profiling-ffi manifest in order to get the crate-type array.


### PR DESCRIPTION
Fat LTO + codegen-units=1 makes the Generate profiling FFI step slow for no reason, this doesn't ship an artifact anyone consumes. Override to thin LTO / codegen-units=16 via CARGO_PROFILE_RELEASE_* env vars for this build only