### PR TITLE
WIP: fix(crashtracker): unwind from saved crash context

### DIFF
--- a/libdd-crashtracker/src/receiver/entry_points.rs
+++ b/libdd-crashtracker/src/receiver/entry_points.rs
@@ -159,9 +159,128 @@ fn resolve_frames(
             .as_ref()
             .context("Unable to resolve frames: No PID specified")?
             .pid;
-        crash_info.enrich_callstacks(pid)?;
+        let enrichment = crash_info.enrich_callstacks(pid);
+        finish_native_stacks(crash_info);
+        enrichment?;
     }
     #[cfg(not(target_os = "linux"))]
     let _ = (config, crash_info);
     Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn finish_native_stacks(crash_info: &mut CrashInfo) {
+    // A software-generated fatal signal is captured while raise/pthread_kill is
+    // still on the stack. Those libc delivery frames describe how the signal
+    // arrived, not what application operation requested it. Remove only the
+    // contiguous leading libc segment and leave the first application frame as
+    // the grouping frame.
+    if crash_info
+        .sig_info
+        .as_ref()
+        .is_some_and(|sig_info| sig_info.si_code <= 0)
+    {
+        trim_signal_delivery_frames(&mut crash_info.error.stack);
+    }
+
+    synthesize_module_offsets(&mut crash_info.error.stack);
+    if let Some(threads) = crash_info.error.threads.as_mut() {
+        for thread in threads {
+            synthesize_module_offsets(&mut thread.stack);
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn trim_signal_delivery_frames(stack: &mut crate::crash_info::StackTrace) {
+    let delivery_frames = stack
+        .frames
+        .iter()
+        .take_while(|frame| {
+            frame.path.as_deref().is_some_and(|path| {
+                let basename = std::path::Path::new(path)
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or(path);
+                basename == "libc.so.6"
+                    || basename.starts_with("libc-")
+                    || basename.starts_with("ld-musl-")
+            })
+        })
+        .count();
+    stack.frames.drain(..delivery_frames);
+}
+
+#[cfg(target_os = "linux")]
+fn synthesize_module_offsets(stack: &mut crate::crash_info::StackTrace) {
+    for frame in &mut stack.frames {
+        if frame.function.is_some() {
+            continue;
+        }
+        let (Some(path), Some(relative_address)) =
+            (frame.path.as_deref(), frame.relative_address.as_deref())
+        else {
+            continue;
+        };
+        let module = std::path::Path::new(path)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or(path);
+        frame.function = Some(format!("{module}+{relative_address}"));
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+    use crate::crash_info::{StackFrame, StackTrace};
+
+    fn frame(path: &str, relative_address: &str, function: Option<&str>) -> StackFrame {
+        StackFrame {
+            path: Some(path.to_string()),
+            relative_address: Some(relative_address.to_string()),
+            function: function.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn trims_only_leading_signal_delivery_frames() {
+        let mut stack = StackTrace::from_frames(
+            vec![
+                frame("/lib/ld-musl-x86_64.so.1", "0x1", Some("raise")),
+                frame("/opt/app", "0x2", Some("main")),
+                frame("/lib/libc.so.6", "0x3", Some("__libc_start_main")),
+            ],
+            false,
+        );
+
+        trim_signal_delivery_frames(&mut stack);
+
+        assert_eq!(stack.frames.len(), 2);
+        assert_eq!(stack.frames[0].function.as_deref(), Some("main"));
+        assert_eq!(
+            stack.frames[1].function.as_deref(),
+            Some("__libc_start_main")
+        );
+    }
+
+    #[test]
+    fn adds_module_offset_only_when_symbolization_has_no_name() {
+        let mut stack = StackTrace::from_frames(
+            vec![
+                frame("/usr/lib/libcupti.so.12", "0x0000000000001234", None),
+                frame("/opt/app", "0x2", Some("main")),
+            ],
+            false,
+        );
+
+        synthesize_module_offsets(&mut stack);
+
+        assert_eq!(
+            stack.frames[0].function.as_deref(),
+            Some("libcupti.so.12+0x0000000000001234")
+        );
+        assert_eq!(stack.frames[1].function.as_deref(), Some("main"));
+    }
 }

--- a/libdd-crashtracker/src/receiver/ptrace_collector.rs
+++ b/libdd-crashtracker/src/receiver/ptrace_collector.rs
@@ -40,7 +40,7 @@ use libdd_libunwind_sys::{
     UNW_REG_IP, UNW_REG_SP,
 };
 
-use crate::crash_info::{StackFrame, StackTrace};
+use crate::crash_info::{StackFrame, StackTrace, Ucontext};
 
 /// Maximum number of stack frames to capture per thread
 const MAX_FRAMES: usize = 512;
@@ -58,6 +58,8 @@ pub enum PtraceError {
     Attach(libc::pid_t, i32),
     /// Failed to detach from a thread
     Detach(libc::pid_t, i32),
+    /// Failed to read or replace the stopped thread's general registers.
+    Registers(libc::pid_t, i32),
 }
 
 impl std::fmt::Display for PtraceError {
@@ -70,7 +72,128 @@ impl std::fmt::Display for PtraceError {
             PtraceError::Detach(tid, errno) => {
                 write!(f, "Failed to detach from thread {}: errno {}", tid, errno)
             }
+            PtraceError::Registers(tid, errno) => {
+                write!(
+                    f,
+                    "Failed to access registers for thread {}: errno {}",
+                    tid, errno
+                )
+            }
         }
+    }
+}
+
+fn parse_register(context: &Ucontext, name: &str) -> Option<u64> {
+    let value = context.registers.get(name)?;
+    u64::from_str_radix(value.strip_prefix("0x").unwrap_or(value), 16).ok()
+}
+
+/// Temporarily replace a stopped thread's general registers with the
+/// kernel-captured crash context. libunwind's remote API always initializes
+/// from the target's current registers; the crashing thread is currently
+/// blocked in the crash handler, so seeding it with the saved ucontext is what
+/// makes the unwind begin at the actual faulting instruction.
+///
+/// The original registers are restored before detaching. Only general
+/// registers are changed; flags, segment registers, and architecture state not
+/// represented by Ucontext retain their stopped-thread values.
+fn replace_registers_from_ucontext(
+    tid: libc::pid_t,
+    context: &Ucontext,
+) -> Result<libc::user_regs_struct, PtraceError> {
+    let mut registers: libc::user_regs_struct = unsafe { std::mem::zeroed() };
+    let mut iov = libc::iovec {
+        iov_base: (&mut registers as *mut libc::user_regs_struct).cast(),
+        iov_len: std::mem::size_of::<libc::user_regs_struct>(),
+    };
+    let result = unsafe {
+        libc::ptrace(
+            libc::PTRACE_GETREGSET,
+            tid as libc::c_long,
+            libc::NT_PRSTATUS as usize as *mut libc::c_void,
+            &mut iov as *mut libc::iovec,
+        )
+    };
+    if result == -1 {
+        return Err(PtraceError::Registers(tid, unsafe {
+            *libc::__errno_location()
+        }));
+    }
+    let original = registers;
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        let expected_arch = "x86_64";
+        if context.arch != expected_arch {
+            return Err(PtraceError::Registers(tid, libc::EINVAL));
+        }
+        macro_rules! set_register {
+            ($field:ident, $name:literal) => {
+                registers.$field = parse_register(context, $name)
+                    .ok_or(PtraceError::Registers(tid, libc::EINVAL))?
+            };
+        }
+        set_register!(rip, "rip");
+        set_register!(rsp, "rsp");
+        set_register!(rbp, "rbp");
+        set_register!(rax, "rax");
+        set_register!(rbx, "rbx");
+        set_register!(rcx, "rcx");
+        set_register!(rdx, "rdx");
+        set_register!(rsi, "rsi");
+        set_register!(rdi, "rdi");
+        set_register!(r8, "r8");
+        set_register!(r9, "r9");
+        set_register!(r10, "r10");
+        set_register!(r11, "r11");
+        set_register!(r12, "r12");
+        set_register!(r13, "r13");
+        set_register!(r14, "r14");
+        set_register!(r15, "r15");
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    {
+        if context.arch != "aarch64" {
+            return Err(PtraceError::Registers(tid, libc::EINVAL));
+        }
+        registers.pc =
+            parse_register(context, "pc").ok_or(PtraceError::Registers(tid, libc::EINVAL))?;
+        registers.sp =
+            parse_register(context, "sp").ok_or(PtraceError::Registers(tid, libc::EINVAL))?;
+        for (index, register) in registers.regs.iter_mut().enumerate() {
+            let name = format!("x{index}");
+            *register =
+                parse_register(context, &name).ok_or(PtraceError::Registers(tid, libc::EINVAL))?;
+        }
+    }
+
+    set_registers(tid, &mut registers)?;
+    Ok(original)
+}
+
+fn set_registers(
+    tid: libc::pid_t,
+    registers: &mut libc::user_regs_struct,
+) -> Result<(), PtraceError> {
+    let mut iov = libc::iovec {
+        iov_base: (registers as *mut libc::user_regs_struct).cast(),
+        iov_len: std::mem::size_of::<libc::user_regs_struct>(),
+    };
+    let result = unsafe {
+        libc::ptrace(
+            libc::PTRACE_SETREGSET,
+            tid as libc::c_long,
+            libc::NT_PRSTATUS as usize as *mut libc::c_void,
+            &mut iov as *mut libc::iovec,
+        )
+    };
+    if result == -1 {
+        Err(PtraceError::Registers(tid, unsafe {
+            *libc::__errno_location()
+        }))
+    } else {
+        Ok(())
     }
 }
 
@@ -357,10 +480,25 @@ pub fn capture_thread_context(
     tid: libc::pid_t,
     addr_space: UnwAddrSpaceT,
     stop_deadline: Instant,
+    initial_context: Option<&Ucontext>,
 ) -> Result<CapturedThreadContext, PtraceError> {
     attach_thread(tid, stop_deadline)?;
 
+    let mut original_registers = match initial_context {
+        Some(context) => match replace_registers_from_ucontext(tid, context) {
+            Ok(registers) => Some(registers),
+            Err(error) => {
+                let _ = detach_thread(tid);
+                return Err(error);
+            }
+        },
+        None => None,
+    };
     let stack_trace = unwind_remote_thread(tid, addr_space);
+
+    if let Some(registers) = original_registers.as_mut() {
+        let _ = set_registers(tid, registers);
+    }
 
     // Best-effort detach: if this fails the thread stays in ptrace-stop, but the
     // receiver exiting will clean it up. Don't discard a good stack trace over it.
@@ -403,11 +541,12 @@ fn capture_with_retry(
     tid: libc::pid_t,
     addr_space: UnwAddrSpaceT,
     overall_deadline: Instant,
+    initial_context: Option<&Ucontext>,
 ) -> Option<CapturedThreadContext> {
     for attempt in 0..=MAX_RETRIES {
         let thread_deadline = (Instant::now() + STOP_TIMEOUT_PER_THREAD).min(overall_deadline);
 
-        match capture_thread_context(tid, addr_space, thread_deadline) {
+        match capture_thread_context(tid, addr_space, thread_deadline, initial_context) {
             Ok(ctx) if !ctx.stack_trace.frames.is_empty() => return Some(ctx),
             Ok(_) => {}                                      // 0 frames -- retry
             Err(ref e) if is_transient_ptrace_error(e) => {} // ETIMEDOUT -- retry
@@ -452,6 +591,7 @@ pub fn stream_thread_contexts<F>(
     crashing_tid: libc::pid_t,
     max_threads: usize,
     timeout: Duration,
+    crashing_context: Option<&Ucontext>,
     mut callback: F,
 ) -> Result<bool, PtraceError>
 where
@@ -472,7 +612,8 @@ where
 
     // Process the crashing thread first so it is never dropped by the cap.
     if crashing_tid != 0 && tids.contains(&crashing_tid) {
-        let context = capture_with_retry(crashing_tid, addr_space, overall_deadline);
+        let context =
+            capture_with_retry(crashing_tid, addr_space, overall_deadline, crashing_context);
         callback(crashing_tid, context.as_ref());
         processed += 1;
     }
@@ -485,7 +626,7 @@ where
             break;
         }
 
-        let context = capture_with_retry(tid, addr_space, overall_deadline);
+        let context = capture_with_retry(tid, addr_space, overall_deadline, None);
         callback(tid, context.as_ref());
         processed += 1;
     }
@@ -567,7 +708,12 @@ mod tests {
             handle.join().unwrap();
             return;
         };
-        match capture_thread_context(tid, addr_space, Instant::now() + Duration::from_secs(5)) {
+        match capture_thread_context(
+            tid,
+            addr_space,
+            Instant::now() + Duration::from_secs(5),
+            None,
+        ) {
             Err(e) => eprintln!("skipping ptrace test (ptrace unavailable): {e}"),
             Ok(ctx) => assert!(
                 !ctx.stack_trace.frames.is_empty(),
@@ -601,6 +747,7 @@ mod tests {
             current_tid(),
             2,
             Duration::from_secs(5),
+            None,
             |_tid, _ctx| collected += 1,
         );
 
@@ -633,6 +780,7 @@ mod tests {
             self_tid,
             64,
             Duration::from_secs(5),
+            None,
             |tid, _ctx| {
                 if tid == worker_tid {
                     seen_worker = true;

--- a/libdd-crashtracker/src/receiver/receive_report.rs
+++ b/libdd-crashtracker/src/receiver/receive_report.rs
@@ -532,12 +532,15 @@ fn collect_and_add_thread_contexts(
     let parent_pid = parent_pid as i32;
 
     let mut collected_threads = Vec::new();
+    let crashing_context = builder.ucontext.clone();
+    let mut crashing_stack = None;
 
     let incomplete = stream_thread_contexts(
         parent_pid,
         crashing_tid,
         config.max_threads(),
         budget,
+        crashing_context.as_ref(),
         |tid, captured_context| {
             let (name, state) = read_thread_stat(parent_pid, tid);
             let name = name.unwrap_or_else(|| tid.to_string());
@@ -546,6 +549,10 @@ fn collect_and_add_thread_contexts(
                 Some(ctx) => ctx.stack_trace.clone(),
                 None => StackTrace::new_incomplete(),
             };
+
+            if tid == crashing_tid && !stack.frames.is_empty() {
+                crashing_stack = Some(stack.clone());
+            }
 
             collected_threads.push(ThreadData {
                 crashed: tid == crashing_tid,
@@ -558,6 +565,13 @@ fn collect_and_add_thread_contexts(
 
     if incomplete {
         let _ = builder.with_counter("threads_incomplete".to_string(), 1);
+    }
+
+    // The frame stream sent by the signal-safe collector is deliberately only
+    // a fallback. Replace it with the CFI unwind rooted at the saved kernel
+    // context so Error Tracking groups and displays the causal crash stack.
+    if let Some(stack) = crashing_stack {
+        builder.with_stack(stack)?;
     }
 
     let _ = builder.with_threads(collected_threads);


### PR DESCRIPTION
## Summary

- seed the stopped crashing thread's registers from the saved signal `ucontext` before remote libunwind collection
- restore the stopped registers before detaching and promote the causal unwind to the primary error stack
- retain all-thread data, synthesize module+offset names for unresolved native frames, and trim leading libc delivery frames for software-generated signals

## Validation

- `cargo check -p libdd-crashtracker --features collector,receiver`
- Linux musl `cargo check -p libdd-crashtracker --features collector,receiver --tests --target x86_64-unknown-linux-musl`
- dd-trace-c optimized `-fomit-frame-pointer` crash integration test
