### PR TITLE
chore: remove inexistent path from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -115,6 +115,3 @@ datadog-sidecar/src/service/ffe_exposures_flusher.rs    @DataDog/libdatadog-php 
 datadog-sidecar/src/service/ffe_metrics_flusher.rs      @DataDog/libdatadog-php @DataDog/libdatadog-apm @DataDog/feature-flagging-and-experimentation-sdk
 .github/workflows/nix.yml                               @DataDog/nix-guild @DataDog/apm-common-components-core
 
-
-# Vendored deps
-vendor/tuf/                          @DataDog/libdatadog-core


### PR DESCRIPTION
# What does this PR do?

Remove previously deleted path from codeowners file.