### PR TITLE
fix(compression): align zstd behavior across targets

### DIFF
--- a/libdd-profiling/src/pprof/test_utils.rs
+++ b/libdd-profiling/src/pprof/test_utils.rs
@@ -6,8 +6,8 @@ use libdd_profiling_protobuf::prost_impls::{Profile, Sample};
 fn deserialize_compressed_pprof(encoded: &[u8]) -> anyhow::Result<Profile> {
     use prost::Message;
 
-    // Miri cannot call native zstd's FFI, so DefaultProfileCodec resolves to
-    // NoopProfileCodec under cfg(miri) and these bytes are intentionally uncompressed.
+    // The zstd bindings use FFI so they don't work under miri. This means the
+    // buffer isn't compressed, so simply convert to a vec.
     #[cfg(miri)]
     let buf = encoded.to_vec();
     #[cfg(all(not(miri), not(target_arch = "wasm32")))]

--- a/libdd-profiling/src/pprof/test_utils.rs
+++ b/libdd-profiling/src/pprof/test_utils.rs
@@ -6,8 +6,8 @@ use libdd_profiling_protobuf::prost_impls::{Profile, Sample};
 fn deserialize_compressed_pprof(encoded: &[u8]) -> anyhow::Result<Profile> {
     use prost::Message;
 
-    // Native zstd uses FFI and is unavailable under Miri, where the default
-    // profile codec remains uncompressed.
+    // Miri cannot call native zstd's FFI, so DefaultProfileCodec resolves to
+    // NoopProfileCodec under cfg(miri) and these bytes are intentionally uncompressed.
     #[cfg(miri)]
     let buf = encoded.to_vec();
     #[cfg(all(not(miri), not(target_arch = "wasm32")))]

--- a/libdd-profiling/src/profiles/compressor.rs
+++ b/libdd-profiling/src/profiles/compressor.rs
@@ -320,7 +320,7 @@ impl<C: ProfileCodec> Write for Compressor<C> {
     }
 }
 
-#[cfg(all(test, not(target_arch = "wasm32")))]
+#[cfg(all(test, not(miri), not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
 

--- a/libdd-profiling/src/profiles/compressor.rs
+++ b/libdd-profiling/src/profiles/compressor.rs
@@ -4,13 +4,22 @@
 use std::io::{self, BufWriter, Read, Write};
 
 const DEFAULT_COMPRESSION_LEVEL: i32 = 3;
+#[cfg(target_arch = "wasm32")]
+const MIN_ZRIP_COMPRESSION_LEVEL: i32 = -7;
+#[cfg(target_arch = "wasm32")]
+const MAX_ZRIP_COMPRESSION_LEVEL: i32 = 4;
 
 fn zstd_compression_level(level: i32) -> i32 {
-    if level == 0 {
+    let level = if level == 0 {
         DEFAULT_COMPRESSION_LEVEL
     } else {
         level
-    }
+    };
+
+    #[cfg(target_arch = "wasm32")]
+    let level = level.clamp(MIN_ZRIP_COMPRESSION_LEVEL, MAX_ZRIP_COMPRESSION_LEVEL);
+
+    level
 }
 
 /// This type wraps a [`Vec`] to provide a [`Write`] interface that has a max
@@ -131,9 +140,9 @@ impl ProfileCodec for NoopProfileCodec {
 
 /// A zstd-compatible profile codec.
 ///
-/// WASM accepts levels `-7..=4`. Native targets accept the range reported by
-/// `zstd::compression_level_range()`, making `-7..=4` the portable range. Level
-/// `0` selects level `3` on every target.
+/// Native targets accept the range reported by `zstd::compression_level_range()`.
+/// WASM clamps levels to zrip's supported range of `-7..=4`. Level `0` selects
+/// level `3` on every target.
 #[allow(unused)]
 pub struct ZstdProfileCodec;
 
@@ -333,5 +342,11 @@ mod tests {
     #[test]
     fn zero_uses_default_compression_level() {
         assert_eq!(compress(0), compress(DEFAULT_COMPRESSION_LEVEL));
+    }
+
+    #[test]
+    fn native_compression_level_is_not_clamped() {
+        assert_eq!(zstd_compression_level(22), 22);
+        assert!(!compress(22).is_empty());
     }
 }

--- a/libdd-profiling/src/profiles/compressor.rs
+++ b/libdd-profiling/src/profiles/compressor.rs
@@ -3,6 +3,16 @@
 
 use std::io::{self, BufWriter, Read, Write};
 
+const DEFAULT_COMPRESSION_LEVEL: i32 = 3;
+
+fn zstd_compression_level(level: i32) -> i32 {
+    if level == 0 {
+        DEFAULT_COMPRESSION_LEVEL
+    } else {
+        level
+    }
+}
+
 /// This type wraps a [`Vec`] to provide a [`Write`] interface that has a max
 /// capacity that won't be exceeded. Additionally, it gracefully handles
 /// out-of-memory conditions instead of panicking (unfortunately not compatible
@@ -119,6 +129,11 @@ impl ProfileCodec for NoopProfileCodec {
     }
 }
 
+/// A zstd-compatible profile codec.
+///
+/// WASM accepts levels `-7..=4`. Native targets accept the range reported by
+/// `zstd::compression_level_range()`, making `-7..=4` the portable range. Level
+/// `0` selects level `3` on every target.
 #[allow(unused)]
 pub struct ZstdProfileCodec;
 
@@ -132,7 +147,10 @@ impl ProfileCodec for ZstdProfileCodec {
         compression_level: i32,
     ) -> io::Result<Self::Encoder> {
         let buffer = SizeRestrictedBuffer::try_new(size_hint, max_capacity)?;
-        zstd::Encoder::<'static, SizeRestrictedBuffer>::new(buffer, compression_level)
+        zstd::Encoder::<'static, SizeRestrictedBuffer>::new(
+            buffer,
+            zstd_compression_level(compression_level),
+        )
     }
 
     fn finish(encoder: Self::Encoder) -> io::Result<Vec<u8>> {
@@ -157,7 +175,8 @@ impl ProfileCodec for ZstdProfileCodec {
         compression_level: i32,
     ) -> io::Result<Self::Encoder> {
         let buffer = SizeRestrictedBuffer::try_new(size_hint, max_capacity)?;
-        zrip::FrameEncoder::new(buffer, compression_level).map_err(io::Error::other)
+        zrip::FrameEncoder::new(buffer, zstd_compression_level(compression_level))
+            .map_err(io::Error::other)
     }
 
     fn finish(encoder: Self::Encoder) -> io::Result<Vec<u8>> {
@@ -267,7 +286,8 @@ impl<C: ProfileCodec> Compressor<C> {
     /// - `size_hint`: beginning capacity for the output buffer. This is a hint for the starting
     ///   size, and the implementation may use something different.
     /// - `max_capacity`: the maximum size for the output buffer (hard limit).
-    /// - `compression_level`: must be supported by the target's zstd encoder.
+    /// - `compression_level`: passed to `C::new_encoder`. For the default [`ZstdProfileCodec`], see
+    ///   its target-specific level documentation.
     pub fn try_new(
         size_hint: usize,
         max_capacity: usize,
@@ -297,5 +317,21 @@ impl<C: ProfileCodec> Write for Compressor<C> {
     #[inline]
     fn flush(&mut self) -> io::Result<()> {
         self.encoder.flush()
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+
+    fn compress(level: i32) -> Vec<u8> {
+        let mut compressor = Compressor::<ZstdProfileCodec>::try_new(256, 4096, level).unwrap();
+        compressor.write_all(b"hello profile").unwrap();
+        compressor.finish().unwrap()
+    }
+
+    #[test]
+    fn zero_uses_default_compression_level() {
+        assert_eq!(compress(0), compress(DEFAULT_COMPRESSION_LEVEL));
     }
 }

--- a/libdd-trace-utils/src/send_with_retry/compression.rs
+++ b/libdd-trace-utils/src/send_with_retry/compression.rs
@@ -8,6 +8,10 @@ use std::io::Write as _;
 const CONTENT_ENCODING_ZSTD: http::HeaderValue = http::HeaderValue::from_static("zstd");
 #[cfg(feature = "compression")]
 const DEFAULT_COMPRESSION_LEVEL: i32 = 3;
+#[cfg(all(feature = "compression", target_arch = "wasm32"))]
+const MIN_ZRIP_COMPRESSION_LEVEL: i32 = -7;
+#[cfg(all(feature = "compression", target_arch = "wasm32"))]
+const MAX_ZRIP_COMPRESSION_LEVEL: i32 = 4;
 
 #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
 type ZstdEncoder = zstd::Encoder<'static, Vec<u8>>;
@@ -16,21 +20,26 @@ type ZstdEncoder = zrip::FrameEncoder<Vec<u8>>;
 
 #[cfg(feature = "compression")]
 fn zstd_compression_level(level: i32) -> i32 {
-    if level == 0 {
+    let level = if level == 0 {
         DEFAULT_COMPRESSION_LEVEL
     } else {
         level
-    }
+    };
+
+    #[cfg(all(feature = "compression", target_arch = "wasm32"))]
+    let level = level.clamp(MIN_ZRIP_COMPRESSION_LEVEL, MAX_ZRIP_COMPRESSION_LEVEL);
+
+    level
 }
 
 #[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
 fn new_zstd_encoder(writer: Vec<u8>, level: i32) -> std::io::Result<ZstdEncoder> {
-    zstd::Encoder::new(writer, zstd_compression_level(level))
+    zstd::Encoder::new(writer, level)
 }
 
 #[cfg(all(feature = "compression", target_arch = "wasm32"))]
 fn new_zstd_encoder(writer: Vec<u8>, level: i32) -> std::io::Result<ZstdEncoder> {
-    zrip::FrameEncoder::new(writer, zstd_compression_level(level)).map_err(std::io::Error::other)
+    zrip::FrameEncoder::new(writer, level).map_err(std::io::Error::other)
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -39,9 +48,9 @@ pub enum CompressionStrategy {
     #[cfg(feature = "compression")]
     /// Zstd-compatible compression.
     ///
-    /// WASM accepts levels `-7..=4`. Native targets accept the range reported by
-    /// `zstd::compression_level_range()`, making `-7..=4` the portable range.
-    /// Level `0` selects level `3` on every target.
+    /// Native targets accept the range reported by `zstd::compression_level_range()`.
+    /// WASM clamps levels to zrip's supported range of `-7..=4`. Level `0` selects
+    /// level `3` on every target.
     Zstd {
         level: i32,
     },
@@ -54,6 +63,8 @@ pub fn compress(data: Vec<u8>, strategy: CompressionStrategy) -> (Vec<u8>, Compr
         CompressionStrategy::None => (data, CompressionStrategy::None),
         #[cfg(feature = "compression")]
         CompressionStrategy::Zstd { level } => {
+            let level = zstd_compression_level(level);
+            let strategy = CompressionStrategy::Zstd { level };
             // Start with an initial buffer
             // Allocate 1/10th of the original buffer, so we shouldn't add too
             // much memory usage, and no less than 256 bytes
@@ -99,7 +110,7 @@ mod tests {
     #[test]
     fn zero_uses_default_compression_level() {
         let data = b"hello zstd".repeat(100);
-        let (default_compressed, _) =
+        let (default_compressed, strategy) =
             compress(data.clone(), CompressionStrategy::Zstd { level: 0 });
         let (level_three_compressed, _) = compress(
             data,
@@ -109,5 +120,16 @@ mod tests {
         );
 
         assert_eq!(default_compressed, level_three_compressed);
+        assert!(matches!(strategy, CompressionStrategy::Zstd { level: 3 }));
+    }
+
+    #[test]
+    fn native_compression_level_is_not_clamped() {
+        let data = b"hello zstd".repeat(100);
+        let (compressed, strategy) =
+            compress(data.clone(), CompressionStrategy::Zstd { level: 22 });
+
+        assert!(matches!(strategy, CompressionStrategy::Zstd { level: 22 }));
+        assert_eq!(decompress(&compressed).unwrap(), data);
     }
 }

--- a/libdd-trace-utils/src/send_with_retry/compression.rs
+++ b/libdd-trace-utils/src/send_with_retry/compression.rs
@@ -6,11 +6,42 @@ use std::io::Write as _;
 
 #[cfg(feature = "compression")]
 const CONTENT_ENCODING_ZSTD: http::HeaderValue = http::HeaderValue::from_static("zstd");
+#[cfg(feature = "compression")]
+const DEFAULT_COMPRESSION_LEVEL: i32 = 3;
+
+#[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+type ZstdEncoder = zstd::Encoder<'static, Vec<u8>>;
+#[cfg(all(feature = "compression", target_arch = "wasm32"))]
+type ZstdEncoder = zrip::FrameEncoder<Vec<u8>>;
+
+#[cfg(feature = "compression")]
+fn zstd_compression_level(level: i32) -> i32 {
+    if level == 0 {
+        DEFAULT_COMPRESSION_LEVEL
+    } else {
+        level
+    }
+}
+
+#[cfg(all(feature = "compression", not(target_arch = "wasm32")))]
+fn new_zstd_encoder(writer: Vec<u8>, level: i32) -> std::io::Result<ZstdEncoder> {
+    zstd::Encoder::new(writer, zstd_compression_level(level))
+}
+
+#[cfg(all(feature = "compression", target_arch = "wasm32"))]
+fn new_zstd_encoder(writer: Vec<u8>, level: i32) -> std::io::Result<ZstdEncoder> {
+    zrip::FrameEncoder::new(writer, zstd_compression_level(level)).map_err(std::io::Error::other)
+}
 
 #[derive(Clone, Copy, Debug)]
 pub enum CompressionStrategy {
     None,
     #[cfg(feature = "compression")]
+    /// Zstd-compatible compression.
+    ///
+    /// WASM accepts levels `-7..=4`. Native targets accept the range reported by
+    /// `zstd::compression_level_range()`, making `-7..=4` the portable range.
+    /// Level `0` selects level `3` on every target.
     Zstd {
         level: i32,
     },
@@ -27,18 +58,10 @@ pub fn compress(data: Vec<u8>, strategy: CompressionStrategy) -> (Vec<u8>, Compr
             // Allocate 1/10th of the original buffer, so we shouldn't add too
             // much memory usage, and no less than 256 bytes
             let writer = Vec::with_capacity((data.len() / 10).max(256));
-            #[cfg(not(target_arch = "wasm32"))]
-            let result = zstd::Encoder::new(writer, level).and_then(|mut e| {
-                e.write_all(&data)?;
-                Ok((e.finish()?, strategy))
+            let result = new_zstd_encoder(writer, level).and_then(|mut encoder| {
+                encoder.write_all(&data)?;
+                Ok((encoder.finish()?, strategy))
             });
-            #[cfg(target_arch = "wasm32")]
-            let result = zrip::FrameEncoder::new(writer, level)
-                .map_err(std::io::Error::other)
-                .and_then(|mut e| {
-                    e.write_all(&data)?;
-                    Ok((e.finish()?, strategy))
-                });
             result.unwrap_or((data, CompressionStrategy::None))
         }
     }
@@ -71,5 +94,20 @@ mod tests {
 
         assert!(matches!(strategy, CompressionStrategy::Zstd { level: 1 }));
         assert_eq!(decompress(&compressed).unwrap(), data);
+    }
+
+    #[test]
+    fn zero_uses_default_compression_level() {
+        let data = b"hello zstd".repeat(100);
+        let (default_compressed, _) =
+            compress(data.clone(), CompressionStrategy::Zstd { level: 0 });
+        let (level_three_compressed, _) = compress(
+            data,
+            CompressionStrategy::Zstd {
+                level: DEFAULT_COMPRESSION_LEVEL,
+            },
+        );
+
+        assert_eq!(default_compressed, level_three_compressed);
     }
 }

--- a/tests/wasm/tests/compression.rs
+++ b/tests/wasm/tests/compression.rs
@@ -37,7 +37,7 @@ fn trace_compression_uses_zrip() {
 }
 
 #[wasm_bindgen_test::wasm_bindgen_test]
-fn trace_compression_levels_are_portable() {
+fn trace_compression_levels_are_clamped() {
     use trace_compression::{compress, CompressionStrategy};
 
     let payload = b"hello zstd".repeat(100);
@@ -46,11 +46,12 @@ fn trace_compression_levels_are_portable() {
         assert!(matches!(strategy, CompressionStrategy::Zstd { level: actual } if actual == level));
         assert_eq!(zrip::decompress(&compressed).unwrap(), payload);
     }
-    for level in [-8, 5] {
-        let (uncompressed, strategy) =
-            compress(payload.clone(), CompressionStrategy::Zstd { level });
-        assert!(matches!(strategy, CompressionStrategy::None));
-        assert_eq!(uncompressed, payload);
+    for (level, expected) in [(-8, -7), (5, 4), (22, 4)] {
+        let (compressed, strategy) = compress(payload.clone(), CompressionStrategy::Zstd { level });
+        assert!(
+            matches!(strategy, CompressionStrategy::Zstd { level: actual } if actual == expected)
+        );
+        assert_eq!(zrip::decompress(&compressed).unwrap(), payload);
     }
 }
 
@@ -59,10 +60,12 @@ fn trace_compression_zero_uses_level_three() {
     use trace_compression::{compress, CompressionStrategy};
 
     let payload = b"hello zstd".repeat(100);
-    let (default_compressed, _) = compress(payload.clone(), CompressionStrategy::Zstd { level: 0 });
+    let (default_compressed, strategy) =
+        compress(payload.clone(), CompressionStrategy::Zstd { level: 0 });
     let (level_three_compressed, _) = compress(payload, CompressionStrategy::Zstd { level: 3 });
 
     assert_eq!(default_compressed, level_three_compressed);
+    assert!(matches!(strategy, CompressionStrategy::Zstd { level: 3 }));
 }
 
 #[wasm_bindgen_test::wasm_bindgen_test]
@@ -82,14 +85,17 @@ fn profiling_codecs_use_zrip() {
 }
 
 #[wasm_bindgen_test::wasm_bindgen_test]
-fn profiling_compression_levels_are_portable() {
+fn profiling_compression_levels_are_clamped() {
     let payload = b"hello profile".repeat(100);
     for level in [-7, 4] {
         let compressed = compress_profile(&payload, level).unwrap();
         assert_eq!(zrip::decompress(&compressed).unwrap(), payload);
     }
-    for level in [-8, 5] {
-        assert!(compress_profile(&payload, level).is_err());
+    for (level, expected) in [(-8, -7), (5, 4), (22, 4)] {
+        assert_eq!(
+            compress_profile(&payload, level).unwrap(),
+            compress_profile(&payload, expected).unwrap()
+        );
     }
 }
 

--- a/tests/wasm/tests/compression.rs
+++ b/tests/wasm/tests/compression.rs
@@ -15,6 +15,14 @@ mod profiling_compressor;
 
 use std::io::{Read, Write};
 
+fn compress_profile(payload: &[u8], level: i32) -> std::io::Result<Vec<u8>> {
+    use profiling_compressor::{Compressor, ZstdProfileCodec};
+
+    let mut compressor = Compressor::<ZstdProfileCodec>::try_new(256, 4096, level)?;
+    compressor.write_all(payload)?;
+    compressor.finish()
+}
+
 #[wasm_bindgen_test::wasm_bindgen_test]
 fn trace_compression_uses_zrip() {
     use trace_compression::{add_headers, compress, CompressionStrategy};
@@ -29,15 +37,40 @@ fn trace_compression_uses_zrip() {
 }
 
 #[wasm_bindgen_test::wasm_bindgen_test]
+fn trace_compression_levels_are_portable() {
+    use trace_compression::{compress, CompressionStrategy};
+
+    let payload = b"hello zstd".repeat(100);
+    for level in [-7, 4] {
+        let (compressed, strategy) = compress(payload.clone(), CompressionStrategy::Zstd { level });
+        assert!(matches!(strategy, CompressionStrategy::Zstd { level: actual } if actual == level));
+        assert_eq!(zrip::decompress(&compressed).unwrap(), payload);
+    }
+    for level in [-8, 5] {
+        let (uncompressed, strategy) =
+            compress(payload.clone(), CompressionStrategy::Zstd { level });
+        assert!(matches!(strategy, CompressionStrategy::None));
+        assert_eq!(uncompressed, payload);
+    }
+}
+
+#[wasm_bindgen_test::wasm_bindgen_test]
+fn trace_compression_zero_uses_level_three() {
+    use trace_compression::{compress, CompressionStrategy};
+
+    let payload = b"hello zstd".repeat(100);
+    let (default_compressed, _) = compress(payload.clone(), CompressionStrategy::Zstd { level: 0 });
+    let (level_three_compressed, _) = compress(payload, CompressionStrategy::Zstd { level: 3 });
+
+    assert_eq!(default_compressed, level_three_compressed);
+}
+
+#[wasm_bindgen_test::wasm_bindgen_test]
 fn profiling_codecs_use_zrip() {
-    use profiling_compressor::{
-        Compressor, ObservationCodec, ZstdObservationCodec, ZstdProfileCodec,
-    };
+    use profiling_compressor::{ObservationCodec, ZstdObservationCodec};
 
     let payload = b"hello profile".repeat(100);
-    let mut compressor = Compressor::<ZstdProfileCodec>::try_new(256, 4096, 1).unwrap();
-    compressor.write_all(&payload).unwrap();
-    let compressed = compressor.finish().unwrap();
+    let compressed = compress_profile(&payload, 1).unwrap();
     assert_eq!(zrip::decompress(&compressed).unwrap(), payload);
 
     let mut encoder = ZstdObservationCodec::new_encoder(256, 4096).unwrap();
@@ -46,4 +79,26 @@ fn profiling_codecs_use_zrip() {
     let mut decoded = Vec::new();
     decoder.read_to_end(&mut decoded).unwrap();
     assert_eq!(decoded, payload);
+}
+
+#[wasm_bindgen_test::wasm_bindgen_test]
+fn profiling_compression_levels_are_portable() {
+    let payload = b"hello profile".repeat(100);
+    for level in [-7, 4] {
+        let compressed = compress_profile(&payload, level).unwrap();
+        assert_eq!(zrip::decompress(&compressed).unwrap(), payload);
+    }
+    for level in [-8, 5] {
+        assert!(compress_profile(&payload, level).is_err());
+    }
+}
+
+#[wasm_bindgen_test::wasm_bindgen_test]
+fn profiling_compression_zero_uses_level_three() {
+    let payload = b"hello profile".repeat(100);
+
+    assert_eq!(
+        compress_profile(&payload, 0).unwrap(),
+        compress_profile(&payload, 3).unwrap()
+    );
 }


### PR DESCRIPTION
# What does this PR do?

Addresses follow-up review feedback from #2386:

- restores the pre-#2386 Miri FFI explanation in the profile test helper;
- documents the WASM and native zstd compression-level contracts;
- maps level `0` to level `3` on every target;
- clamps WASM zrip levels to `-7..=4` while preserving native zstd's broader range;
- reports the effective compression level from trace compression;
- isolates target-specific trace encoder construction and shares the write/finish path; and
- tests native passthrough and WASM clamping at both boundaries.

# Motivation

The zrip WASM backend supports a narrower compression-level range than native zstd and previously assigned a different meaning to level `0`. Out-of-range levels also disabled trace compression or failed profile compression under WASM. The target branches duplicated the common encoder flow.

This follows up on these review threads:

- https://github.com/DataDog/libdatadog/pull/2386#discussion_r3832344788
- https://github.com/DataDog/libdatadog/pull/2386#discussion_r3832363635
- https://github.com/DataDog/libdatadog/pull/2386#discussion_r3832381426

# Additional Notes

Native targets continue to accept the broader range reported by `zstd::compression_level_range()`. WASM clamps requested levels to zrip's supported range, so level `22` becomes `4`; level `0` becomes `3` on every target.

The full trace-utils integration binary was not validated locally because Docker could not pull the private GHCR test-agent image. All 348 trace-utils library tests passed. Strict trace-utils clippy also reports an existing `collapsible_match` warning in unchanged `tracer_payload.rs`; clippy passes with that lint allowed.

This PR was generated by Codex.

# How to test the change?

- `cargo test -p libdd-profiling`
- `cargo test -p libdd-trace-utils --features compression --lib`
- `env CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER=wasm-bindgen-test-runner cargo test -p libdd-wasm-tests --target wasm32-unknown-unknown`
- `cargo +stable clippy -p libdd-profiling --all-targets -- -D warnings`
- `cargo +stable clippy -p libdd-wasm-tests --target wasm32-unknown-unknown --all-targets -- -D warnings`
- `cargo +stable clippy -p libdd-trace-utils --all-targets --features compression -- -D warnings -A clippy::collapsible_match`
- `cargo +nightly-2026-07-26 fmt --all -- --check`
- `cargo test -p libdd-profiling --doc`
- `cargo test -p libdd-trace-utils --features compression --doc`
