### PR TITLE
feat(ffe)!: send the split serial id on exposure events [EX-3425]

### DIFF
--- a/datadog-sidecar-ffi/src/lib.rs
+++ b/datadog-sidecar-ffi/src/lib.rs
@@ -1209,6 +1209,8 @@ pub struct FfeExposure<'a> {
     pub subject_attributes_json: CharSlice<'a>,
     pub allocation_key: CharSlice<'a>,
     pub variant: CharSlice<'a>,
+    pub serial_id: i32,
+    pub has_serial_id: bool,
 }
 
 #[repr(C)]
@@ -1443,6 +1445,7 @@ fn ffe_exposure_from_ffi(exposure: &FfeExposure<'_>) -> Result<SidecarFfeExposur
         subject_attributes_json: char_slice_to_string(exposure.subject_attributes_json)?,
         allocation_key: char_slice_to_string(exposure.allocation_key)?,
         variant: char_slice_to_string(exposure.variant)?,
+        serial_id: exposure.has_serial_id.then_some(exposure.serial_id),
     })
 }
 
@@ -2048,6 +2051,40 @@ mod tests {
         .expect("expected OTLP metrics endpoint");
 
         assert_eq!(endpoint.test_token.as_deref(), Some("metrics-token"));
+    }
+
+    fn ffi_exposure<'a>(serial_id: i32, has_serial_id: bool) -> FfeExposure<'a> {
+        FfeExposure {
+            timestamp_ms: 1_700_000_000_000,
+            flag_key: CharSlice::from("flag-a"),
+            subject_id: CharSlice::from("user-1"),
+            subject_attributes_json: CharSlice::from("{}"),
+            allocation_key: CharSlice::from("alloc-a"),
+            variant: CharSlice::from("blue"),
+            serial_id,
+            has_serial_id,
+        }
+    }
+
+    #[test]
+    fn ffe_exposure_carries_a_present_serial_id() {
+        let converted = ffe_exposure_from_ffi(&ffi_exposure(4242, true)).unwrap();
+
+        assert_eq!(converted.serial_id, Some(4242));
+    }
+
+    #[test]
+    fn ffe_exposure_carries_a_zero_serial_id() {
+        let converted = ffe_exposure_from_ffi(&ffi_exposure(0, true)).unwrap();
+
+        assert_eq!(converted.serial_id, Some(0));
+    }
+
+    #[test]
+    fn ffe_exposure_ignores_the_serial_id_value_when_absent() {
+        let converted = ffe_exposure_from_ffi(&ffi_exposure(4242, false)).unwrap();
+
+        assert_eq!(converted.serial_id, None);
     }
 
     #[test]

--- a/datadog-sidecar/src/service/ffe_exposures_flusher.rs
+++ b/datadog-sidecar/src/service/ffe_exposures_flusher.rs
@@ -84,6 +84,7 @@ mod tests {
             subject_attributes_json: r#"{"tier":"premium"}"#.to_owned(),
             allocation_key: allocation_key.to_owned(),
             variant: variant.to_owned(),
+            serial_id: None,
         }
     }
 

--- a/datadog-sidecar/src/service/sidecar_server.rs
+++ b/datadog-sidecar/src/service/sidecar_server.rs
@@ -1258,6 +1258,7 @@ mod tests {
             subject_attributes_json: "{}".to_owned(),
             allocation_key: "alloc".to_owned(),
             variant: "variant".to_owned(),
+            serial_id: None,
         }
     }
 

--- a/libdd-ffe/src/telemetry/exposures.rs
+++ b/libdd-ffe/src/telemetry/exposures.rs
@@ -419,7 +419,7 @@ mod tests {
             exposure_with_serial_id("user", "alloc", "variant", 0),
         );
 
-        assert!(first.is_some());
+        assert_eq!(first.unwrap()["exposures"][0].get("serial_id"), None);
         assert_eq!(appeared.unwrap()["exposures"][0]["serial_id"], 0);
     }
 
@@ -435,8 +435,42 @@ mod tests {
             exposure_with_serial_id("user", "alloc", "variant", 1),
         );
 
-        assert!(first.is_some());
+        assert_eq!(first.unwrap()["exposures"][0]["serial_id"], 0);
         assert_eq!(changed.unwrap()["exposures"][0]["serial_id"], 1);
+    }
+
+    #[test]
+    fn emits_an_exposure_when_the_serial_id_disappears() {
+        let deduplicator = ExposureDeduplicator::new(4);
+        let first = encode_one(
+            &deduplicator,
+            exposure_with_serial_id("user", "alloc", "variant", 0),
+        );
+        let disappeared = encode_one(&deduplicator, exposure("user", "alloc", "variant"));
+
+        assert_eq!(first.unwrap()["exposures"][0]["serial_id"], 0);
+        assert_eq!(disappeared.unwrap()["exposures"][0].get("serial_id"), None);
+    }
+
+    #[test]
+    fn emits_an_exposure_when_the_serial_id_returns_to_an_earlier_value() {
+        let deduplicator = ExposureDeduplicator::new(4);
+        let first = encode_one(
+            &deduplicator,
+            exposure_with_serial_id("user", "alloc", "variant", 7),
+        );
+        let changed = encode_one(
+            &deduplicator,
+            exposure_with_serial_id("user", "alloc", "variant", 9),
+        );
+        let returned = encode_one(
+            &deduplicator,
+            exposure_with_serial_id("user", "alloc", "variant", 7),
+        );
+
+        assert_eq!(first.unwrap()["exposures"][0]["serial_id"], 7);
+        assert_eq!(changed.unwrap()["exposures"][0]["serial_id"], 9);
+        assert_eq!(returned.unwrap()["exposures"][0]["serial_id"], 7);
     }
 
     #[test]
@@ -451,8 +485,8 @@ mod tests {
             exposure_with_serial_id("user", "alloc", "variant", 0),
         );
 
-        assert!(first.is_some());
-        assert!(duplicate.is_none());
+        assert_eq!(first.unwrap()["exposures"][0]["serial_id"], 0);
+        assert_eq!(duplicate, None);
     }
 
     #[test]

--- a/libdd-ffe/src/telemetry/exposures.rs
+++ b/libdd-ffe/src/telemetry/exposures.rs
@@ -31,6 +31,10 @@ pub struct FfeExposure {
     pub subject_attributes_json: String,
     pub allocation_key: String,
     pub variant: String,
+    /// Serial id of the split the subject was assigned to. Zero-based per
+    /// organization, so `Some(0)` is a real value and must not be treated as
+    /// absent.
+    pub serial_id: Option<i32>,
 }
 
 #[derive(Clone)]
@@ -66,6 +70,7 @@ impl ExposureDeduplicator {
         let value = ExposureCacheValue {
             allocation_key: exposure.allocation_key.clone(),
             variant: exposure.variant.clone(),
+            serial_id: exposure.serial_id,
         };
 
         let mut cache = cache.lock().unwrap_or_else(|e| e.into_inner());
@@ -91,6 +96,7 @@ struct ExposureCacheKey {
 struct ExposureCacheValue {
     allocation_key: String,
     variant: String,
+    serial_id: Option<i32>,
 }
 
 pub fn encode_exposure_batch(
@@ -157,6 +163,8 @@ struct ExposureEvent {
     flag: Key,
     variant: Key,
     subject: Subject,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    serial_id: Option<i32>,
 }
 
 impl From<FfeExposure> for ExposureEvent {
@@ -174,6 +182,7 @@ impl From<FfeExposure> for ExposureEvent {
                 id: value.subject_id,
                 attributes: subject_attributes(&value.subject_attributes_json),
             },
+            serial_id: value.serial_id,
         }
     }
 }
@@ -232,7 +241,32 @@ mod tests {
             subject_attributes_json: r#"{"tier":"premium"}"#.to_owned(),
             allocation_key: allocation_key.to_owned(),
             variant: variant.to_owned(),
+            serial_id: None,
         }
+    }
+
+    fn exposure_with_serial_id(
+        subject_id: &str,
+        allocation_key: &str,
+        variant: &str,
+        serial_id: i32,
+    ) -> FfeExposure {
+        FfeExposure {
+            serial_id: Some(serial_id),
+            ..exposure(subject_id, allocation_key, variant)
+        }
+    }
+
+    fn encode_one(deduplicator: &ExposureDeduplicator, exposure: FfeExposure) -> Option<Value> {
+        encode_exposure_batch(
+            deduplicator,
+            FfeExposureBatch {
+                context: context(),
+                exposures: vec![exposure],
+            },
+        )
+        .unwrap()
+        .map(|payload| serde_json::from_str(&payload).unwrap())
     }
 
     #[test]
@@ -341,6 +375,84 @@ mod tests {
 
         assert!(first.is_some());
         assert!(other_service.is_some());
+    }
+
+    #[test]
+    fn serializes_serial_id_at_the_event_top_level() {
+        let payload = encode_one(
+            &ExposureDeduplicator::new(4),
+            exposure_with_serial_id("user", "alloc", "variant", 4242),
+        )
+        .unwrap();
+
+        assert_eq!(payload["exposures"][0]["serial_id"], 4242);
+    }
+
+    #[test]
+    fn serializes_a_zero_serial_id() {
+        let payload = encode_one(
+            &ExposureDeduplicator::new(4),
+            exposure_with_serial_id("user", "alloc", "variant", 0),
+        )
+        .unwrap();
+
+        assert_eq!(payload["exposures"][0]["serial_id"], 0);
+    }
+
+    #[test]
+    fn omits_an_absent_serial_id() {
+        let payload = encode_one(
+            &ExposureDeduplicator::new(4),
+            exposure("user", "alloc", "variant"),
+        )
+        .unwrap();
+
+        assert_eq!(payload["exposures"][0].get("serial_id"), None);
+    }
+
+    #[test]
+    fn emits_an_exposure_when_only_the_serial_id_appears() {
+        let deduplicator = ExposureDeduplicator::new(4);
+        let first = encode_one(&deduplicator, exposure("user", "alloc", "variant"));
+        let appeared = encode_one(
+            &deduplicator,
+            exposure_with_serial_id("user", "alloc", "variant", 0),
+        );
+
+        assert!(first.is_some());
+        assert_eq!(appeared.unwrap()["exposures"][0]["serial_id"], 0);
+    }
+
+    #[test]
+    fn emits_an_exposure_when_only_the_serial_id_changes() {
+        let deduplicator = ExposureDeduplicator::new(4);
+        let first = encode_one(
+            &deduplicator,
+            exposure_with_serial_id("user", "alloc", "variant", 0),
+        );
+        let changed = encode_one(
+            &deduplicator,
+            exposure_with_serial_id("user", "alloc", "variant", 1),
+        );
+
+        assert!(first.is_some());
+        assert_eq!(changed.unwrap()["exposures"][0]["serial_id"], 1);
+    }
+
+    #[test]
+    fn deduplicates_an_unchanged_serial_id() {
+        let deduplicator = ExposureDeduplicator::new(4);
+        let first = encode_one(
+            &deduplicator,
+            exposure_with_serial_id("user", "alloc", "variant", 0),
+        );
+        let duplicate = encode_one(
+            &deduplicator,
+            exposure_with_serial_id("user", "alloc", "variant", 0),
+        );
+
+        assert!(first.is_some());
+        assert!(duplicate.is_none());
     }
 
     #[test]


### PR DESCRIPTION
# What does this PR do?

Sends the split serial id on FFE exposure events, and adds it to the exposure deduplication cache value.

| File | Change |
|---|---|
| `libdd-ffe/src/telemetry/exposures.rs` | `serial_id` on `FfeExposure`, on the cache value, and on the serialized event |
| `datadog-sidecar-ffi/src/lib.rs` | `serial_id` and `has_serial_id` on the FFI struct, mapped to an `Option` |
| `datadog-sidecar/src/service/{sidecar_server,ffe_exposures_flusher}.rs` | test helpers |

The key is `serial_id` at the top level of each exposure event. An absent value omits the key. The value is not validated here; the flag configuration layer owns validation.

# Motivation

The exposures intake uses the serial id to find the holdout that an allocation comes from. The compiler rewrites a holdout into an ordinary allocation before an SDK receives the flag configuration, so an exposure event records no holdout. The serial id is the only link back to it.

The deduplication cache keyed on allocation key and variant only. A serial id that appeared, or that changed, while both stayed the same was swallowed, and no exposure was sent. This occurs in production: the `ffe.ufc.vac_miss` metric is continuously non-zero, and those misses resolve on a later configuration refresh.

# Additional Notes

Serial ids are zero-based per organization, so `0` is a real value and is the most frequent value across the fleet. A sentinel cannot signal absence, so the FFI carries a value plus a `has_serial_id` flag, matching the existing `FfeResult` convention.

`skip_serializing_if` is on the serialized event only, never on `FfeExposure`, which crosses the bincode IPC boundary to the sidecar.

`dd-trace-php` reaches the intake through this crate, so it needs a submodule bump before it can send the field.

# How to test the change?

```
cargo test -p libdd-ffe --lib --features exposure-events telemetry::exposures
cargo test -p datadog-sidecar-ffi --lib ffe_exposure
```

New tests pin the wire key, a serial id of `0`, omission when absent, an exposure when the serial id appears or changes on an otherwise unchanged assignment, and no second exposure when nothing changes.

*This description was generated by Claude.*
