### PR TITLE
feat(trace-utils)!: add from owned to SpanText

### DIFF
--- a/libdd-data-pipeline/src/trace_exporter/trace_serializer.rs
+++ b/libdd-data-pipeline/src/trace_exporter/trace_serializer.rs
@@ -324,10 +324,10 @@ mod tests {
         let original_span = &original_traces[0][0];
         let deserialized_span = &deserialized_traces[0][0];
 
-        assert_eq!(original_span.name, deserialized_span.name);
-        assert_eq!(original_span.service, deserialized_span.service);
-        assert_eq!(original_span.resource, deserialized_span.resource);
-        assert_eq!(original_span.r#type, deserialized_span.r#type);
+        assert_eq!(original_span.name, deserialized_span.name.as_ref());
+        assert_eq!(original_span.service, deserialized_span.service.as_ref());
+        assert_eq!(original_span.resource, deserialized_span.resource.as_ref());
+        assert_eq!(original_span.r#type, deserialized_span.r#type.as_ref());
         assert_eq!(original_span.start, deserialized_span.start);
         assert_eq!(original_span.duration, deserialized_span.duration);
         assert_eq!(original_span.span_id, deserialized_span.span_id);
@@ -363,10 +363,10 @@ mod tests {
         let original_span = &original_traces[0][0];
         let deserialized_span = &deserialized_traces[0][0];
 
-        assert_eq!(original_span.name, deserialized_span.name);
-        assert_eq!(original_span.service, deserialized_span.service);
-        assert_eq!(original_span.resource, deserialized_span.resource);
-        assert_eq!(original_span.r#type, deserialized_span.r#type);
+        assert_eq!(original_span.name, deserialized_span.name.as_ref());
+        assert_eq!(original_span.service, deserialized_span.service.as_ref());
+        assert_eq!(original_span.resource, deserialized_span.resource.as_ref());
+        assert_eq!(original_span.r#type, deserialized_span.r#type.as_ref());
         assert_eq!(original_span.start, deserialized_span.start);
         assert_eq!(original_span.duration, deserialized_span.duration);
         assert_eq!(original_span.span_id, deserialized_span.span_id);

--- a/libdd-sampling/benches/sampling_bench.rs
+++ b/libdd-sampling/benches/sampling_bench.rs
@@ -10,6 +10,7 @@ use libdd_common::bench_utils::{
 };
 use libdd_sampling::{v04_span::V04SamplingData, DatadogSampler, SamplingRule};
 use libdd_trace_utils::span::{v04::Span, SliceData};
+use std::borrow::Cow;
 
 #[global_allocator]
 static GLOBAL: ReportingAllocator<System> = ReportingAllocator::new(System);
@@ -31,9 +32,9 @@ fn make_span(
     resource: &'static str,
 ) -> Span<SliceData<'static>> {
     Span {
-        name,
-        service,
-        resource,
+        name: Cow::Borrowed(name),
+        service: Cow::Borrowed(service),
+        resource: Cow::Borrowed(resource),
         trace_id: 0x1234_5678_9012_3456_7890_1234_5678_9012_u128,
         ..Default::default()
     }
@@ -170,7 +171,8 @@ fn make_configs() -> Vec<BenchConfig> {
         // 9. Tag rule — matching
         {
             let mut span = make_span("test-operation", "my-service", "test");
-            span.meta.insert("environment", "production");
+            span.meta
+                .insert(Cow::Borrowed("environment"), Cow::Borrowed("production"));
             BenchConfig {
                 name: "tag_rule_matching",
                 sampler: DatadogSampler::new(
@@ -194,7 +196,8 @@ fn make_configs() -> Vec<BenchConfig> {
         // 10. Tag rule — not matching
         {
             let mut span = make_span("test-operation", "my-service", "test");
-            span.meta.insert("environment", "staging");
+            span.meta
+                .insert(Cow::Borrowed("environment"), Cow::Borrowed("staging"));
             BenchConfig {
                 name: "tag_rule_not_matching",
                 sampler: DatadogSampler::new(
@@ -218,9 +221,12 @@ fn make_configs() -> Vec<BenchConfig> {
         // 11. Complex rule — all fields matching
         {
             let mut span = make_span("http.request", "api-service", "/api/v1/users");
-            span.meta.insert("environment", "production");
-            span.meta.insert("http.method", "POST");
-            span.meta.insert("http.route", "/api/v1/users");
+            span.meta
+                .insert(Cow::Borrowed("environment"), Cow::Borrowed("production"));
+            span.meta
+                .insert(Cow::Borrowed("http.method"), Cow::Borrowed("POST"));
+            span.meta
+                .insert(Cow::Borrowed("http.route"), Cow::Borrowed("/api/v1/users"));
             BenchConfig {
                 name: "complex_rule_matching",
                 sampler: DatadogSampler::new(
@@ -244,9 +250,12 @@ fn make_configs() -> Vec<BenchConfig> {
         // 12. Complex rule — partial match (resource doesn't match)
         {
             let mut span = make_span("http.request", "api-service", "/health");
-            span.meta.insert("environment", "staging");
-            span.meta.insert("http.method", "POST");
-            span.meta.insert("http.route", "/health");
+            span.meta
+                .insert(Cow::Borrowed("environment"), Cow::Borrowed("staging"));
+            span.meta
+                .insert(Cow::Borrowed("http.method"), Cow::Borrowed("POST"));
+            span.meta
+                .insert(Cow::Borrowed("http.route"), Cow::Borrowed("/health"));
             BenchConfig {
                 name: "complex_rule_partial_match",
                 sampler: DatadogSampler::new(
@@ -299,7 +308,7 @@ fn make_configs() -> Vec<BenchConfig> {
         {
             let mut span = make_span("test-operation", "my-service", "test");
             for (k, v) in MANY_ATTR_PAIRS {
-                span.meta.insert(k, v);
+                span.meta.insert(Cow::Borrowed(k), Cow::Borrowed(v));
             }
             BenchConfig {
                 name: "many_attributes_tag_rule",

--- a/libdd-sampling/src/v04_span.rs
+++ b/libdd-sampling/src/v04_span.rs
@@ -251,9 +251,9 @@ mod tests {
         resource: &'static str,
     ) -> Span<SliceData<'static>> {
         Span {
-            name,
-            service,
-            resource,
+            name: Cow::Borrowed(name),
+            service: Cow::Borrowed(service),
+            resource: Cow::Borrowed(resource),
             ..Default::default()
         }
     }
@@ -305,8 +305,12 @@ mod tests {
     #[test]
     fn test_v04_span_properties_with_meta() {
         let mut span = make_span("op", "svc", "res");
-        span.meta.insert("env", "staging");
-        span.meta.insert("http.url", "https://example.com");
+        span.meta
+            .insert(Cow::Borrowed("env"), Cow::Borrowed("staging"));
+        span.meta.insert(
+            Cow::Borrowed("http.url"),
+            Cow::Borrowed("https://example.com"),
+        );
 
         let props = V04SpanProperties::from_span(&span);
         assert_eq!(props.env(), "staging");
@@ -319,7 +323,8 @@ mod tests {
     #[test]
     fn test_v04_span_properties_status_code_from_metrics() {
         let mut span = make_span("op", "svc", "res");
-        span.metrics.insert("http.status_code", 200.0);
+        span.metrics
+            .insert(Cow::Borrowed("http.status_code"), 200.0);
 
         let props = V04SpanProperties::from_span(&span);
         assert_eq!(props.status_code(), Some(200));
@@ -329,7 +334,8 @@ mod tests {
     #[test]
     fn test_v04_span_properties_status_code_from_meta() {
         let mut span = make_span("op", "svc", "res");
-        span.meta.insert("http.status_code", "404");
+        span.meta
+            .insert(Cow::Borrowed("http.status_code"), Cow::Borrowed("404"));
 
         let props = V04SpanProperties::from_span(&span);
         assert_eq!(props.status_code(), Some(404));
@@ -338,7 +344,8 @@ mod tests {
     #[test]
     fn test_v04_span_properties_metrics_in_attributes() {
         let mut span = make_span("op", "svc", "res");
-        span.metrics.insert("_sampling_priority_v1", 1.0);
+        span.metrics
+            .insert(Cow::Borrowed("_sampling_priority_v1"), 1.0);
 
         let props = V04SpanProperties::from_span(&span);
         let attr = props
@@ -379,7 +386,8 @@ mod tests {
         // compiler resolves correctly.
         let sampler = DatadogSampler::new(vec![], 100);
         let mut span = make_span("op", "my-service", "my-resource");
-        span.meta.insert("env", "prod");
+        span.meta
+            .insert(Cow::Borrowed("env"), Cow::Borrowed("prod"));
         let data = V04SamplingData {
             is_parent_sampled: None,
             span: &span,
@@ -497,8 +505,8 @@ mod tests {
     fn test_integration_tags_apply_to_span() {
         let sampler = DatadogSampler::new(vec![], 100);
         let span = Span::<SliceData<'static>> {
-            name: "op",
-            service: "svc",
+            name: Cow::Borrowed("op"),
+            service: Cow::Borrowed("svc"),
             ..Default::default()
         };
 
@@ -519,7 +527,7 @@ mod tests {
                         assert!(!value.is_empty());
                     }
                     V04SamplingTag::Metric { key, value } => {
-                        out_span.metrics.insert(key, value);
+                        out_span.metrics.insert(Cow::Borrowed(key), value);
                     }
                 }
             }

--- a/libdd-sampling/src/v04_span.rs
+++ b/libdd-sampling/src/v04_span.rs
@@ -15,10 +15,11 @@
 //! use libdd_sampling::v04_span::{V04AttributeFactory, V04SamplingData, V04SamplingTag};
 //! use libdd_sampling::DatadogSampler;
 //! use libdd_trace_utils::span::{v04::Span, SliceData};
+//! use std::borrow::Cow::*;
 //!
 //! let mut span = Span::<SliceData<'_>>::default();
-//! span.name = "my-operation";
-//! span.service = "my-service";
+//! span.name = Borrowed("my-operation");
+//! span.service = Borrowed("my-service");
 //! span.trace_id = 1234567890u128;
 //!
 //! let sampler = DatadogSampler::new(vec![], 100);

--- a/libdd-trace-stats/src/span_concentrator/aggregation.rs
+++ b/libdd-trace-stats/src/span_concentrator/aggregation.rs
@@ -8,7 +8,6 @@
 use hashbrown::{HashMap, HashSet};
 use libdd_trace_obfuscation::ip_address::quantize_peer_ip_addresses;
 use libdd_trace_protobuf::pb;
-use libdd_trace_utils::span::SpanText;
 use std::{
     borrow::{Borrow, Cow},
     hash::{DefaultHasher, Hash, Hasher as _},
@@ -428,12 +427,9 @@ impl From<pb::ClientGroupedStats> for OwnedAggregationKey {
 }
 
 /// Return true if we care about peer tags on the span
-fn should_track_peer_tags<T>(span_kind: T) -> bool
-where
-    T: SpanText,
-{
+fn should_track_peer_tags(span_kind: &str) -> bool {
     matches!(
-        span_kind.borrow().to_lowercase().as_str(),
+        span_kind.to_lowercase().as_str(),
         "client" | "producer" | "consumer"
     )
 }
@@ -1221,12 +1217,16 @@ mod tests {
             // Span with peer tags with peertags aggregation enabled
             (
                 SpanSlice {
-                    service: "service",
-                    name: "op",
-                    resource: "res",
+                    service: Cow::Borrowed("service"),
+                    name: Cow::Borrowed("op"),
+                    resource: Cow::Borrowed("res"),
                     span_id: 1,
                     parent_id: 0,
-                    meta: vec![("span.kind", "client"), ("aws.s3.bucket", "bucket-a")].into(),
+                    meta: vec![
+                        (Cow::Borrowed("span.kind"), Cow::Borrowed("client")),
+                        (Cow::Borrowed("aws.s3.bucket"), Cow::Borrowed("bucket-a")),
+                    ]
+                    .into(),
                     ..Default::default()
                 },
                 FixedAggregationKey {
@@ -1242,16 +1242,19 @@ mod tests {
             // Span with multiple peer tags with peertags aggregation enabled
             (
                 SpanSlice {
-                    service: "service",
-                    name: "op",
-                    resource: "res",
+                    service: Cow::Borrowed("service"),
+                    name: Cow::Borrowed("op"),
+                    resource: Cow::Borrowed("res"),
                     span_id: 1,
                     parent_id: 0,
                     meta: vec![
-                        ("span.kind", "producer"),
-                        ("aws.s3.bucket", "bucket-a"),
-                        ("db.instance", "dynamo.test.us1"),
-                        ("db.system", "dynamodb"),
+                        (Cow::Borrowed("span.kind"), Cow::Borrowed("producer")),
+                        (Cow::Borrowed("aws.s3.bucket"), Cow::Borrowed("bucket-a")),
+                        (
+                            Cow::Borrowed("db.instance"),
+                            Cow::Borrowed("dynamo.test.us1"),
+                        ),
+                        (Cow::Borrowed("db.system"), Cow::Borrowed("dynamodb")),
                     ]
                     .into(),
                     ..Default::default()
@@ -1274,16 +1277,19 @@ mod tests {
             // server
             (
                 SpanSlice {
-                    service: "service",
-                    name: "op",
-                    resource: "res",
+                    service: Cow::Borrowed("service"),
+                    name: Cow::Borrowed("op"),
+                    resource: Cow::Borrowed("res"),
                     span_id: 1,
                     parent_id: 0,
                     meta: vec![
-                        ("span.kind", "server"),
-                        ("aws.s3.bucket", "bucket-a"),
-                        ("db.instance", "dynamo.test.us1"),
-                        ("db.system", "dynamodb"),
+                        (Cow::Borrowed("span.kind"), Cow::Borrowed("server")),
+                        (Cow::Borrowed("aws.s3.bucket"), Cow::Borrowed("bucket-a")),
+                        (
+                            Cow::Borrowed("db.instance"),
+                            Cow::Borrowed("dynamo.test.us1"),
+                        ),
+                        (Cow::Borrowed("db.system"), Cow::Borrowed("dynamodb")),
                     ]
                     .into(),
                     ..Default::default()
@@ -1330,15 +1336,15 @@ mod tests {
 
         // IPv4 address peer tag gets replaced with blocked-ip-address
         let span_ipv4 = SpanSlice {
-            service: "service",
-            name: "op",
-            resource: "res",
+            service: Cow::Borrowed("service"),
+            name: Cow::Borrowed("op"),
+            resource: Cow::Borrowed("res"),
             span_id: 1,
             parent_id: 0,
             meta: vec![
-                ("span.kind", "client"),
-                ("peer.hostname", "10.1.2.3"),
-                ("db.instance", "my-db"),
+                (Cow::Borrowed("span.kind"), Cow::Borrowed("client")),
+                (Cow::Borrowed("peer.hostname"), Cow::Borrowed("10.1.2.3")),
+                (Cow::Borrowed("db.instance"), Cow::Borrowed("my-db")),
             ]
             .into(),
             ..Default::default()
@@ -1358,14 +1364,17 @@ mod tests {
 
         // IPv6 address peer tag gets replaced with blocked-ip-address
         let span_ipv6 = SpanSlice {
-            service: "service",
-            name: "op",
-            resource: "res",
+            service: Cow::Borrowed("service"),
+            name: Cow::Borrowed("op"),
+            resource: Cow::Borrowed("res"),
             span_id: 1,
             parent_id: 0,
             meta: vec![
-                ("span.kind", "client"),
-                ("peer.hostname", "2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF"),
+                (Cow::Borrowed("span.kind"), Cow::Borrowed("client")),
+                (
+                    Cow::Borrowed("peer.hostname"),
+                    Cow::Borrowed("2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF"),
+                ),
             ]
             .into(),
             ..Default::default()
@@ -1383,12 +1392,19 @@ mod tests {
 
         // Non-IP peer tags pass through unchanged
         let span_non_ip = SpanSlice {
-            service: "service",
-            name: "op",
-            resource: "res",
+            service: Cow::Borrowed("service"),
+            name: Cow::Borrowed("op"),
+            resource: Cow::Borrowed("res"),
             span_id: 1,
             parent_id: 0,
-            meta: vec![("span.kind", "client"), ("db.instance", "dynamo.test.us1")].into(),
+            meta: vec![
+                (Cow::Borrowed("span.kind"), Cow::Borrowed("client")),
+                (
+                    Cow::Borrowed("db.instance"),
+                    Cow::Borrowed("dynamo.test.us1"),
+                ),
+            ]
+            .into(),
             ..Default::default()
         };
         let non_ip_keys = vec!["db.instance".to_string()];

--- a/libdd-trace-stats/src/span_concentrator/tests.rs
+++ b/libdd-trace-stats/src/span_concentrator/tests.rs
@@ -7,6 +7,7 @@ use super::*;
 use libdd_trace_utils::span::v04::VecMap;
 use libdd_trace_utils::span::{trace_utils::compute_top_level_span, v04::SpanSlice};
 use rand::{thread_rng, Rng};
+use std::borrow::Cow;
 
 const BUCKET_SIZE: u64 = Duration::from_secs(2).as_nanos() as u64;
 
@@ -45,11 +46,11 @@ fn get_test_span<'a>(
         parent_id,
         duration,
         start: get_timestamp_in_bucket(aligned_now, BUCKET_SIZE, offset) as i64 - duration,
-        service,
-        name: "query",
-        resource,
+        service: Cow::Borrowed(service),
+        name: Cow::Borrowed("query"),
+        resource: Cow::Borrowed(resource),
         error,
-        r#type: "db",
+        r#type: Cow::Borrowed("db"),
         ..Default::default()
     }
 }
@@ -71,11 +72,11 @@ fn get_test_span_with_meta<'a>(
         now, span_id, parent_id, duration, offset, service, resource, error,
     );
     for (k, v) in meta {
-        span.meta.insert(*k, *v);
+        span.meta.insert(Cow::Borrowed(*k), Cow::Borrowed(*v));
     }
     span.metrics = VecMap::new();
     for (k, v) in metrics {
-        span.metrics.insert(*k, *v);
+        span.metrics.insert(Cow::Borrowed(*k), *v);
     }
     span
 }
@@ -688,7 +689,7 @@ fn test_ignore_partial_spans() {
         .get_mut(0)
         .unwrap()
         .metrics
-        .insert("_dd.partial_version", 830604.0);
+        .insert(Cow::Borrowed("_dd.partial_version"), 830604.0);
     compute_top_level_span(spans.as_mut_slice());
     let mut concentrator = SpanConcentrator::new(
         Duration::from_nanos(BUCKET_SIZE),
@@ -1230,112 +1231,112 @@ fn test_compute_stats_for_span_kind() {
     let test_cases: Vec<(SpanSlice, bool)> = vec![
         (
             SpanSlice {
-                meta: vec![("span.kind", "server")].into(),
+                meta: vec![(Cow::Borrowed("span.kind"), Cow::Borrowed("server"))].into(),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: vec![("span.kind", "consumer")].into(),
+                meta: vec![(Cow::Borrowed("span.kind"), Cow::Borrowed("consumer"))].into(),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: vec![("span.kind", "client")].into(),
+                meta: vec![(Cow::Borrowed("span.kind"), Cow::Borrowed("client"))].into(),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: vec![("span.kind", "producer")].into(),
+                meta: vec![(Cow::Borrowed("span.kind"), Cow::Borrowed("producer"))].into(),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: vec![("span.kind", "internal")].into(),
+                meta: vec![(Cow::Borrowed("span.kind"), Cow::Borrowed("internal"))].into(),
                 ..Default::default()
             },
             false,
         ),
         (
             SpanSlice {
-                meta: vec![("span.kind", "SERVER")].into(),
+                meta: vec![(Cow::Borrowed("span.kind"), Cow::Borrowed("SERVER"))].into(),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: vec![("span.kind", "CONSUMER")].into(),
+                meta: vec![(Cow::Borrowed("span.kind"), Cow::Borrowed("CONSUMER"))].into(),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: vec![("span.kind", "CLIENT")].into(),
+                meta: vec![(Cow::Borrowed("span.kind"), Cow::Borrowed("CLIENT"))].into(),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: vec![("span.kind", "PRODUCER")].into(),
+                meta: vec![(Cow::Borrowed("span.kind"), Cow::Borrowed("PRODUCER"))].into(),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: vec![("span.kind", "INTERNAL")].into(),
+                meta: vec![(Cow::Borrowed("span.kind"), Cow::Borrowed("INTERNAL"))].into(),
                 ..Default::default()
             },
             false,
         ),
         (
             SpanSlice {
-                meta: vec![("span.kind", "SerVER")].into(),
+                meta: vec![(Cow::Borrowed("span.kind"), Cow::Borrowed("SerVER"))].into(),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: vec![("span.kind", "ConSUMeR")].into(),
+                meta: vec![(Cow::Borrowed("span.kind"), Cow::Borrowed("ConSUMeR"))].into(),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: vec![("span.kind", "CLiENT")].into(),
+                meta: vec![(Cow::Borrowed("span.kind"), Cow::Borrowed("CLiENT"))].into(),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: vec![("span.kind", "PROducER")].into(),
+                meta: vec![(Cow::Borrowed("span.kind"), Cow::Borrowed("PROducER"))].into(),
                 ..Default::default()
             },
             true,
         ),
         (
             SpanSlice {
-                meta: vec![("span.kind", "INtERNAL")].into(),
+                meta: vec![(Cow::Borrowed("span.kind"), Cow::Borrowed("INtERNAL"))].into(),
                 ..Default::default()
             },
             false,
         ),
         (
             SpanSlice {
-                meta: vec![("span.kind", "")].into(),
+                meta: vec![(Cow::Borrowed("span.kind"), Cow::Borrowed(""))].into(),
                 ..Default::default()
             },
             false,
@@ -2931,10 +2932,10 @@ fn test_concentrator_truncate_fields_helper(big_resource: bool, obfuscation: boo
         duration,
         start: get_timestamp_in_bucket(aligned_now, BUCKET_SIZE, 5) as i64 - duration,
         error: 0,
-        name: &"query".repeat(20_000),
-        resource: &"🤠".repeat(20_000),
-        service: &"A".repeat(20_000),
-        r#type: &"🫵".repeat(20_000),
+        name: Cow::Owned("query".repeat(20_000)),
+        resource: Cow::Owned("🤠".repeat(20_000)),
+        service: Cow::Owned("A".repeat(20_000)),
+        r#type: Cow::Owned("🫵".repeat(20_000)),
         ..Default::default()
     };
 

--- a/libdd-trace-stats/src/stats_exporter.rs
+++ b/libdd-trace-stats/src/stats_exporter.rs
@@ -347,6 +347,7 @@ mod tests {
     use libdd_shared_runtime::{BlockingRuntime, ForkSafeRuntime, SharedRuntime};
     use libdd_trace_utils::span::{trace_utils, v04::SpanSlice};
     use libdd_trace_utils::test_utils::poll_for_mock_hit;
+    use std::borrow::Cow;
     use time::Duration;
     use time::SystemTime;
 
@@ -402,7 +403,7 @@ mod tests {
 
         for i in 1..100 {
             trace.push(SpanSlice {
-                service: "libdatadog-test",
+                service: Cow::Borrowed("libdatadog-test"),
                 duration: i,
                 ..Default::default()
             })
@@ -685,32 +686,35 @@ mod tests {
 
         let mut trace = vec![
             SpanSlice {
-                service: "svc-a",
-                resource: "resource-a",
+                service: Cow::Borrowed("svc-a"),
+                resource: Cow::Borrowed("resource-a"),
                 duration: 10,
-                meta: VecMap::from_iter([("http.endpoint", "/")]),
+                meta: VecMap::from_iter([(Cow::Borrowed("http.endpoint"), Cow::Borrowed("/"))]),
                 ..Default::default()
             },
             // only resource get collapsed if per-key limits are enabled
             SpanSlice {
-                service: "svc-a",
-                resource: "resource-b",
+                service: Cow::Borrowed("svc-a"),
+                resource: Cow::Borrowed("resource-b"),
                 duration: 20,
-                meta: VecMap::from_iter([("http.endpoint", "/")]),
+                meta: VecMap::from_iter([(Cow::Borrowed("http.endpoint"), Cow::Borrowed("/"))]),
                 ..Default::default()
             },
             // both resource and http_endpoint get collapsed if per-key limits are enabled
             SpanSlice {
-                service: "svc-b",
-                resource: "resource-c",
+                service: Cow::Borrowed("svc-b"),
+                resource: Cow::Borrowed("resource-c"),
                 duration: 20,
-                meta: VecMap::from_iter([("http.endpoint", "/hello.txt")]),
+                meta: VecMap::from_iter([(
+                    Cow::Borrowed("http.endpoint"),
+                    Cow::Borrowed("/hello.txt"),
+                )]),
                 ..Default::default()
             },
             // both resource and http_endpoint get collapsed if per-key limits are enabled
             SpanSlice {
-                service: "svc-b",
-                resource: "resource-b",
+                service: Cow::Borrowed("svc-b"),
+                resource: Cow::Borrowed("resource-b"),
                 duration: 20,
                 ..Default::default()
             },

--- a/libdd-trace-utils/benches/deserialization.rs
+++ b/libdd-trace-utils/benches/deserialization.rs
@@ -5,6 +5,7 @@ use std::alloc::System;
 
 use criterion::{black_box, criterion_group, Criterion};
 use libdd_common::bench_utils::{memory_allocated_measurement, AllocatedBytesMeasurement};
+use libdd_trace_utils::msgpack_decoder;
 use libdd_trace_utils::tracer_payload::{decode_to_trace_chunks, TraceEncoding};
 use serde_json::{json, Value};
 
@@ -106,9 +107,48 @@ fn deserialize_msgpack_to_internal_allocs(c: &mut Criterion<AllocatedBytesMeasur
     );
 }
 
-criterion_group!(deserialize_benches, deserialize_msgpack_to_internal);
+/// Slice/borrowed deserialization path: decodes into `SpanSlice` (backed by `SliceData`, whose
+/// `Text` is `Cow<'a, str>`). This is the path affected by the `&str` -> `Cow` `SpanText` change,
+/// unlike `decode_to_trace_chunks` which decodes into owned `BytesData`.
+fn deserialize_msgpack_to_slice(c: &mut Criterion) {
+    let data = rmp_serde::to_vec(&generate_trace_chunks(20, 2_075))
+        .expect("Failed to serialize test spans.");
+
+    c.bench_function(
+        "benching deserializing traces from msgpack to borrowed slice representation",
+        |b| {
+            b.iter(|| {
+                let result = black_box(msgpack_decoder::v04::from_slice(&data));
+                assert!(result.is_ok());
+                result
+            });
+        },
+    );
+}
+
+fn deserialize_msgpack_to_slice_allocs(c: &mut Criterion<AllocatedBytesMeasurement<System>>) {
+    let data = rmp_serde::to_vec(&generate_trace_chunks(20, 2_075))
+        .expect("Failed to serialize test spans.");
+
+    c.bench_function(
+        "benching deserializing traces from msgpack to borrowed slice representation (allocs)",
+        |b| {
+            b.iter(|| {
+                let result = black_box(msgpack_decoder::v04::from_slice(&data));
+                assert!(result.is_ok());
+                result
+            });
+        },
+    );
+}
+
+criterion_group!(
+    deserialize_benches,
+    deserialize_msgpack_to_internal,
+    deserialize_msgpack_to_slice
+);
 criterion_group!(
     name = deserialize_alloc_benches;
     config = memory_allocated_measurement(&super::GLOBAL);
-    targets = deserialize_msgpack_to_internal_allocs
+    targets = deserialize_msgpack_to_internal_allocs, deserialize_msgpack_to_slice_allocs
 );

--- a/libdd-trace-utils/src/change_buffer/mod.rs
+++ b/libdd-trace-utils/src/change_buffer/mod.rs
@@ -738,6 +738,7 @@ where
 mod segment_isolation_tests {
     use super::*;
     use crate::span::SliceData;
+    use std::borrow::Cow;
 
     // -----------------------------------------------------------------------
     // Minimal builder for the raw change-buffer byte format.
@@ -793,7 +794,12 @@ mod segment_isolation_tests {
                 buf_data.len(),
             )
         };
-        ChangeBufferState::new(cb, "test-service", "javascript", 1)
+        ChangeBufferState::new(
+            cb,
+            Cow::Borrowed("test-service"),
+            Cow::Borrowed("javascript"),
+            1,
+        )
     }
 
     // -----------------------------------------------------------------------
@@ -833,8 +839,8 @@ mod segment_isolation_tests {
 
         let mut buf_data = w.finish();
         let mut state = make_state(&mut buf_data);
-        state.string_table_insert_one(0, "origin-A");
-        state.string_table_insert_one(1, "origin-B");
+        state.string_table_insert_one(0, Cow::Borrowed("origin-A"));
+        state.string_table_insert_one(1, Cow::Borrowed("origin-B"));
 
         state.flush_change_buffer().unwrap();
 
@@ -845,7 +851,7 @@ mod segment_isolation_tests {
         // Segment 1 must carry its own origin, not segment 2's.
         assert_eq!(
             spans[0].meta.get("_dd.origin"),
-            Some(&"origin-A"),
+            Some(&Cow::Borrowed("origin-A")),
             "segment 1 origin was overwritten by segment 2's SetTraceOrigin"
         );
     }
@@ -874,9 +880,9 @@ mod segment_isolation_tests {
 
         let mut buf_data = w.finish();
         let mut state = make_state(&mut buf_data);
-        state.string_table_insert_one(0, "env");
-        state.string_table_insert_one(1, "production");
-        state.string_table_insert_one(2, "staging");
+        state.string_table_insert_one(0, Cow::Borrowed("env"));
+        state.string_table_insert_one(1, Cow::Borrowed("production"));
+        state.string_table_insert_one(2, Cow::Borrowed("staging"));
 
         state.flush_change_buffer().unwrap();
 
@@ -886,7 +892,7 @@ mod segment_isolation_tests {
         // Segment 1's chunk root must not carry segment 2's value.
         assert_eq!(
             spans[0].meta.get("env"),
-            Some(&"production"),
+            Some(&Cow::Borrowed("production")),
             "segment 1 trace meta was polluted by segment 2's SetTraceMetaAttr"
         );
     }
@@ -932,9 +938,9 @@ mod segment_isolation_tests {
         buf_data[..first_buf.len()].copy_from_slice(&first_buf);
 
         let mut state = make_state(&mut buf_data);
-        state.string_table_insert_one(0, "key");
-        state.string_table_insert_one(1, "val");
-        state.string_table_insert_one(2, "service-B");
+        state.string_table_insert_one(0, Cow::Borrowed("key"));
+        state.string_table_insert_one(1, Cow::Borrowed("val"));
+        state.string_table_insert_one(2, Cow::Borrowed("service-B"));
 
         // First flush: creates span A.
         state.flush_change_buffer().unwrap();
@@ -988,8 +994,8 @@ mod segment_isolation_tests {
         buf_data[..first_buf.len()].copy_from_slice(&first_buf);
 
         let mut state = make_state(&mut buf_data);
-        state.string_table_insert_one(0, "key");
-        state.string_table_insert_one(2, "service-B");
+        state.string_table_insert_one(0, Cow::Borrowed("key"));
+        state.string_table_insert_one(2, Cow::Borrowed("service-B"));
 
         state.flush_change_buffer().unwrap();
 
@@ -1030,7 +1036,7 @@ mod segment_isolation_tests {
 
         let mut buf_data = w.finish();
         let mut state = make_state(&mut buf_data);
-        state.string_table_insert_one(0, "priority");
+        state.string_table_insert_one(0, Cow::Borrowed("priority"));
 
         state.flush_change_buffer().unwrap();
 

--- a/libdd-trace-utils/src/msgpack_encoder/v04/mod.rs
+++ b/libdd-trace-utils/src/msgpack_encoder/v04/mod.rs
@@ -112,10 +112,11 @@ fn to_writer<W: RmpWrite, T: TraceData, S: AsRef<[Span<T>]>>(
 /// ```
 /// use libdd_trace_utils::msgpack_encoder::v04::write_to_slice_from_v04;
 /// use libdd_trace_utils::span::v04::SpanSlice;
+/// use std::borrow::Cow;
 ///
 /// let mut buffer = vec![0u8; 1024];
 /// let span = SpanSlice {
-///     name: "test-span",
+///     name: Cow::Borrowed("test-span"),
 ///     ..Default::default()
 /// };
 /// let traces = vec![vec![span]];
@@ -144,9 +145,10 @@ pub fn write_to_slice_from_v04<T: TraceData, S: AsRef<[Span<T>]>>(
 /// ```
 /// use libdd_trace_utils::msgpack_encoder::v04::to_vec_from_v04;
 /// use libdd_trace_utils::span::v04::SpanSlice;
+/// use std::borrow::Cow;
 ///
 /// let span = SpanSlice {
-///     name: "test-span",
+///     name: Cow::Borrowed("test-span"),
 ///     ..Default::default()
 /// };
 /// let traces = vec![vec![span]];
@@ -174,9 +176,10 @@ pub fn to_vec_from_v04<T: TraceData, S: AsRef<[Span<T>]>>(traces: &[S]) -> Vec<u
 /// ```
 /// use libdd_trace_utils::msgpack_encoder::v04::to_vec_with_capacity_from_v04;
 /// use libdd_trace_utils::span::v04::SpanSlice;
+/// use std::borrow::Cow;
 ///
 /// let span = SpanSlice {
-///     name: "test-span",
+///     name: Cow::Borrowed("test-span"),
 ///     ..Default::default()
 /// };
 /// let traces = vec![vec![span]];
@@ -213,9 +216,10 @@ pub fn to_vec_with_capacity_from_v04<T: TraceData, S: AsRef<[Span<T>]>>(
 /// ```
 /// use libdd_trace_utils::msgpack_encoder::v04::to_encoded_byte_len_from_v04;
 /// use libdd_trace_utils::span::v04::SpanSlice;
+/// use std::borrow::Cow;
 ///
 /// let span = SpanSlice {
-///     name: "test-span",
+///     name: Cow::Borrowed("test-span"),
 ///     ..Default::default()
 /// };
 /// let traces = vec![vec![span]];

--- a/libdd-trace-utils/src/span/mod.rs
+++ b/libdd-trace-utils/src/span/mod.rs
@@ -13,7 +13,7 @@ use crate::msgpack_decoder::decode::error::DecodeError;
 use crate::span::v05::dict::SharedDict;
 use libdd_tinybytes::{Bytes, BytesString};
 use serde::Serialize;
-use std::borrow::Borrow;
+use std::borrow::{Borrow, Cow};
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::marker::PhantomData;
@@ -49,11 +49,17 @@ pub trait SpanText: Debug + Eq + Hash + Borrow<str> + Serialize + Default {
     fn to_bytes_string(&self) -> BytesString {
         BytesString::from(<Self as Borrow<str>>::borrow(self).to_string())
     }
+
+    fn from_owned(value: String) -> Self;
 }
 
-impl SpanText for &str {
+impl SpanText for Cow<'_, str> {
     fn from_static_str(value: &'static str) -> Self {
-        value
+        Cow::Borrowed(value)
+    }
+
+    fn from_owned(value: String) -> Self {
+        Cow::Owned(value)
     }
 }
 
@@ -64,6 +70,10 @@ impl SpanText for BytesString {
 
     fn to_bytes_string(&self) -> BytesString {
         self.clone()
+    }
+
+    fn from_owned(value: String) -> Self {
+        BytesString::from_string(value)
     }
 }
 
@@ -167,7 +177,7 @@ impl DeserializableTraceData for BytesData {
 #[derive(Clone, Default, Debug, PartialEq, Serialize)]
 pub struct SliceData<'a>(PhantomData<&'a u8>);
 impl<'a> TraceData for SliceData<'a> {
-    type Text = &'a str;
+    type Text = Cow<'a, str>;
     type Bytes = &'a [u8];
 }
 
@@ -185,18 +195,18 @@ impl<'a> DeserializableTraceData for SliceData<'a> {
     }
 
     #[inline]
-    fn read_string(buf: &mut &'a [u8]) -> Result<&'a str, DecodeError> {
+    fn read_string(buf: &mut &'a [u8]) -> Result<Cow<'a, str>, DecodeError> {
         read_string_ref_nomut(buf).map(|(str, newbuf)| {
             *buf = newbuf;
-            str
+            Cow::Borrowed(str)
         })
     }
 
     #[inline]
-    fn intern_skipped_str(_owner: &&'a [u8], s: &'static str) -> &'a str {
+    fn intern_skipped_str(_owner: &&'a [u8], s: &'static str) -> Cow<'a, str> {
         // No refcounted allocation to preserve here: `s` borrows from a plain slice the
         // caller owns for `'a`, and a `'static` reference is always a valid `'a` reference.
-        s
+        Cow::Borrowed(s)
     }
 }
 

--- a/libdd-trace-utils/src/span/v04/mod.rs
+++ b/libdd-trace-utils/src/span/v04/mod.rs
@@ -339,6 +339,7 @@ mod tests {
     use crate::msgpack_decoder::decode::buffer::Buffer;
     use crate::msgpack_decoder::v04::span::decode_span;
     use crate::span::SliceData;
+    use std::borrow::Cow;
     use std::collections::HashMap;
 
     #[test]
@@ -352,42 +353,50 @@ mod tests {
     #[test]
     fn serialize_deserialize_test() {
         let span: Span<SliceData<'_>> = Span {
-            name: "tracing.operation",
-            resource: "MyEndpoint",
+            name: Cow::Borrowed("tracing.operation"),
+            resource: Cow::Borrowed("MyEndpoint"),
             span_links: vec![SpanLink {
                 trace_id: 42,
-                attributes: HashMap::from([("span", "link")]),
-                tracestate: "running",
+                attributes: HashMap::from([(Cow::Borrowed("span"), Cow::Borrowed("link"))]),
+                tracestate: Cow::Borrowed("running"),
                 ..Default::default()
             }],
             span_events: vec![SpanEvent {
                 time_unix_nano: 1727211691770716000,
-                name: "exception",
+                name: Cow::Borrowed("exception"),
                 attributes: HashMap::from([
                     (
-                        "exception.message",
-                        AttributeAnyValue::SingleValue(AttributeArrayValue::String(
+                        Cow::Borrowed("exception.message"),
+                        AttributeAnyValue::SingleValue(AttributeArrayValue::String(Cow::Borrowed(
                             "Cannot divide by zero",
-                        )),
+                        ))),
                     ),
                     (
-                        "exception.type",
-                        AttributeAnyValue::SingleValue(AttributeArrayValue::String("RuntimeError")),
+                        Cow::Borrowed("exception.type"),
+                        AttributeAnyValue::SingleValue(AttributeArrayValue::String(Cow::Borrowed(
+                            "RuntimeError",
+                        ))),
                     ),
                     (
-                        "exception.escaped",
+                        Cow::Borrowed("exception.escaped"),
                         AttributeAnyValue::SingleValue(AttributeArrayValue::Boolean(false)),
                     ),
                     (
-                        "exception.count",
+                        Cow::Borrowed("exception.count"),
                         AttributeAnyValue::SingleValue(AttributeArrayValue::Integer(1)),
                     ),
                     (
-                        "exception.lines",
+                        Cow::Borrowed("exception.lines"),
                         AttributeAnyValue::Array(vec![
-                            AttributeArrayValue::String("  File \"<string>\", line 1, in <module>"),
-                            AttributeArrayValue::String("  File \"<string>\", line 1, in divide"),
-                            AttributeArrayValue::String("RuntimeError: Cannot divide by zero"),
+                            AttributeArrayValue::String(Cow::Borrowed(
+                                "  File \"<string>\", line 1, in <module>",
+                            )),
+                            AttributeArrayValue::String(Cow::Borrowed(
+                                "  File \"<string>\", line 1, in divide",
+                            )),
+                            AttributeArrayValue::String(Cow::Borrowed(
+                                "RuntimeError: Cannot divide by zero",
+                            )),
                         ]),
                     ),
                 ]),
@@ -428,9 +437,9 @@ mod tests {
         let span: Span<SliceData<'_>> = Span {
             span_events: vec![SpanEvent {
                 time_unix_nano: 1727211691770716000,
-                name: "test",
+                name: Cow::Borrowed("test"),
                 attributes: HashMap::from([(
-                    "test.event",
+                    Cow::Borrowed("test.event"),
                     AttributeAnyValue::SingleValue(AttributeArrayValue::Double(4.2)),
                 )]),
             }],


### PR DESCRIPTION
# Motivation

Obfuscation requires modifying spans in place, and re-writing strings. This is the most natural way to do this.

# What does this PR do?

Add from_owned to SpanText