### PR TITLE
fix(crashtracking): introduce polling timeout for sigchld bin test

### DIFF
--- a/bin_tests/src/modes/behavior.rs
+++ b/bin_tests/src/modes/behavior.rs
@@ -8,6 +8,7 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::Path;
 use std::sync::atomic::{AtomicPtr, Ordering};
+use std::time::{Duration, Instant};
 
 use crate::modes::unix::*;
 use nix::sys::socket;
@@ -29,6 +30,33 @@ pub fn file_content_equals(filepath: &Path, contents: &str) -> anyhow::Result<bo
     let file_contents = std::fs::read_to_string(filepath)
         .with_context(|| format!("Failed to read file: {}", filepath.display()))?;
     Ok(file_contents.trim() == contents)
+}
+
+/// How long to wait for an asynchronously delivered signal's handler to publish its result.
+pub const SIGNAL_HANDLER_TIMEOUT: Duration = Duration::from_secs(5);
+
+const SIGNAL_HANDLER_POLL_INTERVAL: Duration = Duration::from_millis(1);
+
+/// Waits for `filepath` to contain `contents`, polling until `timeout` elapses.
+pub fn wait_for_file_content(filepath: &Path, contents: &str, timeout: Duration) -> Result<()> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        // Reading directly (rather than through `file_content_equals`) keeps whatever the last
+        // observation was around for the error message.
+        let observed = std::fs::read_to_string(filepath);
+        if matches!(&observed, Ok(found) if found.trim() == contents) {
+            return Ok(());
+        }
+
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "File {} did not contain {contents:?} within {timeout:?}, last read: {observed:?}",
+                filepath.display()
+            );
+        }
+
+        std::thread::sleep(SIGNAL_HANDLER_POLL_INTERVAL);
+    }
 }
 
 pub fn file_append_msg(filepath: &Path, contents: &str) -> Result<()> {

--- a/bin_tests/src/modes/unix/test_002_sigchld.rs
+++ b/bin_tests/src/modes/unix/test_002_sigchld.rs
@@ -15,7 +15,7 @@
 use crate::modes::behavior::Behavior;
 use crate::modes::behavior::{
     atom_to_clone, file_write_msg, fileat_content_equals, remove_permissive, removeat_permissive,
-    set_atomic,
+    set_atomic, wait_for_file_content, SIGNAL_HANDLER_TIMEOUT,
 };
 
 use libc;
@@ -98,13 +98,9 @@ fn inner(output_dir: &Path, filename: &str) -> anyhow::Result<()> {
     }
 
     // Now check the output file.  Strongly assumes that nothing happened to change the value of
-    // OUTPUT_FILE within the handler.
-    match fileat_content_equals(output_dir, filename, "O") {
-        Ok(true) => (), // Expected, do nothing
-        _ => {
-            anyhow::bail!("Output file {:?}/{} was not 'O'", output_dir, filename);
-        }
-    }
+    // OUTPUT_FILE within the handler.  The handler runs asynchronously, so the file is waited on
+    // rather than checked once.
+    wait_for_file_content(&ofile, "O", SIGNAL_HANDLER_TIMEOUT)?;
 
     // Delete the file and the INVALID file to remove any previous state
     remove_permissive(&ofile);

--- a/bin_tests/src/modes/unix/test_003_sigchld_with_exec.rs
+++ b/bin_tests/src/modes/unix/test_003_sigchld_with_exec.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::modes::behavior::Behavior;
 use crate::modes::behavior::{
-    atom_to_clone, file_content_equals, file_write_msg, fileat_content_equals, remove_permissive,
-    removeat_permissive, set_atomic,
+    atom_to_clone, file_write_msg, fileat_content_equals, remove_permissive, removeat_permissive,
+    set_atomic, wait_for_file_content, SIGNAL_HANDLER_TIMEOUT,
 };
 
 use libc;
@@ -76,13 +76,9 @@ fn inner(output_dir: &Path, filename: &str) -> anyhow::Result<()> {
     let _ = child.wait();
 
     // Now check the output file.  Strongly assumes that nothing happened to change the value of
-    // OUTPUT_FILE within the handler.
-    match file_content_equals(&ofile, "O") {
-        Ok(true) => (), // Expected, do nothing
-        _ => {
-            anyhow::bail!("Output file {:?}/{} was not 'O'", output_dir, filename);
-        }
-    }
+    // OUTPUT_FILE within the handler.  The handler runs asynchronously, so the file is waited on
+    // rather than checked once.
+    wait_for_file_content(&ofile, "O", SIGNAL_HANDLER_TIMEOUT)?;
 
     // Delete the file and the INVALID file to remove any previous state
     remove_permissive(&ofile);

--- a/bin_tests/src/modes/unix/test_006_sigchld_sigstack.rs
+++ b/bin_tests/src/modes/unix/test_006_sigchld_sigstack.rs
@@ -5,8 +5,8 @@
 // crashtracker when the altstack is used.
 use crate::modes::behavior::Behavior;
 use crate::modes::behavior::{
-    atom_to_clone, file_content_equals, file_write_msg, fileat_content_equals, remove_permissive,
-    removeat_permissive, set_atomic,
+    atom_to_clone, file_write_msg, fileat_content_equals, remove_permissive, removeat_permissive,
+    set_atomic, wait_for_file_content, SIGNAL_HANDLER_TIMEOUT,
 };
 
 use libc;
@@ -91,13 +91,9 @@ fn inner(output_dir: &Path, filename: &str) -> anyhow::Result<()> {
     }
 
     // Now check the output file.  Strongly assumes that nothing happened to change the value of
-    // OUTPUT_FILE within the handler.
-    match file_content_equals(&ofile, "O") {
-        Ok(true) => (), // Expected, do nothing
-        _ => {
-            anyhow::bail!("Output file {:?}/{} was not 'O'", output_dir, filename);
-        }
-    }
+    // OUTPUT_FILE within the handler.  The handler runs asynchronously, so the file is waited on
+    // rather than checked once.
+    wait_for_file_content(&ofile, "O", SIGNAL_HANDLER_TIMEOUT)?;
 
     // Delete the file and the INVALID file to remove any previous state
     remove_permissive(&ofile);


### PR DESCRIPTION
# What does this PR do?

This implements a polling check on file contents for bin tests where the handler writes some value post signal instead of a one shot check


# Motivation

The kernel can mark the child reapable before it posts the signal, so a `waitpid` loop can see ECHILD while the handler has yet to run. Handlers that publish their result through a file therefore have to be waited on rather than checked once.

We have noticed flakes [as such](https://github.com/DataDog/libdatadog/actions/runs/32725689151/job/97426405751#:~:text=stderr%20%E2%94%80%E2%94%80%E2%94%80,was%20not%20%27O%27)

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
