### PR TITLE
fix(rc): avoid depending on the crypto nodejs API for remote config

### DIFF
--- a/libdd-remote-config/Cargo.toml
+++ b/libdd-remote-config/Cargo.toml
@@ -28,6 +28,7 @@ client = [
     "base64",
     "sha2",
     "uuid",
+    "getrandom",
     "dep:futures",
     "futures-util",
     "tokio",
@@ -58,7 +59,8 @@ http-body-util = { version = "0.1", optional = true }
 http = { version = "1.1", optional = true }
 base64 = { version = "0.22.1", optional = true }
 sha2 = { version = "0.10", optional = true }
-uuid = { workspace = true, features = ["v4", "std"], optional = true }
+getrandom = { version = "0.2", optional = true }
+uuid = { workspace = true, features = ["std"], optional = true }
 futures-util = { version = "0.3", optional = true }
 tokio = { workspace = true, optional = true, features = ["macros"] }
 tokio-util = { version = "0.7.10", optional = true }
@@ -95,7 +97,6 @@ hyper-util = { workspace = true, features = [
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
-uuid = { workspace = true, features = ["js", "std"] }
 # For `tuf` ring needs this feature for `SystemRandom` on wasm.
 ring = { version = "0.17", features = ["wasm32_unknown_unknown_js"], optional = true }
 

--- a/libdd-remote-config/src/fetch/mod.rs
+++ b/libdd-remote-config/src/fetch/mod.rs
@@ -25,3 +25,19 @@ pub use multitarget::*;
 #[cfg(not(target_arch = "wasm32"))]
 pub use shared::*;
 pub use single::*;
+
+/// A random UUIDv4 string, used for the ids a fetcher reports itself under.
+///
+/// Workaround to avoid pulling in the "js" feature from uuid crate, which accesses
+/// node APIs in not existing in older node versions.
+pub(crate) fn random_uuid_string() -> String {
+    let mut bytes = [0u8; 16];
+
+    if let Err(error) = getrandom::getrandom(&mut bytes) {
+        tracing::error!("No entropy source for the remote config client id: {error}");
+    }
+
+    uuid::Builder::from_random_bytes(bytes)
+        .into_uuid()
+        .to_string()
+}

--- a/libdd-remote-config/src/fetch/multitarget.rs
+++ b/libdd-remote-config/src/fetch/multitarget.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::fetch::{
-    ConfigApplyState, ConfigFetcherState, ConfigInvariants, ConfigProductCapabilities, FileStorage,
-    RefcountedFile, RefcountingStorage, RefcountingStorageStats, SharedFetcher,
+    random_uuid_string, ConfigApplyState, ConfigFetcherState, ConfigInvariants,
+    ConfigProductCapabilities, FileStorage, RefcountedFile, RefcountingStorage,
+    RefcountingStorageStats, SharedFetcher,
 };
 use crate::{RemoteConfigCapabilities, RemoteConfigProduct, Target};
 use futures_util::future::Shared;
@@ -219,7 +220,7 @@ where
     }
 
     fn generate_synthetic_id() -> String {
-        uuid::Uuid::new_v4().to_string()
+        random_uuid_string()
     }
 
     fn remove_target(

--- a/libdd-remote-config/src/fetch/shared.rs
+++ b/libdd-remote-config/src/fetch/shared.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::fetch::{
-    ConfigApplyState, ConfigClientState, ConfigFetcher, ConfigFetcherState,
+    random_uuid_string, ConfigApplyState, ConfigClientState, ConfigFetcher, ConfigFetcherState,
     ConfigFetcherStateStats, ConfigInvariants, ConfigProductCapabilities, FileStorage,
 };
 use crate::{RemoteConfigPath, Target};
@@ -259,7 +259,7 @@ impl SharedFetcher {
         SharedFetcher {
             target,
             runtime_id: Mutex::new(Arc::new(runtime_id)),
-            client_id: uuid::Uuid::new_v4().to_string(),
+            client_id: random_uuid_string(),
             product_capabilities: Mutex::new(Arc::new(product_capabilities)),
             cancellation: CancellationToken::new(),
             interval: AtomicU64::new(5_000_000_000),

--- a/libdd-remote-config/src/fetch/single.rs
+++ b/libdd-remote-config/src/fetch/single.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::fetch::{
-    ConfigApplyState, ConfigClientState, ConfigFetcher, ConfigFetcherState, ConfigInvariants,
-    ConfigProductCapabilities, FileStorage,
+    random_uuid_string, ConfigApplyState, ConfigClientState, ConfigFetcher, ConfigFetcherState,
+    ConfigInvariants, ConfigProductCapabilities, FileStorage,
 };
 use crate::file_change_tracker::{Change, ChangeTracker, FilePath, UpdatedFiles};
 use crate::{RemoteConfigCapabilities, RemoteConfigPath, RemoteConfigProduct, Target};
@@ -53,7 +53,7 @@ impl<S: FileStorage, C: HttpClientCapability + SleepCapability> SingleFetcher<S,
                 options.capabilities,
             ),
             runtime_id,
-            client_id: uuid::Uuid::new_v4().to_string(),
+            client_id: random_uuid_string(),
             client_state: ConfigClientState::default(),
         })
     }
@@ -79,7 +79,7 @@ impl<S: FileStorage, C: HttpClientCapability + SleepCapability> SingleFetcher<S,
                 options.capabilities,
             ),
             runtime_id,
-            client_id: uuid::Uuid::new_v4().to_string(),
+            client_id: random_uuid_string(),
             client_state: ConfigClientState::default(),
         }
     }


### PR DESCRIPTION
The js feature from the uuid crate pulls that in, so drop it and work around it.