### PR TITLE
fix(ipc)!: gracefully handle SHM errors instead of unwrapping

### DIFF
--- a/datadog-sidecar-ffi/src/lib.rs
+++ b/datadog-sidecar-ffi/src/lib.rs
@@ -212,7 +212,9 @@ pub extern "C" fn ddog_agent_remote_config_write(
     writer: &AgentRemoteConfigWriter<ShmHandle>,
     data: ffi::CharSlice,
 ) {
-    writer.write(data.as_bytes());
+    if let Err(e) = writer.write(data.as_bytes()) {
+        tracing::warn!("Failed to write agent remote config to shared memory: {e}");
+    }
 }
 
 fn ddog_agent_remote_config_read_generic<'a, T>(

--- a/datadog-sidecar/src/agent_remote_config.rs
+++ b/datadog-sidecar/src/agent_remote_config.rs
@@ -90,7 +90,7 @@ impl<T: FileBackedHandle + From<MappedMem<T>>> AgentRemoteConfigReader<T> {
 }
 
 impl<T: FileBackedHandle + From<MappedMem<T>>> AgentRemoteConfigWriter<T> {
-    pub fn write(&self, contents: &[u8]) {
+    pub fn write(&self, contents: &[u8]) -> io::Result<()> {
         self.0.write(contents)
     }
 

--- a/datadog-sidecar/src/service/agent_info.rs
+++ b/datadog-sidecar/src/service/agent_info.rs
@@ -132,20 +132,11 @@ impl AgentInfoFetcher {
                             // `SameState` and other-process shm readers would never observe the
                             // update. Leaving `state` unchanged makes us fetch and retry the write
                             // on the next iteration.
-                            let published = match writer {
-                                Some(ref writer) => {
-                                    match writer.write(&serde_json::to_vec(&status.info).unwrap()) {
-                                        Ok(()) => true,
-                                        Err(e) => {
-                                            error!("Failed to write agent info shm segment: {e}");
-                                            false
-                                        }
-                                    }
+                            if let Some(writer) = &writer {
+                                match writer.write(&serde_json::to_vec(&status.info).unwrap()) {
+                                    Ok(()) => state = Some(status.state_hash),
+                                    Err(e) => error!("Failed to write agent info shm segment: {e}"),
                                 }
-                                None => false,
-                            };
-                            if published {
-                                state = Some(status.state_hash);
                             }
                             if let Some(completer) = completer {
                                 complete_fut = Some(completer.complete(status.info));

--- a/datadog-sidecar/src/service/agent_info.rs
+++ b/datadog-sidecar/src/service/agent_info.rs
@@ -116,7 +116,6 @@ impl AgentInfoFetcher {
                     match fetched {
                         Ok(FetchInfoStatus::SameState) => {}
                         Ok(FetchInfoStatus::NewState(status)) => {
-                            state = Some(status.state_hash);
                             if writer.is_none() {
                                 writer = match OneWayShmWriter::<NamedShmHandle>::new(info_path(
                                     &endpoint,
@@ -128,12 +127,25 @@ impl AgentInfoFetcher {
                                     }
                                 };
                             }
-                            if let Some(ref writer) = writer {
-                                if let Err(e) =
-                                    writer.write(&serde_json::to_vec(&status.info).unwrap())
-                                {
-                                    error!("Failed to write agent info shm segment: {e}");
+                            // Only advance the state hash once the new payload has actually been
+                            // published to shared memory; otherwise the agent will keep reporting
+                            // `SameState` and other-process shm readers would never observe the
+                            // update. Leaving `state` unchanged makes us fetch and retry the write
+                            // on the next iteration.
+                            let published = match writer {
+                                Some(ref writer) => {
+                                    match writer.write(&serde_json::to_vec(&status.info).unwrap()) {
+                                        Ok(()) => true,
+                                        Err(e) => {
+                                            error!("Failed to write agent info shm segment: {e}");
+                                            false
+                                        }
+                                    }
                                 }
+                                None => false,
+                            };
+                            if published {
+                                state = Some(status.state_hash);
                             }
                             if let Some(completer) = completer {
                                 complete_fut = Some(completer.complete(status.info));

--- a/datadog-sidecar/src/service/agent_info.rs
+++ b/datadog-sidecar/src/service/agent_info.rs
@@ -129,7 +129,11 @@ impl AgentInfoFetcher {
                                 };
                             }
                             if let Some(ref writer) = writer {
-                                writer.write(&serde_json::to_vec(&status.info).unwrap())
+                                if let Err(e) =
+                                    writer.write(&serde_json::to_vec(&status.info).unwrap())
+                                {
+                                    error!("Failed to write agent info shm segment: {e}");
+                                }
                             }
                             if let Some(completer) = completer {
                                 complete_fut = Some(completer.complete(status.info));

--- a/datadog-sidecar/src/service/exception_hash_rate_limiter.rs
+++ b/datadog-sidecar/src/service/exception_hash_rate_limiter.rs
@@ -10,15 +10,13 @@ use std::mem::ManuallyDrop;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{LazyLock, Mutex};
 use std::time::Duration;
+use tracing::warn;
 
 pub(crate) static EXCEPTION_HASH_LIMITER: LazyLock<
     Mutex<ManuallyDrop<ManagedExceptionHashRateLimiter>>,
 > = LazyLock::new(|| {
     unsafe { libc::atexit(drop_exception_hash_limiter) };
-    #[allow(clippy::unwrap_used)]
-    Mutex::new(ManuallyDrop::new(
-        ManagedExceptionHashRateLimiter::create().unwrap(),
-    ))
+    Mutex::new(ManuallyDrop::new(ManagedExceptionHashRateLimiter::create()))
 });
 
 extern "C" fn drop_exception_hash_limiter() {
@@ -36,7 +34,7 @@ pub(crate) struct ManagedExceptionHashRateLimiter {
 }
 
 impl ManagedExceptionHashRateLimiter {
-    fn create() -> io::Result<Self> {
+    fn create() -> Self {
         let (send, recv) = tokio::sync::oneshot::channel::<()>();
 
         tokio::spawn(async move {
@@ -58,21 +56,25 @@ impl ManagedExceptionHashRateLimiter {
             }
         });
 
-        Ok(ManagedExceptionHashRateLimiter {
-            limiter: ExceptionHashRateLimiter::create()?,
+        ManagedExceptionHashRateLimiter {
+            limiter: ExceptionHashRateLimiter::create(),
             active: vec![],
             _drop: send,
-        })
+        }
     }
 
     pub fn add(&mut self, hash: u64, granularity: Duration) {
-        let limiter = self.limiter.add(hash, granularity);
-        self.active.push(limiter);
+        if let Some(limiter) = self.limiter.add(hash, granularity) {
+            self.active.push(limiter);
+        }
     }
 }
 
 pub struct ExceptionHashRateLimiter {
-    mem: ShmLimiterMemory<EntryData>,
+    /// `None` when the segment hasn't been created yet, or a previous attempt
+    /// failed (e.g. `ENOSPC`); [`Self::add`] retries creation lazily the next
+    /// time a sample comes in.
+    mem: Option<ShmLimiterMemory<EntryData>>,
 }
 
 struct EntryData {
@@ -95,32 +97,53 @@ fn path() -> CString {
 }
 
 impl ExceptionHashRateLimiter {
-    pub fn create() -> io::Result<Self> {
-        Ok(ExceptionHashRateLimiter {
-            mem: ShmLimiterMemory::create(path())?,
-        })
+    pub fn create() -> Self {
+        ExceptionHashRateLimiter {
+            mem: Self::try_create_mem(),
+        }
+    }
+
+    fn try_create_mem() -> Option<ShmLimiterMemory<EntryData>> {
+        match ShmLimiterMemory::create(path()) {
+            Ok(mem) => Some(mem),
+            Err(e) => {
+                warn!("Failed to create exception hash rate limiter shm segment (will retry): {e}");
+                None
+            }
+        }
     }
 
     pub fn open() -> io::Result<Self> {
         Ok(ExceptionHashRateLimiter {
-            mem: ShmLimiterMemory::open(&path())?,
+            mem: Some(ShmLimiterMemory::open(&path())?),
         })
     }
 
-    fn add(&mut self, hash: u64, granularity: Duration) -> HashLimiter {
-        let allocated = self
-            .mem
-            .alloc_with_granularity(granularity.as_secs() as u32);
+    fn add(&mut self, hash: u64, granularity: Duration) -> Option<HashLimiter> {
+        if self.mem.is_none() {
+            self.mem = Self::try_create_mem();
+        }
+        let mem = self.mem.as_mut()?;
+        let allocated = match mem.alloc_with_granularity(granularity.as_secs() as u32) {
+            Ok(allocated) => allocated,
+            Err(e) => {
+                warn!(
+                    "Failed to allocate exception hash rate limiter entry (will retry on next sample): {e}"
+                );
+                return None;
+            }
+        };
         let data = allocated.data();
         data.hash.store(hash, Ordering::Relaxed);
         allocated.inc(1);
-        HashLimiter { shm: allocated }
+        Some(HashLimiter { shm: allocated })
     }
 
     pub fn find(&self, hash: u64) -> Option<HashLimiter> {
         Some(HashLimiter {
             shm: self
                 .mem
+                .as_ref()?
                 .find(|data| data.hash.load(Ordering::Relaxed) == hash)?,
         })
     }

--- a/datadog-sidecar/src/service/telemetry.rs
+++ b/datadog-sidecar/src/service/telemetry.rs
@@ -492,9 +492,7 @@ impl TelemetryCachedClient {
             match OneWayShmWriter::<NamedShmHandle>::new(self.shm_path.clone()) {
                 Ok(writer) => self.shm_writer = Some(writer),
                 Err(e) => {
-                    warn!(
-                        "Failed to (re)create telemetry shared memory segment: {e}"
-                    );
+                    warn!("Failed to (re)create telemetry shared memory segment: {e}");
                     return;
                 }
             }

--- a/datadog-sidecar/src/service/telemetry.rs
+++ b/datadog-sidecar/src/service/telemetry.rs
@@ -480,12 +480,9 @@ impl TelemetryCachedClient {
     }
 
     pub fn write_shm_file(&mut self) {
-        let buf = match bincode::serialize(&self.shared) {
-            Ok(buf) => buf,
-            Err(_) => {
-                warn!("Failed to serialize telemetry data for shared memory");
-                return;
-            }
+        let Ok(buf) = bincode::serialize(&self.shared) else {
+            warn!("Failed to serialize telemetry data for shared memory");
+            return;
         };
 
         if self.shm_writer.is_none() {

--- a/datadog-sidecar/src/service/telemetry.rs
+++ b/datadog-sidecar/src/service/telemetry.rs
@@ -393,7 +393,9 @@ pub struct TelemetryCachedEntry {
 
 pub struct TelemetryCachedClient {
     pub worker: TelemetryWorkerHandle,
-    pub shm_writer: OneWayShmWriter<NamedShmHandle>,
+    /// `None` when the segment hasn't been created yet, or a previous attempt failed.
+    shm_writer: Option<OneWayShmWriter<NamedShmHandle>>,
+    shm_path: CString,
     pub telemetry_metrics: HashMap<String, ContextKey>,
     pub handle: Option<JoinHandle<()>>,
     pub shared: TelemetryCachedClientShmData,
@@ -458,23 +460,50 @@ impl TelemetryCachedClient {
                 .ok();
         });
 
+        let shm_path = path_for_telemetry(service, env);
+        let shm_writer = match OneWayShmWriter::<NamedShmHandle>::new(shm_path.clone()) {
+            Ok(writer) => Some(writer),
+            Err(e) => {
+                warn!("Failed to create telemetry shared memory segment: {e}");
+                None
+            }
+        };
+
         Self {
             worker: handle,
-            shm_writer: {
-                #[allow(clippy::unwrap_used)]
-                OneWayShmWriter::<NamedShmHandle>::new(path_for_telemetry(service, env)).unwrap()
-            },
+            shm_writer,
+            shm_path,
             shared: TelemetryCachedClientShmData::default(),
             telemetry_metrics: Default::default(),
             handle: None,
         }
     }
 
-    pub fn write_shm_file(&self) {
-        if let Ok(buf) = bincode::serialize(&self.shared) {
-            self.shm_writer.write(&buf);
-        } else {
-            warn!("Failed to serialize telemetry data for shared memory");
+    pub fn write_shm_file(&mut self) {
+        let buf = match bincode::serialize(&self.shared) {
+            Ok(buf) => buf,
+            Err(_) => {
+                warn!("Failed to serialize telemetry data for shared memory");
+                return;
+            }
+        };
+
+        if self.shm_writer.is_none() {
+            match OneWayShmWriter::<NamedShmHandle>::new(self.shm_path.clone()) {
+                Ok(writer) => self.shm_writer = Some(writer),
+                Err(e) => {
+                    warn!(
+                        "Failed to (re)create telemetry shared memory segment: {e}"
+                    );
+                    return;
+                }
+            }
+        }
+
+        if let Some(writer) = &self.shm_writer {
+            if let Err(e) = writer.write(&buf) {
+                warn!("Failed to write telemetry data to shared memory: {e}");
+            }
         }
     }
 
@@ -600,7 +629,9 @@ impl TelemetryCachedClient {
 
 impl Drop for TelemetryCachedClient {
     fn drop(&mut self) {
-        self.shm_writer.write(&[]);
+        if let Some(writer) = &self.shm_writer {
+            let _ = writer.write(&[]);
+        }
     }
 }
 

--- a/datadog-sidecar/src/service/tracing/trace_flusher.rs
+++ b/datadog-sidecar/src/service/tracing/trace_flusher.rs
@@ -208,7 +208,9 @@ impl TraceFlusher {
                 }
             }
         };
-        writer.writer.write(contents.as_slice());
+        if let Err(e) = writer.writer.write(contents.as_slice()) {
+            error!("Failed to write agent provided config shm segment: {e}");
+        }
 
         let now = Instant::now();
         let last = writer.last_write;

--- a/datadog-sidecar/src/shm_remote_config.rs
+++ b/datadog-sidecar/src/shm_remote_config.rs
@@ -3,7 +3,6 @@
 
 use crate::primary_sidecar_identifier;
 use crate::service::{DynamicInstrumentationConfigState, InstanceId};
-use crate::tracer::SHM_LIMITER;
 use base64::prelude::BASE64_URL_SAFE_NO_PAD;
 use base64::Engine;
 use libdd_capabilities_impl::{HttpClientCapability, NativeCapabilities};
@@ -138,7 +137,7 @@ impl RemoteConfigWriter {
         })
     }
 
-    pub fn write(&self, contents: &[u8]) {
+    pub fn write(&self, contents: &[u8]) -> io::Result<()> {
         self.writer.write(contents)
     }
 
@@ -188,7 +187,17 @@ impl<N: NotifyTarget + 'static> FileStorage for ConfigFileStorage<N> {
         Ok(Arc::new(StoredShmFile {
             handle: Mutex::new(Some(store_shm(version, &path, file)?)),
             limiter: if path.product() == RemoteConfigProduct::LiveDebugging {
-                Some(SHM_LIMITER.lock_or_panic().alloc())
+                crate::tracer::with_shm_limiter(|mem| mem.alloc()).and_then(|result| {
+                    result
+                        .inspect_err(|e| {
+                            warn!(
+                                "Failed to allocate a shared-memory rate limiter slot for \
+                                     live debugging config (will retry on the next remote config \
+                                     fetch): {e}"
+                            );
+                        })
+                        .ok()
+                })
             } else {
                 None
             },
@@ -328,7 +337,12 @@ impl<N: NotifyTarget + 'static> MultiTargetHandlers<N, Self, NativeCapabilities>
         }
 
         if writer.writer.as_slice() != serialized {
-            writer.write(&serialized);
+            if let Err(e) = writer.write(&serialized) {
+                warn!(
+                    "Failed to write remote config shm segment (will retry on the next fetch): {e}"
+                );
+                return false;
+            }
 
             debug!(
                 "Active configuration files are: {}",
@@ -351,7 +365,10 @@ impl<N: NotifyTarget + 'static> MultiTargetHandlers<N, Self, NativeCapabilities>
     fn expired(&self, target: &Arc<Target>) {
         if let Some(writer) = self.writers.lock_or_panic().remove(target) {
             // clear to signal it's no longer being fetched
-            writer.write(&[]);
+            if let Err(e) = writer.write(&[]) {
+                // shouldn't happen as it never should increase shm size
+                warn!("Failed to clear remote config shm segment on expiry: {e}");
+            }
         }
     }
 

--- a/datadog-sidecar/src/shm_remote_config.rs
+++ b/datadog-sidecar/src/shm_remote_config.rs
@@ -165,8 +165,22 @@ struct ConfigFileStorage<N: NotifyTarget + 'static> {
 
 struct StoredShmFile {
     handle: Mutex<Option<NamedShmHandle>>, // just an option to use the handle under lock
-    limiter: Option<ShmLimiter<()>>,
+    limiter: Mutex<Option<ShmLimiter<()>>>,
     refcount: FileRefcountData,
+}
+
+fn alloc_live_debugging_limiter() -> Option<ShmLimiter<()>> {
+    crate::tracer::with_shm_limiter(|mem| mem.alloc()).and_then(|result| {
+        result
+            .inspect_err(|e| {
+                warn!(
+                    "Failed to allocate a shared-memory rate limiter slot for \
+                         live debugging config (will retry on the next remote config \
+                         fetch): {e}"
+                );
+            })
+            .ok()
+    })
 }
 
 impl RefcountedFile for StoredShmFile {
@@ -186,21 +200,11 @@ impl<N: NotifyTarget + 'static> FileStorage for ConfigFileStorage<N> {
     ) -> anyhow::Result<Arc<StoredShmFile>> {
         Ok(Arc::new(StoredShmFile {
             handle: Mutex::new(Some(store_shm(version, &path, file)?)),
-            limiter: if path.product() == RemoteConfigProduct::LiveDebugging {
-                crate::tracer::with_shm_limiter(|mem| mem.alloc()).and_then(|result| {
-                    result
-                        .inspect_err(|e| {
-                            warn!(
-                                "Failed to allocate a shared-memory rate limiter slot for \
-                                     live debugging config (will retry on the next remote config \
-                                     fetch): {e}"
-                            );
-                        })
-                        .ok()
-                })
+            limiter: Mutex::new(if path.product() == RemoteConfigProduct::LiveDebugging {
+                alloc_live_debugging_limiter()
             } else {
                 None
-            },
+            }),
             refcount: FileRefcountData::new(version, path),
         }))
     }
@@ -212,6 +216,12 @@ impl<N: NotifyTarget + 'static> FileStorage for ConfigFileStorage<N> {
         contents: Vec<u8>,
     ) -> anyhow::Result<()> {
         *file.handle.lock_or_panic() = Some(store_shm(version, &file.refcount.path, contents)?);
+        if file.refcount.path.product() == RemoteConfigProduct::LiveDebugging {
+            let mut limiter = file.limiter.lock_or_panic();
+            if limiter.is_none() {
+                *limiter = alloc_live_debugging_limiter();
+            }
+        }
         Ok(())
     }
 }
@@ -290,7 +300,7 @@ impl<N: NotifyTarget + 'static> MultiTargetHandlers<N, Self, NativeCapabilities>
                 file.handle.lock_or_panic().as_ref().unwrap().get_path()
             });
             serialized.push(b':');
-            if let Some(ref limiter) = file.limiter {
+            if let Some(ref limiter) = *file.limiter.lock_or_panic() {
                 serialized.extend_from_slice(limiter.index().to_string().as_bytes());
             } else {
                 serialized.push(b'0');

--- a/datadog-sidecar/src/tracer.rs
+++ b/datadog-sidecar/src/tracer.rs
@@ -3,27 +3,40 @@
 
 use crate::primary_sidecar_identifier;
 use http::uri::PathAndQuery;
-use libdd_common::Endpoint;
+use libdd_common::{Endpoint, MutexExt};
 use libdd_ipc::rate_limiter::ShmLimiterMemory;
 use libdd_trace_utils::config_utils::trace_intake_url_prefixed;
 use std::borrow::Cow;
 use std::ffi::CString;
-use std::mem::ManuallyDrop;
 use std::str::FromStr;
 use std::sync::{LazyLock, Mutex};
+use tracing::warn;
 
-pub static SHM_LIMITER: LazyLock<Mutex<ManuallyDrop<ShmLimiterMemory<()>>>> = LazyLock::new(|| {
+pub static SHM_LIMITER: LazyLock<Mutex<Option<ShmLimiterMemory<()>>>> = LazyLock::new(|| {
     unsafe { libc::atexit(drop_shm_limiter) };
-    #[allow(clippy::unwrap_used)]
-    Mutex::new(ManuallyDrop::new(
-        ShmLimiterMemory::create(shm_limiter_path()).unwrap(),
-    ))
+    Mutex::new(create_shm_limiter())
 });
 
+fn create_shm_limiter() -> Option<ShmLimiterMemory<()>> {
+    match ShmLimiterMemory::create(shm_limiter_path()) {
+        Ok(mem) => Some(mem),
+        Err(e) => {
+            warn!("Failed to create shared-memory rate limiter segment: {e}");
+            None
+        }
+    }
+}
+
+pub fn with_shm_limiter<R>(f: impl FnOnce(&mut ShmLimiterMemory<()>) -> R) -> Option<R> {
+    let mut guard = SHM_LIMITER.lock_or_panic();
+    if guard.is_none() {
+        *guard = create_shm_limiter();
+    }
+    guard.as_mut().map(f)
+}
+
 extern "C" fn drop_shm_limiter() {
-    let mut guard = SHM_LIMITER.lock().unwrap_or_else(|e| e.into_inner());
-    // SAFETY: atexit runs once at program exit; no code accesses this static afterward.
-    unsafe { ManuallyDrop::drop(&mut *guard) };
+    SHM_LIMITER.lock().unwrap_or_else(|e| e.into_inner()).take();
 }
 
 #[derive(Default)]

--- a/libdd-ipc/src/one_way_shared_memory.rs
+++ b/libdd-ipc/src/one_way_shared_memory.rs
@@ -284,7 +284,9 @@ impl<T: FileBackedHandle + From<MappedMem<T>>, D> OneWayShmReader<T, D> {
                 #[allow(clippy::unwrap_used)]
                 let handle = reader.handle.as_mut().unwrap();
                 if let Err(e) = handle.ensure_space(size) {
-                    tracing::warn!("Failed to grow shared-memory reader mapping to {size} bytes: {e}");
+                    tracing::warn!(
+                        "Failed to grow shared-memory reader mapping to {size} bytes: {e}"
+                    );
                     return None;
                 }
 

--- a/libdd-ipc/src/one_way_shared_memory.rs
+++ b/libdd-ipc/src/one_way_shared_memory.rs
@@ -283,7 +283,10 @@ impl<T: FileBackedHandle + From<MappedMem<T>>, D> OneWayShmReader<T, D> {
 
                 #[allow(clippy::unwrap_used)]
                 let handle = reader.handle.as_mut().unwrap();
-                handle.ensure_space(size);
+                if let Err(e) = handle.ensure_space(size) {
+                    tracing::warn!("Failed to grow shared-memory reader mapping to {size} bytes: {e}");
+                    return None;
+                }
 
                 // aligned on 8 byte boundary, round up to closest 8 byte boundary
                 let mut new_mem = Vec::<u64>::with_capacity(size.div_ceil(8));
@@ -410,11 +413,11 @@ impl<T: FileBackedHandle + From<MappedMem<T>>> OneWayShmWriter<T> {
     /// Linux this also wakes readers blocked in
     /// [`OneWayShmReader::wait_for_change`]; the wake is a cheap no-op syscall when
     /// there are no waiters.
-    pub fn write(&self, contents: &[u8]) {
+    pub fn write(&self, contents: &[u8]) -> io::Result<()> {
         let mut mapped = self.handle.lock_or_panic();
 
         let size = contents.len() + 1; // trailing zero byte, to keep some C code happy
-        mapped.ensure_space(std::mem::size_of::<RawMetaData>() + size);
+        mapped.ensure_space(std::mem::size_of::<RawMetaData>() + size)?;
 
         // Safety: ShmHandle is always big enough
         // Actually &mut mapped.as_slice_mut() as RawData seems safe, but unsized locals are
@@ -431,6 +434,7 @@ impl<T: FileBackedHandle + From<MappedMem<T>>> OneWayShmWriter<T> {
         // Wake any readers blocked in `wait_for_change` on the generation word.
         // A wake with no waiters is a cheap no-op syscall.
         futex_wake((&data.meta.generation as *const AtomicU64).cast::<u32>());
+        Ok(())
     }
 
     /// Borrow the buffer currently published in the segment (excluding the

--- a/libdd-ipc/src/platform/mem_handle.rs
+++ b/libdd-ipc/src/platform/mem_handle.rs
@@ -263,7 +263,7 @@ mod tests {
         let shm = ShmHandle::new(5).unwrap();
         let mut mapped = shm.map().unwrap();
         _ = mapped.as_slice_mut().write(&[1, 2, 3, 4, 5]).unwrap();
-        mapped.ensure_space(100000);
+        mapped.ensure_space(100000).unwrap();
         assert!(mapped.as_slice().len() >= 100000);
         let mut exp = vec![0u8; mapped.as_slice().len()];
         _ = (&mut exp[..5]).write(&[1, 2, 3, 4, 5]).unwrap();
@@ -277,7 +277,7 @@ mod tests {
         let shm = NamedShmHandle::create(path.clone(), 5).unwrap();
         let mut mapped = shm.map().unwrap();
         _ = mapped.as_slice_mut().write(&[1, 2, 3, 4, 5]).unwrap();
-        mapped.ensure_space(100000);
+        mapped.ensure_space(100000).unwrap();
         assert!(mapped.as_slice().len() >= 100000);
 
         let other = NamedShmHandle::open(&path).unwrap().map().unwrap();

--- a/libdd-ipc/src/platform/unix/mem_handle.rs
+++ b/libdd-ipc/src/platform/unix/mem_handle.rs
@@ -213,18 +213,19 @@ impl NamedShmHandle {
 }
 
 impl<T: FileBackedHandle + From<MappedMem<T>>> MappedMem<T> {
-    pub fn ensure_space(&mut self, expected_size: usize) {
+    pub fn ensure_space(&mut self, expected_size: usize) -> io::Result<()> {
         if expected_size <= self.mem.get_shm().size {
-            return;
+            return Ok(());
         }
 
         // SAFETY: we'll overwrite the original memory later
         let mut handle: T = unsafe { std::ptr::read(self) }.into();
-        _ = handle.resize(expected_size);
+        let resize_result = handle.resize(expected_size);
         #[allow(clippy::unwrap_used)]
         unsafe {
             std::ptr::write(self, handle.map().unwrap())
         };
+        resize_result.map_err(io::Error::other)
     }
 }
 

--- a/libdd-ipc/src/platform/unix/mem_handle_macos.rs
+++ b/libdd-ipc/src/platform/unix/mem_handle_macos.rs
@@ -172,6 +172,7 @@ impl<T: FileBackedHandle + From<MappedMem<T>>> MappedMem<T> {
 
         // SAFETY: we'll overwrite the original memory later
         let mut handle: T = unsafe { std::ptr::read(self) }.into();
+        let previous_size = handle.get_shm().size;
 
         #[allow(clippy::unwrap_used)]
         let page_size = NonZeroUsize::try_from(page_size::get()).unwrap();
@@ -195,6 +196,12 @@ impl<T: FileBackedHandle + From<MappedMem<T>>> MappedMem<T> {
             }
             Ok(())
         })();
+        // If publishing the new size failed, restore the previous local size so a
+        // subsequent `ensure_space` call for the same size retries publication
+        // instead of assuming it already succeeded.
+        if mapped.is_err() {
+            handle.get_shm_mut().size = previous_size;
+        }
 
         #[allow(clippy::unwrap_used)]
         unsafe {

--- a/libdd-ipc/src/platform/unix/mem_handle_macos.rs
+++ b/libdd-ipc/src/platform/unix/mem_handle_macos.rs
@@ -158,17 +158,16 @@ impl NamedShmHandle {
 }
 
 impl<T: FileBackedHandle + From<MappedMem<T>>> MappedMem<T> {
-    pub fn ensure_space(&mut self, expected_size: usize) {
+    pub fn ensure_space(&mut self, expected_size: usize) -> io::Result<()> {
         if expected_size <= self.mem.get_shm().size {
-            return;
+            return Ok(());
         }
-        #[allow(clippy::panic)]
         if expected_size > MAPPING_MAX_SIZE - page_size::get() {
-            panic!(
+            return Err(io::Error::other(format!(
                 "Tried to allocate {} bytes for shared mapping (limit: {} bytes)",
                 expected_size,
                 MAPPING_MAX_SIZE - page_size::get()
-            );
+            )));
         }
 
         // SAFETY: we'll overwrite the original memory later
@@ -176,28 +175,32 @@ impl<T: FileBackedHandle + From<MappedMem<T>>> MappedMem<T> {
 
         #[allow(clippy::unwrap_used)]
         let page_size = NonZeroUsize::try_from(page_size::get()).unwrap();
-        unsafe {
-            _ = handle.set_mapping_size(expected_size);
+        let mapped = (|| -> io::Result<()> {
+            unsafe {
+                handle
+                    .set_mapping_size(expected_size)
+                    .map_err(io::Error::other)?;
 
-            #[allow(clippy::unwrap_used)]
-            let ptr = mmap(
-                None,
-                page_size,
-                ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
-                MapFlags::MAP_SHARED,
-                handle.get_shm().handle.as_owned_fd().unwrap(),
-                (MAPPING_MAX_SIZE - usize::from(page_size)) as off_t,
-            )
-            .unwrap();
-            let size = AtomicUsize::from_ptr(ptr.cast::<usize>().as_ptr());
-            size.fetch_max(handle.get_size(), Ordering::SeqCst);
-            _ = munmap(ptr, usize::from(page_size));
-        }
+                let ptr = mmap(
+                    None,
+                    page_size,
+                    ProtFlags::PROT_READ | ProtFlags::PROT_WRITE,
+                    MapFlags::MAP_SHARED,
+                    handle.get_shm().handle.as_owned_fd()?,
+                    (MAPPING_MAX_SIZE - usize::from(page_size)) as off_t,
+                )?;
+                let size = AtomicUsize::from_ptr(ptr.cast::<usize>().as_ptr());
+                size.fetch_max(handle.get_size(), Ordering::SeqCst);
+                _ = munmap(ptr, usize::from(page_size));
+            }
+            Ok(())
+        })();
 
         #[allow(clippy::unwrap_used)]
         unsafe {
             std::ptr::write(self, handle.map().unwrap())
         };
+        mapped
     }
 }
 

--- a/libdd-ipc/src/platform/windows/mem_handle.rs
+++ b/libdd-ipc/src/platform/windows/mem_handle.rs
@@ -163,25 +163,25 @@ impl NamedShmHandle {
 }
 
 impl<T: FileBackedHandle + From<MappedMem<T>>> MappedMem<T> {
-    pub fn ensure_space(&mut self, expected_size: usize) {
+    pub fn ensure_space(&mut self, expected_size: usize) -> io::Result<()> {
         let current_size = self.mem.get_shm().size;
         if expected_size <= current_size {
-            return;
+            return Ok(());
         }
 
-        #[allow(clippy::panic)]
         if expected_size > MAPPING_MAX_SIZE {
-            panic!(
+            return Err(io::Error::other(format!(
                 "Tried to allocate {expected_size} bytes for shared mapping (limit: {MAPPING_MAX_SIZE} bytes)",
-            );
+            )));
         }
 
-        #[allow(clippy::unwrap_used)]
         unsafe {
-            self.mem.set_mapping_size(expected_size).unwrap();
+            self.mem
+                .set_mapping_size(expected_size)
+                .map_err(io::Error::other)?;
         }
         let new_size = self.mem.get_shm().size;
-        unsafe {
+        let committed = unsafe {
             VirtualAlloc(
                 (self.ptr.as_ptr() as usize + current_size) as LPVOID,
                 new_size - current_size,
@@ -189,5 +189,10 @@ impl<T: FileBackedHandle + From<MappedMem<T>>> MappedMem<T> {
                 PAGE_READWRITE,
             )
         };
+        if committed.is_null() {
+            self.mem.get_shm_mut().size = current_size;
+            return Err(Error::last_os_error());
+        }
+        Ok(())
     }
 }

--- a/libdd-ipc/src/rate_limiter.rs
+++ b/libdd-ipc/src/rate_limiter.rs
@@ -72,7 +72,7 @@ impl<Inner> ShmLimiterMemory<Inner> {
         }
     }
 
-    fn next_free(&mut self) -> u32 {
+    fn next_free(&mut self) -> io::Result<u32> {
         let mut first_free = self.first_free_ref().load(Ordering::Relaxed);
         loop {
             let mut target_next_free = ShmLimiter {
@@ -90,7 +90,7 @@ impl<Inner> ShmLimiterMemory<Inner> {
                 #[allow(clippy::unwrap_used)]
                 self.mem.write().unwrap().ensure_space(
                     target_next_free as usize + std::mem::size_of::<ShmLimiterData<Inner>>(),
-                );
+                )?;
             }
             match self.first_free_ref().compare_exchange(
                 first_free,
@@ -98,19 +98,19 @@ impl<Inner> ShmLimiterMemory<Inner> {
                 Ordering::Release,
                 Ordering::Relaxed,
             ) {
-                Ok(_) => return first_free,
+                Ok(_) => return Ok(first_free),
                 Err(found) => first_free = found,
             }
         }
     }
 
-    pub fn alloc(&mut self) -> ShmLimiter<Inner> {
+    pub fn alloc(&mut self) -> io::Result<ShmLimiter<Inner>> {
         self.alloc_with_granularity(1)
     }
 
-    pub fn alloc_with_granularity(&mut self, seconds: u32) -> ShmLimiter<Inner> {
+    pub fn alloc_with_granularity(&mut self, seconds: u32) -> io::Result<ShmLimiter<Inner>> {
         let reference = ShmLimiter {
-            idx: self.next_free(),
+            idx: self.next_free()?,
             memory: self.clone(),
         };
         let limiter = reference.limiter();
@@ -121,7 +121,7 @@ impl<Inner> ShmLimiterMemory<Inner> {
                 .limiter
                 .reset(seconds)
         };
-        reference
+        Ok(reference)
     }
 
     fn ensure_index(&self, idx: u32) -> Option<()> {
@@ -131,7 +131,7 @@ impl<Inner> ShmLimiterMemory<Inner> {
             let mut mem = self.mem.write().unwrap();
             let mut cur_size = mem.mem.get_size() as u32;
             if cur_size < end {
-                mem.ensure_space(end as usize);
+                mem.ensure_space(end as usize).ok()?;
                 cur_size = mem.mem.get_size() as u32;
                 if cur_size < end {
                     return None;
@@ -337,7 +337,7 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     fn test_limiters() {
         let mut limiters = ShmLimiterMemory::<()>::create(path()).unwrap();
-        let limiter = limiters.alloc();
+        let limiter = limiters.alloc().unwrap();
         let limiter_idx = limiter.idx;
         // Two are allowed, then one more because a small amount of time passed since the first one
         assert!(limiter.inc(2));
@@ -352,17 +352,17 @@ mod tests {
         assert!(!limiter.inc(2));
 
         // Now test the free list
-        let limiter2 = limiters.alloc();
+        let limiter2 = limiters.alloc().unwrap();
         assert_eq!(
             limiter2.idx,
             limiter_idx + std::mem::size_of::<ShmLimiterData<()>>() as u32
         );
         drop(limiter);
 
-        let limiter = limiters.alloc();
+        let limiter = limiters.alloc().unwrap();
         assert_eq!(limiter.idx, limiter_idx);
 
-        let limiter3 = limiters.alloc();
+        let limiter3 = limiters.alloc().unwrap();
         assert_eq!(
             limiter3.idx,
             limiter2.idx + std::mem::size_of::<ShmLimiterData<()>>() as u32


### PR DESCRIPTION
This prevents errors especially around ENOSPC on customers environments from stopping the sidecar alltogether.

BREAKING CHANGE: `OneWayShmWriter::write`, `MappedMem::ensure_space`, `ShmLimiterMemory::alloc`, and `ShmLimiterMemory::alloc_with_granularity` in `libdd-ipc` now return `io::Result` instead of panicking on failure.