### PR TITLE
ci: drive Devflow from GitHub merge queue

### DIFF
--- a/.github/chainguard/self.enforce-datadog-merge-queue.comment-pr.sts.yaml
+++ b/.github/chainguard/self.enforce-datadog-merge-queue.comment-pr.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject: repo:DataDog/libdatadog:pull_request
+
+claim_pattern:
+  event_name: pull_request
+  job_workflow_ref: DataDog/libdatadog/\.github/workflows/enforce-datadog-merge-queue\.yml@refs/pull/[0-9]+/merge
+
+permissions:
+  issues: write
+  pull_requests: write

--- a/.github/chainguard/self.enforce-datadog-merge-queue.comment-pr.sts.yaml
+++ b/.github/chainguard/self.enforce-datadog-merge-queue.comment-pr.sts.yaml
@@ -3,9 +3,10 @@ issuer: https://token.actions.githubusercontent.com
 subject: repo:DataDog/libdatadog:pull_request
 
 claim_pattern:
-  event_name: pull_request
-  job_workflow_ref: DataDog/libdatadog/\.github/workflows/enforce-datadog-merge-queue\.yml@refs/pull/[0-9]+/merge
+  event_name: pull_request_target
+  ref: refs/heads/main
+  ref_protected: "true"
+  job_workflow_ref: DataDog/libdatadog/\.github/workflows/enforce-datadog-merge-queue\.yml@refs/heads/main
 
 permissions:
   issues: write
-  pull_requests: write

--- a/.github/workflows/enforce-datadog-merge-queue.yml
+++ b/.github/workflows/enforce-datadog-merge-queue.yml
@@ -1,0 +1,41 @@
+name: Enforce Datadog Merge Queue
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, enqueued]
+    branches:
+      - main
+  merge_group:
+
+jobs:
+  enforce_datadog_merge_queue:
+    name: Merge queue check
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for OIDC token federation.
+    steps:
+      - name: Block GitHub merge queue
+        if: github.event_name == 'merge_group'
+        run: |
+          echo "Merge is handled by the Datadog merge queue."
+          echo "Use /merge to enqueue the pull request directly."
+          exit 1
+      - name: Get GitHub App token
+        if: github.event.action == 'enqueued'
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        id: octo-sts
+        with:
+          scope: DataDog/libdatadog
+          policy: self.enforce-datadog-merge-queue.comment-pr
+      - name: Add pull request to the Datadog merge queue
+        if: github.event.action == 'enqueued'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ steps.octo-sts.outputs.token }}
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: '/merge'
+            });

--- a/.github/workflows/enforce-datadog-merge-queue.yml
+++ b/.github/workflows/enforce-datadog-merge-queue.yml
@@ -2,33 +2,46 @@ name: Enforce Datadog Merge Queue
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, enqueued]
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+  pull_request_target:
+    types: [enqueued]
     branches:
       - main
   merge_group:
 
 jobs:
-  enforce_datadog_merge_queue:
+  merge_queue_check:
     name: Merge queue check
+    if: github.event_name != 'pull_request_target'
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write # Required for OIDC token federation.
+    permissions: {}
     steps:
+      - name: Allow pull request to enter GitHub merge queue
+        if: github.event_name == 'pull_request'
+        run: echo "Pull request is eligible for the GitHub merge queue."
       - name: Block GitHub merge queue
         if: github.event_name == 'merge_group'
         run: |
           echo "Merge is handled by the Datadog merge queue."
           echo "Use /merge to enqueue the pull request directly."
           exit 1
+
+  enqueue_datadog_merge_queue:
+    name: Add pull request to Datadog merge queue
+    if: github.event_name == 'pull_request_target' && github.event.action == 'enqueued'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for OIDC token federation.
+    steps:
       - name: Get GitHub App token
-        if: github.event.action == 'enqueued'
         uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
         id: octo-sts
         with:
           scope: DataDog/libdatadog
           policy: self.enforce-datadog-merge-queue.comment-pr
       - name: Add pull request to the Datadog merge queue
-        if: github.event.action == 'enqueued'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ steps.octo-sts.outputs.token }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           submodules: recursive
       - name: Run actionlint
-        uses: devops-actions/actionlint@c6744a34774e4e1c1df0ff66bdb07ec7ee480ca0 # 0.1.9
+        uses: devops-actions/actionlint@9fb9c192862f19e684586ca84b500461bcd8a541 # 0.1.12
         with:
           shellcheck_opts: '-e SC2086'
 


### PR DESCRIPTION
# What does this PR do?

Adds the supported bridge between GitHub's native merge queue and the Datadog
Devflow merge queue.

When a contributor clicks **Merge when ready**, the flow is:

1. GitHub emits the pull request `enqueued` event.
2. A `pull_request_target` workflow loaded from protected `main` obtains a
   narrowly scoped Octo STS GitHub App token.
3. The app posts `/merge` on the pull request.
4. The `merge_group` check deliberately fails, preventing GitHub from merging
   the pull request itself.
5. Devflow performs its existing validation, queueing, and merge process.

# Motivation

The current repository configuration disables the normal merge control for
contributors, requiring them to know and post the `/merge` command manually.
This provides GitHub's standard **Merge when ready** experience without
allowing GitHub to bypass the custom Devflow queue.

The implementation follows the existing `dd-trace-java` integration documented
in the internal "GitHub Merge Queue 💜 Datadog Merge Queue" guide.

# Additional Notes

The actionlint wrapper is updated from `0.1.9` to `0.1.12`. The former bundles
actionlint `1.7.7`, whose event schema predates GitHub's supported
`pull_request_target: enqueued` activity; `0.1.12` bundles actionlint `1.7.12`.

## Steps to enable after this PR lands

These repository settings are intentionally not changed by this PR. A repository
administrator should:

1. Land this PR using the existing `/merge` flow.
2. Open **Settings → Rules → Rulesets** for `DataDog/libdatadog`.
3. Add a branch ruleset targeting the default branch.
4. Enable **Require merge queue**.
5. Set **Minimum group size** to `1`, so the bridge runs immediately.
6. Add **Merge queue check** as a required status check.
7. Leave repository auto-merge disabled. The supported entry point is GitHub's
   native merge queue and its **Merge when ready** button.

### Compatibility with existing open pull requests

Enabling the ruleset does not trigger this workflow for pull requests that were
already open. Their current head commits may therefore lack **Merge queue
check** and will not be able to use **Merge when ready** immediately.

Those pull requests can continue using the existing `/merge` command; Devflow's
merge app uses its established ruleset bypass path. No mass backfill or reopening
is required. An existing pull request will gain the new check naturally after
its branch is updated or the pull request is reopened, after which it can use
**Merge when ready** as well.

The failure on `merge_group` is intentional: it removes the pull request from
GitHub's queue before Devflow takes ownership. Existing `devflow/mergegate`
rules and `repository.datadog.yml` remain unchanged.

# How to test the change?

- `SHELLCHECK_OPTS='-e SC2086' actionlint`
- Parse both new files as YAML.
- After enabling the ruleset, use a test PR to confirm that **Merge when ready**
  produces an Octo STS `/merge` comment and queues the PR in Devflow.

*Generated by Codex.*
