### PR TITLE
feat(ffe): support arbitrary semver core parts

### DIFF
--- a/libdd-ffe/src/rules_based/eval/eval_rules.rs
+++ b/libdd-ffe/src/rules_based/eval/eval_rules.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::rules_based::{
-    ufc::{ComparisonOperator, Condition, ConditionCheck, RuleWire, SemverComparisonOperator},
+    ufc::{
+        ComparisonOperator, Condition, ConditionCheck, ExtendedVersion, RuleWire,
+        SemverComparisonOperator,
+    },
     Attribute, EvaluationContext,
 };
 
@@ -66,7 +69,7 @@ impl ConditionCheck {
                 comparand,
             } => {
                 let attr_str = attribute?.as_str()?;
-                let attr_version = semver::Version::parse(attr_str.as_ref()).ok()?;
+                let attr_version = ExtendedVersion::parse(attr_str.as_ref())?;
                 let ordering = attr_version.cmp_precedence(comparand);
                 match operator {
                     SemverComparisonOperator::Eq => ordering.is_eq(),
@@ -88,7 +91,10 @@ mod tests {
     use std::{collections::HashMap, sync::Arc};
 
     use crate::rules_based::{
-        ufc::{ComparisonOperator, Condition, ConditionCheck, RuleWire, SemverComparisonOperator},
+        ufc::{
+            ComparisonOperator, Condition, ConditionCheck, ExtendedVersion, RuleWire,
+            SemverComparisonOperator,
+        },
         EvaluationContext,
     };
 
@@ -304,8 +310,8 @@ mod tests {
         )));
     }
 
-    fn semver(s: &str) -> semver::Version {
-        semver::Version::parse(s).unwrap()
+    fn semver(s: &str) -> ExtendedVersion {
+        ExtendedVersion::parse(s).unwrap()
     }
 
     #[test]
@@ -389,13 +395,32 @@ mod tests {
     }
 
     #[test]
-    fn semver_invalid_attribute_returns_false() {
+    fn semver_supports_indefinite_core_version_parts() {
+        let equal = ConditionCheck::SemverComparison {
+            operator: SemverComparisonOperator::Eq,
+            comparand: semver("18.0.0"),
+        };
+        assert!(equal.eval(Some(&"18".into())));
+        assert!(equal.eval(Some(&"18.0".into())));
+        assert!(equal.eval(Some(&"18.0.0.0.0.0".into())));
+
+        let greater = ConditionCheck::SemverComparison {
+            operator: SemverComparisonOperator::Gt,
+            comparand: semver("18.0.0.0.0.1"),
+        };
+        assert!(greater.eval(Some(&"18.0.0.0.0.2".into())));
+        assert!(greater.eval(Some(&"18.0.0.0.0.1.0.0.1".into())));
+    }
+
+    #[test]
+    fn semver_malformed_attribute_returns_false() {
         let check = ConditionCheck::SemverComparison {
             operator: SemverComparisonOperator::Gte,
             comparand: semver("1.0.0"),
         };
         assert!(!check.eval(Some(&"not-a-version".into())));
-        assert!(!check.eval(Some(&"1.2".into())));
+        assert!(!check.eval(Some(&"1..2".into())));
+        assert!(!check.eval(Some(&"1.02.3".into())));
         assert!(!check.eval(None));
     }
 }

--- a/libdd-ffe/src/rules_based/ufc/models.rs
+++ b/libdd-ffe/src/rules_based/ufc/models.rs
@@ -1,7 +1,7 @@
 // Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, num::NonZeroU32, sync::Arc};
+use std::{cmp::Ordering, collections::HashMap, num::NonZeroU32, sync::Arc};
 
 use libdd_common::regex_engine::Regex;
 use serde::{Deserialize, Serialize};
@@ -201,7 +201,7 @@ pub(crate) enum ConditionCheck {
     },
     SemverComparison {
         operator: SemverComparisonOperator,
-        comparand: semver::Version,
+        comparand: ExtendedVersion,
     },
 }
 
@@ -295,7 +295,7 @@ impl From<Condition> for ConditionWire {
             } => (
                 operator.into(),
                 ConditionValue::Single(SingleConditionValue::String(Str::from(
-                    comparand.to_string().as_str(),
+                    comparand.original.as_ref(),
                 ))),
             ),
         };
@@ -425,9 +425,9 @@ impl TryFrom<ConditionWire> for Condition {
                         return Err(EvaluationError::ConfigurationParseError);
                     }
                 };
-                let comparand = semver::Version::parse(&semver_string).map_err(|err| {
+                let comparand = ExtendedVersion::parse(&semver_string).ok_or_else(|| {
                     log::warn!(
-                        "failed to parse condition: invalid semver {:?}: {err:?}",
+                        "failed to parse condition: invalid semver {:?}",
                         semver_string
                     );
                     EvaluationError::ConfigurationParseError
@@ -439,6 +439,82 @@ impl TryFrom<ConditionWire> for Condition {
             }
         };
         Ok(Condition { attribute, check })
+    }
+}
+
+/// A semantic version with one or more numeric core components.
+///
+/// The UFC format permits abbreviated and extended core versions. Missing components compare as
+/// zero; build metadata does not affect precedence, matching SemVer's comparison rules.
+#[derive(Debug, Clone)]
+pub(crate) struct ExtendedVersion {
+    original: Box<str>,
+    core: Box<[u64]>,
+    normalized: semver::Version,
+}
+
+impl ExtendedVersion {
+    pub(crate) fn parse(value: &str) -> Option<Self> {
+        let (without_build, build) = match value.split_once('+') {
+            Some((version, build)) if !build.is_empty() && !build.contains('+') => {
+                (version, Some(build))
+            }
+            Some(_) => return None,
+            None => (value, None),
+        };
+        let (core, prerelease) = match without_build.split_once('-') {
+            Some((core, prerelease)) if !prerelease.is_empty() => (core, Some(prerelease)),
+            Some(_) => return None,
+            None => (without_build, None),
+        };
+
+        let core: Box<[u64]> = core
+            .split('.')
+            .map(|component| {
+                (!component.is_empty()
+                    && component.bytes().all(|byte| byte.is_ascii_digit())
+                    && (component == "0" || !component.starts_with('0')))
+                .then(|| component.parse().ok())?
+            })
+            .collect::<Option<Vec<_>>>()?
+            .into();
+        if core.is_empty() {
+            return None;
+        }
+
+        let mut normalized = format!(
+            "{}.{}.{}",
+            core[0],
+            *core.get(1).unwrap_or(&0),
+            *core.get(2).unwrap_or(&0)
+        );
+        if let Some(prerelease) = prerelease {
+            normalized.push('-');
+            normalized.push_str(prerelease);
+        }
+        if let Some(build) = build {
+            normalized.push('+');
+            normalized.push_str(build);
+        }
+
+        Some(Self {
+            original: value.into(),
+            core,
+            normalized: semver::Version::parse(&normalized).ok()?,
+        })
+    }
+
+    pub(crate) fn cmp_precedence(&self, other: &Self) -> Ordering {
+        let component_ordering = self
+            .core
+            .iter()
+            .copied()
+            .chain(std::iter::repeat(0))
+            .zip(other.core.iter().copied().chain(std::iter::repeat(0)))
+            .take(self.core.len().max(other.core.len()))
+            .find_map(|(left, right)| (left != right).then(|| left.cmp(&right)));
+
+        component_ordering.unwrap_or_else(|| self.normalized.cmp_precedence(&other.normalized))
     }
 }
 


### PR DESCRIPTION
## Summary
- pin canonical FFE fixtures to 2c0c8d55f665fe4a847fc0ded3abf59b7e2896fc
- accept and compare SemVer core versions with any positive number of numeric dot-separated parts
- preserve abbreviated version normalization and SemVer prerelease/build precedence

## Testing
- cargo test -p libdd-ffe semver --lib
- cargo nextest run -p libdd-ffe-test-suite
- cargo check -p libdd-ffe
- cargo +stable clippy -p libdd-ffe --all-targets -- -D warnings
- cargo +nightly-2026-07-26 fmt --all -- --check