### PR TITLE
chore(crashtracking): bump libdd-libunwind-sys to v1.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3208,9 +3208,9 @@ dependencies = [
 
 [[package]]
 name = "libdd-libunwind-sys"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227f0e30af5fbb91d1b3768db7997fdd1ded87c44b371663783c4ff3eb686908"
+checksum = "cf4d5ce7d99aa9244d4dff12d25faf8ad96793183ed049b20f366ce88cf59e68"
 dependencies = [
  "cc",
  "libc",

--- a/libdd-crashtracker/Cargo.toml
+++ b/libdd-crashtracker/Cargo.toml
@@ -43,7 +43,7 @@ blazesym = "=0.2.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libdd-gotter = { version = "1.0.0", path = "../libdd-gotter" }
-libdd-libunwind-sys = { version = "1.0.2" }
+libdd-libunwind-sys = { version = "1.0.3" }
 
 [dependencies]
 anyhow.workspace = true


### PR DESCRIPTION
# What does this PR do?

[v1.0.3](https://github.com/DataDog/libdatadog-libunwind/pull/16) contains hardening and a bugfix for ELF out of bounds check. Lets bump the version to include this change.


# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
