### PR TITLE
feat(common)!: add HTTPS_PROXY support for hyper_backend

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -153,14 +153,14 @@ jobs:
             cargo test --workspace $CRASHTRACKER_FEATURE --exclude builder --doc --verbose
             # shellcheck disable=SC2086
             cargo nextest run --workspace $CRASHTRACKER_FEATURE --profile ci --verbose --no-tests=pass -E '!test(tracing_integration_tests::)'
-            cargo nextest run -p libdd-http-client --no-default-features --features hyper-backend,https --profile ci --verbose
+            cargo nextest run -p libdd-http-client --no-default-features --features hyper-backend,hyper-proxy,https --profile ci --verbose
           else
             # shellcheck disable=SC2086
             cargo test $PACKAGES $CRASHTRACKER_FEATURE --doc --verbose
             # shellcheck disable=SC2086
             cargo nextest run $PACKAGES $CRASHTRACKER_FEATURE --profile ci --verbose --no-tests=pass -E '!test(tracing_integration_tests::)'
             if echo "$PACKAGES" | grep -q "libdd-http-client"; then
-              cargo nextest run -p libdd-http-client --no-default-features --features hyper-backend,https --profile ci --verbose
+              cargo nextest run -p libdd-http-client --no-default-features --features hyper-backend,hyper-proxy,https --profile ci --verbose
             fi
           fi
       - name: "[${{ steps.rust-version.outputs.version}}] cargo nextest run -p libdd-common --no-default-features --features fips"

--- a/libdd-common/Cargo.toml
+++ b/libdd-common/Cargo.toml
@@ -107,8 +107,8 @@ regex-lite = ["dep:regex-lite"]
 require-regex-full = []
 # FIPS mode uses the FIPS-compliant cryptographic provider (Unix only)
 fips = ["tls-core", "hyper-rustls/fips"]
-# Honor HTTPS_PROXY/NO_PROXY environment variables for the hyper connector,
-hyper-proxy = ["tls-core", "hyper-util/client-proxy"]
+# Honor HTTP(S)_PROXY/NO_PROXY environment variables for the hyper connector,
+hyper-proxy = ["hyper-util/client-proxy"]
 # Enable reqwest client builder support with file dump debugging
 reqwest = ["dep:reqwest", "test-utils"]
 # Enable test utilities for use in other crates

--- a/libdd-common/Cargo.toml
+++ b/libdd-common/Cargo.toml
@@ -107,6 +107,8 @@ regex-lite = ["dep:regex-lite"]
 require-regex-full = []
 # FIPS mode uses the FIPS-compliant cryptographic provider (Unix only)
 fips = ["tls-core", "hyper-rustls/fips"]
+# Honor HTTPS_PROXY/NO_PROXY environment variables for the hyper connector,
+hyper-proxy = ["tls-core", "hyper-util/client-proxy"]
 # Enable reqwest client builder support with file dump debugging
 reqwest = ["dep:reqwest", "test-utils"]
 # Enable test utilities for use in other crates

--- a/libdd-common/src/connector/conn_stream.rs
+++ b/libdd-common/src/connector/conn_stream.rs
@@ -19,7 +19,6 @@ pub enum ConnStream {
         #[pin]
         transport: TokioIo<tokio::net::TcpStream>,
     },
-    #[cfg(feature = "tls-core")]
     Tls {
         #[pin]
         transport: wrapped::BoxedConn,
@@ -36,12 +35,14 @@ pub enum ConnStream {
     },
 }
 
-#[cfg(feature = "tls-core")]
 /// Wrapped connection, usable from hyper directly, or e.g. a hyper proxy wrapper
 mod wrapped {
     use super::*;
 
-    pub trait EstablishedConn: hyper::rt::Read + hyper::rt::Write + connect::Connection + Send {}
+    pub trait EstablishedConn:
+        hyper::rt::Read + hyper::rt::Write + connect::Connection + Send
+    {
+    }
 
     impl<T: hyper::rt::Read + hyper::rt::Write + connect::Connection + Send> EstablishedConn for T {}
 
@@ -79,7 +80,10 @@ mod wrapped {
             self.get_mut().0.as_mut().poll_write(cx, buf)
         }
 
-        fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+        fn poll_flush(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Result<(), std::io::Error>> {
             self.get_mut().0.as_mut().poll_flush(cx)
         }
 
@@ -174,6 +178,26 @@ impl ConnStream {
             })
         }
     }
+
+    pub fn from_tunnel_with_uri<C>(
+        c: &mut C,
+        uri: hyper::Uri,
+    ) -> impl Future<Output = Result<ConnStream, ConnStreamError>> + 'static
+    where
+        C: Service<hyper::Uri> + 'static,
+        C::Response:
+            hyper::rt::Read + hyper::rt::Write + connect::Connection + Send + Unpin + 'static,
+        C::Future: Send + 'static,
+        C::Error: Into<Box<dyn core::error::Error + Send + Sync>>,
+    {
+        let stream_fut = c.call(uri);
+        async move {
+            let stream = stream_fut.await.map_err(Into::into)?;
+            Ok(ConnStream::Tls {
+                transport: wrapped::BoxedConn::new(stream),
+            })
+        }
+    }
 }
 
 impl hyper::rt::Read for ConnStream {
@@ -184,7 +208,6 @@ impl hyper::rt::Read for ConnStream {
     ) -> Poll<std::io::Result<()>> {
         match self.project() {
             ConnStreamProj::Tcp { transport } => transport.poll_read(cx, buf),
-            #[cfg(feature = "tls-core")]
             ConnStreamProj::Tls { transport } => transport.poll_read(cx, buf),
             #[cfg(unix)]
             ConnStreamProj::Udp { transport } => transport.poll_read(cx, buf),
@@ -198,7 +221,6 @@ impl connect::Connection for ConnStream {
     fn connected(&self) -> connect::Connected {
         match self {
             Self::Tcp { transport } => transport.connected(),
-            #[cfg(feature = "tls-core")]
             Self::Tls { transport } => transport.connected(),
             #[cfg(unix)]
             Self::Udp { transport: _ } => connect::Connected::new(),
@@ -216,7 +238,6 @@ impl hyper::rt::Write for ConnStream {
     ) -> Poll<Result<usize, std::io::Error>> {
         match self.project() {
             ConnStreamProj::Tcp { transport } => transport.poll_write(cx, buf),
-            #[cfg(feature = "tls-core")]
             ConnStreamProj::Tls { transport } => transport.poll_write(cx, buf),
             #[cfg(unix)]
             ConnStreamProj::Udp { transport } => transport.poll_write(cx, buf),
@@ -231,7 +252,6 @@ impl hyper::rt::Write for ConnStream {
     ) -> Poll<Result<(), std::io::Error>> {
         match self.project() {
             ConnStreamProj::Tcp { transport } => transport.poll_shutdown(cx),
-            #[cfg(feature = "tls-core")]
             ConnStreamProj::Tls { transport } => transport.poll_shutdown(cx),
             #[cfg(unix)]
             ConnStreamProj::Udp { transport } => transport.poll_shutdown(cx),
@@ -243,7 +263,6 @@ impl hyper::rt::Write for ConnStream {
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
         match self.project() {
             ConnStreamProj::Tcp { transport } => transport.poll_flush(cx),
-            #[cfg(feature = "tls-core")]
             ConnStreamProj::Tls { transport } => transport.poll_flush(cx),
             #[cfg(unix)]
             ConnStreamProj::Udp { transport } => transport.poll_flush(cx),

--- a/libdd-common/src/connector/conn_stream.rs
+++ b/libdd-common/src/connector/conn_stream.rs
@@ -12,6 +12,8 @@ use pin_project::pin_project;
 
 #[pin_project(project=ConnStreamProj)]
 #[derive(Debug)]
+// `BoxedConn` is internal, and the field anyway not pub.
+#[allow(private_interfaces)]
 pub enum ConnStream {
     Tcp {
         #[pin]
@@ -20,8 +22,7 @@ pub enum ConnStream {
     #[cfg(feature = "tls-core")]
     Tls {
         #[pin]
-        transport:
-            Box<TokioIo<tokio_rustls::client::TlsStream<TokioIo<TokioIo<tokio::net::TcpStream>>>>>,
+        transport: wrapped::BoxedConn,
     },
     #[cfg(unix)]
     Udp {
@@ -33,6 +34,68 @@ pub enum ConnStream {
         #[pin]
         transport: TokioIo<tokio::net::windows::named_pipe::NamedPipeClient>,
     },
+}
+
+#[cfg(feature = "tls-core")]
+/// Wrapped connection, usable from hyper directly, or e.g. a hyper proxy wrapper
+mod wrapped {
+    use super::*;
+
+    pub trait EstablishedConn: hyper::rt::Read + hyper::rt::Write + connect::Connection + Send {}
+
+    impl<T: hyper::rt::Read + hyper::rt::Write + connect::Connection + Send> EstablishedConn for T {}
+
+    #[derive(Debug)]
+    pub struct BoxedConn(Pin<Box<dyn EstablishedConn>>);
+
+    impl core::fmt::Debug for dyn EstablishedConn {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            f.write_str("EstablishedConn")
+        }
+    }
+
+    impl BoxedConn {
+        pub fn new<T: EstablishedConn + 'static>(inner: T) -> Self {
+            Self(Box::pin(inner))
+        }
+    }
+
+    impl hyper::rt::Read for BoxedConn {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: ReadBufCursor<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            self.get_mut().0.as_mut().poll_read(cx, buf)
+        }
+    }
+
+    impl hyper::rt::Write for BoxedConn {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<Result<usize, std::io::Error>> {
+            self.get_mut().0.as_mut().poll_write(cx, buf)
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
+            self.get_mut().0.as_mut().poll_flush(cx)
+        }
+
+        fn poll_shutdown(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Result<(), std::io::Error>> {
+            self.get_mut().0.as_mut().poll_shutdown(cx)
+        }
+    }
+
+    impl connect::Connection for BoxedConn {
+        fn connected(&self) -> connect::Connected {
+            self.0.connected()
+        }
+    }
 }
 
 pub type ConnStreamError = Box<dyn core::error::Error + Send + Sync>;
@@ -93,7 +156,9 @@ impl ConnStream {
         require_tls: bool,
     ) -> impl Future<Output = Result<ConnStream, ConnStreamError>> + 'static
     where
-        C: Service<hyper::Uri, Response = TokioIo<tokio::net::TcpStream>> + 'static,
+        C: Service<hyper::Uri> + 'static,
+        C::Response:
+            hyper::rt::Read + hyper::rt::Write + connect::Connection + Send + Unpin + 'static,
         C::Future: Send + 'static,
         C::Error: Into<Box<dyn core::error::Error + Send + Sync>>,
     {
@@ -101,19 +166,12 @@ impl ConnStream {
         let stream_fut = c.call(uri.to_string().parse().unwrap());
         async move {
             let stream = stream_fut.await?;
-            match stream {
-                // move only require_tls
-                hyper_rustls::MaybeHttpsStream::Http(t) => {
-                    if require_tls {
-                        Err(super::errors::Error::CannotEstablishTlsConnection.into())
-                    } else {
-                        Ok(ConnStream::Tcp { transport: t })
-                    }
-                }
-                hyper_rustls::MaybeHttpsStream::Https(t) => Ok(ConnStream::Tls {
-                    transport: Box::from(t),
-                }),
+            if require_tls && matches!(stream, hyper_rustls::MaybeHttpsStream::Http(_)) {
+                return Err(super::errors::Error::CannotEstablishTlsConnection.into());
             }
+            Ok(ConnStream::Tls {
+                transport: wrapped::BoxedConn::new(stream),
+            })
         }
     }
 }
@@ -141,10 +199,7 @@ impl connect::Connection for ConnStream {
         match self {
             Self::Tcp { transport } => transport.connected(),
             #[cfg(feature = "tls-core")]
-            Self::Tls { transport } => {
-                let (tcp, _) = transport.inner().get_ref();
-                tcp.inner().inner().connected()
-            }
+            Self::Tls { transport } => transport.connected(),
             #[cfg(unix)]
             Self::Udp { transport: _ } => connect::Connected::new(),
             #[cfg(windows)]

--- a/libdd-common/src/connector/conn_stream.rs
+++ b/libdd-common/src/connector/conn_stream.rs
@@ -87,11 +87,16 @@ impl ConnStream {
     }
 
     #[cfg(feature = "tls-core")]
-    pub fn from_https_connector_with_uri(
-        c: &mut hyper_rustls::HttpsConnector<connect::HttpConnector>,
+    pub fn from_https_connector_with_uri<C>(
+        c: &mut hyper_rustls::HttpsConnector<C>,
         uri: hyper::Uri,
         require_tls: bool,
-    ) -> impl Future<Output = Result<ConnStream, ConnStreamError>> + 'static {
+    ) -> impl Future<Output = Result<ConnStream, ConnStreamError>> + 'static
+    where
+        C: Service<hyper::Uri, Response = TokioIo<tokio::net::TcpStream>> + 'static,
+        C::Future: Send + 'static,
+        C::Error: Into<Box<dyn core::error::Error + Send + Sync>>,
+    {
         #[allow(clippy::unwrap_used)]
         let stream_fut = c.call(uri.to_string().parse().unwrap());
         async move {

--- a/libdd-common/src/connector/mod.rs
+++ b/libdd-common/src/connector/mod.rs
@@ -123,9 +123,23 @@ mod https {
     #[cfg(not(feature = "https"))]
     fn ensure_crypto_provider_initialized() {}
 
+    #[cfg(any(feature = "https", feature = "fips"))]
+    fn require_crypto_provider() -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    #[cfg(not(any(feature = "https", feature = "fips")))]
+    fn require_crypto_provider() -> anyhow::Result<()> {
+        if rustls::crypto::CryptoProvider::get_default().is_none() {
+            anyhow::bail!("no rustls CryptoProvider installed");
+        }
+        Ok(())
+    }
+
     #[cfg(feature = "use_webpki_roots")]
     pub(super) fn build_tls_config() -> anyhow::Result<ClientConfig> {
         ensure_crypto_provider_initialized(); // One-time initialization of a crypto provider if needed
+        require_crypto_provider()?;
 
         Ok(ClientConfig::builder()
             .with_webpki_roots()
@@ -140,6 +154,7 @@ mod https {
         use rustls_platform_verifier::BuilderVerifierExt;
 
         ensure_crypto_provider_initialized(); // One-time initialization of a crypto provider if needed
+        require_crypto_provider()?;
 
         Ok(ClientConfig::builder()
             .with_platform_verifier()?

--- a/libdd-common/src/connector/mod.rs
+++ b/libdd-common/src/connector/mod.rs
@@ -20,11 +20,18 @@ pub mod errors;
 mod conn_stream;
 use conn_stream::{ConnStream, ConnStreamError};
 
+#[cfg(feature = "hyper-proxy")]
+mod proxy;
+
 #[derive(Clone)]
+// `proxy::HttpsProxyConnector` is crate internal, and the field anyway not pub.
+#[allow(private_interfaces)]
 pub enum Connector {
     Http(connect::HttpConnector),
     #[cfg(feature = "tls-core")]
     Https(hyper_rustls::HttpsConnector<connect::HttpConnector>),
+    #[cfg(feature = "hyper-proxy")]
+    HttpsProxy(Box<proxy::HttpsProxyConnector>),
 }
 
 static DEFAULT_CONNECTOR: LazyLock<Connector> = LazyLock::new(Connector::new);
@@ -39,14 +46,22 @@ impl Connector {
     /// Make sure this function is not called frequently. Fetching the root certificates is an
     /// expensive operation. Access the globally cached connector via Connector::default().
     fn new() -> Self {
+        #[cfg(feature = "hyper-proxy")]
+        {
+            Connector::HttpsProxy(Box::new(proxy::HttpsProxyConnector::new(
+                Self::new_no_proxy(),
+            )))
+        }
+        #[cfg(not(feature = "hyper-proxy"))]
+        {
+            Self::new_no_proxy()
+        }
+    }
+
+    pub(super) fn new_no_proxy() -> Self {
         #[cfg(feature = "tls-core")]
         {
-            #[cfg(feature = "use_webpki_roots")]
-            let https_connector_fn = https::build_https_connector_with_webpki_roots;
-            #[cfg(not(feature = "use_webpki_roots"))]
-            let https_connector_fn = https::build_https_connector;
-
-            match https_connector_fn() {
+            match https::build_https_connector() {
                 Ok(connector) => Connector::Https(connector),
                 Err(_) => Connector::Http(connect::HttpConnector::new()),
             }
@@ -77,6 +92,8 @@ impl Connector {
             Self::Https(c) => {
                 ConnStream::from_https_connector_with_uri(c, uri, require_tls).boxed()
             }
+            #[cfg(feature = "hyper-proxy")]
+            Self::HttpsProxy(p) => p.build_conn_stream(uri, require_tls),
         }
     }
 }
@@ -107,38 +124,33 @@ mod https {
     fn ensure_crypto_provider_initialized() {}
 
     #[cfg(feature = "use_webpki_roots")]
-    pub(super) fn build_https_connector_with_webpki_roots() -> anyhow::Result<
-        hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
-    > {
+    pub(super) fn build_tls_config() -> anyhow::Result<ClientConfig> {
         ensure_crypto_provider_initialized(); // One-time initialization of a crypto provider if needed
 
-        let client_config = ClientConfig::builder()
+        Ok(ClientConfig::builder()
             .with_webpki_roots()
-            .with_no_client_auth();
-        Ok(hyper_rustls::HttpsConnectorBuilder::new()
-            .with_tls_config(client_config)
-            .https_or_http()
-            .enable_http1()
-            .build())
+            .with_no_client_auth())
     }
 
     #[cfg(not(feature = "use_webpki_roots"))]
-    /// Returns a default connector that uses the system trust roots.
+    /// Builds the client TLS config using the system trust roots.
     /// `SSL_CERT_FILE` and `SSL_CERT_DIR` variable are only supported on linux, see
     /// `rustls_platform_verifier` doc for details.
-    pub(super) fn build_https_connector() -> anyhow::Result<
-        hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
-    > {
+    pub(super) fn build_tls_config() -> anyhow::Result<ClientConfig> {
         use rustls_platform_verifier::BuilderVerifierExt;
 
         ensure_crypto_provider_initialized(); // One-time initialization of a crypto provider if needed
 
-        let client_config = ClientConfig::builder()
+        Ok(ClientConfig::builder()
             .with_platform_verifier()?
-            .with_no_client_auth();
+            .with_no_client_auth())
+    }
 
+    pub(super) fn build_https_connector() -> anyhow::Result<
+        hyper_rustls::HttpsConnector<hyper_util::client::legacy::connect::HttpConnector>,
+    > {
         Ok(hyper_rustls::HttpsConnectorBuilder::new()
-            .with_tls_config(client_config)
+            .with_tls_config(build_tls_config()?)
             .https_or_http()
             .enable_http1()
             .build())
@@ -168,6 +180,8 @@ impl tower_service::Service<hyper::Uri> for Connector {
             Connector::Http(c) => c.poll_ready(cx).map_err(|e| e.into()),
             #[cfg(feature = "tls-core")]
             Connector::Https(c) => c.poll_ready(cx),
+            #[cfg(feature = "hyper-proxy")]
+            Connector::HttpsProxy(p) => p.poll_ready(cx),
         }
     }
 }
@@ -212,7 +226,7 @@ mod tests {
 
         env::set_var(ENV_SSL_CERT_FILE, "this/folder/does/not/exist");
         env::set_var(ENV_SSL_CERT_DIR, "this/folder/does/not/exist");
-        let connector = Connector::new();
+        let connector = Connector::new_no_proxy();
 
         assert!(matches!(connector, Connector::Http(_)));
 
@@ -231,7 +245,7 @@ mod tests {
         let old_value = env::var(ENV_SSL_CERT_FILE).unwrap_or_default();
 
         env::set_var(ENV_SSL_CERT_FILE, "this/folder/does/not/exist");
-        let connector = Connector::new();
+        let connector = Connector::new_no_proxy();
         assert!(matches!(connector, Connector::Https(_)));
 
         env::set_var(ENV_SSL_CERT_FILE, old_value);

--- a/libdd-common/src/connector/mod.rs
+++ b/libdd-common/src/connector/mod.rs
@@ -24,14 +24,14 @@ use conn_stream::{ConnStream, ConnStreamError};
 mod proxy;
 
 #[derive(Clone)]
-// `proxy::HttpsProxyConnector` is crate internal, and the field anyway not pub.
+// `proxy::HttpProxyConnector` is crate internal, and the field anyway not pub.
 #[allow(private_interfaces)]
 pub enum Connector {
     Http(connect::HttpConnector),
     #[cfg(feature = "tls-core")]
     Https(hyper_rustls::HttpsConnector<connect::HttpConnector>),
     #[cfg(feature = "hyper-proxy")]
-    HttpsProxy(Box<proxy::HttpsProxyConnector>),
+    Proxy(Box<proxy::HttpProxyConnector>),
 }
 
 static DEFAULT_CONNECTOR: LazyLock<Connector> = LazyLock::new(Connector::new);
@@ -48,7 +48,7 @@ impl Connector {
     fn new() -> Self {
         #[cfg(feature = "hyper-proxy")]
         {
-            Connector::HttpsProxy(Box::new(proxy::HttpsProxyConnector::new(
+            Connector::Proxy(Box::new(proxy::HttpProxyConnector::new(
                 Self::new_no_proxy(),
             )))
         }
@@ -93,7 +93,7 @@ impl Connector {
                 ConnStream::from_https_connector_with_uri(c, uri, require_tls).boxed()
             }
             #[cfg(feature = "hyper-proxy")]
-            Self::HttpsProxy(p) => p.build_conn_stream(uri, require_tls),
+            Self::Proxy(p) => p.build_conn_stream(uri, require_tls),
         }
     }
 }
@@ -196,7 +196,7 @@ impl tower_service::Service<hyper::Uri> for Connector {
             #[cfg(feature = "tls-core")]
             Connector::Https(c) => c.poll_ready(cx),
             #[cfg(feature = "hyper-proxy")]
-            Connector::HttpsProxy(p) => p.poll_ready(cx),
+            Connector::Proxy(p) => p.poll_ready(cx),
         }
     }
 }

--- a/libdd-common/src/connector/proxy.rs
+++ b/libdd-common/src/connector/proxy.rs
@@ -15,22 +15,30 @@ use super::{https, Connector};
 // Read getenv only once at init to avoid concurrency issues with the environment.
 static PROXY_MATCHER: LazyLock<Matcher> = LazyLock::new(Matcher::from_env);
 
-/// Wraps a direct `Connector` to additionally honor the `HTTPS_PROXY`/`https_proxy`
+/// Wraps a direct `Connector` to additionally honor the `HTTP(S)_PROXY`/`http(s)_proxy`
 /// and `NO_PROXY`/`no_proxy` environment variables.
 #[derive(Clone)]
 pub(super) struct HttpsProxyConnector {
     matcher: &'static Matcher,
     tls_config: Option<rustls::ClientConfig>,
-    http: HttpConnector,
+    proxy_dialer: Option<hyper_rustls::HttpsConnector<HttpConnector>>,
     direct: Connector,
 }
 
 impl HttpsProxyConnector {
     pub(super) fn new(direct: Connector) -> Self {
+        let tls_config = https::build_tls_config().ok();
+        let proxy_dialer = tls_config.clone().map(|tls_config| {
+            hyper_rustls::HttpsConnectorBuilder::new()
+                .with_tls_config(tls_config)
+                .https_or_http()
+                .enable_http1()
+                .build()
+        });
         Self {
             matcher: &PROXY_MATCHER,
-            tls_config: https::build_tls_config().ok(),
-            http: HttpConnector::new(),
+            tls_config,
+            proxy_dialer,
             direct,
         }
     }
@@ -45,10 +53,12 @@ impl HttpsProxyConnector {
         require_tls: bool,
     ) -> BoxFuture<'static, Result<ConnStream, ConnStreamError>> {
         if require_tls {
-            if let (Some(tls_config), Some(intercept)) =
-                (&self.tls_config, self.matcher.intercept(&uri))
-            {
-                let mut tunnel = Tunnel::new(intercept.uri().clone(), self.http.clone());
+            if let (Some(tls_config), Some(proxy_dialer), Some(intercept)) = (
+                &self.tls_config,
+                &self.proxy_dialer,
+                self.matcher.intercept(&uri),
+            ) {
+                let mut tunnel = Tunnel::new(intercept.uri().clone(), proxy_dialer.clone());
                 if let Some(auth) = intercept.basic_auth() {
                     tunnel = tunnel.with_auth(auth.clone());
                 }

--- a/libdd-common/src/connector/proxy.rs
+++ b/libdd-common/src/connector/proxy.rs
@@ -1,0 +1,68 @@
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+use core::task::{Context, Poll};
+use std::sync::LazyLock;
+
+use futures::future::BoxFuture;
+use futures::FutureExt;
+use hyper_util::client::legacy::connect::{proxy::Tunnel, HttpConnector};
+use hyper_util::client::proxy::matcher::Matcher;
+
+use super::conn_stream::{ConnStream, ConnStreamError};
+use super::{https, Connector};
+
+// Read getenv only once at init to avoid concurrency issues with the environment.
+static PROXY_MATCHER: LazyLock<Matcher> = LazyLock::new(Matcher::from_env);
+
+/// Wraps a direct `Connector` to additionally honor the `HTTPS_PROXY`/`https_proxy`
+/// and `NO_PROXY`/`no_proxy` environment variables.
+#[derive(Clone)]
+pub(super) struct HttpsProxyConnector {
+    matcher: &'static Matcher,
+    tls_config: Option<rustls::ClientConfig>,
+    http: HttpConnector,
+    direct: Connector,
+}
+
+impl HttpsProxyConnector {
+    pub(super) fn new(direct: Connector) -> Self {
+        Self {
+            matcher: &PROXY_MATCHER,
+            tls_config: https::build_tls_config().ok(),
+            http: HttpConnector::new(),
+            direct,
+        }
+    }
+
+    pub(super) fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), ConnStreamError>> {
+        tower_service::Service::poll_ready(&mut self.direct, cx)
+    }
+
+    pub(super) fn build_conn_stream(
+        &mut self,
+        uri: hyper::Uri,
+        require_tls: bool,
+    ) -> BoxFuture<'static, Result<ConnStream, ConnStreamError>> {
+        if require_tls {
+            if let (Some(tls_config), Some(intercept)) =
+                (&self.tls_config, self.matcher.intercept(&uri))
+            {
+                let mut tunnel = Tunnel::new(intercept.uri().clone(), self.http.clone());
+                if let Some(auth) = intercept.basic_auth() {
+                    tunnel = tunnel.with_auth(auth.clone());
+                }
+
+                let mut https = hyper_rustls::HttpsConnectorBuilder::new()
+                    .with_tls_config(tls_config.clone())
+                    .https_or_http()
+                    .enable_http1()
+                    .wrap_connector(tunnel);
+
+                return ConnStream::from_https_connector_with_uri(&mut https, uri, true).boxed();
+            }
+        }
+
+        tower_service::Service::call(&mut self.direct, uri)
+    }
+}

--- a/libdd-common/src/connector/proxy.rs
+++ b/libdd-common/src/connector/proxy.rs
@@ -10,7 +10,9 @@ use hyper_util::client::legacy::connect::{proxy::Tunnel, HttpConnector};
 use hyper_util::client::proxy::matcher::Matcher;
 
 use super::conn_stream::{ConnStream, ConnStreamError};
-use super::{https, Connector};
+#[cfg(feature = "tls-core")]
+use super::https;
+use super::Connector;
 
 // Read getenv only once at init to avoid concurrency issues with the environment.
 static PROXY_MATCHER: LazyLock<Matcher> = LazyLock::new(Matcher::from_env);
@@ -18,16 +20,20 @@ static PROXY_MATCHER: LazyLock<Matcher> = LazyLock::new(Matcher::from_env);
 /// Wraps a direct `Connector` to additionally honor the `HTTP(S)_PROXY`/`http(s)_proxy`
 /// and `NO_PROXY`/`no_proxy` environment variables.
 #[derive(Clone)]
-pub(super) struct HttpsProxyConnector {
+pub(super) struct HttpProxyConnector {
     matcher: &'static Matcher,
+    #[cfg(feature = "tls-core")]
     tls_config: Option<rustls::ClientConfig>,
+    #[cfg(feature = "tls-core")]
     proxy_dialer: Option<hyper_rustls::HttpsConnector<HttpConnector>>,
     direct: Connector,
 }
 
-impl HttpsProxyConnector {
+impl HttpProxyConnector {
     pub(super) fn new(direct: Connector) -> Self {
+        #[cfg(feature = "tls-core")]
         let tls_config = https::build_tls_config().ok();
+        #[cfg(feature = "tls-core")]
         let proxy_dialer = tls_config.clone().map(|tls_config| {
             hyper_rustls::HttpsConnectorBuilder::new()
                 .with_tls_config(tls_config)
@@ -37,7 +43,9 @@ impl HttpsProxyConnector {
         });
         Self {
             matcher: &PROXY_MATCHER,
+            #[cfg(feature = "tls-core")]
             tls_config,
+            #[cfg(feature = "tls-core")]
             proxy_dialer,
             direct,
         }
@@ -52,25 +60,33 @@ impl HttpsProxyConnector {
         uri: hyper::Uri,
         require_tls: bool,
     ) -> BoxFuture<'static, Result<ConnStream, ConnStreamError>> {
-        if require_tls {
-            if let (Some(tls_config), Some(proxy_dialer), Some(intercept)) = (
-                &self.tls_config,
-                &self.proxy_dialer,
-                self.matcher.intercept(&uri),
-            ) {
-                let mut tunnel = Tunnel::new(intercept.uri().clone(), proxy_dialer.clone());
-                if let Some(auth) = intercept.basic_auth() {
-                    tunnel = tunnel.with_auth(auth.clone());
-                }
+        let Some(intercept) = self.matcher.intercept(&uri) else {
+            return tower_service::Service::call(&mut self.direct, uri);
+        };
 
-                let mut https = hyper_rustls::HttpsConnectorBuilder::new()
-                    .with_tls_config(tls_config.clone())
-                    .https_or_http()
-                    .enable_http1()
-                    .wrap_connector(tunnel);
-
-                return ConnStream::from_https_connector_with_uri(&mut https, uri, true).boxed();
+        #[cfg(feature = "tls-core")]
+        if let (Some(tls_config), Some(proxy_dialer)) = (&self.tls_config, &self.proxy_dialer) {
+            let mut tunnel = Tunnel::new(intercept.uri().clone(), proxy_dialer.clone());
+            if let Some(auth) = intercept.basic_auth() {
+                tunnel = tunnel.with_auth(auth.clone());
             }
+
+            let mut https = hyper_rustls::HttpsConnectorBuilder::new()
+                .with_tls_config(tls_config.clone())
+                .https_or_http()
+                .enable_http1()
+                .wrap_connector(tunnel);
+
+            return ConnStream::from_https_connector_with_uri(&mut https, uri, require_tls).boxed();
+        }
+
+        // No crypto provider is available, proxy only via http
+        if !require_tls && intercept.uri().scheme_str() == Some("http") {
+            let mut tunnel = Tunnel::new(intercept.uri().clone(), HttpConnector::new());
+            if let Some(auth) = intercept.basic_auth() {
+                tunnel = tunnel.with_auth(auth.clone());
+            }
+            return ConnStream::from_tunnel_with_uri(&mut tunnel, uri).boxed();
         }
 
         tower_service::Service::call(&mut self.direct, uri)

--- a/libdd-http-client/Cargo.toml
+++ b/libdd-http-client/Cargo.toml
@@ -19,6 +19,8 @@ default = ["https", "reqwest-backend"]
 https = ["dep:reqwest", "reqwest?/rustls-no-provider", "libdd-common?/https"]
 reqwest-backend = ["dep:reqwest", "reqwest?/hickory-dns", "reqwest?/multipart"]
 hyper-backend = ["dep:libdd-common", "dep:hyper", "dep:hyper-util", "dep:http-body-util"]
+# Honor HTTPS_PROXY/NO_PROXY environment variables in the hyper backend.
+hyper-proxy = ["hyper-backend", "libdd-common?/hyper-proxy"]
 fips = ["dep:reqwest", "reqwest?/rustls-no-provider", "dep:rustls", "rustls?/aws-lc-rs", "libdd-common?/fips"]
 
 [dependencies]

--- a/libdd-http-client/tests/hyper_proxy_test.rs
+++ b/libdd-http-client/tests/hyper_proxy_test.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! The proxy environment variables are read only once, ever, on the first
-//! `HttpsProxyConnector` constructed in the process (see `PROXY_MATCHER` in
+//! `HttpProxyConnector` constructed in the process (see `PROXY_MATCHER` in
 //! `libdd_common::connector::proxy`) to avoid racing a concurrent `setenv`.
-//! This file must therefore stay the only test that touches `HTTPS_PROXY` in
-//! this binary, and must set it before constructing its first `HttpClient`.
+//! Therefore, there must be only a single test in thie file that touches
+//! `HTTPS_PROXY`, and must set it before constructing its first `HttpClient`.
 #![cfg(feature = "hyper-proxy")]
 
 use libdd_http_client::{HttpClient, HttpMethod, HttpRequest};

--- a/libdd-http-client/tests/hyper_proxy_test.rs
+++ b/libdd-http-client/tests/hyper_proxy_test.rs
@@ -1,0 +1,99 @@
+// Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+//! The proxy environment variables are read only once, ever, on the first
+//! `HttpsProxyConnector` constructed in the process (see `PROXY_MATCHER` in
+//! `libdd_common::connector::proxy`) to avoid racing a concurrent `setenv`.
+//! This file must therefore stay the only test that touches `HTTPS_PROXY` in
+//! this binary, and must set it before constructing its first `HttpClient`.
+#![cfg(feature = "hyper-proxy")]
+
+use libdd_http_client::{HttpClient, HttpMethod, HttpRequest};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+fn ensure_crypto_provider() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
+/// A minimal HTTP CONNECT proxy stand-in: accepts one connection, verifies
+/// it received a CONNECT request, replies with a successful tunnel
+/// establishment, then closes. This is enough to prove the client routed
+/// the request through the configured proxy rather than dialing the
+/// destination directly.
+async fn spawn_fake_connect_proxy() -> (std::net::SocketAddr, Arc<AtomicBool>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let hit = Arc::new(AtomicBool::new(false));
+    let hit_clone = hit.clone();
+
+    tokio::spawn(async move {
+        let Ok((mut socket, _)) = listener.accept().await else {
+            return;
+        };
+
+        let mut buf = [0u8; 1024];
+        let mut received = Vec::new();
+        loop {
+            let n = socket.read(&mut buf).await.unwrap_or(0);
+            if n == 0 {
+                return;
+            }
+            received.extend_from_slice(&buf[..n]);
+            if received.windows(4).any(|w| w == b"\r\n\r\n") {
+                break;
+            }
+        }
+
+        if received.starts_with(b"CONNECT ") {
+            hit_clone.store(true, Ordering::SeqCst);
+        }
+
+        let _ = socket
+            .write_all(b"HTTP/1.1 200 Connection Established\r\n\r\n")
+            .await;
+        // Close without ever performing a TLS handshake: the client's request
+        // is expected to fail past this point, which is fine — we only care
+        // that it got routed through us.
+    });
+
+    (addr, hit)
+}
+
+#[cfg_attr(miri, ignore)]
+#[tokio::test]
+async fn test_https_request_is_routed_through_https_proxy() {
+    ensure_crypto_provider();
+
+    let (proxy_addr, proxy_hit) = spawn_fake_connect_proxy().await;
+    // SAFETY: no other threads in this test process mutate the environment
+    // concurrently.
+    unsafe {
+        std::env::set_var("HTTPS_PROXY", format!("http://{proxy_addr}"));
+    }
+
+    let client = HttpClient::new(
+        "https://example.invalid/".to_owned(),
+        Duration::from_secs(5),
+    )
+    .unwrap();
+    let req = HttpRequest::new(HttpMethod::Get, "https://example.invalid/get".to_owned());
+
+    // The fake proxy never completes a real TLS handshake, so the request
+    // itself is expected to fail...
+    let _ = client.send(req).await;
+
+    unsafe {
+        std::env::remove_var("HTTPS_PROXY");
+    }
+
+    // ...but it must have gone through the proxy rather than trying (and
+    // failing on DNS resolution) to dial example.invalid directly.
+    assert!(
+        proxy_hit.load(Ordering::SeqCst),
+        "request was not routed through the configured HTTPS_PROXY"
+    );
+}


### PR DESCRIPTION
We make sure to fetch the env vars only once at init, at basically the same time than the TLS envs are read too.

This allows users to redirect requests going to the datadog backend through egress proxies, rather than having to hack around with DNS and MITM TLS certificates.