### PR TITLE
fix(trace-utils): use vec map dedup when serializing

### DIFF
--- a/libdd-data-pipeline/src/trace_exporter/mod.rs
+++ b/libdd-data-pipeline/src/trace_exporter/mod.rs
@@ -655,9 +655,14 @@ impl<
     /// Sends trace chunks to the Datadog agentless intake (`/v1/input`) as JSON.
     async fn send_agentless_traces_inner<T: TraceData>(
         &self,
-        traces: Vec<Vec<Span<T>>>,
+        mut traces: Vec<Vec<Span<T>>>,
         config: &AgentlessTraceConfig,
     ) -> Result<AgentResponse, TraceExporterError> {
+        for chunk in &mut traces {
+            for span in chunk.iter_mut() {
+                span.dedup();
+            }
+        }
         let trace_count = traces.len();
         let json_body = libdd_trace_utils::agentless_encoder::encode_payload(
             &traces,

--- a/libdd-trace-utils/src/agentless_encoder/mod.rs
+++ b/libdd-trace-utils/src/agentless_encoder/mod.rs
@@ -217,7 +217,7 @@ fn encode_span<T: TraceData, S: Serializer>(
             let mut compute_stats_seen = false;
 
             let mut meta = ser.serialize_map(None)?;
-            for (k, v) in span.meta.iter() {
+            for (k, v) in span.meta.defensive_dedup().iter() {
                 let key: &str = k.borrow();
                 match key {
                     "_dd.p.tid" => p_tid_seen = true,
@@ -259,7 +259,7 @@ fn encode_span<T: TraceData, S: Serializer>(
         &ser_fn!(<T: TraceData> |ser, span: &'a Span<T>| {
             let mut metrics = ser.serialize_map(None)?;
             let mut trace_root_seen = false;
-            for (k, v) in span.metrics.iter() {
+            for (k, v) in span.metrics.defensive_dedup().iter() {
                 let key: &str = k.borrow();
                 // serde_json refuses to serialize NaN/Inf; drop them silently.
                 if v.is_finite() {


### PR DESCRIPTION
# Motivation

Duplicate meta/metrics attributes were not deduped before being serialized in the agentless encoder

