### PR TITLE
fix(APMSP-3164): prevent untrusted code from being executed

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,10 +5,21 @@ variables:
     value: "main"
     description: "downstream jobs are triggered on this branch"
 
+  # To bump: docker buildx imagetools inspect registry.ddbuild.io/ci/benchmarking-platform:libdatadog-benchmarks
+  BASE_CI_IMAGE: registry.ddbuild.io/ci/benchmarking-platform:libdatadog-benchmarks@sha256:c23806c552973ba3177ec77377e0ed597cb70b05b116561e96ade5e47e0706e4
+
+  # To bump: get commit sha from repo: https://gitlab.ddbuild.io/DataDog/benchmarking-platform branch: libdatadog/benchmarks
+  BENCHMARKING_PLATFORM_SHA: "1d6ed8466bbe6e8fca75f899a7ec3bdc3003ce4e"
+
 include:
   - local: .gitlab/impacted-crates.yml
   - local: .gitlab/benchmarks.yml
   - local: .gitlab/fuzz.yml
+
+.untrusted_ref_guard:
+  rules:
+    - if: '$CI_EXTERNAL_PULL_REQUEST_SOURCE_REPOSITORY && $CI_EXTERNAL_PULL_REQUEST_SOURCE_REPOSITORY != $CI_EXTERNAL_PULL_REQUEST_TARGET_REPOSITORY'
+      when: never
 
 trigger_internal_build:
   variables:

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -24,6 +24,7 @@
         # hand it to that code for free.
         git -C /platform remote set-url origin "https://gitlab.ddbuild.io/DataDog/benchmarking-platform"
       )
+    - unset CI_JOB_TOKEN
 
 # The benchmark suite is sharded across parallel jobs to reduce wall-clock time. Each shard runs
 # both candidate and baseline for its assigned crates on the same runner (so the comparison stays

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -1,13 +1,5 @@
-variables:
-  BASE_CI_IMAGE: registry.ddbuild.io/ci/benchmarking-platform:libdatadog-benchmarks
-  # The Dockerfile to this image is located at:
-  # https://github.com/DataDog/benchmarking-platform/tree/libdatadog/benchmarks
-
-# Shared rules for the benchmark jobs: skip merge-queue and release/hotfix branches (whether they
-# arrive as a branch pipeline or an external PR), and run the full suite on main. Release/hotfix are
-# version bumps + merge-backs of code already benchmarked on its originating PR and on main, so
-# re-running here would add nothing.
 .benchmark_run_rules: &benchmark_run_rules
+  - !reference [.untrusted_ref_guard, rules]
   - if: '$CI_COMMIT_BRANCH =~ /^mq-working-branch-/'
     when: never
   - if: '$CI_COMMIT_BRANCH =~ /^(release|hotfix)[-\/]/'
@@ -17,6 +9,21 @@ variables:
   - if: '$CI_COMMIT_BRANCH == "main"'
     interruptible: false
   - interruptible: true
+
+.clone_benchmarking_platform:
+  script:
+    # Wrapped in a subshell so `set -euo pipefail` stays local.
+    - |
+      (
+        set -euo pipefail
+        git clone --branch libdatadog/benchmarks \
+          "https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform" /platform
+        git -C /platform checkout --detach "${BENCHMARKING_PLATFORM_SHA}"
+        # Drop the credential-bearing remote. Neither job pushes, and code from the tested commit
+        # runs later in this same container -- leaving $CI_JOB_TOKEN in /platform/.git/config would
+        # hand it to that code for free.
+        git -C /platform remote set-url origin "https://gitlab.ddbuild.io/DataDog/benchmarking-platform"
+      )
 
 # The benchmark suite is sharded across parallel jobs to reduce wall-clock time. Each shard runs
 # both candidate and baseline for its assigned crates on the same runner (so the comparison stays
@@ -58,7 +65,8 @@ benchmarks:
           ;;
       esac
     - export ARTIFACTS_DIR="$(pwd)/reports" && (mkdir "${ARTIFACTS_DIR}" || :)
-    - git clone --branch libdatadog/benchmarks https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform /platform && cd /platform
+    - !reference [.clone_benchmarking_platform, script]
+    - cd /platform
     - ./steps/capture-hardware-software-info.sh
     - |
       SCRIPT_DIR="$(pwd)/steps"
@@ -132,7 +140,7 @@ benchmarks_combine:
         echo "No shard reports produced -> nothing to combine."
         exit 0
       fi
-    - git clone --branch libdatadog/benchmarks https://gitlab-ci-token:${CI_JOB_TOKEN}@gitlab.ddbuild.io/DataDog/benchmarking-platform /platform
+    - !reference [.clone_benchmarking_platform, script]
     - |
       # Assemble the files post-pr-comment.sh reads by concatenating each shard's markdown.
       export ARTIFACTS_DIR="${CI_PROJECT_DIR}/reports"

--- a/.gitlab/fuzz.yml
+++ b/.gitlab/fuzz.yml
@@ -2,15 +2,13 @@
 # This job discovers, builds, and uploads all cargo-fuzz targets to the internal fuzzing infrastructure
 # See ci/README_FUZZING.md for more information
 
-variables:
-  BASE_CI_IMAGE: registry.ddbuild.io/ci/benchmarking-platform:libdatadog-benchmarks
-
 fuzz:
   tags: ["arch:amd64"]
   needs: []
   image:
     name: $BASE_CI_IMAGE
   rules:
+    - !reference [.untrusted_ref_guard, rules]
     # runs on gitlab schedule and on merge to main.
     # Also allow manual run in branches for ease of debug / testing
     - if: '$CI_COMMIT_BRANCH == "main" && $CI_PIPELINE_SOURCE == "schedule"'

--- a/.gitlab/impacted-crates.yml
+++ b/.gitlab/impacted-crates.yml
@@ -10,9 +10,6 @@
 #
 # Only the benchmarks job consumes this today; other test jobs can depend on it later.
 
-variables:
-  BASE_CI_IMAGE: registry.ddbuild.io/ci/benchmarking-platform:libdatadog-benchmarks
-
 compute_impacted_crates:
   stage: test
   tags: ["arch:amd64"]
@@ -20,6 +17,7 @@ compute_impacted_crates:
     name: $BASE_CI_IMAGE
   needs: []
   rules:
+    - !reference [.untrusted_ref_guard, rules]
     # Nothing to compute where benchmarks won't consume it: main runs the full suite, and
     # release/hotfix/merge-queue/scheduled pipelines don't run benchmarks at all.
     - if: '$CI_COMMIT_BRANCH == "main"'


### PR DESCRIPTION
# What does this PR do?

1. Adds a a guard in order to prevent untrusted sources to execute code. This guard is added to the following workflows:

- benchmarks
- fuzz
- impacted crates

2. Removes `$CI_JOB_TOKEN` from being persisted on disk.
3. Pins bothe the benchmark's image and script so unwanted changes don't get executed.

# Motivation

Fix AMPSP-3164.