### PR TITLE
chore: migrate to noqueue merge queue strategy

### DIFF
--- a/repository.datadog.yml
+++ b/repository.datadog.yml
@@ -4,6 +4,15 @@
 schema-version: v1
 kind: mergequeue
 merge_method: squash
+# Each PR in the MQ will be rebased on the base branch before merging
+# conflicts between PRs in the MQ will not be able to be detected
+workflow_type: noqueue
+gitlab_check_enable: true
+# Do not auto-retry any failed GitLab jobs
+gitlab_jobs_retry_enable: false
+# Fail the MQ request as soon as any job fails
+# Note: the MQ will honor any `retry: #` and `allow_failures: true` set on a job
+gitlab_fail_fast: true
 ---
 schema-version: v1
 kind: mergegate


### PR DESCRIPTION
# What does this PR do?

These are similar settings adopted by dd-trace-py.

noqueue is recommended for repos who have "slow" CI such that multiple PRs in the MQ don't stack and delay each other.

While a PR being added to the MQ will get rebased on base branch first, we lose the guarantee of no conflicts between multiple PRs in the MQ.

The net result should be faster MQ merges since PRs won't stack.


The other valuable settings are for ensuring the MQ workflow fails as soon as any GitLab jobs fail, so a failing MQ run won't wait for the pipeline to complete first before bailing.

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
