### PR TITLE
feat(ffe)!: send flagevaluation producer identity

### DIFF
--- a/datadog-sidecar/src/service/ffe_flagevaluation_flusher.rs
+++ b/datadog-sidecar/src/service/ffe_flagevaluation_flusher.rs
@@ -22,6 +22,8 @@ use std::time::Duration;
 use tokio::sync::Mutex as AsyncMutex;
 
 const USER_AGENT: &str = concat!("ddtrace-sidecar/", env!("CARGO_PKG_VERSION"));
+const EVP_ORIGIN: &str = "ddtrace-sidecar";
+const EVP_ORIGIN_VERSION: &str = env!("CARGO_PKG_VERSION");
 const COALESCE_DELAY: Duration = Duration::from_millis(250);
 
 pub(crate) const FLAG_EVALUATION_DROPPED_EVALUATIONS_METRIC: &str =
@@ -38,13 +40,19 @@ pub(crate) const FLAG_EVALUATION_REASON_PAYLOAD_LIMIT: &str = "payload_limit";
 struct DestinationKey {
     endpoint: Endpoint,
     context: FfeTelemetryContext,
+    send_config: FlagEvaluationEvpSendConfig,
 }
 
 impl DestinationKey {
-    fn new(endpoint: Endpoint, context: &FfeTelemetryContext) -> Self {
+    fn new(
+        endpoint: Endpoint,
+        context: &FfeTelemetryContext,
+        send_config: FlagEvaluationEvpSendConfig,
+    ) -> Self {
         Self {
             endpoint,
             context: context.clone(),
+            send_config,
         }
     }
 }
@@ -62,7 +70,27 @@ impl FlagEvaluationCoalescer {
         endpoint: Endpoint,
         batch: FfeFlagEvaluationBatch,
     ) {
-        let destination_key = DestinationKey::new(endpoint, &batch.context);
+        let send_config =
+            match FlagEvaluationEvpSendConfig::new(USER_AGENT, EVP_ORIGIN, EVP_ORIGIN_VERSION) {
+                Ok(config) => config,
+                Err(error) => {
+                    tracing::error!(
+                        "invalid sidecar flagevaluation EVP send configuration: {error}"
+                    );
+                    return;
+                }
+            };
+        self.enqueue_with_config(client, endpoint, batch, send_config);
+    }
+
+    fn enqueue_with_config(
+        &self,
+        client: NativeCapabilities,
+        endpoint: Endpoint,
+        batch: FfeFlagEvaluationBatch,
+        send_config: FlagEvaluationEvpSendConfig,
+    ) {
+        let destination_key = DestinationKey::new(endpoint, &batch.context, send_config);
         if self.inner.enqueue(destination_key, batch) {
             let coalescer = self.clone();
             tokio::spawn(async move {
@@ -82,8 +110,14 @@ impl FlagEvaluationCoalescer {
             let client = client.clone();
             let coalescer = self.inner.clone();
             async move {
-                send_batch_with_writer_stats(&client, &destination.endpoint, batch, &coalescer)
-                    .await
+                send_batch_with_writer_stats(
+                    &client,
+                    &destination.endpoint,
+                    batch,
+                    &destination.send_config,
+                    &coalescer,
+                )
+                .await
             }
         }))
         .await;
@@ -120,10 +154,10 @@ async fn send_batch_with_writer_stats(
     client: &NativeCapabilities,
     endpoint: &Endpoint,
     batch: FfeFlagEvaluationBatch,
+    send_config: &FlagEvaluationEvpSendConfig,
     coalescer: &CommonFlagEvaluationEvpCoalescer<DestinationKey>,
 ) {
-    let config = FlagEvaluationEvpSendConfig::new(USER_AGENT);
-    if let Some(result) = send_flag_evaluation_batch(client, endpoint, batch, &config).await {
+    if let Some(result) = send_flag_evaluation_batch(client, endpoint, batch, send_config).await {
         coalescer.record_payload_build_result(&result);
     }
 }
@@ -217,6 +251,9 @@ mod tests {
             .mock_async(|when, then| {
                 when.method(httpmock::Method::POST)
                     .path(EVP_FLAGEVALUATION_PATH)
+                    .header("user-agent", USER_AGENT)
+                    .header("DD-EVP-ORIGIN", EVP_ORIGIN)
+                    .header("DD-EVP-ORIGIN-VERSION", EVP_ORIGIN_VERSION)
                     .body_includes("\"evaluation_count\":10");
                 then.status(202);
             })
@@ -238,6 +275,67 @@ mod tests {
         }
 
         mock.assert_calls_async(1).await;
+    }
+
+    #[tokio::test]
+    #[cfg_attr(miri, ignore)]
+    async fn does_not_coalesce_different_producer_identities() {
+        const TEST_USER_AGENT: &str = "shared-user-agent";
+
+        let server = MockServer::start_async().await;
+        let baseline = server
+            .mock_async(|when, then| {
+                when.method(httpmock::Method::POST)
+                    .path(EVP_FLAGEVALUATION_PATH)
+                    .header("user-agent", TEST_USER_AGENT)
+                    .header("DD-EVP-ORIGIN", "producer-a")
+                    .header("DD-EVP-ORIGIN-VERSION", "1.0.0")
+                    .body_includes("\"evaluation_count\":5");
+                then.status(202);
+            })
+            .await;
+        let different_origin = server
+            .mock_async(|when, then| {
+                when.method(httpmock::Method::POST)
+                    .path(EVP_FLAGEVALUATION_PATH)
+                    .header("user-agent", TEST_USER_AGENT)
+                    .header("DD-EVP-ORIGIN", "producer-b")
+                    .header("DD-EVP-ORIGIN-VERSION", "1.0.0")
+                    .body_includes("\"evaluation_count\":5");
+                then.status(202);
+            })
+            .await;
+        let different_origin_version = server
+            .mock_async(|when, then| {
+                when.method(httpmock::Method::POST)
+                    .path(EVP_FLAGEVALUATION_PATH)
+                    .header("user-agent", TEST_USER_AGENT)
+                    .header("DD-EVP-ORIGIN", "producer-a")
+                    .header("DD-EVP-ORIGIN-VERSION", "2.0.0")
+                    .body_includes("\"evaluation_count\":5");
+                then.status(202);
+            })
+            .await;
+
+        let base = endpoint_for(&server);
+        let ep = flagevaluation_endpoint(&base).unwrap();
+        let client = NativeCapabilities::new_client();
+        let coalescer = FlagEvaluationCoalescer::default();
+        let baseline_config =
+            FlagEvaluationEvpSendConfig::new(TEST_USER_AGENT, "producer-a", "1.0.0").unwrap();
+        let different_origin_config =
+            FlagEvaluationEvpSendConfig::new(TEST_USER_AGENT, "producer-b", "1.0.0").unwrap();
+        let different_origin_version_config =
+            FlagEvaluationEvpSendConfig::new(TEST_USER_AGENT, "producer-a", "2.0.0").unwrap();
+
+        coalescer.enqueue_with_config(client.clone(), ep.clone(), batch(), baseline_config);
+        coalescer.enqueue_with_config(client.clone(), ep.clone(), batch(), different_origin_config);
+        coalescer.enqueue_with_config(client.clone(), ep, batch(), different_origin_version_config);
+        coalescer.flush_now(client).await;
+
+        baseline.assert_calls_async(1).await;
+        different_origin.assert_calls_async(1).await;
+        different_origin_version.assert_calls_async(1).await;
     }
 
     #[tokio::test]

--- a/libdd-ffe/src/telemetry/flagevaluation.rs
+++ b/libdd-ffe/src/telemetry/flagevaluation.rs
@@ -33,7 +33,8 @@ use std::sync::{Arc, Mutex};
 mod sender;
 pub use sender::{
     flagevaluation_agent_proxy_endpoint, send_flag_evaluation_batch, FlagEvaluationEvpSendConfig,
-    EVP_FLAGEVALUATION_PATH, EVP_PAYLOAD_SIZE_LIMIT, EVP_SUBDOMAIN_HEADER, EVP_SUBDOMAIN_VALUE,
+    FlagEvaluationEvpSendConfigError, EVP_FLAGEVALUATION_PATH, EVP_PAYLOAD_SIZE_LIMIT,
+    EVP_SUBDOMAIN_HEADER, EVP_SUBDOMAIN_VALUE,
 };
 
 // ── Aggregation caps ────────────────────────────────────────────────────────

--- a/libdd-ffe/src/telemetry/flagevaluation/sender.rs
+++ b/libdd-ffe/src/telemetry/flagevaluation/sender.rs
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{encode_flag_evaluation_payloads, FfeFlagEvaluationBatch};
+use http::header::{HeaderValue, InvalidHeaderValue};
 use http::uri::PathAndQuery;
 use http::Method;
 use libdd_capabilities::{Bytes, HttpClientCapability, SleepCapability};
 use libdd_common::Endpoint;
 use std::time::Duration;
+use thiserror::Error;
 
 /// EVP proxy path for FFE flag evaluation intake.
 pub const EVP_FLAGEVALUATION_PATH: &str = "/evp_proxy/v2/api/v2/flagevaluation";
@@ -14,6 +16,8 @@ pub const EVP_FLAGEVALUATION_PATH: &str = "/evp_proxy/v2/api/v2/flagevaluation";
 pub const EVP_SUBDOMAIN_HEADER: &str = "X-Datadog-EVP-Subdomain";
 /// EVP subdomain that routes requests to event-platform intake.
 pub const EVP_SUBDOMAIN_VALUE: &str = "event-platform-intake";
+const EVP_ORIGIN_HEADER: &str = "DD-EVP-ORIGIN";
+const EVP_ORIGIN_VERSION_HEADER: &str = "DD-EVP-ORIGIN-VERSION";
 /// Agent EVP proxy uncompressed request-body limit.
 ///
 /// Revalidated against `DataDog/datadog-agent` on 2026-07-01:
@@ -23,18 +27,58 @@ pub const EVP_SUBDOMAIN_VALUE: &str = "event-platform-intake";
 /// `apiutil.NewLimitedReader`.
 pub const EVP_PAYLOAD_SIZE_LIMIT: usize = 10 * 1024 * 1024;
 
-#[derive(Clone, Debug)]
+#[derive(Debug, Error)]
+pub enum FlagEvaluationEvpSendConfigError {
+    #[error("EVP origin must not be empty")]
+    EmptyOrigin,
+    #[error("EVP origin version must not be empty")]
+    EmptyOriginVersion,
+    #[error("EVP origin is not a valid HTTP header value")]
+    InvalidOrigin(#[source] InvalidHeaderValue),
+    #[error("EVP origin version is not a valid HTTP header value")]
+    InvalidOriginVersion(#[source] InvalidHeaderValue),
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct FlagEvaluationEvpSendConfig {
     user_agent: String,
+    origin: HeaderValue,
+    origin_version: HeaderValue,
     payload_size_limit: usize,
 }
 
 impl FlagEvaluationEvpSendConfig {
-    pub fn new(user_agent: impl Into<String>) -> Self {
-        Self {
-            user_agent: user_agent.into(),
-            payload_size_limit: EVP_PAYLOAD_SIZE_LIMIT,
+    /// Creates a send configuration with required producer identity metadata.
+    ///
+    /// Origin and origin version must both contain a non-whitespace character
+    /// and be valid HTTP header values. Validating them here ensures every
+    /// request built from this configuration carries usable producer identity
+    /// metadata. Accepted values are stored without normalization.
+    pub fn new(
+        user_agent: impl Into<String>,
+        origin: impl Into<String>,
+        origin_version: impl Into<String>,
+    ) -> Result<Self, FlagEvaluationEvpSendConfigError> {
+        let origin = origin.into();
+        if origin.trim().is_empty() {
+            return Err(FlagEvaluationEvpSendConfigError::EmptyOrigin);
         }
+        let origin = HeaderValue::try_from(origin.as_str())
+            .map_err(FlagEvaluationEvpSendConfigError::InvalidOrigin)?;
+
+        let origin_version = origin_version.into();
+        if origin_version.trim().is_empty() {
+            return Err(FlagEvaluationEvpSendConfigError::EmptyOriginVersion);
+        }
+        let origin_version = HeaderValue::try_from(origin_version.as_str())
+            .map_err(FlagEvaluationEvpSendConfigError::InvalidOriginVersion)?;
+
+        Ok(Self {
+            user_agent: user_agent.into(),
+            origin,
+            origin_version,
+            payload_size_limit: EVP_PAYLOAD_SIZE_LIMIT,
+        })
     }
 
     pub fn with_payload_size_limit(mut self, payload_size_limit: usize) -> Self {
@@ -115,6 +159,8 @@ async fn send_payload<C: HttpClientCapability + SleepCapability>(
         .method(Method::POST)
         .header("Content-Type", "application/json")
         .header(EVP_SUBDOMAIN_HEADER, EVP_SUBDOMAIN_VALUE)
+        .header(EVP_ORIGIN_HEADER, config.origin.clone())
+        .header(EVP_ORIGIN_VERSION_HEADER, config.origin_version.clone())
         .body(Bytes::from(payload))
     {
         Ok(r) => r,
@@ -273,7 +319,8 @@ mod tests {
     }
 
     fn send_config() -> FlagEvaluationEvpSendConfig {
-        FlagEvaluationEvpSendConfig::new("libdd-ffe-test/0.0.0")
+        FlagEvaluationEvpSendConfig::new("libdd-ffe-test/0.0.0", "libdd-ffe-test-origin", "1.2.3")
+            .unwrap()
     }
 
     fn batch() -> FfeFlagEvaluationBatch {
@@ -292,7 +339,10 @@ mod tests {
                 when.method(httpmock::Method::POST)
                     .path(EVP_FLAGEVALUATION_PATH)
                     .header(EVP_SUBDOMAIN_HEADER, EVP_SUBDOMAIN_VALUE)
-                    .header("content-type", "application/json");
+                    .header("content-type", "application/json")
+                    .header("user-agent", "libdd-ffe-test/0.0.0")
+                    .header(EVP_ORIGIN_HEADER, "libdd-ffe-test-origin")
+                    .header(EVP_ORIGIN_VERSION_HEADER, "1.2.3");
                 then.status(202);
             })
             .await;
@@ -304,6 +354,30 @@ mod tests {
 
         mock.assert_async().await;
         assert_eq!(mock.calls_async().await, 1);
+    }
+
+    #[test]
+    fn send_config_rejects_empty_whitespace_or_invalid_producer_identity() {
+        for empty_origin in ["", " ", "\t", " \t "] {
+            assert!(matches!(
+                FlagEvaluationEvpSendConfig::new("user-agent", empty_origin, "1.2.3"),
+                Err(FlagEvaluationEvpSendConfigError::EmptyOrigin)
+            ));
+        }
+        for empty_origin_version in ["", " ", "\t", " \t "] {
+            assert!(matches!(
+                FlagEvaluationEvpSendConfig::new("user-agent", "origin", empty_origin_version),
+                Err(FlagEvaluationEvpSendConfigError::EmptyOriginVersion)
+            ));
+        }
+        assert!(matches!(
+            FlagEvaluationEvpSendConfig::new("user-agent", "invalid\norigin", "1.2.3"),
+            Err(FlagEvaluationEvpSendConfigError::InvalidOrigin(_))
+        ));
+        assert!(matches!(
+            FlagEvaluationEvpSendConfig::new("user-agent", "origin", "invalid\nversion"),
+            Err(FlagEvaluationEvpSendConfigError::InvalidOriginVersion(_))
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
# What does this PR do?

Adds explicit producer identity metadata to libdatadog flag-evaluation EVP requests.

- requires and validates non-empty `origin` and `origin_version` values in `FlagEvaluationEvpSendConfig`
- sends `DD-EVP-ORIGIN` and `DD-EVP-ORIGIN-VERSION` on every request
- attributes sidecar-forwarded evaluations to `dd-trace-php` using the originating session's tracer version
- keeps the sidecar `User-Agent` independent from the originating SDK identity
- includes the send configuration in the coalescer destination key so different producer identities cannot share a request
- adds sender and sidecar tests for exact headers, invalid configuration, identity-specific batching, and originating tracer attribution

# Motivation

Implements [FFL-3019](https://datadoghq.atlassian.net/browse/FFL-3019). The Agent now forwards EVP origin metadata, so libdatadog needs to provide the originating SDK identity for flag-evaluation intake attribution.

# Additional Notes

This follows the same transport contract as [dd-trace-rb#6254](https://github.com/DataDog/dd-trace-rb/pull/6254) and [dd-trace-go#5283](https://github.com/DataDog/dd-trace-go/pull/5283): request-level SDK identity headers use the producer's stable name and release version while preserving existing routing headers and event payloads. The shared libdatadog sender accepts explicit producer identity; the current sidecar call site supplies `dd-trace-php` and the tracer version already stored in its session configuration.

The sidecar is a transport rather than the source SDK, so it remains represented only by `User-Agent`. This does not add an event-level `source` field or change payload limits, endpoint routing, timeout handling, metrics, or delivery behavior.

# How to test the change?

```bash
cargo +nightly-2026-07-26 fmt --all -- --check
cargo check -p libdd-ffe --features flagevaluation-evp
cargo nextest run -p libdd-ffe --features flagevaluation-evp
cargo clippy -p libdd-ffe --all-targets --all-features -- -D warnings
cargo test -p libdd-ffe --doc --features flagevaluation-evp
cargo check -p datadog-sidecar
cargo nextest run -p datadog-sidecar
cargo clippy -p datadog-sidecar --all-targets -- -D warnings
cargo test -p datadog-sidecar --doc
```

[FFL-3019]: https://datadoghq.atlassian.net/browse/FFL-3019
