### PR TITLE
fix(ipc): drop the signal feature from libdd-ipc

### DIFF
--- a/libdd-ipc/Cargo.toml
+++ b/libdd-ipc/Cargo.toml
@@ -49,7 +49,7 @@ spawn_worker = { path = "../spawn_worker" }
 [target.'cfg(not(windows))'.dependencies]
 nix = { version = "0.29", features = ["fs", "mman", "process", "poll", "socket", "uio", "user"] }
 sendfd = { version = "0.4", features = ["tokio"] }
-tokio = { version = "1.23", features = ["sync", "io-util", "signal"] }
+tokio = { version = "1.23", features = ["sync", "io-util"] }
 
 [target.'cfg(target_env = "gnu")'.build-dependencies]
 glibc_version = "0.1.2"
@@ -57,7 +57,7 @@ glibc_version = "0.1.2"
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["handleapi", "memoryapi", "winbase", "winnt", "winerror", "processthreadsapi", "fileapi", "minwinbase"] }
 windows-sys = { version = "0.48.0", features = ["Win32_System", "Win32_System_WindowsProgramming", "Win32_Foundation", "Win32_System_Pipes", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Threading"] }
-tokio = { version = "1.23", features = ["sync", "io-util", "signal", "net", "rt-multi-thread", "rt"] }
+tokio = { version = "1.23", features = ["sync", "io-util", "net", "rt-multi-thread", "rt"] }
 
 [lib]
 bench = false


### PR DESCRIPTION
This seems to mess with python / is fork-unsafe.
Has seemingly zero functionality in the ipc crate itself.