### PR TITLE
fix(ipc)

### DIFF
--- a/datadog-sidecar/src/crashtracker.rs
+++ b/datadog-sidecar/src/crashtracker.rs
@@ -82,6 +82,31 @@ pub fn connect_to_sidecar_receiver(unix_socket_path: &str) -> std::os::fd::RawFd
     if socket::connect(fd.as_raw_fd(), &addr).is_err() {
         return -1;
     }
+
+    // This connector runs outside the normal libdd-ipc wrapper. Authenticate the peer before
+    // sending the crashtracker request so a process that squats the predictable socket cannot
+    // receive crash data. A registered receiver PID is stronger than the same-UID fallback and
+    // is set during the normal sidecar connection setup.
+    let mut cred: libc::ucred = unsafe { std::mem::zeroed() };
+    let mut cred_len = std::mem::size_of::<libc::ucred>() as libc::socklen_t;
+    let expected_pid = libdd_crashtracker::get_expected_receiver_pid();
+    let peer_authenticated = unsafe {
+        libc::getsockopt(
+            fd.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_PEERCRED,
+            &mut cred as *mut _ as *mut libc::c_void,
+            &mut cred_len,
+        ) == 0
+    } && if expected_pid > 0 {
+        cred.pid == expected_pid
+    } else {
+        cred.uid == unsafe { libc::geteuid() }
+    };
+    if !peer_authenticated {
+        return -1;
+    }
+
     if socket::send(
         fd.as_raw_fd(),
         crashtracker_receiver_request_bytes(),

--- a/datadog-sidecar/src/setup/mod.rs
+++ b/datadog-sidecar/src/setup/mod.rs
@@ -39,7 +39,8 @@ pub trait Liaison: Sized {
 
 /// The liaison a subprocess sidecar listens on / connects to for the given `ipc_mode`. Shared by
 /// `start_or_connect_to_sidecar` and the crashtracker collector (`crashtracker_ipc_socket_path`) so
-/// both always target the same socket. (Thread mode keys the socket by the master PID instead.)
+/// both always target the same socket. (Thread mode keys the socket by the master PID and an
+/// inherited random identifier instead.)
 pub fn liaison_for_ipc_mode(ipc_mode: crate::config::IpcMode) -> DefaultLiason {
     match ipc_mode {
         crate::config::IpcMode::Shared => DefaultLiason::ipc_shared(),

--- a/datadog-sidecar/src/setup/thread_listener.rs
+++ b/datadog-sidecar/src/setup/thread_listener.rs
@@ -46,6 +46,12 @@ impl MasterListener {
             return Err(io::Error::other("Master listener is already running"));
         }
 
+        // Initialize before forking so workers inherit the same unpredictable channel name.
+        #[cfg(target_os = "linux")]
+        AbstractUnixSocketLiaison::initialize_thread_channel_id();
+        #[cfg(not(target_os = "linux"))]
+        SharedDirLiaison::initialize_thread_channel_id();
+
         let (shutdown_tx, shutdown_rx) = oneshot::channel();
 
         let thread_handle = thread::Builder::new()
@@ -131,6 +137,7 @@ async fn accept_socket_loop_thread(
     async_listener: AsyncFd<SeqpacketListener>,
     handler: Box<dyn Fn(SeqpacketConn)>,
     mut shutdown_rx: oneshot::Receiver<()>,
+    master_pid: u32,
 ) -> io::Result<()> {
     loop {
         tokio::select! {
@@ -141,8 +148,19 @@ async fn accept_socket_loop_thread(
             ready = async_listener.readable() => {
                 match ready {
                     Ok(mut guard) => {
-                        match guard.try_io(|inner| inner.get_ref().try_accept()) {
+                        match guard.try_io(|inner| inner.get_ref().try_accept_unchecked()) {
                             Ok(Ok(conn)) => {
+                                #[cfg(target_os = "linux")]
+                                if !is_process_descendant(
+                                    conn.peer_credentials()?.pid,
+                                    master_pid,
+                                ) {
+                                    error!(
+                                        "Rejected IPC connection from a process outside the master process tree"
+                                    );
+                                    continue;
+                                }
+
                                 // On the first connection, get the worker's UID and
                                 // fchown the SHM to that UID so cross-user access works when
                                 // the master runs as root and workers run as a different user.
@@ -170,6 +188,35 @@ async fn accept_socket_loop_thread(
         }
     }
     Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn is_process_descendant(mut pid: u32, ancestor_pid: u32) -> bool {
+    if pid == ancestor_pid {
+        return true;
+    }
+
+    for _ in 0..64 {
+        let status = match std::fs::read_to_string(format!("/proc/{pid}/status")) {
+            Ok(status) => status,
+            Err(_) => return false,
+        };
+        let parent_pid = status
+            .lines()
+            .find_map(|line| line.strip_prefix("PPid:")?.trim().parse::<u32>().ok());
+        let Some(parent_pid) = parent_pid else {
+            return false;
+        };
+        if parent_pid == ancestor_pid {
+            return true;
+        }
+        if parent_pid == 0 || parent_pid == pid {
+            return false;
+        }
+        pid = parent_pid;
+    }
+
+    false
 }
 
 /// Entry point for thread listener.
@@ -211,7 +258,7 @@ fn run_listener(pid: u32, _config: Config, shutdown_rx: oneshot::Receiver<()>) -
         .block_on(async {
             let async_listener = listener.into_async_listener()?;
             crate::entry::main_loop(
-                move |handler| accept_socket_loop_thread(async_listener, handler, shutdown_rx),
+                move |handler| accept_socket_loop_thread(async_listener, handler, shutdown_rx, pid),
                 Arc::new(cancel),
                 loop_config,
             )
@@ -229,14 +276,21 @@ fn run_listener(pid: u32, _config: Config, shutdown_rx: oneshot::Receiver<()>) -
 pub fn connect_to_master(pid: i32) -> io::Result<Box<SidecarTransport>> {
     info!("Connecting to master listener (PID {})", pid);
 
+    let expected_pid = u32::try_from(pid)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "master PID must be positive"))?;
+
     #[cfg(target_os = "linux")]
-    let liaison = AbstractUnixSocketLiaison::ipc_for_pid(pid as u32);
+    let liaison = AbstractUnixSocketLiaison::ipc_for_pid(expected_pid);
     #[cfg(not(target_os = "linux"))]
-    let liaison = SharedDirLiaison::ipc_for_pid(pid as u32);
+    let liaison = SharedDirLiaison::ipc_for_pid(expected_pid);
 
     let conn = liaison
         .connect_to_server()
         .map_err(|e| io::Error::other(format!("Failed to connect to master listener: {}", e)))?;
+    conn.verify_peer_pid(expected_pid)?;
+    if let Some(peer_pid) = conn.peer_pid().ok().and_then(|pid| i32::try_from(pid).ok()) {
+        libdd_crashtracker::set_expected_receiver_pid(peer_pid);
+    }
 
     info!("Successfully connected to master listener");
     Ok(Box::new(SidecarTransport::from(conn)))

--- a/datadog-sidecar/src/setup/thread_listener_windows.rs
+++ b/datadog-sidecar/src/setup/thread_listener_windows.rs
@@ -37,7 +37,10 @@ impl MasterListener {
             return Err(io::Error::other("Master listener is already running"));
         }
 
-        let liaison = NamedPipeLiaison::new(format!("libdatadog_{}_", pid));
+        // Initialize before forking so workers inherit the same unpredictable channel name.
+        NamedPipeLiaison::initialize_thread_channel_id();
+
+        let liaison = NamedPipeLiaison::ipc_for_pid(pid);
         let listener = liaison
             .attempt_listen()?
             .ok_or_else(|| io::Error::other("Failed to bind master listener pipe"))?;
@@ -163,10 +166,17 @@ fn run_listener_windows(
 pub fn connect_to_master(pid: i32) -> io::Result<Box<SidecarTransport>> {
     info!("Connecting to master listener via named pipe (PID {})", pid);
 
-    let liaison = NamedPipeLiaison::new(format!("libdatadog_{}_", pid));
+    let expected_pid = u32::try_from(pid)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "master PID must be positive"))?;
+
+    let liaison = NamedPipeLiaison::ipc_for_pid(pid);
     let conn = liaison
         .connect_to_server()
         .map_err(|e| io::Error::other(format!("Failed to connect to master listener: {}", e)))?;
+    conn.verify_peer_pid(expected_pid)?;
+    if let Some(peer_pid) = conn.peer_pid().ok().and_then(|pid| i32::try_from(pid).ok()) {
+        libdd_crashtracker::set_expected_receiver_pid(peer_pid);
+    }
 
     info!("Successfully connected to master listener");
     Ok(Box::new(SidecarTransport::from(conn)))

--- a/datadog-sidecar/src/setup/unix.rs
+++ b/datadog-sidecar/src/setup/unix.rs
@@ -13,6 +13,8 @@ use crate::setup::Liaison;
 use libdd_ipc::platform::locks::FLock;
 use libdd_ipc::{SeqpacketConn, SeqpacketListener};
 
+static THREAD_RANDOM_ID: LazyLock<u64> = LazyLock::new(rand::random);
+
 #[cfg(feature = "logging")]
 use log::{debug, warn};
 #[cfg(not(feature = "logging"))]
@@ -38,11 +40,16 @@ fn ensure_dir_exists<P: AsRef<Path>>(path: P) -> io::Result<()> {
 pub struct SharedDirLiaison {
     socket_path: PathBuf,
     lock_path: PathBuf,
+    authenticate_peer: bool,
 }
 
 impl Liaison for SharedDirLiaison {
     fn connect_to_server(&self) -> io::Result<SeqpacketConn> {
-        SeqpacketConn::connect(&self.socket_path)
+        if self.authenticate_peer {
+            SeqpacketConn::connect(&self.socket_path)
+        } else {
+            SeqpacketConn::connect_unchecked(&self.socket_path)
+        }
     }
 
     fn attempt_listen(&self) -> io::Result<Option<SeqpacketListener>> {
@@ -78,7 +85,7 @@ impl Liaison for SharedDirLiaison {
     }
 
     fn ipc_per_process() -> Self {
-        static PROCESS_RANDOM_ID: LazyLock<u16> = LazyLock::new(rand::random);
+        static PROCESS_RANDOM_ID: LazyLock<u64> = LazyLock::new(rand::random);
 
         let pid = std::process::id();
         let liason_path = env::temp_dir().join(format!("libdatadog.{}.{pid}", *PROCESS_RANDOM_ID));
@@ -102,6 +109,7 @@ impl SharedDirLiaison {
         Self {
             socket_path,
             lock_path,
+            authenticate_peer: true,
         }
     }
 
@@ -111,7 +119,12 @@ impl SharedDirLiaison {
 
     pub fn ipc_for_pid(pid: u32) -> Self {
         let base_dir = env::temp_dir().join("libdatadog");
-        let versioned_socket_basename = format!("libdd.{}@{}.sock", crate::sidecar_version!(), pid);
+        let versioned_socket_basename = format!(
+            "libdd.{}@{}-{}.sock",
+            crate::sidecar_version!(),
+            pid,
+            *THREAD_RANDOM_ID
+        );
         let socket_path = base_dir.join(&versioned_socket_basename);
         let lock_path = base_dir
             .join(&versioned_socket_basename)
@@ -119,12 +132,17 @@ impl SharedDirLiaison {
         Self {
             socket_path,
             lock_path,
+            authenticate_peer: false,
         }
     }
 
     /// The filesystem socket path this liaison binds/connects to.
     pub fn socket_path(&self) -> &Path {
         &self.socket_path
+    }
+
+    pub fn initialize_thread_channel_id() {
+        LazyLock::force(&THREAD_RANDOM_ID);
     }
 }
 
@@ -149,14 +167,21 @@ mod linux {
 
     use super::Liaison;
 
+    static THREAD_RANDOM_ID: std::sync::LazyLock<u64> = std::sync::LazyLock::new(rand::random);
+
     pub struct AbstractUnixSocketLiaison {
         path: PathBuf,
+        authenticate_peer: bool,
     }
     pub type DefaultLiason = AbstractUnixSocketLiaison;
 
     impl Liaison for AbstractUnixSocketLiaison {
         fn connect_to_server(&self) -> io::Result<SeqpacketConn> {
-            platform::sockets::connect_abstract(&self.path)
+            if self.authenticate_peer {
+                platform::sockets::connect_abstract(&self.path)
+            } else {
+                platform::sockets::connect_abstract_unchecked(&self.path)
+            }
         }
 
         fn attempt_listen(&self) -> io::Result<Option<SeqpacketListener>> {
@@ -172,25 +197,38 @@ mod linux {
                 concat!("libdatadog/", crate::sidecar_version!(), "@{}.sock"),
                 crate::primary_sidecar_identifier()
             ));
-            Self { path }
+            Self {
+                path,
+                authenticate_peer: true,
+            }
         }
 
         fn ipc_per_process() -> AbstractUnixSocketLiaison {
+            static PROCESS_RANDOM_ID: std::sync::LazyLock<u64> =
+                std::sync::LazyLock::new(rand::random);
+
             let path = PathBuf::from(format!(
-                concat!("libdatadog/", crate::sidecar_version!(), ".{}.sock"),
-                getpid()
+                concat!("libdatadog/", crate::sidecar_version!(), ".{}-{}.sock"),
+                getpid(),
+                *PROCESS_RANDOM_ID
             ));
-            Self { path }
+            Self {
+                path,
+                authenticate_peer: true,
+            }
         }
     }
 
     impl AbstractUnixSocketLiaison {
         pub fn ipc_for_pid(pid: u32) -> Self {
             let path = PathBuf::from(format!(
-                concat!("libdatadog/", crate::sidecar_version!(), "@{}.sock"),
-                pid
+                concat!("libdatadog/", crate::sidecar_version!(), "@{}-{}.sock"),
+                pid, *THREAD_RANDOM_ID
             ));
-            Self { path }
+            Self {
+                path,
+                authenticate_peer: false,
+            }
         }
 
         /// The abstract socket name this liaison binds/connects to.
@@ -199,6 +237,10 @@ mod linux {
         /// IPC socket the sidecar listens on.
         pub fn path(&self) -> &std::path::Path {
             &self.path
+        }
+
+        pub fn initialize_thread_channel_id() {
+            std::sync::LazyLock::force(&THREAD_RANDOM_ID);
         }
     }
 

--- a/datadog-sidecar/src/setup/windows.rs
+++ b/datadog-sidecar/src/setup/windows.rs
@@ -7,6 +7,9 @@ use libc::getpid;
 use libdd_ipc::platform::PIPE_PATH;
 use libdd_ipc::{AsyncConn, SeqpacketConn, SeqpacketListener};
 use std::io;
+use std::sync::LazyLock;
+
+static THREAD_RANDOM_ID: LazyLock<u64> = LazyLock::new(rand::random);
 
 pub type IpcClient = AsyncConn;
 pub type IpcServer = SeqpacketListener;
@@ -38,11 +41,25 @@ impl Liaison for NamedPipeLiaison {
     }
 
     fn ipc_per_process() -> Self {
-        Self::new(format!("libdatadog_{}_", unsafe { getpid() }))
+        static PROCESS_RANDOM_ID: LazyLock<u64> = LazyLock::new(rand::random);
+
+        Self::new(format!(
+            "libdatadog_{}_{}-",
+            unsafe { getpid() },
+            *PROCESS_RANDOM_ID
+        ))
     }
 }
 
 impl NamedPipeLiaison {
+    pub fn ipc_for_pid(pid: i32) -> Self {
+        Self::new(format!("libdatadog_{}_{}-", pid, *THREAD_RANDOM_ID))
+    }
+
+    pub fn initialize_thread_channel_id() {
+        LazyLock::force(&THREAD_RANDOM_ID);
+    }
+
     pub fn new<P: AsRef<str>>(prefix: P) -> Self {
         Self {
             socket_path: format!(

--- a/libdd-ipc/src/platform/unix/sockets/linux.rs
+++ b/libdd-ipc/src/platform/unix/sockets/linux.rs
@@ -45,8 +45,23 @@ impl SeqpacketListener {
     /// Accept a new connection (non-blocking in non-blocking mode).
     ///
     /// Skips intermittent connections left by `is_listening` probes: after `accept()`, peek to
-    /// check if the peer has already closed the connection (EOF). If so, discard and loop.
+    /// check if the peer has already closed the connection (EOF). If so, discard and loop. Peers
+    /// belonging to another Unix user are also discarded before the connection is returned.
     pub fn try_accept(&self) -> io::Result<SeqpacketConn> {
+        loop {
+            let conn = self.try_accept_unchecked()?;
+            if conn.verify_peer_uid(unsafe { libc::geteuid() }).is_ok() {
+                return Ok(conn);
+            }
+            // Do not expose a connection from an untrusted Unix user to the IPC dispatcher.
+        }
+    }
+
+    /// Accept a connection without checking its Unix peer UID.
+    ///
+    /// This is reserved for the thread listener, which intentionally accepts workers running
+    /// under a different UID and authenticates those workers using the master PID instead.
+    pub fn try_accept_unchecked(&self) -> io::Result<SeqpacketConn> {
         loop {
             let new_fd = accept(self.inner.as_raw_fd()).map_err(io::Error::from)?;
             let owned = unsafe { OwnedFd::from_raw_fd(new_fd) };
@@ -86,18 +101,50 @@ impl SeqpacketConn {
 
     /// Connect to a filesystem socket path.
     pub fn connect(path: impl AsRef<Path>) -> io::Result<Self> {
+        Self::connect_inner(path, true)
+    }
+
+    /// Connect to a filesystem socket path without checking the Unix peer UID.
+    ///
+    /// This is reserved for the thread listener, which intentionally connects across UIDs and
+    /// authenticates the peer using its expected process ID.
+    pub fn connect_unchecked(path: impl AsRef<Path>) -> io::Result<Self> {
+        Self::connect_inner(path, false)
+    }
+
+    fn connect_inner(path: impl AsRef<Path>, verify_peer: bool) -> io::Result<Self> {
         let fd = create_seqpacket_socket()?;
         let addr = UnixAddr::new(path.as_ref()).map_err(io::Error::from)?;
         connect(fd.as_raw_fd(), &addr).map_err(io::Error::from)?;
-        Self::from_owned(fd)
+        let conn = Self::from_owned(fd)?;
+        if verify_peer {
+            conn.verify_peer_uid(unsafe { libc::geteuid() })?;
+        }
+        Ok(conn)
     }
 
     /// Connect to a Linux abstract socket name.
     pub fn connect_abstract(name: &[u8]) -> io::Result<Self> {
+        Self::connect_abstract_inner(name, true)
+    }
+
+    /// Connect to a Linux abstract socket name without checking the Unix peer UID.
+    ///
+    /// This is reserved for the thread listener, which intentionally connects across UIDs and
+    /// authenticates the peer using its expected process ID.
+    pub fn connect_abstract_unchecked(name: &[u8]) -> io::Result<Self> {
+        Self::connect_abstract_inner(name, false)
+    }
+
+    fn connect_abstract_inner(name: &[u8], verify_peer: bool) -> io::Result<Self> {
         let fd = create_seqpacket_socket()?;
         let addr = UnixAddr::new_abstract(name).map_err(io::Error::from)?;
         connect(fd.as_raw_fd(), &addr).map_err(io::Error::from)?;
-        Self::from_owned(fd)
+        let conn = Self::from_owned(fd)?;
+        if verify_peer {
+            conn.verify_peer_uid(unsafe { libc::geteuid() })?;
+        }
+        Ok(conn)
     }
 }
 
@@ -114,6 +161,11 @@ pub fn is_listening<P: AsRef<Path>>(path: P) -> io::Result<bool> {
 /// Connect to a Linux abstract socket (path used as name bytes).
 pub fn connect_abstract<P: AsRef<Path>>(path: P) -> io::Result<SeqpacketConn> {
     SeqpacketConn::connect_abstract(path.as_ref().as_os_str().as_bytes())
+}
+
+/// Connect to a Linux abstract socket without checking the Unix peer UID.
+pub fn connect_abstract_unchecked<P: AsRef<Path>>(path: P) -> io::Result<SeqpacketConn> {
+    SeqpacketConn::connect_abstract_unchecked(path.as_ref().as_os_str().as_bytes())
 }
 
 /// Bind an abstract socket (path used as name bytes).
@@ -140,4 +192,24 @@ pub fn get_peer_credentials(fd: RawFd) -> io::Result<PeerCredentials> {
         pid: cred.pid as u32,
         uid: cred.uid,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn peer_uid_verification_rejects_a_different_uid() {
+        let (conn, _) = SeqpacketConn::socketpair().expect("socketpair");
+        let uid = unsafe { libc::geteuid() };
+
+        conn.verify_peer_uid(uid)
+            .expect("same UID should be accepted");
+        assert_eq!(
+            conn.verify_peer_uid(uid.wrapping_add(1))
+                .expect_err("different UID should be rejected")
+                .kind(),
+            io::ErrorKind::PermissionDenied
+        );
+    }
 }

--- a/libdd-ipc/src/platform/unix/sockets/macos.rs
+++ b/libdd-ipc/src/platform/unix/sockets/macos.rs
@@ -76,6 +76,20 @@ impl SeqpacketListener {
     /// Silently discards messages without SCM_RIGHTS (liveness probes from `is_listening`).
     pub fn try_accept(&self) -> io::Result<SeqpacketConn> {
         loop {
+            let conn = self.try_accept_unchecked()?;
+            if conn.verify_peer_uid(unsafe { libc::geteuid() }).is_ok() {
+                return Ok(conn);
+            }
+            // Do not expose a connection from an untrusted Unix user to the IPC dispatcher.
+        }
+    }
+
+    /// Accept a connection without checking its Unix peer UID.
+    ///
+    /// This is reserved for the thread listener, which intentionally accepts workers running
+    /// under a different UID and authenticates those workers using the master PID instead.
+    pub fn try_accept_unchecked(&self) -> io::Result<SeqpacketConn> {
+        loop {
             let mut buf = [0u8; 1];
             let (_, owned_fds) =
                 super::recvmsg_raw(self.inner.as_raw_fd(), &mut buf, MsgFlags::MSG_DONTWAIT)?;
@@ -117,6 +131,18 @@ impl SeqpacketConn {
     /// `SeqpacketConn` (closing `liveness_read`), `POLLHUP` appears on `liveness_write`
     /// and subsequent sends return `BrokenPipe`.
     pub fn connect(path: impl AsRef<Path>) -> io::Result<Self> {
+        Self::connect_inner(path, true)
+    }
+
+    /// Connect to a server without checking the Unix peer UID.
+    ///
+    /// This is reserved for the thread listener, which intentionally connects across UIDs and
+    /// authenticates the peer using its expected process ID.
+    pub fn connect_unchecked(path: impl AsRef<Path>) -> io::Result<Self> {
+        Self::connect_inner(path, false)
+    }
+
+    fn connect_inner(path: impl AsRef<Path>, verify_peer: bool) -> io::Result<Self> {
         let mut fds = [0i32; 2];
         if unsafe { libc::socketpair(libc::AF_UNIX, libc::SOCK_DGRAM, 0, fds.as_mut_ptr()) } == -1 {
             return Err(io::Error::last_os_error());
@@ -165,7 +191,11 @@ impl SeqpacketConn {
         // peer end of a SOCK_DGRAM socketpair disconnects this end even when the peer socket
         // is alive in the daemon via SCM_RIGHTS.
         // Keep liveness_w (liveness_write) to detect daemon death via POLLHUP.
-        Self::from_owned_pair(fd_client, fd_server, Some(liveness_write))
+        let conn = Self::from_owned_pair(fd_client, fd_server, Some(liveness_write))?;
+        if verify_peer {
+            conn.verify_peer_uid(unsafe { libc::geteuid() })?;
+        }
+        Ok(conn)
     }
 
     pub(super) fn poll_liveness_pipe(&self) -> io::Result<()> {
@@ -240,9 +270,14 @@ pub fn get_peer_credentials(fd: RawFd) -> io::Result<PeerCredentials> {
     {
         return Err(io::Error::last_os_error());
     }
+    let mut uid: libc::uid_t = 0;
+    let mut gid: libc::gid_t = 0;
+    if unsafe { libc::getpeereid(fd, &mut uid, &mut gid) } < 0 {
+        return Err(io::Error::last_os_error());
+    }
     Ok(PeerCredentials {
         pid: pid as u32,
-        uid: 0,
+        uid,
     })
 }
 

--- a/libdd-ipc/src/platform/unix/sockets/mod.rs
+++ b/libdd-ipc/src/platform/unix/sockets/mod.rs
@@ -251,6 +251,36 @@ impl SeqpacketConn {
         get_peer_credentials(self.inner.as_raw_fd())
     }
 
+    /// Verify that the connected peer belongs to the expected Unix user.
+    pub fn verify_peer_uid(&self, expected_uid: u32) -> io::Result<()> {
+        let peer = self.peer_credentials()?;
+        if peer.uid != expected_uid {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!(
+                    "IPC peer UID {} does not match expected UID {}",
+                    peer.uid, expected_uid
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Verify that the connected peer has the expected process ID.
+    pub fn verify_peer_pid(&self, expected_pid: u32) -> io::Result<()> {
+        let peer = self.peer_credentials()?;
+        if peer.pid != expected_pid {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!(
+                    "IPC peer PID {} does not match expected PID {}",
+                    peer.pid, expected_pid
+                ),
+            ));
+        }
+        Ok(())
+    }
+
     /// Non-blocking send. Returns `Err(WouldBlock)` if the socket buffer is full.
     ///
     /// `data` is passed as `&mut Vec<u8>` for API symmetry with the Windows implementation

--- a/libdd-ipc/src/platform/windows/sockets.rs
+++ b/libdd-ipc/src/platform/windows/sockets.rs
@@ -45,7 +45,7 @@ use winapi::um::handleapi::{CloseHandle, DuplicateHandle, INVALID_HANDLE_VALUE};
 use winapi::um::minwinbase::SECURITY_ATTRIBUTES;
 use winapi::um::processthreadsapi::{GetCurrentProcess, GetCurrentProcessId, OpenProcess};
 use winapi::um::winbase::{GetNamedPipeClientProcessId, GetNamedPipeServerProcessId};
-use winapi::um::winnt::{DUPLICATE_SAME_ACCESS, HANDLE, PROCESS_DUP_HANDLE};
+use winapi::um::winnt::{DUPLICATE_SAME_ACCESS, HANDLE, PROCESS_DUP_HANDLE, SECURITY_SQOS_PRESENT};
 
 // windows-sys – used for all pipe/IO/threading syscalls
 use windows_sys::Win32::Foundation::{HANDLE as SysHANDLE, WAIT_OBJECT_0, WAIT_TIMEOUT};
@@ -486,7 +486,9 @@ impl SeqpacketConn {
                 0,
                 null_mut(),
                 OPEN_EXISTING,
-                0, // synchronous, non-overlapped
+                // Request SECURITY_ANONYMOUS and mark the SQOS settings as present. The IPC
+                // server only transports bytes and must not be able to impersonate the client.
+                SECURITY_SQOS_PRESENT, // synchronous, non-overlapped
                 null_mut(),
             )
         };
@@ -614,6 +616,25 @@ impl SeqpacketConn {
             pid: self.peer_pid,
             uid: 0,
         })
+    }
+
+    /// Verify that the connected pipe was created by the expected process.
+    pub fn verify_peer_pid(&self, expected_pid: u32) -> io::Result<()> {
+        let mut server_pid: ULONG = 0;
+        if unsafe { GetNamedPipeServerProcessId(self.raw_handle() as HANDLE, &mut server_pid) } == 0
+        {
+            return Err(io::Error::last_os_error());
+        }
+        if server_pid != expected_pid {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!(
+                    "IPC pipe server PID {} does not match expected PID {}",
+                    server_pid, expected_pid
+                ),
+            ));
+        }
+        Ok(())
     }
 
     /// Non-blocking send.


### PR DESCRIPTION
<!-- dd-meta {"pullId":"44498650-7a34-470e-8f19-db442bd2e211","source":"chat","resourceId":"0c46f05f-1534-41b2-8eb1-f86e6c79587e","workflowId":"6c143cb8-c8bd-4196-9933-37ac4fd68bee","codeChangeId":"6c143cb8-c8bd-4196-9933-37ac4fd68bee","sourceType":"chat"} -->
# What does this PR do?

Hardens libdatadog sidecar IPC against local channel squatting and unauthorized peers.

# Motivation

VMSBX-77 identified predictable, unauthenticated local IPC channels that could let an untrusted local process intercept sidecar traffic, inject requests, or capture crash data. The change closes that trust-boundary gap while preserving the existing intentional cross-UID thread-mode behavior.

# Changes

- Verify Unix peer UIDs on normal connect and accept paths using kernel-provided credentials.
- Authenticate thread-mode clients to the expected master process and reject non-descendant Linux clients.
- Use 64-bit random identifiers for per-process and inherited thread-mode channel names.
- Open Windows named-pipe clients with SECURITY_SQOS_PRESENT and anonymous impersonation.
- Apply the same peer check to the crashtracker connector that bypasses the regular IPC wrapper.

# Additional Notes

The shared sidecar endpoint remains discoverable for same-UID processes by design; peer identity is enforced before IPC traffic is dispatched. Thread mode continues to support workers under a different UID, but its channel is randomized and tied to the master process. The unrelated shared-memory finding VULN-2061 is not included.

# How to test the change?

- Passed source formatting checks with rustfmt on all changed Rust files.
- Passed cargo metadata parsing and git diff validation.
- cargo check -p libdd-ipc and cargo check -p datadog-sidecar could not complete because the sandbox could not fetch the repository's pinned Git proptest dependency; offline mode also lacks the registry cache.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/0c46f05f-1534-41b2-8eb1-f86e6c79587e)

Comment @datadog to request changes