### PR TITLE
chore(ci): re-enable all thread collection bin tests

### DIFF
--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -490,6 +490,7 @@ fn test_crash_tracking_multi_thread_collection() {
     run_crash_test_with_artifacts(&config, &artifacts_map, &artifacts, validator).unwrap();
 }
 
+
 /// Spawns default max threads and verifies the crash report contains all of them.
 #[test]
 #[cfg(target_os = "linux")]

--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -208,7 +208,6 @@ fn test_crash_tracking_bin_assert_fail() {
 #[test]
 #[cfg(target_os = "linux")]
 #[cfg_attr(miri, ignore)]
-#[ignore = "requires ptrace attach permission (yama ptrace_scope <= 1 or CAP_SYS_PTRACE)"]
 fn test_crash_tracking_bin_unhandled_exception_multi_thread() {
     let config = CrashTestConfig::new(
         BuildProfile::Release,
@@ -360,7 +359,6 @@ fn test_crash_tracking_bin_runtime_callback_frame() {
 #[test]
 #[cfg(target_os = "linux")]
 #[cfg_attr(miri, ignore)]
-#[ignore = "requires ptrace attach permission (yama ptrace_scope <= 1 or CAP_SYS_PTRACE)"]
 fn test_crash_tracking_multi_thread_collection() {
     let config = CrashTestConfig::new(
         BuildProfile::Release,
@@ -489,7 +487,6 @@ fn test_crash_tracking_multi_thread_collection() {
 
     run_crash_test_with_artifacts(&config, &artifacts_map, &artifacts, validator).unwrap();
 }
-
 
 /// Spawns default max threads and verifies the crash report contains all of them.
 #[test]
@@ -670,7 +667,6 @@ fn test_crash_tracking_sidecar_basic() {
 #[test]
 #[cfg(target_os = "linux")]
 #[cfg_attr(miri, ignore)]
-#[ignore = "requires ptrace attach permission (yama ptrace_scope <= 1 or CAP_SYS_PTRACE)"]
 fn test_crash_tracking_sidecar_multi_thread_collection() {
     const RECEIVER_TIMEOUT_MS: &str = "15000";
     const RECEIVER_WAIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);


### PR DESCRIPTION
# What does this PR do?

All thread collection bin tests were disabled because yama ptrace scope was raised here [security(kernel): add kptr_restrict=1 and yama.ptrace_scope=2](https://github.com/DataDog/k8s-platform-machine-images/pull/2125)

This broke all thread collection tests which used ptrace, so these tests were disabled in this PR to unblock this repository: [chore(ci): skip multi thread collection tests](https://github.com/DataDog/libdatadog/pull/2438)

New gitlab-runner with `SYS_PTRACE` capabilities have been deployed, so we are going to re-enable these tests

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
