### PR TITLE
feat: do not entirely disable connection pooling for periodic connections

### DIFF
--- a/libdd-capabilities-impl/src/http.rs
+++ b/libdd-capabilities-impl/src/http.rs
@@ -45,12 +45,9 @@ mod native {
     }
 
     impl NativeHttpClient {
-        /// Like [`HttpClientCapability::new_client`], but disables connection pooling.
-        ///
-        /// Intended for clients that issue requests on a fixed interval (e.g. remote
-        /// config polling): the agent's low keep-alive setting can close an idle
-        /// connection between polls, which turns a pooled/reused connection into
-        /// intermittent request failures.
+        /// Like [`HttpClientCapability::new_client`], but sets a small lifetime on pooled
+        /// connections. See [`HttpClientCapability::new_without_connection_pooling`] for the
+        /// rationale.
         pub fn new_without_connection_pooling() -> Self {
             Self {
                 client: Arc::new(OnceLock::new()),

--- a/libdd-capabilities/src/http.rs
+++ b/libdd-capabilities/src/http.rs
@@ -56,7 +56,25 @@ pub type BodySender = Box<dyn StreamingBodySender>;
 pub trait HttpClientCapability: Clone + std::fmt::Debug {
     fn new_client() -> Self;
 
-    /// Construct a client that does not reuse connections.
+    /// Construct a client for periodic one-shot communication (typically regularly flushing to the
+    /// agent or to the backend). Depending on the capabilities of the underlying implementation,
+    /// this constructor either:
+    ///
+    /// - sets the lifetime of pooled connections to a timeout much smaller than 60s (e.g. 5s)
+    /// - disables connection pooling entirely if the timeout isn't configurable
+    /// - does nothing if there's no connection pooling support to begin with
+    ///
+    /// The rationale for having limited connection pooling is that we've experienced races when the
+    /// connection pooling timeout is higher than the keep-alive timeout of the receiving end. It's
+    /// then possible to pick an idle connection and start a request while the connection get
+    /// closed at the same time by the receiver, causing an error.
+    ///
+    /// Connection pooling was initially entirely disabled by this constructor, but it happens that
+    /// we send multiple separate requests in a short span of time (e.g. for telemetry on very
+    /// short-lived apps). In that situation, if we're agentless, making separate HTTPS connections
+    /// is quite costly (can be on the order of magnitude of 0.5sec per connection). Having pooling
+    /// with a short lifetime is a better choice, since we can reuse the same connection for those
+    /// multiple consecutive requests, while avoiding the race condition.
     fn new_without_connection_pooling() -> Self;
 
     fn request(

--- a/libdd-common/src/http_common.rs
+++ b/libdd-common/src/http_common.rs
@@ -3,6 +3,7 @@
 
 use core::convert::Infallible;
 use core::fmt;
+use core::time::Duration;
 
 use thiserror::Error;
 
@@ -80,6 +81,7 @@ mod native {
     use crate::connector::Connector;
     use http_body_util::BodyExt;
     use hyper::body::Incoming;
+    use hyper_util::rt::TokioTimer;
     use pin_project::pin_project;
 
     impl From<hyper::Error> for ClientError {
@@ -115,15 +117,25 @@ mod native {
 
     pub type ResponseFuture = hyper_util::client::legacy::ResponseFuture;
 
+    /// Idle timeout for connections kept alive by a client configured for periodic use (see
+    /// [`new_client_periodic`]).
+    ///
+    /// Kept much smaller than typical keep-alive timeouts on the receiving end (e.g. the Datadog
+    /// agent), so that an idle pooled connection is dropped by our side before the receiver closes
+    /// it.
+    pub(crate) const PERIODIC_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(5);
+
     /// Create a new default configuration hyper client for fixed interval sending.
     ///
-    /// This client does not keep connections because otherwise we would get a pipe closed
-    /// every second connection because of low keep alive in the agent.
+    /// This client pools connections with a small timeout (smaller than any potential keep-alive on
+    /// the receiver side), because otherwise we would get a pipe closed every second connection
+    /// because of the keep alive in the agent or the backend.
     ///
-    /// This is on general not a problem if we use the client once every tens of seconds.
+    /// This is in general not a problem if we use the client once every tens of seconds.
     pub fn new_client_periodic() -> GenericHttpClient<Connector> {
         hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::default())
-            .pool_max_idle_per_host(0)
+            .pool_timer(TokioTimer::new())
+            .pool_idle_timeout(PERIODIC_POOL_IDLE_TIMEOUT)
             .build(Connector::default())
     }
 

--- a/libdd-common/src/http_common.rs
+++ b/libdd-common/src/http_common.rs
@@ -124,6 +124,9 @@ mod native {
     /// agent), so that an idle pooled connection is dropped by our side before the receiver closes
     /// it.
     pub(crate) const PERIODIC_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(5);
+    /// Max number of idle connections in a client's connection pool. This is a safety resource
+    /// bound that we don't really expect to hit in practice.
+    pub(crate) const POOL_MAX_IDLE: usize = 20;
 
     /// Create a new default configuration hyper client for fixed interval sending.
     ///
@@ -136,6 +139,7 @@ mod native {
         hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::default())
             .pool_timer(TokioTimer::new())
             .pool_idle_timeout(PERIODIC_POOL_IDLE_TIMEOUT)
+            .pool_max_idle_per_host(POOL_MAX_IDLE)
             .build(Connector::default())
     }
 
@@ -144,6 +148,7 @@ mod native {
     /// It will keep connections open for a longer time and reuse them.
     pub fn new_default_client() -> GenericHttpClient<Connector> {
         hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::default())
+            .pool_max_idle_per_host(POOL_MAX_IDLE)
             .build(Connector::default())
     }
 


### PR DESCRIPTION
# What does this PR do?

This PR slightly changes the HTTP behavior for periodic connections (most flushes to the agent/agentless intake). Instead of disabling connection pooling to avoid data races entirely, it restricts the lifetime of pooled connections.

This PR aims to be a backward-compatible hotfix.  A subsequent PR is coming with renaming (since `no_connection_pooling` isn't really true anymore) and mirroring the change in libdd-http-client and libdd-agent-client as well.

# Motivation

Mitigates [APMS-20441](https://datadoghq.atlassian.net/browse/APMS-20441?atlOrigin=eyJpIjoiZjcyY2U2Zjk3Njg2NGNlZGE5YjNhNTllNzU5Nzk1MDgiLCJwIjoiaiJ9) / https://github.com/DataDog/dd-trace-py/issues/19915: some telemetry events can generate several requests for short-lived scripts. In the agentless case, this means opening several new HTTPS connection in a row, which is slow.

# Additional Notes

Applying the setting to all periodic connections sounds reasonable, as multiple requests could reasonably be issued for other things than telemetry. It should impact single-request workflows.

# How to test the change?

This was tested with the repro in 20441, reducing the shutdown delay to 0.750ms locally, which indicates there's indeed a single HTTPS connection (vs double before the change).

[APMS-20441]: https://datadoghq.atlassian.net/browse/APMS-20441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ