### PR TITLE
fix(obfuscation): prevent crash and cap recursion in SQL/HTTP obfuscation

### DIFF
--- a/libdd-trace-obfuscation/src/http.rs
+++ b/libdd-trace-obfuscation/src/http.rs
@@ -71,6 +71,35 @@ fn encode_char(out: &mut String, c: char) {
     }
 }
 
+/// Best-effort userinfo stripping for URLs that fail strict RFC 3986 parsing (or contain control
+/// chars) and would otherwise be returned unchanged: credentials must never survive obfuscation
+/// even when we can't fully parse the rest of the URL.
+///
+/// `prefix_end` bounds the scan to the path portion (before query/fragment) so a `@` inside the
+/// query or fragment is never mistaken for userinfo.
+///
+/// This is a heuristic, not a parser: it may occasionally strip more than necessary on
+/// non-URL-like malformed input, but it never leaves real credentials in the output.
+fn strip_userinfo_best_effort(url: &str, prefix_end: usize) -> String {
+    let prefix = &url[..prefix_end];
+    let Some(marker) = prefix.find("//") else {
+        return url.to_string();
+    };
+    let authority_start = marker + 2;
+    let authority_end = prefix[authority_start..]
+        .find('/')
+        .map_or(prefix.len(), |i| authority_start + i);
+    let authority = &prefix[authority_start..authority_end];
+    let Some(at_pos) = authority.rfind('@') else {
+        return url.to_string();
+    };
+    let mut out = String::with_capacity(url.len());
+    out.push_str(&url[..authority_start]);
+    out.push_str(&authority[at_pos + 1..]);
+    out.push_str(&url[authority_end..]);
+    out
+}
+
 fn redact_path_digits(path: &str) -> String {
     path.split('/')
         .map(|seg| {
@@ -187,7 +216,7 @@ pub fn obfuscate_url_string(
         return if remove_query_string || remove_path_digits {
             "?".to_string()
         } else {
-            url.to_string()
+            strip_userinfo_best_effort(url, path_query_end)
         };
     }
 
@@ -232,7 +261,7 @@ pub fn obfuscate_url_string(
         return if remove_query_string || remove_path_digits {
             "?".to_string()
         } else {
-            url.to_string()
+            strip_userinfo_best_effort(url, path_end)
         };
     };
 
@@ -366,6 +395,12 @@ mod tests {
     [parity_not_a_url_both_false] [false] [false] ["this is not a valid url"] ["this%20is%20not%20a%20valid%20url"];
     [parity_not_a_url_both_true] [true] [true] ["this is not a valid url"] ["this%20is%20not%20a%20valid%20url"];
     [parity_disabled_userinfo] [false] [false] ["http://user:password@foo.com/1/2/3?q=james"] ["http://foo.com/1/2/3?q=james"];
+    // Regression for APMSP-3086: malformed percent-encoding fails strict parsing and used to
+    // fall back to returning the URL (with userinfo) unchanged.
+    [regression_malformed_pct_encoding_strips_userinfo] [false] [false] ["http://user:password@foo.com/%"] ["http://foo.com/%"];
+    // Regression for APMSP-3086: a control char in the path also fell back to returning the URL
+    // (with userinfo) unchanged when both flags are false.
+    [regression_control_char_strips_userinfo] [false] [false] ["http://user:password@foo.com/\u{1}"] ["http://foo.com/\u{1}"];
     [parity_colon_both_false] [false] [false] [":"] [":"];
     [parity_pct_both_false] [false] [false] ["%"] ["%"];
     [parity_ctrl_in_scheme_both_false] [false] [false] ["C:\u{1}"] ["C:\u{1}"];

--- a/libdd-trace-obfuscation/src/http.rs
+++ b/libdd-trace-obfuscation/src/http.rs
@@ -216,7 +216,7 @@ pub fn obfuscate_url_string(
         return if remove_query_string || remove_path_digits {
             "?".to_string()
         } else {
-            strip_userinfo_best_effort(url, path_query_end)
+            strip_userinfo_best_effort(url, path_end)
         };
     }
 
@@ -401,6 +401,10 @@ mod tests {
     // Regression for APMSP-3086: a control char in the path also fell back to returning the URL
     // (with userinfo) unchanged when both flags are false.
     [regression_control_char_strips_userinfo] [false] [false] ["http://user:password@foo.com/\u{1}"] ["http://foo.com/\u{1}"];
+    // Regression: an '@' in the query (not real userinfo) must not be mistaken for userinfo
+    // when a control char forces the best-effort stripping fallback. The authority scan must
+    // stop at the query delimiter, not the fragment delimiter.
+    [regression_control_char_query_at_not_mistaken_for_userinfo] [false] [false] ["http://example.com?email=a@b\u{0}"] ["http://example.com?email=a@b\u{0}"];
     [parity_colon_both_false] [false] [false] [":"] [":"];
     [parity_pct_both_false] [false] [false] ["%"] ["%"];
     [parity_ctrl_in_scheme_both_false] [false] [false] ["C:\u{1}"] ["C:\u{1}"];

--- a/libdd-trace-obfuscation/src/sql.rs
+++ b/libdd-trace-obfuscation/src/sql.rs
@@ -217,7 +217,7 @@ struct Tokenizer<'a> {
     dbms: DbmsKind,
     config: &'a SqlObfuscateConfig,
     // Nesting depth of dollar-quote recursion; see MAX_DOLLAR_QUOTE_DEPTH.
-    depth: usize,
+    dollar_recursion_depth: usize,
     // For alias stripping: length of result before we emitted the most recent ' AS' segment
     before_as_len: Option<usize>,
     // After SAVEPOINT keyword, next token should become ?
@@ -233,7 +233,12 @@ struct Tokenizer<'a> {
 }
 
 impl<'a> Tokenizer<'a> {
-    fn new(s: &'a str, config: &'a SqlObfuscateConfig, dbms: DbmsKind, depth: usize) -> Self {
+    fn new(
+        s: &'a str,
+        config: &'a SqlObfuscateConfig,
+        dbms: DbmsKind,
+        dollar_recursion_depth: usize,
+    ) -> Self {
         Self {
             s,
             bytes: s.as_bytes(),
@@ -241,7 +246,7 @@ impl<'a> Tokenizer<'a> {
             result: String::with_capacity(s.len()),
             dbms,
             config,
-            depth,
+            dollar_recursion_depth,
             before_as_len: None,
             pending_savepoint: false,
             last_was_placeholder: false,
@@ -1066,7 +1071,7 @@ impl<'a> Tokenizer<'a> {
                                         inner,
                                         self.config,
                                         self.dbms,
-                                        self.depth + 1,
+                                        self.dollar_recursion_depth + 1,
                                     );
                                     self.space();
                                     self.result.push_str(tag_str);
@@ -1079,7 +1084,7 @@ impl<'a> Tokenizer<'a> {
                                     let tag_str = &self.s[start..inner_start];
                                     let inner = &self.s[inner_start..inner_end];
                                     let close_tag = &self.s[inner_end..outer_end];
-                                    if self.depth + 1 >= MAX_DOLLAR_QUOTE_DEPTH {
+                                    if self.dollar_recursion_depth + 1 >= MAX_DOLLAR_QUOTE_DEPTH {
                                         self.emit_placeholder();
                                         self.pos = outer_end;
                                         continue;
@@ -1088,7 +1093,7 @@ impl<'a> Tokenizer<'a> {
                                         inner,
                                         self.config,
                                         self.dbms,
-                                        self.depth + 1,
+                                        self.dollar_recursion_depth + 1,
                                     );
                                     // If inner collapses to just '?' (trivial content), emit ?
                                     // directly
@@ -2221,15 +2226,15 @@ fn obfuscate_sql_at_depth(
     s: &str,
     config: &SqlObfuscateConfig,
     dbms: DbmsKind,
-    depth: usize,
+    dollar_recursion_depth: usize,
 ) -> String {
     if s.is_empty() {
         return String::new();
     }
-    if depth >= MAX_DOLLAR_QUOTE_DEPTH {
+    if dollar_recursion_depth >= MAX_DOLLAR_QUOTE_DEPTH {
         return s.to_string();
     }
-    let mut tokenizer = Tokenizer::new(s, config, dbms, depth);
+    let mut tokenizer = Tokenizer::new(s, config, dbms, dollar_recursion_depth);
     tokenizer.process();
     let raw = tokenizer.finalize();
     // collapse_grouped_values applies in legacy mode and obfuscate_and_normalize mode.

--- a/libdd-trace-obfuscation/src/sql.rs
+++ b/libdd-trace-obfuscation/src/sql.rs
@@ -206,6 +206,9 @@ fn find_dollar_quote_end(bytes: &[u8], start: usize) -> Option<(usize, usize, us
     None
 }
 
+/// Maximum recursion depth for nested dollar-quoted strings (`$tag$...$tag$`).
+const MAX_DOLLAR_QUOTE_DEPTH: usize = 64;
+
 struct Tokenizer<'a> {
     s: &'a str,
     bytes: &'a [u8],
@@ -213,6 +216,8 @@ struct Tokenizer<'a> {
     result: String,
     dbms: DbmsKind,
     config: &'a SqlObfuscateConfig,
+    // Nesting depth of dollar-quote recursion; see MAX_DOLLAR_QUOTE_DEPTH.
+    depth: usize,
     // For alias stripping: length of result before we emitted the most recent ' AS' segment
     before_as_len: Option<usize>,
     // After SAVEPOINT keyword, next token should become ?
@@ -228,7 +233,7 @@ struct Tokenizer<'a> {
 }
 
 impl<'a> Tokenizer<'a> {
-    fn new(s: &'a str, config: &'a SqlObfuscateConfig, dbms: DbmsKind) -> Self {
+    fn new(s: &'a str, config: &'a SqlObfuscateConfig, dbms: DbmsKind, depth: usize) -> Self {
         Self {
             s,
             bytes: s.as_bytes(),
@@ -236,6 +241,7 @@ impl<'a> Tokenizer<'a> {
             result: String::with_capacity(s.len()),
             dbms,
             config,
+            depth,
             before_as_len: None,
             pending_savepoint: false,
             last_was_placeholder: false,
@@ -1056,19 +1062,34 @@ impl<'a> Tokenizer<'a> {
                                     let tag_str = &self.s[start..inner_start];
                                     let inner = &self.s[inner_start..inner_end];
                                     let close_tag = &self.s[inner_end..outer_end];
-                                    let normalized_inner =
-                                        obfuscate_sql(inner, self.config, self.dbms);
+                                    let normalized_inner = obfuscate_sql_at_depth(
+                                        inner,
+                                        self.config,
+                                        self.dbms,
+                                        self.depth + 1,
+                                    );
                                     self.space();
                                     self.result.push_str(tag_str);
                                     self.result.push_str(&normalized_inner);
                                     self.result.push_str(close_tag);
                                 } else if self.config.dollar_quoted_func {
-                                    // Obfuscate the content inside dollar quotes
+                                    // Obfuscate the content inside dollar quotes.
+                                    // Past MAX_DOLLAR_QUOTE_DEPTH, use a placeholder directly
+                                    // rather than recursing, so the nested literal can't leak.
                                     let tag_str = &self.s[start..inner_start];
                                     let inner = &self.s[inner_start..inner_end];
                                     let close_tag = &self.s[inner_end..outer_end];
-                                    let obfuscated_inner =
-                                        obfuscate_sql(inner, self.config, self.dbms);
+                                    if self.depth + 1 >= MAX_DOLLAR_QUOTE_DEPTH {
+                                        self.emit_placeholder();
+                                        self.pos = outer_end;
+                                        continue;
+                                    }
+                                    let obfuscated_inner = obfuscate_sql_at_depth(
+                                        inner,
+                                        self.config,
+                                        self.dbms,
+                                        self.depth + 1,
+                                    );
                                     // If inner collapses to just '?' (trivial content), emit ?
                                     // directly
                                     if obfuscated_inner.trim() == "?" {
@@ -2188,10 +2209,27 @@ fn collapse_limit_two_args(s: &str) -> String {
 /// Obfuscates a SQL string using a proper tokenizer.
 #[must_use]
 pub fn obfuscate_sql(s: &str, config: &SqlObfuscateConfig, dbms: DbmsKind) -> String {
+    obfuscate_sql_at_depth(s, config, dbms, 0)
+}
+
+/// Same as `obfuscate_sql`, tracking recursion depth for nested dollar-quoted strings.
+/// Once `MAX_DOLLAR_QUOTE_DEPTH` is reached, this returns the content unmodified rather than
+/// recursing further, so pathologically nested input can't overflow the stack. The
+/// `dollar_quoted_func` obfuscate branch guards against this itself (see its call site) so it
+/// never leaks a literal this way; only the `NormalizeOnly` caller relies on this fallback.
+fn obfuscate_sql_at_depth(
+    s: &str,
+    config: &SqlObfuscateConfig,
+    dbms: DbmsKind,
+    depth: usize,
+) -> String {
     if s.is_empty() {
         return String::new();
     }
-    let mut tokenizer = Tokenizer::new(s, config, dbms);
+    if depth >= MAX_DOLLAR_QUOTE_DEPTH {
+        return s.to_string();
+    }
+    let mut tokenizer = Tokenizer::new(s, config, dbms, depth);
     tokenizer.process();
     let raw = tokenizer.finalize();
     // collapse_grouped_values applies in legacy mode and obfuscate_and_normalize mode.
@@ -2289,6 +2327,55 @@ fn normalize_plan_sql(s: &str) -> String {
 mod tests {
     use super::{DbmsKind, SqlObfuscateConfig, SqlObfuscationMode};
     use core::fmt::Write;
+
+    #[test]
+    fn test_dollar_quote_nesting_does_not_overflow_stack() {
+        const NESTING: usize = 20_000;
+        let mut sql = String::new();
+        for i in 0..NESTING {
+            let _ = write!(sql, "$a{i}$");
+        }
+        sql.push_str("SELECT 1");
+        for i in (0..NESTING).rev() {
+            let _ = write!(sql, "$a{i}$");
+        }
+
+        let config = SqlObfuscateConfig {
+            dollar_quoted_func: true,
+            ..Default::default()
+        };
+        let _ = super::obfuscate_sql(&sql, &config, DbmsKind::Postgresql);
+
+        let normalize_config = SqlObfuscateConfig {
+            obfuscation_mode: SqlObfuscationMode::NormalizeOnly,
+            ..Default::default()
+        };
+        let _ = super::obfuscate_sql(&sql, &normalize_config, DbmsKind::Postgresql);
+    }
+
+    #[test]
+    fn test_dollar_quote_nesting_past_depth_limit_does_not_leak_literal() {
+        const NESTING: usize = 100; // comfortably past MAX_DOLLAR_QUOTE_DEPTH (64)
+        let secret = "'123-45-6789'";
+        let mut sql = String::new();
+        for i in 0..NESTING {
+            let _ = write!(sql, "$a{i}$");
+        }
+        sql.push_str(secret);
+        for i in (0..NESTING).rev() {
+            let _ = write!(sql, "$a{i}$");
+        }
+
+        let config = SqlObfuscateConfig {
+            dollar_quoted_func: true,
+            ..Default::default()
+        };
+        let got = super::obfuscate_sql(&sql, &config, DbmsKind::Postgresql);
+        assert!(
+            !got.contains(secret),
+            "obfuscated SQL must not contain the nested literal: {got:?}"
+        );
+    }
 
     #[test]
     fn test_sql_obfuscation() {
@@ -2972,7 +3059,7 @@ mod tests {
         let config = SqlObfuscateConfig::default();
         let input = "SELECT * FROM public.table ( array [ ROW ( array [ 'magic', 'foo',";
         // First check raw (pre-collapse) output
-        let mut tok = super::Tokenizer::new(input, &config, DbmsKind::Generic);
+        let mut tok = super::Tokenizer::new(input, &config, DbmsKind::Generic, 0);
         tok.process();
         let raw = tok.finalize();
         eprintln!("RAW: {raw:?}");

--- a/libdd-trace-obfuscation/src/sql.rs
+++ b/libdd-trace-obfuscation/src/sql.rs
@@ -2333,6 +2333,7 @@ mod tests {
     use super::{DbmsKind, SqlObfuscateConfig, SqlObfuscationMode};
     use core::fmt::Write;
 
+    #[cfg_attr(miri, ignore)] // huge nested input, prohibitively slow under Miri
     #[test]
     fn test_dollar_quote_nesting_does_not_overflow_stack() {
         const NESTING: usize = 20_000;


### PR DESCRIPTION
## Summary
- Cap recursion depth for nested dollar-quoted SQL strings so pathologically nested input can no longer exhaust the stack and abort the process.
- Fix a fallback path in URL obfuscation that could return an unparseable URL with userinfo still attached instead of stripping it.

Fixes APMSP-3086 and APMSP-3085

## Test plan
- [x] `cargo nextest run -p libdd-trace-obfuscation` (343 tests, incl. new regression tests for both fixes)
- [x] `cargo fmt --check` / `cargo clippy -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)