### PR TITLE
feat(build-common): embed Windows VERSIONINFO resource in cdylib builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,6 +718,7 @@ dependencies = [
  "cbindgen",
  "serde",
  "serde_json",
+ "winresource",
 ]
 
 [[package]]
@@ -7261,6 +7262,15 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "winresource"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0986a8b1d586b7d3e4fe3d9ea39fb451ae22869dcea4aa109d287a374d866087"
+dependencies = [
+ "version_check",
 ]
 
 [[package]]

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -488,6 +488,7 @@ value-bag,https://github.com/sval-rs/value-bag,Apache-2.0 OR MIT,Ashley Mannix <
 value-bag-serde1,https://github.com/sval-rs/value-bag,Apache-2.0 OR MIT,Ashley Mannix <ashleymannix@live.com.au>
 value-bag-sval2,https://github.com/sval-rs/value-bag,Apache-2.0 OR MIT,Ashley Mannix <ashleymannix@live.com.au>
 value-trait,https://github.com/simd-lite/value-trait,Apache-2.0 OR MIT,Heinz N. Gies <heinz@licenser.net>
+version_check,https://github.com/SergioBenitez/version_check,MIT OR Apache-2.0,Sergio Benitez <sb@sergio.bz>
 wait-timeout,https://github.com/alexcrichton/wait-timeout,MIT OR Apache-2.0,Alex Crichton <alex@alexcrichton.com>
 walkdir,https://github.com/BurntSushi/walkdir,Unlicense OR MIT,Andrew Gallant <jamslam@gmail.com>
 want,https://github.com/seanmonstar/want,MIT,Sean McArthur <sean@seanmonstar.com>
@@ -531,6 +532,7 @@ windows_x86_64_gnullvm,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0
 windows_x86_64_msvc,https://github.com/microsoft/windows-rs,MIT OR Apache-2.0,Microsoft
 winnow,https://github.com/winnow-rs/winnow,MIT,The winnow Authors
 winreg,https://github.com/gentoo90/winreg-rs,MIT,Igor Shaula <gentoo90@gmail.com>
+winresource,https://github.com/BenjaminRi/winresource,MIT,Max Resch <resch.max@gmail.com>
 winver,https://github.com/rhysd/winver,MIT,rhysd <lin90162@yahoo.co.jp>
 wit-bindgen-rt,https://github.com/bytecodealliance/wit-bindgen,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,The wit-bindgen-rt Authors
 write16,https://github.com/hsivonen/write16,Apache-2.0 OR MIT,The write16 Authors

--- a/build-common/Cargo.toml
+++ b/build-common/Cargo.toml
@@ -12,11 +12,18 @@ publish = false
 [features]
 default = []
 cbindgen = []
+winresource = ["dep:winresource"]
 
 [dependencies]
 cbindgen = { version = "0.29" }
 serde = "1.0"
 serde_json = "1.0"
+# Not target-gated on `cfg(windows)`: build scripts (and their dependencies) always
+# compile for the *host*, so a target-gated dependency can't be reconciled with the
+# `CARGO_CFG_TARGET_OS` runtime check `embed_windows_version_info` uses to support
+# cross-compiling to Windows from non-Windows hosts. Gating on the `winresource`
+# feature instead keeps it out of consumers that never call that function.
+winresource = { version = "0.1", default-features = false, optional = true }
 
 [lib]
 bench = false

--- a/build-common/src/lib.rs
+++ b/build-common/src/lib.rs
@@ -15,6 +15,14 @@ mod cbindgen;
 #[cfg(feature = "cbindgen")]
 pub use crate::cbindgen::*;
 
+#[cfg(not(feature = "winresource"))]
+pub fn embed_windows_version_info(_name: &str, _description: &str) {}
+
+#[cfg(feature = "winresource")]
+mod version_info;
+#[cfg(feature = "winresource")]
+pub use crate::version_info::*;
+
 /// Locate the `gcc-ld/` shim directory shipped with the Rust toolchain.
 ///
 /// This directory contains an `ld.lld` wrapper that delegates to `rust-lld`.

--- a/build-common/src/version_info.rs
+++ b/build-common/src/version_info.rs
@@ -93,13 +93,16 @@ pub fn embed_windows_version_info(name: &str, description: &str) {
         }
     }
 
-    if let Err(err) = res.compile() {
-        println!(
-            "cargo:warning={name}: failed to embed the Windows VERSIONINFO resource, \
-             continuing without it ({err}). This is expected when cross-compiling to a \
-             Windows target without a resource compiler (llvm-rc / *-windres) on PATH."
-        );
-    }
+   if let Err(err) = res.compile() {                                                                                                                                                                                                                                                           
+       if cfg!(windows) {                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
+           panic!("{name}: failed to embed the Windows VERSIONINFO resource on a native \                                                                                                                                                                                                      
+                   Windows build ({err}); refusing to ship a DLL without it.");                                                                                                                                                                                                                
+       }                                                                                                                                                                                                                                                                                       
+       println!(                                                                                                                                                                                                                                                                               
+           "cargo:warning={name}: failed to embed the Windows VERSIONINFO resource, \                                                                                                                                                                                                          
+            continuing without it ({err}). This is expected when cross-compiling ..."                                                                                                                                                                                                          
+       );                                                                                                                                                                                                                                                                                      
+   }   
 }
 
 /// Packs a `major.minor.patch[-prerelease][+build]` semver string into the `u64`

--- a/build-common/src/version_info.rs
+++ b/build-common/src/version_info.rs
@@ -1,0 +1,156 @@
+// Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+use std::env;
+
+use winresource::VersionInfo;
+
+/// The libdatadog *release* version — the workspace-wide version bumped by
+/// `scripts/create-release.sh` (the "libdatadog vNN.0.0" that ships to customers
+/// and that support engineers compare against a tracer's expected libdatadog
+/// version) — as opposed to `CARGO_PKG_VERSION` of whichever crate's build script
+/// calls [`embed_windows_version_info`]. Individual FFI crates such as
+/// `libdd-profiling-ffi` pin their own, independently- and far more slowly-bumped
+/// crate semver (currently frozen at `1.0.0`), which would make `FileVersion`
+/// meaningless for that comparison — and, more importantly, would make it
+/// *identical across every future release*, so Windows Installer's version-based
+/// file-replacement logic would stop replacing this file again after the very
+/// first release built with this resource, silently reproducing the bug this
+/// helper exists to fix.
+///
+/// `build_common` itself always declares `version.workspace = true` in its own
+/// `Cargo.toml`, so `env!("CARGO_PKG_VERSION")` here — resolved at *build_common's
+/// own compile time*, not at the calling build script's runtime — is exactly the
+/// release version we want, regardless of which crate ends up calling this
+/// function.
+const RELEASE_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Embeds a Windows `VERSIONINFO` resource (`FileVersion`/`ProductVersion` — both
+/// the string table and the binary `VS_FIXEDFILEINFO` fields `MsiGetFileVersion`
+/// actually compares — plus the company/product/description string table) into
+/// the artifact currently being built.
+///
+/// Windows Installer's file-replacement logic on upgrade is version-based: a
+/// `<File>` with no `VERSIONINFO` resource makes it fall back to comparing
+/// created-vs-modified timestamps, which can preserve a stale DLL across an
+/// in-place upgrade.
+///
+/// # Cross-compilation
+///
+/// Call this unconditionally from `build.rs` — never guard the call with
+/// `#[cfg(windows)]` / `cfg!(windows)`. Build scripts always run on the *host*, so
+/// a compile-time `cfg` reflects the host platform, not whatever target Cargo is
+/// building for. This function instead reads `CARGO_CFG_TARGET_OS` at
+/// build-script *runtime*, which Cargo always sets to the real target, and no-ops
+/// immediately when it isn't `"windows"`.
+///
+/// # Failure handling
+///
+/// Never fails the build. Cross-compiling to a Windows target from Linux/macOS CI
+/// without a resource compiler on `PATH` (`llvm-rc` for the `msvc` ABI,
+/// `*-windres` for the `gnu` ABI) is expected; embedding a version resource is a
+/// nice-to-have, so a missing toolchain degrades to a `cargo:warning` instead of
+/// aborting the build. Likewise, a `RELEASE_VERSION` that fails to parse as
+/// `major.minor.patch` degrades to a warning rather than aborting; the string
+/// table fields are still set correctly in that case, only the binary
+/// `VS_FIXEDFILEINFO` fields fall back to whatever `WindowsResource::new()`
+/// defaulted them to.
+///
+/// # Arguments
+///
+/// * `name` - the artifact's file stem, without extension, e.g. `datadog_profiling_ffi`. Used for
+///   `OriginalFilename`/`InternalName`.
+/// * `description` - human-readable `FileDescription`, e.g. `"Datadog libdatadog FFI"`.
+pub fn embed_windows_version_info(name: &str, description: &str) {
+    if env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("windows") {
+        return;
+    }
+
+    let mut res = winresource::WindowsResource::new();
+    res.set("FileVersion", RELEASE_VERSION)
+        .set("ProductVersion", RELEASE_VERSION)
+        .set("CompanyName", "Datadog")
+        .set("ProductName", "libdatadog")
+        .set("OriginalFilename", &format!("{name}.dll"))
+        .set("InternalName", name)
+        .set("FileDescription", description)
+        .set(
+            "LegalCopyright",
+            "Copyright 2021-Present Datadog, Inc. https://www.datadoghq.com/",
+        );
+
+    match pack_version(RELEASE_VERSION) {
+        Some(packed) => {
+            res.set_version_info(VersionInfo::FILEVERSION, packed);
+            res.set_version_info(VersionInfo::PRODUCTVERSION, packed);
+        }
+        None => {
+            println!(
+                "cargo:warning={name}: could not parse release version {RELEASE_VERSION:?} \
+                 as major.minor.patch; the binary VERSIONINFO struct will report 0.0.0.0 \
+                 even though the FileVersion/ProductVersion strings are correct."
+            );
+        }
+    }
+
+    if let Err(err) = res.compile() {
+        println!(
+            "cargo:warning={name}: failed to embed the Windows VERSIONINFO resource, \
+             continuing without it ({err}). This is expected when cross-compiling to a \
+             Windows target without a resource compiler (llvm-rc / *-windres) on PATH."
+        );
+    }
+}
+
+/// Packs a `major.minor.patch[-prerelease][+build]` semver string into the `u64`
+/// layout winresource's [`VersionInfo::FILEVERSION`]/[`VersionInfo::PRODUCTVERSION`]
+/// expect: four 16-bit words, `major << 48 | minor << 32 | patch << 16 | release`.
+/// There is no separate "release"/build number in our versioning, so that last
+/// word is always 0.
+fn pack_version(version: &str) -> Option<u64> {
+    let mut parts = version.split('.');
+    let major: u16 = parts.next()?.parse().ok()?;
+    let minor: u16 = parts.next()?.parse().ok()?;
+    // Take only the leading digits of the patch component, in case of a semver
+    // pre-release/build-metadata suffix (e.g. "1.2.3-rc.1" or "1.2.3+abc").
+    let patch_str = parts.next()?;
+    let patch_str = patch_str
+        .split(|c: char| !c.is_ascii_digit())
+        .next()
+        .unwrap_or(patch_str);
+    let patch: u16 = patch_str.parse().ok()?;
+
+    Some(u64::from(major) << 48 | u64::from(minor) << 32 | u64::from(patch) << 16)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pack_version;
+
+    #[test]
+    fn packs_plain_semver() {
+        assert_eq!(
+            pack_version("43.0.0"),
+            Some(43_u64 << 48),
+            "major=43, minor=0, patch=0, release=0"
+        );
+        assert_eq!(
+            pack_version("1.2.3"),
+            Some((1_u64 << 48) | (2_u64 << 32) | (3_u64 << 16))
+        );
+    }
+
+    #[test]
+    fn strips_prerelease_and_build_metadata_suffixes() {
+        assert_eq!(pack_version("1.2.3-rc.1"), pack_version("1.2.3"));
+        assert_eq!(pack_version("1.2.3+abc"), pack_version("1.2.3"));
+    }
+
+    #[test]
+    fn rejects_malformed_versions() {
+        assert_eq!(pack_version(""), None);
+        assert_eq!(pack_version("1"), None);
+        assert_eq!(pack_version("1.2"), None);
+        assert_eq!(pack_version("a.b.c"), None);
+    }
+}

--- a/build-common/src/version_info.rs
+++ b/build-common/src/version_info.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::env;
+use std::ffi::OsStr;
+use std::path::Path;
 
 use winresource::VersionInfo;
 
@@ -58,8 +60,12 @@ const RELEASE_VERSION: &str = env!("CARGO_PKG_VERSION");
 ///
 /// # Arguments
 ///
-/// * `name` - the artifact's file stem, without extension, e.g. `datadog_profiling_ffi`. Used for
-///   `OriginalFilename`/`InternalName`.
+/// * `name` - the artifact's file name, with extension, e.g. `datadog_profiling_ffi.dll` for a
+///   `cdylib` or `crashtracker_receiver.exe` for a binary. Cargo exposes neither `[lib] name` nor
+///   the final artifact file name to build scripts, so callers spell this out literally; the
+///   Windows extension is the right one to use unconditionally because this function no-ops on
+///   non-Windows targets. Used verbatim for `OriginalFilename`, and with the extension removed for
+///   `InternalName`.
 /// * `description` - human-readable `FileDescription`, e.g. `"Datadog libdatadog FFI"`.
 pub fn embed_windows_version_info(name: &str, description: &str) {
     if env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("windows") {
@@ -71,8 +77,8 @@ pub fn embed_windows_version_info(name: &str, description: &str) {
         .set("ProductVersion", RELEASE_VERSION)
         .set("CompanyName", "Datadog")
         .set("ProductName", "libdatadog")
-        .set("OriginalFilename", &format!("{name}.dll"))
-        .set("InternalName", name)
+        .set("OriginalFilename", name)
+        .set("InternalName", internal_name(name))
         .set("FileDescription", description)
         .set(
             "LegalCopyright",
@@ -93,16 +99,34 @@ pub fn embed_windows_version_info(name: &str, description: &str) {
         }
     }
 
-   if let Err(err) = res.compile() {                                                                                                                                                                                                                                                           
-       if cfg!(windows) {                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
-           panic!("{name}: failed to embed the Windows VERSIONINFO resource on a native \                                                                                                                                                                                                      
-                   Windows build ({err}); refusing to ship a DLL without it.");                                                                                                                                                                                                                
-       }                                                                                                                                                                                                                                                                                       
-       println!(                                                                                                                                                                                                                                                                               
-           "cargo:warning={name}: failed to embed the Windows VERSIONINFO resource, \                                                                                                                                                                                                          
-            continuing without it ({err}). This is expected when cross-compiling ..."                                                                                                                                                                                                          
-       );                                                                                                                                                                                                                                                                                      
-   }   
+    if let Err(err) = res.compile() {
+        if cfg!(windows) {
+            panic!(
+                "{name}: failed to embed the Windows VERSIONINFO resource on a native Windows \
+                 build ({err}); refusing to ship the artifact without it."
+            );
+        }
+        println!(
+            "cargo:warning={name}: failed to embed the Windows VERSIONINFO resource, continuing \
+             without it ({err}). This is expected when cross-compiling to Windows without a \
+             resource compiler (llvm-rc for the msvc ABI, *-windres for the gnu ABI) on PATH."
+        );
+    }
+}
+
+/// Derives the `InternalName` string-table field from an artifact file name:
+/// Windows convention keeps the extension in `OriginalFilename` but leaves it out
+/// of `InternalName`. Strips whatever the extension happens to be (`.dll` for a
+/// `cdylib`, `.exe` for a binary, `.pyd`/`.node` for a runtime-specific extension
+/// module) rather than assuming one, and returns the name unchanged when there is
+/// no extension at all.
+fn internal_name(file_name: &str) -> &str {
+    // `file_stem` yields an `OsStr`, and the `to_str` can only fail for non-UTF-8
+    // input, which a `&str` argument rules out; both fallbacks are unreachable.
+    Path::new(file_name)
+        .file_stem()
+        .and_then(OsStr::to_str)
+        .unwrap_or(file_name)
 }
 
 /// Packs a `major.minor.patch[-prerelease][+build]` semver string into the `u64`
@@ -128,7 +152,23 @@ fn pack_version(version: &str) -> Option<u64> {
 
 #[cfg(test)]
 mod tests {
-    use super::pack_version;
+    use super::{internal_name, pack_version};
+
+    #[test]
+    fn internal_name_strips_whatever_extension_is_present() {
+        assert_eq!(
+            internal_name("datadog_profiling_ffi.dll"),
+            "datadog_profiling_ffi"
+        );
+        assert_eq!(
+            internal_name("crashtracker_receiver.exe"),
+            "crashtracker_receiver"
+        );
+        assert_eq!(internal_name("ddup.pyd"), "ddup");
+        // Only the last extension goes, and a name without one is left alone.
+        assert_eq!(internal_name("datadog.profiling.dll"), "datadog.profiling");
+        assert_eq!(internal_name("no_extension"), "no_extension");
+    }
 
     #[test]
     fn packs_plain_semver() {

--- a/libdd-profiling-ffi/Cargo.toml
+++ b/libdd-profiling-ffi/Cargo.toml
@@ -65,7 +65,7 @@ otel-thread-ctx-ffi = ["dep:libdd-otel-thread-ctx-ffi"]
 regex-lite = ["libdd-common/regex-lite"]
 
 [build-dependencies]
-build_common = { path = "../build-common" }
+build_common = { path = "../build-common", features = ["winresource"] }
 
 [dependencies]
 allocator-api2 = { workspace = true, features = ["alloc"] }

--- a/libdd-profiling-ffi/build.rs
+++ b/libdd-profiling-ffi/build.rs
@@ -7,5 +7,5 @@ use build_common::{embed_windows_version_info, generate_and_configure_header};
 fn main() {
     let header_name = "profiling.h";
     generate_and_configure_header(header_name);
-    embed_windows_version_info("datadog_profiling_ffi", "Datadog libdatadog FFI");
+    embed_windows_version_info("datadog_profiling_ffi.dll", "Datadog libdatadog FFI");
 }

--- a/libdd-profiling-ffi/build.rs
+++ b/libdd-profiling-ffi/build.rs
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 extern crate build_common;
 
-use build_common::generate_and_configure_header;
+use build_common::{embed_windows_version_info, generate_and_configure_header};
 
 fn main() {
     let header_name = "profiling.h";
     generate_and_configure_header(header_name);
+    embed_windows_version_info("datadog_profiling_ffi", "Datadog libdatadog FFI");
 }


### PR DESCRIPTION
# What does this PR do?

`datadog_profiling_ffi.dll` ships with no VERSIONINFO resource, so Windows Installer's file-replacement logic on upgrade falls back to comparing created-vs-modified timestamps instead of comparing versions. That let an MSI in-place upgrade leave a stale libdatadog v20.0.0 DLL on disk next to freshly-upgraded v25.0.0 native modules, and a fatal AV inside a static initializer (LibraryConfig ABI mismatch) on next startup.

Add `build_common::embed_windows_version_info`, a `winresource`-backed helper that populates FileVersion/ProductVersion from the libdatadog release version (build_common's own CARGO_PKG_VERSION, since it declares `version.workspace = true` -- deliberately not the calling crate's, since leaf FFI crates like libdd-profiling-ffi pin their own far-more-slowly bumped semver and would make the version compare identical release over release), plus CompanyName/ProductName/OriginalFilename/FileDescription/ LegalCopyright. Wire it into libdd-profiling-ffi's build.rs.

# Motivation

This crash report https://app.datadoghq.com/error-tracking/issue/593381a8-a5ba-11f1-bb8f-da7ad0900002?query=source%3Adotnet+service%3Ainstrumentation-telemetry-data%2A+%40tags.crash_datadog%3Atrue+%40library_version.major%3A3+-%40tags.crash_profiler%3Atrue+-%40tags.crash_asm%3Atrue+-%40tags.crash_runtime_metrics%3Atrue+%40library_version.minor%3A%3E%3D31+issue.age%3A%3C%3D3600000&from_ts=1788149319000&to_ts=1788235719000&live=false&monitor_id=236533719&monitor_sub_type=.new%28%29&link_source=monitor_notif shows a failed upgrade: 
An old version of .NET APM was installed using MSI. After some time, the customer used a newer version of the MSI. But the `datadog_profiling_ffi.dll` was not changed because it was missing the `VERSIONINFO` resource. Since the default overwrite rule is version based, it will compare the created vs modified timestamps. Since the file was not modified, it's kept.


# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
