### PR TITLE
refactor!: apply small timeout pooling strategy to libdd-http-client as well

### DIFF
--- a/datadog-sidecar/src/service/ffe_exposures_flusher.rs
+++ b/datadog-sidecar/src/service/ffe_exposures_flusher.rs
@@ -201,7 +201,7 @@ mod tests {
             Self
         }
 
-        fn new_without_connection_pooling() -> Self {
+        fn new_periodic() -> Self {
             Self
         }
 

--- a/datadog-sidecar/src/service/ffe_metrics_flusher.rs
+++ b/datadog-sidecar/src/service/ffe_metrics_flusher.rs
@@ -195,7 +195,7 @@ mod tests {
             Self
         }
 
-        fn new_without_connection_pooling() -> Self {
+        fn new_periodic() -> Self {
             Self
         }
 

--- a/datadog-sidecar/src/shm_remote_config.rs
+++ b/datadog-sidecar/src/shm_remote_config.rs
@@ -451,11 +451,8 @@ impl<N: NotifyTarget + 'static> ShmRemoteConfigs<N> {
             on_dead: Arc::new(Mutex::new(Some(on_dead))),
             _phantom: Default::default(),
         };
-        let fetcher = MultiTargetFetcher::new(
-            storage,
-            invariants,
-            NativeCapabilities::new_without_connection_pooling(),
-        );
+        let fetcher =
+            MultiTargetFetcher::new(storage, invariants, NativeCapabilities::new_periodic());
         fetcher
             .remote_config_interval
             .store(interval.as_nanos() as u64, Ordering::Relaxed);

--- a/libdd-agent-client/src/builder.rs
+++ b/libdd-agent-client/src/builder.rs
@@ -180,10 +180,10 @@ impl AgentClientBuilder {
     /// Set whether this client is used for periodic one-shot communication (typically regularly
     /// flushing to the agent). Defaults to `true`.
     ///
-    /// Depending on the capabilities of the HTTP backend of [libdd_http_client], this setting
-    /// either sets the lifetime of pooled connections to a timeout much smaller than 60s (e.g.
-    /// 5s), disables connection pooling entirely, or does nothing if the backend has no
-    /// connection pooling to begin with. See [libdd_http_client::HttpClientBuilder::periodic].
+    /// Depending on the capabilities of the HTTP backend of [libdd_http_client], this setting sets
+    /// the lifetime of pooled connections to a timeout much smaller than 60s (e.g. 5s), or does
+    /// nothing if the backend has no connection pooling support. See
+    /// [libdd_http_client::HttpClientBuilder::periodic].
     ///
     /// The Datadog agent has a low keep-alive timeout, and reusing an idle pooled connection that
     /// the agent has closed on its side causes "pipe closed" errors on every second connection.

--- a/libdd-agent-client/src/builder.rs
+++ b/libdd-agent-client/src/builder.rs
@@ -79,15 +79,31 @@ impl Default for AgentTransport {
 ///
 /// Call [`AgentClientBuilder::test_agent_session_token`] to inject
 /// `x-datadog-test-session-token` on every request.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct AgentClientBuilder {
     transport: Option<AgentTransport>,
     test_token: Option<String>,
     timeout: Option<Duration>,
     language: Option<LanguageMetadata>,
     retry: Option<RetryConfig>,
-    allow_connection_pooling: bool,
+    /// If this client is setup for periodic flushes. This mostly affects connection pooling, see
+    /// [`AgentClientBuilder::periodic`].
+    periodic: bool,
     extra_headers: Vec<(String, String)>,
+}
+
+impl Default for AgentClientBuilder {
+    fn default() -> Self {
+        Self {
+            transport: None,
+            test_token: None,
+            timeout: None,
+            language: None,
+            retry: None,
+            periodic: true,
+            extra_headers: Vec::new(),
+        }
+    }
 }
 
 impl AgentClientBuilder {
@@ -161,20 +177,21 @@ impl AgentClientBuilder {
         self
     }
 
-    /// Allow connection pooling. Defaults to `false`.
+    /// Set whether this client is used for periodic one-shot communication (typically regularly
+    /// flushing to the agent). Defaults to `true`.
     ///
-    /// Note that whether pooling is actually used depends on the HTTP backend of
-    /// [libdd_http_client], though both currently available backends (reqwest and hyper) support
-    /// pooling. This setting should be understood as: if set to `false`, no connection pooling will
-    /// happen. If set to `true`, connection pooling may happen, at the discretion of the HTTP
-    /// backend.
+    /// Depending on the capabilities of the HTTP backend of [libdd_http_client], this setting
+    /// either sets the lifetime of pooled connections to a timeout much smaller than 60s (e.g.
+    /// 5s), disables connection pooling entirely, or does nothing if the backend has no
+    /// connection pooling to begin with. See [libdd_http_client::HttpClientBuilder::periodic].
     ///
-    /// The Datadog agent has a low keep-alive timeout that causes "pipe closed" errors on every
-    /// second connection. The default of `false` is correct for all periodic-flush writers (traces,
-    /// stats, data streams). Set to `true` only for high-frequency continuous senders (e.g. a
-    /// streaming profiling exporter).
-    pub fn allow_connection_pooling(mut self, enabled: bool) -> Self {
-        self.allow_connection_pooling = enabled;
+    /// The Datadog agent has a low keep-alive timeout, and reusing an idle pooled connection that
+    /// the agent has closed on its side causes "pipe closed" errors on every second connection.
+    /// The default of `true` is correct for all periodic-flush writers (traces, stats, data
+    /// streams). Set to `false` only for high-frequency continuous senders (e.g. a streaming
+    /// profiling exporter).
+    pub fn periodic(mut self, enabled: bool) -> Self {
+        self.periodic = enabled;
         self
     }
 
@@ -193,9 +210,8 @@ impl AgentClientBuilder {
             .unwrap_or(Duration::from_millis(DEFAULT_TIMEOUT_MS));
         let retry = self.retry.unwrap_or_default();
 
-        let http =
-            Self::build_http_client(transport, timeout, retry, self.allow_connection_pooling)
-                .map_err(BuildError::HttpClient)?;
+        let http = Self::build_http_client(transport, timeout, retry, self.periodic)
+            .map_err(BuildError::HttpClient)?;
 
         let static_headers =
             Self::build_static_headers(language, self.test_token, self.extra_headers);
@@ -207,7 +223,7 @@ impl AgentClientBuilder {
         transport: AgentTransport,
         timeout: Duration,
         retry: RetryConfig,
-        allow_connection_pooling: bool,
+        periodic: bool,
     ) -> Result<libdd_http_client::HttpClient, libdd_http_client::HttpClientError> {
         let base_url = match &transport {
             AgentTransport::Http { host, port } => format!("http://{}:{}", host, port),
@@ -226,7 +242,7 @@ impl AgentClientBuilder {
             // This allows methods like `agent_info` to interpret 404 as Ok(None) rather than
             // an error, and avoids retrying on HTTP 4xx/5xx.
             .treat_http_errors_as_errors(false)
-            .allow_connection_pooling(allow_connection_pooling)
+            .periodic(periodic)
             .retry(retry);
 
         match transport {

--- a/libdd-agent-client/src/builder.rs
+++ b/libdd-agent-client/src/builder.rs
@@ -80,31 +80,16 @@ impl Default for AgentTransport {
 /// Call [`AgentClientBuilder::test_agent_session_token`] to inject
 /// `x-datadog-test-session-token` on every request.
 #[derive(Debug)]
+#[derive(Default)]
 pub struct AgentClientBuilder {
     transport: Option<AgentTransport>,
     test_token: Option<String>,
     timeout: Option<Duration>,
     language: Option<LanguageMetadata>,
     retry: Option<RetryConfig>,
-    /// If this client is setup for periodic flushes. This mostly affects connection pooling, see
-    /// [`AgentClientBuilder::periodic`].
-    periodic: bool,
     extra_headers: Vec<(String, String)>,
 }
 
-impl Default for AgentClientBuilder {
-    fn default() -> Self {
-        Self {
-            transport: None,
-            test_token: None,
-            timeout: None,
-            language: None,
-            retry: None,
-            periodic: true,
-            extra_headers: Vec::new(),
-        }
-    }
-}
 
 impl AgentClientBuilder {
     /// Create a new builder with default settings.
@@ -177,24 +162,6 @@ impl AgentClientBuilder {
         self
     }
 
-    /// Set whether this client is used for periodic one-shot communication (typically regularly
-    /// flushing to the agent). Defaults to `true`.
-    ///
-    /// Depending on the capabilities of the HTTP backend of [libdd_http_client], this setting sets
-    /// the lifetime of pooled connections to a timeout much smaller than 60s (e.g. 5s), or does
-    /// nothing if the backend has no connection pooling support. See
-    /// [libdd_http_client::HttpClientBuilder::periodic].
-    ///
-    /// The Datadog agent has a low keep-alive timeout, and reusing an idle pooled connection that
-    /// the agent has closed on its side causes "pipe closed" errors on every second connection.
-    /// The default of `true` is correct for all periodic-flush writers (traces, stats, data
-    /// streams). Set to `false` only for high-frequency continuous senders (e.g. a streaming
-    /// profiling exporter).
-    pub fn periodic(mut self, enabled: bool) -> Self {
-        self.periodic = enabled;
-        self
-    }
-
     /// Additional custom headers to inject.
     pub fn extra_headers(mut self, headers: Vec<(String, String)>) -> Self {
         self.extra_headers = headers;
@@ -210,8 +177,8 @@ impl AgentClientBuilder {
             .unwrap_or(Duration::from_millis(DEFAULT_TIMEOUT_MS));
         let retry = self.retry.unwrap_or_default();
 
-        let http = Self::build_http_client(transport, timeout, retry, self.periodic)
-            .map_err(BuildError::HttpClient)?;
+        let http =
+            Self::build_http_client(transport, timeout, retry).map_err(BuildError::HttpClient)?;
 
         let static_headers =
             Self::build_static_headers(language, self.test_token, self.extra_headers);
@@ -223,7 +190,6 @@ impl AgentClientBuilder {
         transport: AgentTransport,
         timeout: Duration,
         retry: RetryConfig,
-        periodic: bool,
     ) -> Result<libdd_http_client::HttpClient, libdd_http_client::HttpClientError> {
         let base_url = match &transport {
             AgentTransport::Http { host, port } => format!("http://{}:{}", host, port),
@@ -242,7 +208,7 @@ impl AgentClientBuilder {
             // This allows methods like `agent_info` to interpret 404 as Ok(None) rather than
             // an error, and avoids retrying on HTTP 4xx/5xx.
             .treat_http_errors_as_errors(false)
-            .periodic(periodic)
+            .periodic(true)
             .retry(retry);
 
         match transport {

--- a/libdd-agent-client/src/builder.rs
+++ b/libdd-agent-client/src/builder.rs
@@ -79,8 +79,7 @@ impl Default for AgentTransport {
 ///
 /// Call [`AgentClientBuilder::test_agent_session_token`] to inject
 /// `x-datadog-test-session-token` on every request.
-#[derive(Debug)]
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct AgentClientBuilder {
     transport: Option<AgentTransport>,
     test_token: Option<String>,
@@ -89,7 +88,6 @@ pub struct AgentClientBuilder {
     retry: Option<RetryConfig>,
     extra_headers: Vec<(String, String)>,
 }
-
 
 impl AgentClientBuilder {
     /// Create a new builder with default settings.

--- a/libdd-capabilities-impl/src/http.rs
+++ b/libdd-capabilities-impl/src/http.rs
@@ -24,7 +24,9 @@ mod native {
     #[derive(Clone)]
     pub struct NativeHttpClient {
         client: Arc<OnceLock<GenericHttpClient<Connector>>>,
-        connection_pooling: bool,
+        /// If this client is setup for periodic flushes. This mostly affects connection pooling,
+        /// see [`HttpClientCapability::new_periodic`].
+        periodic: bool,
     }
 
     pub struct NativeBodySender(libdd_common::http_common::Sender);
@@ -39,19 +41,18 @@ mod native {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             f.debug_struct("NativeHttpClient")
                 .field("initialized", &self.client.get().is_some())
-                .field("connection_pooling", &self.connection_pooling)
+                .field("periodic", &self.periodic)
                 .finish()
         }
     }
 
     impl NativeHttpClient {
-        /// Like [`HttpClientCapability::new_client`], but sets a small lifetime on pooled
-        /// connections. See [`HttpClientCapability::new_without_connection_pooling`] for the
-        /// rationale.
-        pub fn new_without_connection_pooling() -> Self {
+        /// Like [`HttpClientCapability::new_client`], but disables connection pooling. See
+        /// [`HttpClientCapability::new_periodic`].
+        pub fn new_periodic() -> Self {
             Self {
                 client: Arc::new(OnceLock::new()),
-                connection_pooling: false,
+                periodic: true,
             }
         }
     }
@@ -112,12 +113,12 @@ mod native {
         fn new_client() -> Self {
             Self {
                 client: Arc::new(OnceLock::new()),
-                connection_pooling: true,
+                periodic: false,
             }
         }
 
-        fn new_without_connection_pooling() -> Self {
-            NativeHttpClient::new_without_connection_pooling()
+        fn new_periodic() -> Self {
+            NativeHttpClient::new_periodic()
         }
 
         #[allow(clippy::manual_async_fn)]
@@ -126,7 +127,7 @@ mod native {
             req: http::Request<bytes::Bytes>,
         ) -> impl Future<Output = Result<http::Response<bytes::Bytes>, HttpError>> + MaybeSend
         {
-            let connection_pooling = self.connection_pooling;
+            let periodic = self.periodic;
             let client_lock = self.client.clone();
             async move {
                 // file:// URIs short-circuit to the on-disk recorder used by tests.
@@ -137,10 +138,10 @@ mod native {
 
                 let client = client_lock
                     .get_or_init(|| {
-                        if connection_pooling {
-                            new_default_client()
-                        } else {
+                        if periodic {
                             new_client_periodic()
+                        } else {
+                            new_default_client()
                         }
                     })
                     .clone();

--- a/libdd-capabilities-impl/src/http.rs
+++ b/libdd-capabilities-impl/src/http.rs
@@ -47,8 +47,8 @@ mod native {
     }
 
     impl NativeHttpClient {
-        /// Like [`HttpClientCapability::new_client`], but disables connection pooling. See
-        /// [`HttpClientCapability::new_periodic`].
+        /// Like [`HttpClientCapability::new_client`], but sets a small lifetime on pooled
+        /// connections. See [`HttpClientCapability::new_periodic`] for rationale.
         pub fn new_periodic() -> Self {
             Self {
                 client: Arc::new(OnceLock::new()),

--- a/libdd-capabilities-impl/src/lib.rs
+++ b/libdd-capabilities-impl/src/lib.rs
@@ -67,9 +67,9 @@ impl HttpClientCapability for NativeCapabilities {
         Self::new()
     }
 
-    fn new_without_connection_pooling() -> Self {
+    fn new_periodic() -> Self {
         Self {
-            http: NativeHttpClient::new_without_connection_pooling(),
+            http: NativeHttpClient::new_periodic(),
             sleep: NativeSleepCapability,
             env: NativeEnvCapability,
             file: NativeFileCapability,

--- a/libdd-capabilities/src/http.rs
+++ b/libdd-capabilities/src/http.rs
@@ -75,7 +75,7 @@ pub trait HttpClientCapability: Clone + std::fmt::Debug {
     /// is quite costly (can be on the order of magnitude of 0.5sec per connection). Having pooling
     /// with a short lifetime is a better choice, since we can reuse the same connection for those
     /// multiple consecutive requests, while avoiding the race condition.
-    fn new_without_connection_pooling() -> Self;
+    fn new_periodic() -> Self;
 
     fn request(
         &self,

--- a/libdd-data-pipeline-core/src/agentless/exporter.rs
+++ b/libdd-data-pipeline-core/src/agentless/exporter.rs
@@ -202,7 +202,7 @@ mod tests {
             Self::default()
         }
 
-        fn new_without_connection_pooling() -> Self {
+        fn new_periodic() -> Self {
             Self::default()
         }
 

--- a/libdd-data-pipeline/src/trace_exporter/mod.rs
+++ b/libdd-data-pipeline/src/trace_exporter/mod.rs
@@ -1399,9 +1399,9 @@ mod tests {
             Self(NativeCapabilities::new_client())
         }
 
-        fn new_without_connection_pooling() -> Self {
+        fn new_periodic() -> Self {
             LOG_CAPTURE.with(|c| c.borrow_mut().clear());
-            Self(NativeCapabilities::new_without_connection_pooling())
+            Self(NativeCapabilities::new_periodic())
         }
 
         fn request(

--- a/libdd-data-pipeline/tests/common/mock_http.rs
+++ b/libdd-data-pipeline/tests/common/mock_http.rs
@@ -208,7 +208,7 @@ impl HttpClientCapability for MockHttpCapabilities {
         Self { inner }
     }
 
-    fn new_without_connection_pooling() -> Self {
+    fn new_periodic() -> Self {
         Self::new_client()
     }
 

--- a/libdd-ffe/src/telemetry/flagevaluation/sender.rs
+++ b/libdd-ffe/src/telemetry/flagevaluation/sender.rs
@@ -491,7 +491,7 @@ mod tests {
             Self
         }
 
-        fn new_without_connection_pooling() -> Self {
+        fn new_periodic() -> Self {
             Self
         }
 

--- a/libdd-http-client/Cargo.toml
+++ b/libdd-http-client/Cargo.toml
@@ -38,9 +38,9 @@ reqwest = { workspace = true, optional = true }
 rustls = { workspace = true, optional = true }
 libdd-common = { version = "6.0.0", path = "../libdd-common", default-features = false, optional = true }
 hyper = { workspace = true, optional = true, features = ["http1", "client"] }
-hyper-util = { workspace = true, optional = true, features = ["http1", "client", "client-legacy"] }
+# `tokio` is required for the pool timer used by periodic clients (see the hyper backend)
+hyper-util = { workspace = true, optional = true, features = ["http1", "client", "client-legacy", "tokio"] }
 http-body-util = { workspace = true, optional = true }
-
 
 [dev-dependencies]
 httpmock.workspace = true

--- a/libdd-http-client/Cargo.toml
+++ b/libdd-http-client/Cargo.toml
@@ -38,7 +38,6 @@ reqwest = { workspace = true, optional = true }
 rustls = { workspace = true, optional = true }
 libdd-common = { version = "6.0.0", path = "../libdd-common", default-features = false, optional = true }
 hyper = { workspace = true, optional = true, features = ["http1", "client"] }
-# `tokio` is required for the pool timer used by periodic clients (see the hyper backend)
 hyper-util = { workspace = true, optional = true, features = ["http1", "client", "client-legacy", "tokio"] }
 http-body-util = { workspace = true, optional = true }
 

--- a/libdd-http-client/src/backend/hyper_backend.rs
+++ b/libdd-http-client/src/backend/hyper_backend.rs
@@ -150,6 +150,9 @@ impl super::Backend for HyperBackend {
     ) -> Result<Self, HttpClientError> {
         let mut builder = http_common::client_builder();
 
+        // Limit the number of idle connections kept in the pool, as a safety resource bound.
+        builder.pool_max_idle_per_host(crate::config::POOL_MAX_IDLE);
+
         if client_config.periodic() {
             // Pool connections with a small idle timeout instead of disabling pooling entirely,
             // so consecutive requests within a flush interval can still reuse a connection

--- a/libdd-http-client/src/backend/hyper_backend.rs
+++ b/libdd-http-client/src/backend/hyper_backend.rs
@@ -150,8 +150,13 @@ impl super::Backend for HyperBackend {
     ) -> Result<Self, HttpClientError> {
         let mut builder = http_common::client_builder();
 
-        if !client_config.allow_connection_pooling() {
-            builder.pool_max_idle_per_host(0);
+        if client_config.periodic() {
+            // Pool connections with a small idle timeout instead of disabling pooling entirely,
+            // so consecutive requests within a flush interval can still reuse a connection
+            // while avoiding reusing connections the receiver may have closed.
+            builder
+                .pool_timer(hyper_util::rt::TokioTimer::new())
+                .pool_idle_timeout(crate::config::PERIODIC_POOL_IDLE_TIMEOUT);
         }
 
         Ok(Self {

--- a/libdd-http-client/src/backend/reqwest_backend.rs
+++ b/libdd-http-client/src/backend/reqwest_backend.rs
@@ -35,6 +35,9 @@ impl super::Backend for ReqwestBackend {
             }
         }
 
+        // Limit the number of idle connections kept in the pool, as a safety resource bound.
+        builder = builder.pool_max_idle_per_host(crate::config::POOL_MAX_IDLE);
+
         if client_config.periodic() {
             // Pool connections with a small idle timeout instead of disabling pooling entirely,
             // so consecutive requests within a flush interval can still reuse a connection

--- a/libdd-http-client/src/backend/reqwest_backend.rs
+++ b/libdd-http-client/src/backend/reqwest_backend.rs
@@ -35,8 +35,11 @@ impl super::Backend for ReqwestBackend {
             }
         }
 
-        if !client_config.allow_connection_pooling() {
-            builder = builder.pool_max_idle_per_host(0);
+        if client_config.periodic() {
+            // Pool connections with a small idle timeout instead of disabling pooling entirely,
+            // so consecutive requests within a flush interval can still reuse a connection
+            // while avoiding reusing connections the receiver may have closed.
+            builder = builder.pool_idle_timeout(crate::config::PERIODIC_POOL_IDLE_TIMEOUT);
         }
 
         let client = builder

--- a/libdd-http-client/src/config.rs
+++ b/libdd-http-client/src/config.rs
@@ -166,23 +166,20 @@ impl HttpClientBuilder {
     /// Set whether this client is used for periodic one-shot communication (typically
     /// regularly flushing to the agent or to the backend). Defaults to `false`.
     ///
-    /// Depending on the capabilities of the underlying backend, this setting either:
+    /// This setting sets the lifetime of pooled connections to a timeout much smaller than 60s
+    /// (e.g. 5s).
     ///
-    /// - sets the lifetime of pooled connections to a timeout much smaller than 60s (e.g. 5s)
-    /// - disables connection pooling entirely if the timeout isn't configurable
-    /// - does nothing if there's no connection pooling support to begin with
-    ///
-    /// The rationale for having limited connection pooling is that we've experienced races when
+    /// The rationale for having short-lived connection pooling is that we've experienced races when
     /// the connection pooling timeout is higher than the keep-alive timeout of the receiving end.
     /// It's then possible to pick an idle connection and start a request while the connection get
     /// closed at the same time by the receiver, causing an error.
     ///
-    /// Connection pooling was initially entirely disabled by this setting, but it happens that
-    /// we send multiple separate requests in a short span of time (e.g. for telemetry on very
-    /// short-lived apps). In that situation, if we're agentless, making separate HTTPS connections
-    /// is quite costly (can be on the order of magnitude of 0.5sec per connection). Having pooling
-    /// with a short lifetime is a better choice, since we can reuse the same connection for those
-    /// multiple consecutive requests, while avoiding the race condition.
+    /// Connection pooling was initially entirely disabled by this setting, but it happens that we
+    /// send multiple separate requests in a short span of time (e.g. for telemetry on short-lived
+    /// apps). In that situation, if we're agentless, making separate HTTPS connections is quite
+    /// costly (can be on the order of magnitude of 0.5sec per connection). Having pooling with a
+    /// short lifetime is a better choice, since we can reuse the same connection for those multiple
+    /// consecutive requests, while avoiding the race condition.
     pub fn periodic(mut self, periodic: bool) -> Self {
         self.periodic = periodic;
         self

--- a/libdd-http-client/src/config.rs
+++ b/libdd-http-client/src/config.rs
@@ -24,6 +24,13 @@ pub(crate) enum TransportConfig {
     WindowsNamedPipe(std::ffi::OsString),
 }
 
+/// Idle timeout for connections kept alive by a client configured for periodic use (see
+/// [`HttpClientBuilder::periodic`]).
+///
+/// Kept much smaller than typical keep-alive timeouts on the receiving end (e.g. the Datadog
+/// agent), so that an idle pooled connection is dropped by our side before the receiver closes it.
+pub(crate) const PERIODIC_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(5);
+
 /// Configuration for an [`crate::HttpClient`] instance.
 ///
 /// Constructed via [`crate::HttpClient::new`] or [`HttpClientBuilder::build`].
@@ -33,7 +40,9 @@ pub struct HttpClientConfig {
     timeout: Duration,
     treat_http_errors_as_errors: bool,
     retry: Option<RetryConfig>,
-    allow_connection_pooling: bool,
+    /// If this client is setup for periodic flushes. This mostly affects connection pooling, see
+    /// [`HttpClientBuilder::periodic`].
+    periodic: bool,
 }
 
 impl HttpClientConfig {
@@ -45,7 +54,7 @@ impl HttpClientConfig {
             timeout,
             treat_http_errors_as_errors: true,
             retry: None,
-            allow_connection_pooling: true,
+            periodic: false,
         }
     }
 
@@ -69,10 +78,9 @@ impl HttpClientConfig {
         self.retry.as_ref()
     }
 
-    /// Whether connection pooling can be used, when available. See
-    /// [HttpClientBuilder::allow_connection_pooling].
-    pub fn allow_connection_pooling(&self) -> bool {
-        self.allow_connection_pooling
+    /// If this client is setup for periodic flushes. See [HttpClientBuilder::periodic].
+    pub fn periodic(&self) -> bool {
+        self.periodic
     }
 }
 
@@ -86,7 +94,7 @@ pub struct HttpClientBuilder {
     treat_http_errors_as_errors: bool,
     retry: Option<RetryConfig>,
     transport: TransportConfig,
-    allow_connection_pooling: bool,
+    periodic: bool,
 }
 
 impl Default for HttpClientBuilder {
@@ -97,7 +105,7 @@ impl Default for HttpClientBuilder {
             treat_http_errors_as_errors: true,
             retry: Default::default(),
             transport: Default::default(),
-            allow_connection_pooling: true,
+            periodic: false,
         }
     }
 }
@@ -155,15 +163,28 @@ impl HttpClientBuilder {
         self
     }
 
-    /// Allow connection pooling. Defaults to `true`.
+    /// Set whether this client is used for periodic one-shot communication (typically
+    /// regularly flushing to the agent or to the backend). Defaults to `false`.
     ///
-    /// Note that whether pooling is actually used depends on the HTTP backend of
-    /// [crate], though both currently available backends (reqwest and hyper) support
-    /// pooling. This setting should be understood as: if set to `true`, the default behavior of the
-    /// underlying backend will be selected, which might or might not do connection pooling by
-    /// default. If set to `false`, we guarantee no connection pooling will happen.
-    pub fn allow_connection_pooling(mut self, allow: bool) -> Self {
-        self.allow_connection_pooling = allow;
+    /// Depending on the capabilities of the underlying backend, this setting either:
+    ///
+    /// - sets the lifetime of pooled connections to a timeout much smaller than 60s (e.g. 5s)
+    /// - disables connection pooling entirely if the timeout isn't configurable
+    /// - does nothing if there's no connection pooling support to begin with
+    ///
+    /// The rationale for having limited connection pooling is that we've experienced races when
+    /// the connection pooling timeout is higher than the keep-alive timeout of the receiving end.
+    /// It's then possible to pick an idle connection and start a request while the connection get
+    /// closed at the same time by the receiver, causing an error.
+    ///
+    /// Connection pooling was initially entirely disabled by this setting, but it happens that
+    /// we send multiple separate requests in a short span of time (e.g. for telemetry on very
+    /// short-lived apps). In that situation, if we're agentless, making separate HTTPS connections
+    /// is quite costly (can be on the order of magnitude of 0.5sec per connection). Having pooling
+    /// with a short lifetime is a better choice, since we can reuse the same connection for those
+    /// multiple consecutive requests, while avoiding the race condition.
+    pub fn periodic(mut self, periodic: bool) -> Self {
+        self.periodic = periodic;
         self
     }
 
@@ -183,7 +204,7 @@ impl HttpClientBuilder {
             timeout,
             treat_http_errors_as_errors: self.treat_http_errors_as_errors,
             retry: self.retry,
-            allow_connection_pooling: self.allow_connection_pooling,
+            periodic: self.periodic,
         };
         crate::HttpClient::from_config_and_transport(config, self.transport)
     }
@@ -268,26 +289,26 @@ mod tests {
 
     #[cfg_attr(miri, ignore)] // real TLS/HTTP client construction is prohibitively slow under Miri
     #[test]
-    fn builder_allow_connection_pooling_defaults_true() {
+    fn builder_periodic_defaults_false() {
         ensure_crypto_provider();
         let client = HttpClientBuilder::new()
             .base_url("http://localhost".to_owned())
             .timeout(Duration::from_secs(1))
             .build()
             .unwrap();
-        assert!(client.config().allow_connection_pooling());
+        assert!(!client.config().periodic());
     }
 
     #[cfg_attr(miri, ignore)] // real TLS/HTTP client construction is prohibitively slow under Miri
     #[test]
-    fn builder_allow_connection_pooling_set_false() {
+    fn builder_periodic_set_true() {
         ensure_crypto_provider();
         let client = HttpClientBuilder::new()
             .base_url("http://localhost".to_owned())
             .timeout(Duration::from_secs(1))
-            .allow_connection_pooling(false)
+            .periodic(true)
             .build()
             .unwrap();
-        assert!(!client.config().allow_connection_pooling());
+        assert!(client.config().periodic());
     }
 }

--- a/libdd-http-client/src/config.rs
+++ b/libdd-http-client/src/config.rs
@@ -175,7 +175,7 @@ impl HttpClientBuilder {
     ///
     /// The rationale for having short-lived connection pooling is that we've experienced races when
     /// the connection pooling timeout is higher than the keep-alive timeout of the receiving end.
-    /// It's then possible to pick an idle connection and start a request while the connection get
+    /// It's then possible to pick an idle connection and start a request while the connection gets
     /// closed at the same time by the receiver, causing an error.
     ///
     /// Connection pooling was initially entirely disabled by this setting, but it happens that we

--- a/libdd-http-client/src/config.rs
+++ b/libdd-http-client/src/config.rs
@@ -31,6 +31,10 @@ pub(crate) enum TransportConfig {
 /// agent), so that an idle pooled connection is dropped by our side before the receiver closes it.
 pub(crate) const PERIODIC_POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Max number of idle connections kept in a client's connection pool. This is a safety resource
+/// bound that we don't really expect to hit in practice.
+pub(crate) const POOL_MAX_IDLE: usize = 20;
+
 /// Configuration for an [`crate::HttpClient`] instance.
 ///
 /// Constructed via [`crate::HttpClient::new`] or [`HttpClientBuilder::build`].

--- a/libdd-live-debugger/src/sender.rs
+++ b/libdd-live-debugger/src/sender.rs
@@ -848,7 +848,7 @@ mod tests {
             Self(Arc::new(AtomicBool::new(false)))
         }
 
-        fn new_without_connection_pooling() -> Self {
+        fn new_periodic() -> Self {
             Self::new_client()
         }
 

--- a/libdd-remote-config/examples/remote_config_agentless_bench.rs
+++ b/libdd-remote-config/examples/remote_config_agentless_bench.rs
@@ -149,7 +149,7 @@ async fn run_one_iteration(
         target,
         RUNTIME_ID.to_string(),
         options,
-        libdd_capabilities_impl::NativeCapabilities::new_without_connection_pooling(),
+        libdd_capabilities_impl::NativeCapabilities::new_periodic(),
     ));
     let mut fetcher = Instrumented::new(fetcher_fut, &mut init_poll).await?;
     let init = Sample {

--- a/libdd-remote-config/examples/remote_config_fetch.rs
+++ b/libdd-remote-config/examples/remote_config_fetch.rs
@@ -109,7 +109,7 @@ async fn main() {
             products: vec![ApmTracing],
             capabilities: vec![],
         },
-        NativeCapabilities::new_without_connection_pooling(),
+        NativeCapabilities::new_periodic(),
     )
     .await
     .expect("Failed to create SingleChangesFetcher");

--- a/libdd-remote-config/src/fetch/agentless.rs
+++ b/libdd-remote-config/src/fetch/agentless.rs
@@ -1516,7 +1516,7 @@ mod tests {
             NativeAgentlessFetcher::new(
                 cfg,
                 endpoint,
-                <libdd_capabilities_impl::NativeCapabilities as libdd_capabilities::HttpClientCapability>::new_without_connection_pooling(),
+                <libdd_capabilities_impl::NativeCapabilities as libdd_capabilities::HttpClientCapability>::new_periodic(),
             )
             .await
             .unwrap_or_else(|e| panic!("failed to instantiate fetcher for site {site}: {e}"));

--- a/libdd-remote-config/src/fetch/agentless/integration_tests.rs
+++ b/libdd-remote-config/src/fetch/agentless/integration_tests.rs
@@ -116,7 +116,7 @@ impl HttpClientCapability for MockHttp {
         Self::new()
     }
 
-    fn new_without_connection_pooling() -> Self {
+    fn new_periodic() -> Self {
         Self::new()
     }
 

--- a/libdd-remote-config/src/fetch/fetcher.rs
+++ b/libdd-remote-config/src/fetch/fetcher.rs
@@ -849,7 +849,7 @@ pub mod tests {
             storage.clone(),
             Arc::new(ConfigFetcherState::with_client(
                 server.dummy_options().invariants,
-                NativeCapabilities::new_without_connection_pooling(),
+                NativeCapabilities::new_periodic(),
             )),
         )
         .await
@@ -889,7 +889,7 @@ pub mod tests {
             storage.clone(),
             Arc::new(ConfigFetcherState::with_client(
                 server.dummy_options().invariants,
-                NativeCapabilities::new_without_connection_pooling(),
+                NativeCapabilities::new_periodic(),
             )),
         )
         .await
@@ -1009,7 +1009,7 @@ pub mod tests {
             storage.clone(),
             Arc::new(ConfigFetcherState::with_client(
                 invariants,
-                NativeCapabilities::new_without_connection_pooling(),
+                NativeCapabilities::new_periodic(),
             )),
         )
         .await
@@ -1199,7 +1199,7 @@ pub mod tests {
             storage,
             Arc::new(ConfigFetcherState::with_client(
                 server.dummy_options().invariants,
-                NativeCapabilities::new_without_connection_pooling(),
+                NativeCapabilities::new_periodic(),
             )),
         )
         .await
@@ -1303,7 +1303,7 @@ pub mod tests {
             storage,
             Arc::new(ConfigFetcherState::with_client(
                 server.dummy_options().invariants,
-                NativeCapabilities::new_without_connection_pooling(),
+                NativeCapabilities::new_periodic(),
             )),
         )
         .await

--- a/libdd-remote-config/src/fetch/multitarget.rs
+++ b/libdd-remote-config/src/fetch/multitarget.rs
@@ -971,7 +971,7 @@ mod tests {
         let fetcher = MultiTargetFetcher::<Notifier, MultiFileStorage, NativeCapabilities>::new(
             storage.clone(),
             server.dummy_options().invariants,
-            NativeCapabilities::new_without_connection_pooling(),
+            NativeCapabilities::new_periodic(),
         );
         fetcher.remote_config_interval.store(1000, Ordering::SeqCst);
 

--- a/libdd-remote-config/src/fetch/shared.rs
+++ b/libdd-remote-config/src/fetch/shared.rs
@@ -460,7 +460,7 @@ pub mod tests {
             storage.clone(),
             ConfigFetcherState::with_client(
                 server.dummy_options().invariants,
-                NativeCapabilities::new_without_connection_pooling(),
+                NativeCapabilities::new_periodic(),
             ),
         );
 
@@ -525,7 +525,7 @@ pub mod tests {
             storage.clone(),
             ConfigFetcherState::with_client(
                 server.dummy_options().invariants,
-                NativeCapabilities::new_without_connection_pooling(),
+                NativeCapabilities::new_periodic(),
             ),
         );
 

--- a/libdd-remote-config/src/fetch/single.rs
+++ b/libdd-remote-config/src/fetch/single.rs
@@ -277,7 +277,7 @@ mod tests {
             target,
             "old-runtime-id".to_string(),
             server.dummy_options(),
-            NativeCapabilities::new_without_connection_pooling(),
+            NativeCapabilities::new_periodic(),
         )
         .with_client_id("old-client-id".to_string());
 

--- a/libdd-telemetry/src/worker/mod.rs
+++ b/libdd-telemetry/src/worker/mod.rs
@@ -1426,7 +1426,7 @@ impl TelemetryWorkerBuilder {
         let config = self.config;
         let telemetry_heartbeat_interval = config.telemetry_heartbeat_interval;
         let telemetry_extended_heartbeat_interval = config.telemetry_extended_heartbeat_interval;
-        let capabilities = C::new_without_connection_pooling();
+        let capabilities = C::new_periodic();
 
         let metrics_flush_interval =
             telemetry_heartbeat_interval.min(MetricBuckets::METRICS_FLUSH_INTERVAL);

--- a/libdd-tracer-flare/src/lib.rs
+++ b/libdd-tracer-flare/src/lib.rs
@@ -196,7 +196,7 @@ impl TracerFlareManager {
             Target::new(service, env, app_version, vec![], vec![]),
             runtime_id,
             config_to_fetch,
-            NativeCapabilities::new_without_connection_pooling(),
+            NativeCapabilities::new_periodic(),
         ));
 
         Ok(tracer_flare)


### PR DESCRIPTION
# What does this PR do?

Follow-up of #2440. Rename `new_no_connection_pooling` to reflect the more nuanced semantics of the function. Apply the same treatment to the equivalent functions in libdd-http-client and libdd-agent-client.

# Motivation

See #2440.

# How to test the change?

Tested locally on the repro mentioned in #2440.