### PR TITLE
chore: bump platform base_image to contain sccache

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ variables:
     description: "downstream jobs are triggered on this branch"
 
   # To bump: docker buildx imagetools inspect registry.ddbuild.io/ci/benchmarking-platform:libdatadog-benchmarks
-  BASE_CI_IMAGE: registry.ddbuild.io/ci/benchmarking-platform:libdatadog-benchmarks@sha256:c23806c552973ba3177ec77377e0ed597cb70b05b116561e96ade5e47e0706e4
+  BASE_CI_IMAGE: registry.ddbuild.io/ci/benchmarking-platform:libdatadog-benchmarks@sha256:941d9b580302c07194e9bd2141d5f47c6cfb97d5a73c8ce9af2fce7a76034a0b
 
   # To bump: get commit sha from repo: https://gitlab.ddbuild.io/DataDog/benchmarking-platform branch: libdatadog/benchmarks
   BENCHMARKING_PLATFORM_SHA: "1d6ed8466bbe6e8fca75f899a7ec3bdc3003ce4e"

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -133,7 +133,6 @@ benchmarks:
     SCCACHE_REGION: us-east-1
     SCCACHE_S3_KEY_PREFIX: libdatadog/benchmarks/sccache
     SCCACHE_ERROR_LOG: /tmp/sccache.log
-    SCCACHE_LOG: debug
     # Required: candidate and baseline compile at different absolute paths, and
     # without a basedir sccache keys on the path, so they would share nothing.
     # Both leaf dirs, not the parent: sccache keys on the unmatched remainder.

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -123,16 +123,19 @@ benchmarks:
     KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: libdatadog
     FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
 
-    # sccache, consumed by benchmark/run_benchmarks_ci.sh. Its own key prefix, not
-    # libddprof-build's: that pipeline builds --release and cargo bench uses [profile.bench], so
-    # the -C flags -- and therefore the cache keys -- never match.
+    # sccache, consumed by benchmark/run_benchmarks_ci.sh. Its own key prefix,
+    # not libddprof-build's: that pipeline builds --release and cargo bench uses
+    # [profile.bench], so the -C flags -- and therefore the cache keys -- never
+    # match.
     SCCACHE_BUCKET: dd-ci-artefacts-build-stable
     SCCACHE_REGION: us-east-1
     SCCACHE_S3_KEY_PREFIX: libdatadog/benchmarks/sccache
     SCCACHE_ERROR_LOG: /tmp/sccache.log
-    # Required: candidate and baseline compile at different absolute paths below this one, and
-    # without a basedir sccache keys on the path, so they would share nothing.
-    SCCACHE_BASEDIRS: /platform/workspace
+    SCCACHE_LOG: debug
+    # Required: candidate and baseline compile at different absolute paths below
+    # this one, and without a basedir sccache keys on the path, so they would
+    # share nothing.
+    SCCACHE_BASEDIRS: /platform/workspace/candidate:/platform/workspace/baseline
     # Incompatible with a shared compiler cache.
     CARGO_INCREMENTAL: "0"
 

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -127,14 +127,16 @@ benchmarks:
     # not libddprof-build's: that pipeline builds --release and cargo bench uses
     # [profile.bench], so the -C flags -- and therefore the cache keys -- never
     # match.
-    SCCACHE_BUCKET: dd-ci-artefacts-build-stable
+    # Our CI role is granted only "libdatadog/*" in this bucket, so the key
+    # prefix must stay under it (cloud-inventory gitlab-repositories/libdatadog.json).
+    SCCACHE_BUCKET: dd-sccache-storage-us1-ddbuild-io
     SCCACHE_REGION: us-east-1
     SCCACHE_S3_KEY_PREFIX: libdatadog/benchmarks/sccache
     SCCACHE_ERROR_LOG: /tmp/sccache.log
     SCCACHE_LOG: debug
-    # Required: candidate and baseline compile at different absolute paths below
-    # this one, and without a basedir sccache keys on the path, so they would
-    # share nothing.
+    # Required: candidate and baseline compile at different absolute paths, and
+    # without a basedir sccache keys on the path, so they would share nothing.
+    # Both leaf dirs, not the parent: sccache keys on the unmatched remainder.
     SCCACHE_BASEDIRS: /platform/workspace/candidate:/platform/workspace/baseline
     # Incompatible with a shared compiler cache.
     CARGO_INCREMENTAL: "0"

--- a/benchmark/run_benchmarks_ci.sh
+++ b/benchmark/run_benchmarks_ci.sh
@@ -72,11 +72,30 @@ start_compiler_cache() {
     message "sccache not present in this image; building without a compiler cache"
     return 1
   fi
-  if ! sccache --start-server > /dev/null 2>&1; then
-    message "sccache: server startup failed; building without a compiler cache (see ${SCCACHE_ERROR_LOG:-unset})"
+  # Keep --start-server's stderr: it names the reason (bad basedir, unresolvable credentials, an
+  # unreachable bucket) and discarding it is why an earlier failure was undiagnosable.
+  local startup_output
+  if ! startup_output="$(sccache --start-server 2>&1)"; then
+    message "sccache: server startup failed; building without a compiler cache"
+    message "sccache: --start-server reported: ${startup_output:-<no output>}"
+    dump_compiler_cache_diagnostics
     return 1
   fi
   return 0
+}
+
+# $SCCACHE_ERROR_LOG lives on the job's ephemeral filesystem and is not in artifacts:paths, so a
+# startup failure is otherwise unreproducible after the fact. Echo it into the job log instead.
+# Only variable *names* for AWS_*: the value of AWS_SECRET_ACCESS_KEY must not reach a CI log.
+dump_compiler_cache_diagnostics() {
+  message "sccache: AWS_* variables present: $(env | sed -n 's/^\(AWS_[A-Z_]*\)=.*/\1/p' | sort | tr '\n' ' ')"
+  message "sccache: SCCACHE_* config: $(env | grep '^SCCACHE_' | sort | tr '\n' ' ')"
+  if [[ -s "${SCCACHE_ERROR_LOG:-/nonexistent}" ]]; then
+    message "sccache: last 50 lines of ${SCCACHE_ERROR_LOG}:"
+    tail -n 50 "${SCCACHE_ERROR_LOG}" >&2
+  else
+    message "sccache: ${SCCACHE_ERROR_LOG:-unset} is empty or absent (server may have died before logging)"
+  fi
 }
 
 if (( ${#package_args[@]} == 0 )); then

--- a/benchmark/run_benchmarks_ci.sh
+++ b/benchmark/run_benchmarks_ci.sh
@@ -72,8 +72,6 @@ start_compiler_cache() {
     message "sccache not present in this image; building without a compiler cache"
     return 1
   fi
-  # Keep --start-server's stderr: it names the reason (bad basedir, unresolvable credentials, an
-  # unreachable bucket) and discarding it is why an earlier failure was undiagnosable.
   local startup_output
   if ! startup_output="$(sccache --start-server 2>&1)"; then
     message "sccache: server startup failed; building without a compiler cache"
@@ -84,9 +82,8 @@ start_compiler_cache() {
   return 0
 }
 
-# $SCCACHE_ERROR_LOG lives on the job's ephemeral filesystem and is not in artifacts:paths, so a
-# startup failure is otherwise unreproducible after the fact. Echo it into the job log instead.
-# Only variable *names* for AWS_*: the value of AWS_SECRET_ACCESS_KEY must not reach a CI log.
+# $SCCACHE_ERROR_LOG is not in artifacts:paths; echo it into the job log.
+# AWS_* names only -- one of them is a secret.
 dump_compiler_cache_diagnostics() {
   message "sccache: AWS_* variables present: $(env | sed -n 's/^\(AWS_[A-Z_]*\)=.*/\1/p' | sort | tr '\n' ' ')"
   message "sccache: SCCACHE_* config: $(env | grep '^SCCACHE_' | sort | tr '\n' ' ')"

--- a/benchmark/run_benchmarks_ci.sh
+++ b/benchmark/run_benchmarks_ci.sh
@@ -65,8 +65,8 @@ for crate in ${BENCH_PACKAGES}; do
   done
 done
 
-# Start the shared compiler cache if this image has one. Best-effort: nodes can still be serving
-# a pre-sccache image, and a cache problem must never fail a benchmark job.
+# Start the shared compiler cache. Still best-effort either way: a compiler
+# cache is an optimisation, and no cache problem may ever fail a benchmark job.
 start_compiler_cache() {
   if ! command -v sccache > /dev/null 2>&1; then
     message "sccache not present in this image; building without a compiler cache"


### PR DESCRIPTION
# What does this PR do?

bump base image to ci platform that contain sccache

# Motivation

have sccache enabled on benchmarks jobs

# Additional Notes

-

# How to test the change?

see the jobs log