### PR TITLE
perf(trace): encode agentless IDs without formatting

### DIFF
--- a/libdd-trace-utils/benches/agentless_encoding.rs
+++ b/libdd-trace-utils/benches/agentless_encoding.rs
@@ -1,0 +1,117 @@
+// Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+//! Agentless JSON encoding for a representative HTTP flush: 20 five-span traces with repeated
+//! runtime and HTTP metadata. A second case adds one span link to each root span.
+
+use criterion::{black_box, criterion_group, BenchmarkId, Criterion, Throughput};
+use libdd_tinybytes::BytesString;
+use libdd_trace_utils::agentless_encoder::encode_payload;
+use libdd_trace_utils::span::v04::{Span, SpanLink, VecMap};
+use libdd_trace_utils::span::BytesData;
+use libdd_trace_utils::tracer_metadata::TracerMetadata;
+
+const NUM_TRACES: usize = 20;
+const SPANS_PER_TRACE: usize = 5;
+
+fn bytes(value: &'static str) -> BytesString {
+    BytesString::from_static(value)
+}
+
+fn metadata() -> TracerMetadata {
+    TracerMetadata {
+        hostname: "benchmark-host".to_string(),
+        env: "production".to_string(),
+        runtime_id: "f0e1d2c3-b4a5-6789-0abc-def012345678".to_string(),
+        tracer_version: "1.2.3".to_string(),
+        language: "nodejs".to_string(),
+        language_version: "24.7.0".to_string(),
+        ..Default::default()
+    }
+}
+
+fn traces(with_span_links: bool) -> Vec<Vec<Span<BytesData>>> {
+    let mut traces = Vec::with_capacity(NUM_TRACES);
+
+    for trace_index in 0..NUM_TRACES {
+        let trace_index = u64::try_from(trace_index).expect("NUM_TRACES must fit in u64");
+        let mut spans = Vec::with_capacity(SPANS_PER_TRACE);
+        let trace_id =
+            ((u128::from(trace_index) + 1) << 64) | (100_000_000_000 + u128::from(trace_index));
+        let root_span_id = 100_000_000_000 + trace_index;
+
+        for span_index in 0..SPANS_PER_TRACE {
+            let span_index = u64::try_from(span_index).expect("SPANS_PER_TRACE must fit in u64");
+            let span_id = root_span_id + span_index;
+            let parent_id = if span_index == 0 { 0 } else { root_span_id };
+            let span_links = if with_span_links && span_index == 0 {
+                vec![SpanLink {
+                    trace_id: root_span_id + 1,
+                    trace_id_high: trace_index + 1,
+                    span_id: root_span_id + 2,
+                    attributes: [(bytes("link.name"), bytes("scheduled_by"))].into(),
+                    flags: 1,
+                    tracestate: bytes("dd=s:1"),
+                }]
+            } else {
+                Vec::new()
+            };
+
+            let mut span = Span {
+                service: bytes("benchmark-service"),
+                name: bytes("http.request"),
+                resource: bytes("GET /api/v1/resource"),
+                r#type: bytes("web"),
+                trace_id,
+                span_id,
+                parent_id,
+                start: 1_700_000_000_000_000_000,
+                duration: 123_456,
+                meta: VecMap::from_iter([
+                    (bytes("component"), bytes("http")),
+                    (bytes("span.kind"), bytes("server")),
+                    (bytes("http.method"), bytes("GET")),
+                    (bytes("http.status_code"), bytes("200")),
+                    (bytes("peer.hostname"), bytes("api.example.com")),
+                    (
+                        bytes("runtime-id"),
+                        bytes("f0e1d2c3-b4a5-6789-0abc-def012345678"),
+                    ),
+                ]),
+                metrics: VecMap::from_iter([
+                    (bytes("_sampling_priority_v1"), 1.0),
+                    (bytes("_dd.measured"), 1.0),
+                    (bytes("process_id"), 1234.0),
+                ]),
+                span_links,
+                ..Default::default()
+            };
+            span.dedup();
+            spans.push(span);
+        }
+        traces.push(spans);
+    }
+
+    traces
+}
+
+fn agentless_encoding_benches(c: &mut Criterion) {
+    let metadata = metadata();
+    let mut group = c.benchmark_group("agentless_encoding");
+    let span_count =
+        u64::try_from(NUM_TRACES * SPANS_PER_TRACE).expect("benchmark span count must fit in u64");
+    group.throughput(Throughput::Elements(span_count));
+
+    for (name, with_span_links) in [("common_http", false), ("http_with_span_links", true)] {
+        let traces = traces(with_span_links);
+        group.bench_with_input(BenchmarkId::new(name, "20x5"), &traces, |b, traces| {
+            b.iter(|| {
+                black_box(encode_payload(black_box(traces), black_box(&metadata), false).unwrap())
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(agentless_encoding, agentless_encoding_benches);

--- a/libdd-trace-utils/benches/main.rs
+++ b/libdd-trace-utils/benches/main.rs
@@ -9,6 +9,7 @@ use libdd_common::bench_utils::ReportingAllocator;
 #[global_allocator]
 pub static GLOBAL: ReportingAllocator<System> = ReportingAllocator::new(System);
 
+mod agentless_encoding;
 mod deserialization;
 mod deserialization_v05;
 mod otlp_encoding;
@@ -21,6 +22,7 @@ criterion_main!(
     deserialization::deserialize_alloc_benches,
     deserialization_v05::deserialize_v05_benches,
     deserialization_v05::deserialize_v05_alloc_benches,
+    agentless_encoding::agentless_encoding,
     otlp_encoding::otlp_benches,
     span_pool::span_pool_benches,
     span_pool::span_pool_alloc_benches

--- a/libdd-trace-utils/src/agentless_encoder/mod.rs
+++ b/libdd-trace-utils/src/agentless_encoder/mod.rs
@@ -26,14 +26,13 @@
 //!
 //! TODO: span normalization (service/name/resource/type truncation + defaults)
 
+use crate::hex::{hex_low_u64, hex_u128, hex_u64};
 use crate::span::v04::{AttributeAnyValue, AttributeArrayValue, Span, SpanEvent, SpanLink};
 use crate::span::v1;
 use crate::span::{TraceData, SPAN_LINK_FLAGS_SET_SENTINEL};
 use crate::tracer_metadata::TracerMetadata;
-use serde::{
-    ser::{Error as _, SerializeMap, SerializeSeq},
-    Serializer,
-};
+use serde::ser::{SerializeMap, SerializeSeq};
+use serde::Serializer;
 use std::borrow::{Borrow, Cow};
 use std::collections::HashSet;
 use std::fmt::Write as _;
@@ -42,31 +41,6 @@ use std::fmt::Write as _;
 const MAX_META_VALUE_LEN: usize = 25_000;
 /// Suffix appended when a `meta` value is truncated.
 const TRUNCATION_SUFFIX: &str = "...";
-const HEX_DIGITS: &[u8; 16] = b"0123456789abcdef";
-
-struct FixedHex<const N: usize>([u8; N]);
-
-impl<const N: usize> serde::Serialize for FixedHex<N> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let value = std::str::from_utf8(&self.0).map_err(S::Error::custom)?;
-        serializer.serialize_str(value)
-    }
-}
-
-fn fixed_hex<const N: usize>(mut value: u128) -> FixedHex<N> {
-    let mut encoded = [b'0'; N];
-    let mut index = N;
-
-    while index != 0 {
-        index -= 1;
-        // The mask guarantees that the conversion fits and indexes HEX_DIGITS.
-        encoded[index] = HEX_DIGITS[(value & 0x0f) as usize];
-        value >>= 4;
-    }
-
-    FixedHex(encoded)
-}
-
 /// # Why are we doing this?
 ///
 /// The JSON agentless format is different from the in-memory model of v04 spans (and to v03/v04/v05
@@ -199,9 +173,9 @@ fn encode_span<T: TraceData, S: Serializer>(
 ) -> Result<S::Ok, S::Error> {
     let mut map = ser.serialize_map(None)?;
 
-    map.serialize_entry("trace_id", &fixed_hex::<16>(span.trace_id))?;
-    map.serialize_entry("span_id", &fixed_hex::<16>(u128::from(span.span_id)))?;
-    map.serialize_entry("parent_id", &fixed_hex::<16>(u128::from(span.parent_id)))?;
+    map.serialize_entry("trace_id", &hex_low_u64(span.trace_id))?;
+    map.serialize_entry("span_id", &hex_u64(span.span_id))?;
+    map.serialize_entry("parent_id", &hex_u64(span.parent_id))?;
 
     // Resource defaults to name when empty.
     let name_str: &str = span.name.borrow();
@@ -249,7 +223,7 @@ fn encode_span<T: TraceData, S: Serializer>(
                 meta.serialize_entry(key, val)?;
             }
             if !p_tid_seen && upper_bits != 0 {
-                meta.serialize_entry("_dd.p.tid", &fixed_hex::<16>(u128::from(upper_bits)))?;
+                meta.serialize_entry("_dd.p.tid", &hex_u64(upper_bits))?;
             }
             if !span_links_seen && !span.span_links.is_empty() {
                 if let Some(s) = serialize_span_links(&span.span_links) {
@@ -339,8 +313,8 @@ fn encode_span_link<T: TraceData, S: Serializer>(
 ) -> Result<S::Ok, S::Error> {
     let mut map = ser.serialize_map(None)?;
     let trace_id_128 = (u128::from(link.trace_id_high) << 64) | u128::from(link.trace_id);
-    map.serialize_entry("trace_id", &fixed_hex::<32>(trace_id_128))?;
-    map.serialize_entry("span_id", &fixed_hex::<16>(u128::from(link.span_id)))?;
+    map.serialize_entry("trace_id", &hex_u128(trace_id_128))?;
+    map.serialize_entry("span_id", &hex_u64(link.span_id))?;
     if !link.attributes.is_empty() {
         map.serialize_entry(
             "attributes",
@@ -720,22 +694,9 @@ fn encode_span_v1<'a, T: TraceData, S: Serializer>(
     trace_id_high_bytes.copy_from_slice(&chunk.trace_id[0..8]);
     let trace_id_low = u64::from_be_bytes(trace_id_low_bytes);
     let trace_id_high = u64::from_be_bytes(trace_id_high_bytes);
-    map.serialize_entry(
-        "trace_id",
-        &ser_fn!(|ser, trace_id_low: u64| {
-            ser.collect_str(&format_args!("{trace_id_low:016x}"))
-        }),
-    )?;
-    let span_id = span.span_id;
-    map.serialize_entry(
-        "span_id",
-        &ser_fn!(|ser, span_id: u64| { ser.collect_str(&format_args!("{span_id:016x}")) }),
-    )?;
-    let parent_id = span.parent_id;
-    map.serialize_entry(
-        "parent_id",
-        &ser_fn!(|ser, parent_id: u64| { ser.collect_str(&format_args!("{parent_id:016x}")) }),
-    )?;
+    map.serialize_entry("trace_id", &hex_u64(trace_id_low))?;
+    map.serialize_entry("span_id", &hex_u64(span.span_id))?;
+    map.serialize_entry("parent_id", &hex_u64(span.parent_id))?;
 
     // Resource defaults to name when empty.
     let name_str: &str = span.name.borrow();
@@ -818,12 +779,7 @@ fn encode_span_v1<'a, T: TraceData, S: Serializer>(
                 meta.serialize_entry(key, val)?;
             }
             if !p_tid_seen && trace_id_high != 0 {
-                meta.serialize_entry(
-                    "_dd.p.tid",
-                    &ser_fn!(|ser, trace_id_high: u64| {
-                        ser.collect_str(&format_args!("{trace_id_high:016x}"))
-                    }),
-                )?;
+                meta.serialize_entry("_dd.p.tid", &hex_u64(trace_id_high))?;
             }
             if !span_links_seen && !span.span_links.is_empty() {
                 if let Some(s) = serialize_span_links_v1(&span.span_links) {
@@ -913,8 +869,8 @@ fn encode_span_link_v1<T: TraceData, S: Serializer>(
 ) -> Result<S::Ok, S::Error> {
     let mut map = ser.serialize_map(None)?;
     let trace_id_128 = u128::from_be_bytes(link.trace_id);
-    map.serialize_entry("trace_id", &format!("{trace_id_128:032x}"))?;
-    map.serialize_entry("span_id", &format!("{:016x}", link.span_id))?;
+    map.serialize_entry("trace_id", &hex_u128(trace_id_128))?;
+    map.serialize_entry("span_id", &hex_u64(link.span_id))?;
     let attrs_dd = link.attributes.defensive_dedup();
     let attrs_dd = &attrs_dd;
     let has_attributes = attrs_dd.iter().any(|(_, v)| {

--- a/libdd-trace-utils/src/agentless_encoder/mod.rs
+++ b/libdd-trace-utils/src/agentless_encoder/mod.rs
@@ -31,7 +31,7 @@ use crate::span::v1;
 use crate::span::{TraceData, SPAN_LINK_FLAGS_SET_SENTINEL};
 use crate::tracer_metadata::TracerMetadata;
 use serde::{
-    ser::{SerializeMap, SerializeSeq},
+    ser::{Error as _, SerializeMap, SerializeSeq},
     Serializer,
 };
 use std::borrow::{Borrow, Cow};
@@ -42,6 +42,30 @@ use std::fmt::Write as _;
 const MAX_META_VALUE_LEN: usize = 25_000;
 /// Suffix appended when a `meta` value is truncated.
 const TRUNCATION_SUFFIX: &str = "...";
+const HEX_DIGITS: &[u8; 16] = b"0123456789abcdef";
+
+struct FixedHex<const N: usize>([u8; N]);
+
+impl<const N: usize> serde::Serialize for FixedHex<N> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let value = std::str::from_utf8(&self.0).map_err(S::Error::custom)?;
+        serializer.serialize_str(value)
+    }
+}
+
+fn fixed_hex<const N: usize>(mut value: u128) -> FixedHex<N> {
+    let mut encoded = [b'0'; N];
+    let mut index = N;
+
+    while index != 0 {
+        index -= 1;
+        // The mask guarantees that the conversion fits and indexes HEX_DIGITS.
+        encoded[index] = HEX_DIGITS[(value & 0x0f) as usize];
+        value >>= 4;
+    }
+
+    FixedHex(encoded)
+}
 
 /// # Why are we doing this?
 ///
@@ -175,25 +199,9 @@ fn encode_span<T: TraceData, S: Serializer>(
 ) -> Result<S::Ok, S::Error> {
     let mut map = ser.serialize_map(None)?;
 
-    let trace_id = span.trace_id;
-    map.serialize_entry(
-        "trace_id",
-        &ser_fn!(|ser, trace_id: u128| {
-            ser.collect_str(&format_args!("{:016x}", trace_id as u64))
-        }),
-    )?;
-    let span_id = span.span_id;
-    map.serialize_entry(
-        "span_id",
-        &ser_fn!(|ser, span_id: u64| { ser.collect_str(&format_args!("{:016x}", span_id as u64)) }),
-    )?;
-    let parent_id = span.parent_id;
-    map.serialize_entry(
-        "parent_id",
-        &ser_fn!(|ser, parent_id: u64| {
-            ser.collect_str(&format_args!("{:016x}", parent_id as u64))
-        }),
-    )?;
+    map.serialize_entry("trace_id", &fixed_hex::<16>(span.trace_id))?;
+    map.serialize_entry("span_id", &fixed_hex::<16>(u128::from(span.span_id)))?;
+    map.serialize_entry("parent_id", &fixed_hex::<16>(u128::from(span.parent_id)))?;
 
     // Resource defaults to name when empty.
     let name_str: &str = span.name.borrow();
@@ -241,12 +249,7 @@ fn encode_span<T: TraceData, S: Serializer>(
                 meta.serialize_entry(key, val)?;
             }
             if !p_tid_seen && upper_bits != 0 {
-                meta.serialize_entry(
-                    "_dd.p.tid",
-                    &ser_fn!(|ser, upper_bits: u64| {
-                        ser.collect_str(&format_args!("{:016x}", upper_bits as u64))
-                    }),
-                )?;
+                meta.serialize_entry("_dd.p.tid", &fixed_hex::<16>(u128::from(upper_bits)))?;
             }
             if !span_links_seen && !span.span_links.is_empty() {
                 if let Some(s) = serialize_span_links(&span.span_links) {
@@ -335,9 +338,9 @@ fn encode_span_link<T: TraceData, S: Serializer>(
     link: &SpanLink<T>,
 ) -> Result<S::Ok, S::Error> {
     let mut map = ser.serialize_map(None)?;
-    let trace_id_128: u128 = ((link.trace_id_high as u128) << 64) | (link.trace_id as u128);
-    map.serialize_entry("trace_id", &format!("{:032x}", trace_id_128))?;
-    map.serialize_entry("span_id", &format!("{:016x}", link.span_id))?;
+    let trace_id_128 = (u128::from(link.trace_id_high) << 64) | u128::from(link.trace_id);
+    map.serialize_entry("trace_id", &fixed_hex::<32>(trace_id_128))?;
+    map.serialize_entry("span_id", &fixed_hex::<16>(u128::from(link.span_id)))?;
     if !link.attributes.is_empty() {
         map.serialize_entry(
             "attributes",

--- a/libdd-trace-utils/src/agentless_encoder/tests.rs
+++ b/libdd-trace-utils/src/agentless_encoder/tests.rs
@@ -133,6 +133,42 @@ fn keeps_existing_dd_p_tid_in_meta() {
 
 #[cfg_attr(miri, ignore)] // serde_json/rmp_serde overhead is prohibitively slow under Miri
 #[test]
+fn ids_preserve_fixed_width_lowercase_wire_format_at_numeric_edges() {
+    let link = SpanLink::<BytesData> {
+        trace_id: 0,
+        trace_id_high: u64::MAX,
+        span_id: 0,
+        ..Default::default()
+    };
+    let span: Span<BytesData> = Span {
+        service: bs("svc"),
+        name: bs("op"),
+        trace_id: u128::MAX,
+        span_id: u64::MAX,
+        parent_id: 0x0123_4567_89ab_cdef,
+        start: 0,
+        duration: 1,
+        span_links: vec![link],
+        ..Default::default()
+    };
+
+    let bytes = encode_payload(&[vec![span]], &base_metadata(), false).unwrap();
+    let encoded = std::str::from_utf8(&bytes).unwrap();
+    assert!(encoded.contains(
+        r#""trace_id":"ffffffffffffffff","span_id":"ffffffffffffffff","parent_id":"0123456789abcdef""#
+    ));
+
+    let payload = json_from_bytes(&bytes);
+    let meta = &payload["traces"][0]["spans"][0]["meta"];
+    assert_eq!(meta["_dd.p.tid"], "ffffffffffffffff");
+    assert_eq!(
+        meta["_dd.span_links"],
+        r#"[{"trace_id":"ffffffffffffffff0000000000000000","span_id":"0000000000000000"}]"#
+    );
+}
+
+#[cfg_attr(miri, ignore)] // serde_json/rmp_serde overhead is prohibitively slow under Miri
+#[test]
 fn span_links_serialised_into_meta_as_json_string() {
     // Span links are JSON-stringified and stored in meta["_dd.span_links"];
     // no top-level `span_links` field is emitted.

--- a/libdd-trace-utils/src/hex.rs
+++ b/libdd-trace-utils/src/hex.rs
@@ -8,14 +8,12 @@ const HEX_DIGITS: &[u8; 16] = b"0123456789abcdef";
 pub(crate) struct FixedHex<const N: usize>([u8; N]);
 
 impl<const N: usize> Serialize for FixedHex<N> {
-    #[inline]
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let value = std::str::from_utf8(&self.0).map_err(S::Error::custom)?;
         serializer.serialize_str(value)
     }
 }
 
-#[inline]
 fn fixed_hex<const N: usize>(mut value: u128) -> FixedHex<N> {
     let mut encoded = [b'0'; N];
     let mut index = N;
@@ -30,17 +28,14 @@ fn fixed_hex<const N: usize>(mut value: u128) -> FixedHex<N> {
     FixedHex(encoded)
 }
 
-#[inline]
 pub(crate) fn hex_u64(value: u64) -> FixedHex<16> {
     fixed_hex(u128::from(value))
 }
 
-#[inline]
 pub(crate) fn hex_low_u64(value: u128) -> FixedHex<16> {
     fixed_hex(value)
 }
 
-#[inline]
 pub(crate) fn hex_u128(value: u128) -> FixedHex<32> {
     fixed_hex(value)
 }

--- a/libdd-trace-utils/src/hex.rs
+++ b/libdd-trace-utils/src/hex.rs
@@ -1,0 +1,46 @@
+// Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{ser::Error as _, Serialize, Serializer};
+
+const HEX_DIGITS: &[u8; 16] = b"0123456789abcdef";
+
+pub(crate) struct FixedHex<const N: usize>([u8; N]);
+
+impl<const N: usize> Serialize for FixedHex<N> {
+    #[inline]
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let value = std::str::from_utf8(&self.0).map_err(S::Error::custom)?;
+        serializer.serialize_str(value)
+    }
+}
+
+#[inline]
+fn fixed_hex<const N: usize>(mut value: u128) -> FixedHex<N> {
+    let mut encoded = [b'0'; N];
+    let mut index = N;
+
+    while index != 0 {
+        index -= 1;
+        // The mask guarantees that the conversion fits and indexes HEX_DIGITS.
+        encoded[index] = HEX_DIGITS[(value & 0x0f) as usize];
+        value >>= 4;
+    }
+
+    FixedHex(encoded)
+}
+
+#[inline]
+pub(crate) fn hex_u64(value: u64) -> FixedHex<16> {
+    fixed_hex(u128::from(value))
+}
+
+#[inline]
+pub(crate) fn hex_low_u64(value: u128) -> FixedHex<16> {
+    fixed_hex(value)
+}
+
+#[inline]
+pub(crate) fn hex_u128(value: u128) -> FixedHex<32> {
+    fixed_hex(value)
+}

--- a/libdd-trace-utils/src/json_log_encoder/span.rs
+++ b/libdd-trace-utils/src/json_log_encoder/span.rs
@@ -15,41 +15,19 @@
 //! trait bound) rather than the whole `T`, so the encoder does not require a
 //! `T: Serialize` bound — keeping the public exporter API free of that bound.
 
+use crate::hex::{hex_low_u64, hex_u128, hex_u64};
 use crate::span::v04::{Span, SpanEvent, SpanLink};
 use crate::span::{TraceData, SPAN_LINK_FLAGS_SET_SENTINEL};
 use serde::ser::{SerializeSeq, SerializeStruct};
 use serde::{Serialize, Serializer};
 use std::borrow::Borrow;
 
-const HEX_DIGITS: &[u8; 16] = b"0123456789abcdef";
-
-/// Writes `value` as 16 zero-padded lowercase hex bytes into the start of `out`.
-///
-/// The caller guarantees `out` has room for at least 16 bytes.
-fn fill_hex(out: &mut [u8], value: u64) {
-    for i in 0..16 {
-        out[15 - i] = HEX_DIGITS[((value >> (i * 4)) & 0xf) as usize];
-    }
-}
-
-/// Serializes `buf` as a JSON string. `buf` must only contain ASCII hex digits,
-/// so the UTF-8 check below never fails in practice.
-fn serialize_ascii_hex<S: Serializer>(serializer: S, buf: &[u8]) -> Result<S::Ok, S::Error> {
-    match std::str::from_utf8(buf) {
-        Ok(text) => serializer.serialize_str(text),
-        // Unreachable: `fill_hex` only writes ASCII hex digits.
-        Err(_) => serializer.serialize_str(""),
-    }
-}
-
 /// A `u64` id rendered as a 16-char zero-padded lowercase hex JSON string.
 pub(super) struct HexU64(pub(super) u64);
 
 impl Serialize for HexU64 {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut buf = [0u8; 16];
-        fill_hex(&mut buf, self.0);
-        serialize_ascii_hex(serializer, &buf)
+        hex_u64(self.0).serialize(serializer)
     }
 }
 
@@ -59,17 +37,10 @@ pub(super) struct HexTraceId(pub(super) u128);
 
 impl Serialize for HexTraceId {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let high = (self.0 >> 64) as u64;
-        let low = self.0 as u64;
-        if high == 0 {
-            let mut buf = [0u8; 16];
-            fill_hex(&mut buf, low);
-            serialize_ascii_hex(serializer, &buf)
+        if self.0 >> 64 == 0 {
+            hex_low_u64(self.0).serialize(serializer)
         } else {
-            let mut buf = [0u8; 32];
-            fill_hex(&mut buf[0..16], high);
-            fill_hex(&mut buf[16..32], low);
-            serialize_ascii_hex(serializer, &buf)
+            hex_u128(self.0).serialize(serializer)
         }
     }
 }

--- a/libdd-trace-utils/src/lib.rs
+++ b/libdd-trace-utils/src/lib.rs
@@ -9,6 +9,7 @@
 
 pub mod agentless_encoder;
 pub mod config_utils;
+mod hex;
 pub mod json_log_encoder;
 pub mod msgpack_decoder;
 pub mod msgpack_encoder;


### PR DESCRIPTION
# What does this PR do?

Replaces formatting-backed agentless trace, span, parent, and link ID serialization with fixed-width lowercase hexadecimal buffers. Exact wire tests and lasting Criterion workloads cover common HTTP and span-link traces.

# Motivation

Formatting allocated temporary strings for every serialized ID in the agentless hot path.

# Additional Notes

With production-deduplicated spans, position-balanced Criterion runs improved common HTTP traces by 32.35% and span-link traces by 44.48% on macOS arm64.

# How to test the change?

Run `cargo test -p libdd-trace-utils --lib agentless_encoder` and `cargo bench -p libdd-trace-utils --bench main -- agentless_encoding`.