### PR TITLE
perf(trace): write agentless JSON directly

### DIFF
--- a/libdd-data-pipeline/src/otlp/grpc_exporter.rs
+++ b/libdd-data-pipeline/src/otlp/grpc_exporter.rs
@@ -643,7 +643,7 @@ mod integration_tests {
     fn cfg() -> OtlpGrpcTraceConfig {
         OtlpGrpcTraceConfig {
             headers: vec![],
-            timeout: Duration::from_secs(2),
+            timeout: crate::otlp::config::DEFAULT_OTLP_TIMEOUT,
             otel_trace_semantics_enabled: false,
         }
     }

--- a/libdd-trace-utils/src/agentless_encoder/mod.rs
+++ b/libdd-trace-utils/src/agentless_encoder/mod.rs
@@ -31,8 +31,10 @@ use crate::span::v04::{AttributeAnyValue, AttributeArrayValue, Span, SpanEvent, 
 use crate::span::v1;
 use crate::span::{TraceData, SPAN_LINK_FLAGS_SET_SENTINEL};
 use crate::tracer_metadata::TracerMetadata;
-use serde::ser::{SerializeMap, SerializeSeq};
-use serde::Serializer;
+use serde::{
+    ser::{SerializeMap, SerializeSeq},
+    Serialize, Serializer,
+};
 use std::borrow::{Borrow, Cow};
 use std::collections::HashSet;
 use std::fmt::Write as _;
@@ -100,192 +102,242 @@ pub fn encode_payload<T: TraceData>(
     client_side_stats: bool,
 ) -> Result<Vec<u8>, serde_json::Error> {
     let mut bytes = Vec::new();
-    let mut serializer = serde_json::Serializer::new(&mut bytes);
-
-    let mut map_ser = serializer.serialize_map(Some(1))?;
-    map_ser.serialize_entry(
-        "traces",
-        &ser_fn!(<T: TraceData> |ser, traces: &'a [Vec<Span<T>>], metadata: &'a TracerMetadata, client_side_stats: bool| {
-            let mut traces_serializer = ser.serialize_seq(Some(traces.len()))?;
-            for chunk in traces {
-                traces_serializer.serialize_element(&ser_fn!(<T: TraceData> |ser, chunk: &'a Vec<Span<T>>, metadata: &'a TracerMetadata, client_side_stats: bool| {
-                    encode_trace(ser, chunk, metadata, client_side_stats)
-                }))?;
-            }
-            traces_serializer.end()
-        }),
-    )?;
-    SerializeMap::end(map_ser)?;
+    bytes.extend_from_slice(br#"{"traces":["#);
+    for (index, chunk) in traces.iter().enumerate() {
+        if index != 0 {
+            bytes.push(b',');
+        }
+        encode_trace(&mut bytes, chunk, metadata, client_side_stats)?;
+    }
+    bytes.extend_from_slice(b"]}");
     Ok(bytes)
 }
 
-fn encode_trace<T: TraceData, S: Serializer>(
-    ser: S,
+#[inline(always)]
+fn serialize_json<T: ?Sized + Serialize>(
+    bytes: &mut Vec<u8>,
+    value: &T,
+) -> Result<(), serde_json::Error> {
+    value.serialize(&mut serde_json::Serializer::new(bytes))
+}
+
+#[inline(always)]
+fn write_entry_separator(bytes: &mut Vec<u8>, first: &mut bool) {
+    if *first {
+        *first = false;
+    } else {
+        bytes.push(b',');
+    }
+}
+
+#[inline(always)]
+fn serialize_fixed_entry<T: ?Sized + Serialize>(
+    bytes: &mut Vec<u8>,
+    first: &mut bool,
+    key: &[u8],
+    value: &T,
+) -> Result<(), serde_json::Error> {
+    write_entry_separator(bytes, first);
+    bytes.extend_from_slice(key);
+    serialize_json(bytes, value)
+}
+
+#[inline(always)]
+fn serialize_dynamic_entry<T: ?Sized + Serialize>(
+    bytes: &mut Vec<u8>,
+    first: &mut bool,
+    key: &str,
+    value: &T,
+) -> Result<(), serde_json::Error> {
+    write_entry_separator(bytes, first);
+    serialize_json(bytes, key)?;
+    bytes.push(b':');
+    serialize_json(bytes, value)
+}
+
+fn encode_trace<T: TraceData>(
+    bytes: &mut Vec<u8>,
     chunk: &[Span<T>],
     metadata: &TracerMetadata,
     client_side_stats: bool,
-) -> Result<S::Ok, S::Error> {
-    let mut map = ser.serialize_map(None)?;
+) -> Result<(), serde_json::Error> {
+    bytes.push(b'{');
+    let mut first = true;
 
     // Per-trace metadata. Always include hostname; other fields when set.
-    map.serialize_entry("hostname", &metadata.hostname)?;
+    serialize_fixed_entry(bytes, &mut first, br#""hostname":"#, &metadata.hostname)?;
     if !metadata.env.is_empty() {
-        map.serialize_entry("env", &metadata.env)?;
+        serialize_fixed_entry(bytes, &mut first, br#""env":"#, &metadata.env)?;
     }
     if !metadata.language.is_empty() {
-        map.serialize_entry("languageName", &metadata.language)?;
+        serialize_fixed_entry(bytes, &mut first, br#""languageName":"#, &metadata.language)?;
     }
     if !metadata.language_version.is_empty() {
-        map.serialize_entry("languageVersion", &metadata.language_version)?;
+        serialize_fixed_entry(
+            bytes,
+            &mut first,
+            br#""languageVersion":"#,
+            &metadata.language_version,
+        )?;
     }
     if !metadata.tracer_version.is_empty() {
-        map.serialize_entry("tracerVersion", &metadata.tracer_version)?;
+        serialize_fixed_entry(
+            bytes,
+            &mut first,
+            br#""tracerVersion":"#,
+            &metadata.tracer_version,
+        )?;
     }
     if !metadata.runtime_id.is_empty() {
-        map.serialize_entry("runtimeID", &metadata.runtime_id)?;
+        serialize_fixed_entry(bytes, &mut first, br#""runtimeID":"#, &metadata.runtime_id)?;
     }
     if let Some(container_id) = libdd_common::entity_id::get_container_id() {
-        map.serialize_entry("containerID", container_id)?;
+        serialize_fixed_entry(bytes, &mut first, br#""containerID":"#, container_id)?;
     }
 
-    map.serialize_entry(
-        "spans",
-        &ser_fn!(<T: TraceData> |ser, chunk: &'a [Span<T>], client_side_stats: bool| {
-            let mut seq = ser.serialize_seq(Some(chunk.len()))?;
-            for (i, span) in chunk.iter().enumerate() {
-                let is_first = i == 0;
-                seq.serialize_element(&ser_fn!(<T: TraceData> |ser, span: &'a Span<T>, is_first: bool, client_side_stats: bool| {
-                    encode_span(ser, span, is_first, client_side_stats)
-                }))?;
-            }
-            seq.end()
-        }),
-    )?;
-
-    map.end()
+    write_entry_separator(bytes, &mut first);
+    bytes.extend_from_slice(br#""spans":["#);
+    for (index, span) in chunk.iter().enumerate() {
+        if index != 0 {
+            bytes.push(b',');
+        }
+        encode_span(bytes, span, index == 0, client_side_stats)?;
+    }
+    bytes.extend_from_slice(b"]}");
+    Ok(())
 }
 
-fn encode_span<T: TraceData, S: Serializer>(
-    ser: S,
+fn encode_span<T: TraceData>(
+    bytes: &mut Vec<u8>,
     span: &Span<T>,
     is_first_in_trace: bool,
     client_side_stats: bool,
-) -> Result<S::Ok, S::Error> {
-    let mut map = ser.serialize_map(None)?;
+) -> Result<(), serde_json::Error> {
+    bytes.push(b'{');
+    let mut first = true;
 
-    map.serialize_entry("trace_id", &hex_low_u64(span.trace_id))?;
-    map.serialize_entry("span_id", &hex_u64(span.span_id))?;
-    map.serialize_entry("parent_id", &hex_u64(span.parent_id))?;
+    serialize_fixed_entry(
+        bytes,
+        &mut first,
+        br#""trace_id":"#,
+        &hex_low_u64(span.trace_id),
+    )?;
+    serialize_fixed_entry(bytes, &mut first, br#""span_id":"#, &hex_u64(span.span_id))?;
+    serialize_fixed_entry(
+        bytes,
+        &mut first,
+        br#""parent_id":"#,
+        &hex_u64(span.parent_id),
+    )?;
 
     // Resource defaults to name when empty.
     let name_str: &str = span.name.borrow();
     let resource_str: &str = span.resource.borrow();
     let service_str: &str = span.service.borrow();
-    map.serialize_entry("name", name_str)?;
-    map.serialize_entry(
-        "resource",
+    serialize_fixed_entry(bytes, &mut first, br#""name":"#, name_str)?;
+    serialize_fixed_entry(
+        bytes,
+        &mut first,
+        br#""resource":"#,
         if resource_str.is_empty() {
             name_str
         } else {
             resource_str
         },
     )?;
-    map.serialize_entry("service", service_str)?;
-    map.serialize_entry("error", &span.error)?;
-    map.serialize_entry("start", &span.start.max(0))?;
-    map.serialize_entry("duration", &span.duration)?;
+    serialize_fixed_entry(bytes, &mut first, br#""service":"#, service_str)?;
+    serialize_fixed_entry(bytes, &mut first, br#""error":"#, &span.error)?;
+    serialize_fixed_entry(bytes, &mut first, br#""start":"#, &span.start.max(0))?;
+    serialize_fixed_entry(bytes, &mut first, br#""duration":"#, &span.duration)?;
 
     let type_str: &str = span.r#type.borrow();
     if !type_str.is_empty() {
-        map.serialize_entry("type", type_str)?;
+        serialize_fixed_entry(bytes, &mut first, br#""type":"#, type_str)?;
     }
 
-    map.serialize_entry(
-        "meta",
-        &ser_fn!(<T: TraceData> |ser, span: &'a Span<T>, is_first_in_trace: bool, client_side_stats: bool| {
-            let upper_bits = (span.trace_id >> 64) as u64;
-            let mut p_tid_seen = false;
-            let mut span_links_seen = false;
-            let mut events_seen = false;
-            let mut compute_stats_seen = false;
+    write_entry_separator(bytes, &mut first);
+    bytes.extend_from_slice(br#""meta":{"#);
+    let mut first_meta = true;
+    let upper_bits = (span.trace_id >> 64) as u64;
+    let mut p_tid_seen = false;
+    let mut span_links_seen = false;
+    let mut events_seen = false;
+    let mut compute_stats_seen = false;
 
-            let mut meta = ser.serialize_map(None)?;
-            for (k, v) in span.meta.defensive_dedup().iter() {
-                let key: &str = k.borrow();
-                match key {
-                    "_dd.p.tid" => p_tid_seen = true,
-                    "_dd.span_links" => span_links_seen = true,
-                    "events" => events_seen = true,
-                    "_dd.compute_stats"=> compute_stats_seen = true,
-                    _ => {}
-                };
-                let val: &str = v.borrow();
-                meta.serialize_entry(key, val)?;
-            }
-            if !p_tid_seen && upper_bits != 0 {
-                meta.serialize_entry("_dd.p.tid", &hex_u64(upper_bits))?;
-            }
-            if !span_links_seen && !span.span_links.is_empty() {
-                if let Some(s) = serialize_span_links(&span.span_links) {
-                    meta.serialize_entry("_dd.span_links", &s)?;
-                }
-            }
-            if !events_seen && !span.span_events.is_empty() {
-                if let Some(s) = serialize_span_events(&span.span_events) {
-                    meta.serialize_entry("events", &s)?;
-                }
-            }
-            if !compute_stats_seen && is_first_in_trace && !client_side_stats {
-                meta.serialize_entry("_dd.compute_stats", "1")?;
-            }
-            meta.end()
-        }),
-    )?;
-
-    map.serialize_entry(
-        "metrics",
-        &ser_fn!(<T: TraceData> |ser, span: &'a Span<T>| {
-            let mut metrics = ser.serialize_map(None)?;
-            let mut trace_root_seen = false;
-            for (k, v) in span.metrics.defensive_dedup().iter() {
-                let key: &str = k.borrow();
-                // serde_json refuses to serialize NaN/Inf; drop them silently.
-                if v.is_finite() {
-                    match key {
-                        "_trace_root" => trace_root_seen = true,
-                        "_top_level" => {
-                            metrics.serialize_entry(key, &(*v as u32))?;
-                            continue
-                        },
-                        _ => {},
-                    }
-                    metrics.serialize_entry(key, v)?
-                }
-            }
-            if !trace_root_seen && span.parent_id == 0 {
-                metrics.serialize_entry("_trace_root", &1u32)?;
-            }
-            metrics.end()
-        }),
-    )?;
-
-    if !span.meta_struct.is_empty() {
-        map.serialize_entry(
-            "meta_struct",
-            &ser_fn!(<T: TraceData> |ser, span: &'a Span<T>| {
-                let mut ms = ser.serialize_map(None)?;
-                for (k, v) in span.meta_struct.iter() {
-                    let key: &str = k.borrow();
-                    let bytes: &[u8] = v.borrow();
-
-                    // abort whole payload on malformed entry
-                    ms.serialize_entry(key, &MsgpackAsJson(bytes))?;
-                }
-                ms.end()
-            }),
+    for (key, value) in span.meta.defensive_dedup().iter() {
+        let key: &str = key.borrow();
+        match key {
+            "_dd.p.tid" => p_tid_seen = true,
+            "_dd.span_links" => span_links_seen = true,
+            "events" => events_seen = true,
+            "_dd.compute_stats" => compute_stats_seen = true,
+            _ => {}
+        };
+        let value: &str = value.borrow();
+        serialize_dynamic_entry(bytes, &mut first_meta, key, value)?;
+    }
+    if !p_tid_seen && upper_bits != 0 {
+        serialize_fixed_entry(
+            bytes,
+            &mut first_meta,
+            br#""_dd.p.tid":"#,
+            &hex_u64(upper_bits),
         )?;
     }
-    map.end()
+    if !span_links_seen && !span.span_links.is_empty() {
+        if let Some(value) = serialize_span_links(&span.span_links) {
+            serialize_fixed_entry(bytes, &mut first_meta, br#""_dd.span_links":"#, &value)?;
+        }
+    }
+    if !events_seen && !span.span_events.is_empty() {
+        if let Some(value) = serialize_span_events(&span.span_events) {
+            serialize_fixed_entry(bytes, &mut first_meta, br#""events":"#, &value)?;
+        }
+    }
+    if !compute_stats_seen && is_first_in_trace && !client_side_stats {
+        serialize_fixed_entry(bytes, &mut first_meta, br#""_dd.compute_stats":"#, "1")?;
+    }
+    bytes.push(b'}');
+
+    write_entry_separator(bytes, &mut first);
+    bytes.extend_from_slice(br#""metrics":{"#);
+    let mut first_metric = true;
+    let mut trace_root_seen = false;
+    for (key, value) in span.metrics.defensive_dedup().iter() {
+        let key: &str = key.borrow();
+        // serde_json refuses to serialize NaN/Inf; drop them silently.
+        if value.is_finite() {
+            match key {
+                "_trace_root" => trace_root_seen = true,
+                "_top_level" => {
+                    serialize_dynamic_entry(bytes, &mut first_metric, key, &(*value as u32))?;
+                    continue;
+                }
+                _ => {}
+            }
+            serialize_dynamic_entry(bytes, &mut first_metric, key, value)?;
+        }
+    }
+    if !trace_root_seen && span.parent_id == 0 {
+        serialize_fixed_entry(bytes, &mut first_metric, br#""_trace_root":"#, &1u32)?;
+    }
+    bytes.push(b'}');
+
+    if !span.meta_struct.is_empty() {
+        write_entry_separator(bytes, &mut first);
+        bytes.extend_from_slice(br#""meta_struct":{"#);
+        let mut first_meta_struct = true;
+        for (key, value) in span.meta_struct.iter() {
+            let key: &str = key.borrow();
+            let value: &[u8] = value.borrow();
+
+            // Abort the whole payload on a malformed entry.
+            serialize_dynamic_entry(bytes, &mut first_meta_struct, key, &MsgpackAsJson(value))?;
+        }
+        bytes.push(b'}');
+    }
+    bytes.push(b'}');
+    Ok(())
 }
 
 /// Serialize span links to a JSON string suitable for `meta['_dd.span_links']`.

--- a/libdd-trace-utils/src/agentless_encoder/tests.rs
+++ b/libdd-trace-utils/src/agentless_encoder/tests.rs
@@ -30,6 +30,204 @@ fn json_from_bytes(b: &[u8]) -> Value {
     serde_json::from_slice(b).expect("payload must be valid JSON")
 }
 
+fn expected_container_field() -> String {
+    libdd_common::entity_id::get_container_id()
+        .map(|container_id| format!(",\"containerID\":\"{container_id}\""))
+        .unwrap_or_default()
+}
+
+fn expected_payload_with_span(span: &str) -> String {
+    let container = expected_container_field();
+    format!(r#"{{"traces":[{{"hostname":""{container},"spans":[{span}]}}]}}"#)
+}
+
+#[cfg_attr(miri, ignore)] // serde_json/rmp_serde overhead is prohibitively slow under Miri
+#[test]
+fn fixed_json_structure_preserves_minimal_and_optional_metadata_bytes() {
+    let payload = encode_payload::<BytesData>(&[], &TracerMetadata::default(), true).unwrap();
+    assert_eq!(payload, br#"{"traces":[]}"#);
+
+    let metadata = TracerMetadata {
+        hostname: "host".to_string(),
+        env: "prod".to_string(),
+        language: "nodejs".to_string(),
+        language_version: "24".to_string(),
+        tracer_version: "1.2.3".to_string(),
+        runtime_id: "runtime".to_string(),
+        ..Default::default()
+    };
+    let trace = encode_payload::<BytesData>(&[Vec::new()], &metadata, true).unwrap();
+    let container = expected_container_field();
+    let expected = format!(
+        r#"{{"traces":[{{"hostname":"host","env":"prod","languageName":"nodejs","languageVersion":"24","tracerVersion":"1.2.3","runtimeID":"runtime"{container},"spans":[]}}]}}"#
+    );
+    assert_eq!(trace, expected.as_bytes());
+
+    let traces = encode_payload::<BytesData>(&[Vec::new(), Vec::new()], &metadata, true).unwrap();
+    let expected = format!(
+        r#"{{"traces":[{{"hostname":"host","env":"prod","languageName":"nodejs","languageVersion":"24","tracerVersion":"1.2.3","runtimeID":"runtime"{container},"spans":[]}},{{"hostname":"host","env":"prod","languageName":"nodejs","languageVersion":"24","tracerVersion":"1.2.3","runtimeID":"runtime"{container},"spans":[]}}]}}"#
+    );
+    assert_eq!(traces, expected.as_bytes());
+}
+
+#[cfg_attr(miri, ignore)] // serde_json/rmp_serde overhead is prohibitively slow under Miri
+#[test]
+fn span_preserves_escaped_dynamic_values_ids_and_metrics_bytes() {
+    let mut span: Span<BytesData> = Span {
+        service: bs("svc\\"),
+        name: bs("op\"\n"),
+        r#type: bs("web\t"),
+        trace_id: 0x1122_3344_5566_7788_aabb_ccdd_eeff_0011,
+        span_id: 1,
+        parent_id: 0,
+        start: -1,
+        duration: 2,
+        error: 1,
+        meta: VecMap::from_iter([(bs("tag\""), bs("line\n\\"))]),
+        metrics: VecMap::from_iter([
+            (bs("fraction"), 1.5),
+            (bs("_top_level"), 2.9),
+            (bs("nan"), f64::NAN),
+            (bs("infinity"), f64::INFINITY),
+        ]),
+        ..Default::default()
+    };
+    span.metrics.dedup();
+
+    let encoded = encode_payload(&[vec![span]], &TracerMetadata::default(), true).unwrap();
+    let expected = expected_payload_with_span(
+        r#"{"trace_id":"aabbccddeeff0011","span_id":"0000000000000001","parent_id":"0000000000000000","name":"op\"\n","resource":"op\"\n","service":"svc\\","error":1,"start":0,"duration":2,"type":"web\t","meta":{"tag\"":"line\n\\","_dd.p.tid":"1122334455667788"},"metrics":{"_top_level":2,"fraction":1.5,"_trace_root":1}}"#,
+    );
+    assert_eq!(encoded, expected.as_bytes());
+}
+
+#[cfg_attr(miri, ignore)] // serde_json/rmp_serde overhead is prohibitively slow under Miri
+#[test]
+fn defensive_dedup_preserves_last_meta_and_metric_values() {
+    let span: Span<BytesData> = Span {
+        name: bs("op"),
+        trace_id: 1,
+        span_id: 2,
+        parent_id: 9,
+        start: 3,
+        duration: 4,
+        meta: VecMap::from_iter([
+            (bs("duplicate"), bs("first")),
+            (bs("duplicate"), bs("last")),
+        ]),
+        metrics: VecMap::from_iter([(bs("duplicate"), 1.5), (bs("duplicate"), 2.5)]),
+        ..Default::default()
+    };
+
+    let encoded = encode_payload(&[vec![span]], &TracerMetadata::default(), true).unwrap();
+    let expected = expected_payload_with_span(
+        r#"{"trace_id":"0000000000000001","span_id":"0000000000000002","parent_id":"0000000000000009","name":"op","resource":"op","service":"","error":0,"start":3,"duration":4,"meta":{"duplicate":"last"},"metrics":{"duplicate":2.5}}"#,
+    );
+    assert_eq!(encoded, expected.as_bytes());
+}
+
+#[cfg_attr(miri, ignore)] // serde_json/rmp_serde overhead is prohibitively slow under Miri
+#[test]
+fn existing_synthetic_meta_and_root_metric_values_win() {
+    let mut span: Span<BytesData> = Span {
+        name: bs("op"),
+        trace_id: 0x0000_0000_0000_0002_0000_0000_0000_0001,
+        span_id: 2,
+        parent_id: 0,
+        start: 3,
+        duration: 4,
+        meta: VecMap::from_iter([
+            (bs("_dd.p.tid"), bs("kept-tid")),
+            (bs("_dd.compute_stats"), bs("kept-stats")),
+            (bs("events"), bs("kept-events")),
+            (bs("_dd.span_links"), bs("kept-links")),
+        ]),
+        metrics: VecMap::from_iter([(bs("_trace_root"), 7.5)]),
+        span_links: vec![SpanLink::default()],
+        span_events: vec![SpanEvent::default()],
+        ..Default::default()
+    };
+    span.meta.dedup();
+
+    let encoded = encode_payload(&[vec![span]], &TracerMetadata::default(), false).unwrap();
+    let expected = expected_payload_with_span(
+        r#"{"trace_id":"0000000000000001","span_id":"0000000000000002","parent_id":"0000000000000000","name":"op","resource":"op","service":"","error":0,"start":3,"duration":4,"meta":{"_dd.span_links":"kept-links","events":"kept-events","_dd.compute_stats":"kept-stats","_dd.p.tid":"kept-tid"},"metrics":{"_trace_root":7.5}}"#,
+    );
+    assert_eq!(encoded, expected.as_bytes());
+}
+
+#[cfg_attr(miri, ignore)] // serde_json/rmp_serde overhead is prohibitively slow under Miri
+#[test]
+fn span_links_and_events_preserve_nested_serde_json_bytes() {
+    let link = SpanLink::<BytesData> {
+        trace_id: 1,
+        trace_id_high: 2,
+        span_id: 3,
+        attributes: HashMap::from([(bs("role"), bs("queue"))]),
+        flags: 1,
+        tracestate: bs("dd=s:1"),
+    };
+    let event = SpanEvent::<BytesData> {
+        time_unix_nano: 7,
+        name: bs("exception"),
+        attributes: HashMap::from([(
+            bs("message"),
+            AttributeAnyValue::SingleValue(AttributeArrayValue::String(bs("bad"))),
+        )]),
+    };
+    let span: Span<BytesData> = Span {
+        name: bs("op"),
+        trace_id: 1,
+        span_id: 2,
+        parent_id: 9,
+        start: 3,
+        duration: 4,
+        span_links: vec![link],
+        span_events: vec![event],
+        ..Default::default()
+    };
+
+    let encoded = encode_payload(&[vec![span]], &TracerMetadata::default(), true).unwrap();
+    let expected = expected_payload_with_span(
+        r#"{"trace_id":"0000000000000001","span_id":"0000000000000002","parent_id":"0000000000000009","name":"op","resource":"op","service":"","error":0,"start":3,"duration":4,"meta":{"_dd.span_links":"[{\"trace_id\":\"00000000000000020000000000000001\",\"span_id\":\"0000000000000003\",\"attributes\":{\"role\":\"queue\"},\"flags\":1,\"tracestate\":\"dd=s:1\"}]","events":"[{\"name\":\"exception\",\"time_unix_nano\":7,\"attributes\":{\"message\":\"bad\"}}]"},"metrics":{}}"#,
+    );
+    assert_eq!(encoded, expected.as_bytes());
+}
+
+#[cfg_attr(miri, ignore)] // serde_json/rmp_serde overhead is prohibitively slow under Miri
+#[test]
+fn meta_struct_preserves_exact_bytes_and_propagates_malformed_values() {
+    #[derive(serde::Serialize)]
+    struct Value {
+        answer: u8,
+    }
+
+    let mut span: Span<BytesData> = Span {
+        name: bs("op"),
+        trace_id: 1,
+        span_id: 2,
+        parent_id: 9,
+        start: 3,
+        duration: 4,
+        ..Default::default()
+    };
+    span.meta_struct.insert(
+        bs("app\"key"),
+        Bytes::from(rmp_serde::to_vec_named(&Value { answer: 42 }).unwrap()),
+    );
+
+    let encoded = encode_payload(&[vec![span.clone()]], &TracerMetadata::default(), true).unwrap();
+    let expected = expected_payload_with_span(
+        r#"{"trace_id":"0000000000000001","span_id":"0000000000000002","parent_id":"0000000000000009","name":"op","resource":"op","service":"","error":0,"start":3,"duration":4,"meta":{},"metrics":{},"meta_struct":{"app\"key":{"answer":42}}}"#,
+    );
+    assert_eq!(encoded, expected.as_bytes());
+
+    span.meta_struct
+        .insert(bs("malformed"), Bytes::from(vec![0xc1]));
+    let error = encode_payload(&[vec![span]], &TracerMetadata::default(), true).unwrap_err();
+    assert!(error.is_data(), "unexpected error category: {error}");
+}
+
 #[cfg_attr(miri, ignore)] // serde_json/rmp_serde overhead is prohibitively slow under Miri
 #[test]
 fn top_level_payload_shape_and_metadata() {


### PR DESCRIPTION
# What does this PR do?

Writes fixed agentless JSON framing and field names directly into the output buffer. serde_json still owns every dynamic key, value, escape, and MessagePack conversion.

# Motivation

The generic serializer state machine adds overhead for a fixed wire schema.

# Additional Notes

This draft is stacked on the fixed-ID branch and contains only the JSON writer layer. Position-balanced Criterion runs improved that baseline by 35.44% for common HTTP traces and 20.18% for span-link traces.

# How to test the change?

Run `cargo test -p libdd-trace-utils --lib agentless_encoder` and `cargo bench -p libdd-trace-utils --bench main -- agentless_encoding`.