### PR TITLE
perf(common): add full regex ASCII mode

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -60,6 +60,11 @@ jobs:
           RUSTUP_TOOLCHAIN: ${{ steps.nightly-version.outputs.version }}
         run: |
           cargo llvm-cov --all-features --workspace --no-report nextest --no-tests=pass
+          cargo llvm-cov -p libdd-common \
+            --no-default-features \
+            --features regex-ascii,regex-lite \
+            --no-report nextest \
+            --no-tests=pass
           cargo llvm-cov --all-features --workspace --no-report --doc
           cargo llvm-cov report --doctests --lcov --output-path lcov.info
       # Forked PRs get no id-token permission, so on failure the upload below

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,6 +186,28 @@ jobs:
           fi
         env:
           RUST_BACKTRACE: full
+      - name: "[${{ steps.rust-version.outputs.version}}] cargo test (ASCII full regex)"
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          if [[ -z "$PACKAGES" ]] || echo "$PACKAGES" | grep -q "libdd-common"; then
+            cargo test \
+              --manifest-path libdd-common/tests/regex-ascii/Cargo.toml \
+              --verbose
+          fi
+        env:
+          RUST_BACKTRACE: full
+      - name: "[${{ steps.rust-version.outputs.version}}] cargo nextest run (default Unicode regex)"
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          if [[ -z "$PACKAGES" ]] || echo "$PACKAGES" | grep -q "libdd-data-pipeline-core"; then
+            cargo nextest run -p libdd-data-pipeline-core \
+              applies_unicode_replacement_rules \
+              --no-tests=fail
+          fi
+        env:
+          RUST_BACKTRACE: full
       - name: "[${{ steps.rust-version.outputs.version}}] cargo nextest run --all-features"
         shell: bash
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,13 +150,14 @@ jobs:
         run: |
           if [[ -z "$PACKAGES" ]] || echo "$PACKAGES" | \
             grep -Eq "libdd-(common|dogstatsd-client|http-client|trace-utils)"; then
-            cargo check -p libdd-dogstatsd-client --no-default-features
+            cargo check -p libdd-dogstatsd-client --no-default-features \
+              --features regex-unicode
             cargo check -p libdd-http-client --no-default-features \
-              --features hyper-backend
+              --features hyper-backend,regex-unicode
             cargo check -p libdd-trace-utils --no-default-features \
-              --features mini_agent
+              --features mini_agent,regex-unicode
             cargo check -p libdd-trace-utils --no-default-features \
-              --features test-utils
+              --features regex-unicode,test-utils
           fi
       - name: "[${{ steps.rust-version.outputs.version}}] cargo test (doc) and cargo nextest run"
         shell: bash
@@ -167,14 +168,18 @@ jobs:
             cargo test --workspace $CRASHTRACKER_FEATURE --exclude builder --doc --verbose
             # shellcheck disable=SC2086
             cargo nextest run --workspace $CRASHTRACKER_FEATURE --profile ci --verbose --no-tests=pass -E '!test(tracing_integration_tests::)'
-            cargo nextest run -p libdd-http-client --no-default-features --features hyper-backend,hyper-proxy,https --profile ci --verbose
+            cargo nextest run -p libdd-http-client --no-default-features \
+              --features hyper-backend,hyper-proxy,https,regex-unicode \
+              --profile ci --verbose
           else
             # shellcheck disable=SC2086
             cargo test $PACKAGES $CRASHTRACKER_FEATURE --doc --verbose
             # shellcheck disable=SC2086
             cargo nextest run $PACKAGES $CRASHTRACKER_FEATURE --profile ci --verbose --no-tests=pass -E '!test(tracing_integration_tests::)'
             if echo "$PACKAGES" | grep -q "libdd-http-client"; then
-              cargo nextest run -p libdd-http-client --no-default-features --features hyper-backend,hyper-proxy,https --profile ci --verbose
+              cargo nextest run -p libdd-http-client --no-default-features \
+                --features hyper-backend,hyper-proxy,https,regex-unicode \
+                --profile ci --verbose
             fi
           fi
       - name: "[${{ steps.rust-version.outputs.version}}] cargo nextest run -p libdd-common --no-default-features --features fips"
@@ -182,10 +187,25 @@ jobs:
         shell: bash
         run: |
           if echo "$PACKAGES" | grep -q "libdd-common"; then
-            cargo nextest run -p libdd-common --no-default-features --features fips --profile ci --verbose
+            cargo nextest run -p libdd-common --no-default-features \
+              --features fips,regex-unicode --profile ci --verbose
           fi
         env:
           RUST_BACKTRACE: full
+      - name: "[${{ steps.rust-version.outputs.version}}] reject missing regex mode"
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          if [[ -z "$PACKAGES" ]] || echo "$PACKAGES" | grep -q "libdd-common"; then
+            if output=$(cargo check -p libdd-common --no-default-features 2>&1); then
+              echo "::error::libdd-common compiled without a regex mode"
+              exit 1
+            fi
+            if ! grep -Fq "enable one regex engine feature" <<< "$output"; then
+              echo "$output"
+              exit 1
+            fi
+          fi
       - name: "[${{ steps.rust-version.outputs.version}}] cargo test (ASCII full regex)"
         if: runner.os == 'Linux'
         shell: bash
@@ -510,7 +530,7 @@ jobs:
       - name: Install wasm-bindgen test runner
         run: cargo install wasm-bindgen-cli --version 0.2.100 --locked
       - name: "cargo check -p libdd-data-pipeline --target wasm32-unknown-unknown --no-default-features"
-        run: cargo check -p libdd-data-pipeline --target wasm32-unknown-unknown --no-default-features
+        run: cargo check -p libdd-data-pipeline --target wasm32-unknown-unknown --no-default-features --features regex-ascii
         env:
           RUSTFLAGS: "-D warnings -A unused-imports -A dead-code -A unused-variables"
       - name: Run WASM tests
@@ -518,7 +538,7 @@ jobs:
         env:
           CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER: wasm-bindgen-test-runner
       - name: "cargo check -p libdd-remote-config --target wasm32-unknown-unknown --features client,agentless"
-        run: cargo check -p libdd-remote-config --target wasm32-unknown-unknown --no-default-features --features client,agentless
+        run: cargo check -p libdd-remote-config --target wasm32-unknown-unknown --no-default-features --features client,agentless,regex-unicode
         env:
           RUSTFLAGS: "-D warnings -A unused-imports -A dead-code -A unused-variables"
           # ring compiles C for wasm32, which the runner's default `cc` (gcc) cannot target.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ Iterate fastest with `cargo check -p <crate>` while editing; validate each affec
   # Default (reqwest) backend — covered by the workspace test run
   cargo nextest run -p libdd-http-client
   # Hyper backend
-  cargo nextest run -p libdd-http-client --no-default-features --features hyper-backend,https
+  cargo nextest run -p libdd-http-client --no-default-features --features hyper-backend,https,regex-unicode
   ```
 - **test_spawn_from_lib**: `cargo nextest run --package test_spawn_from_lib --features prefer-dynamic`.
 

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -20,6 +20,7 @@ default = [
   "ddsketch",
   "ffe",
   "shared-runtime",
+  "regex-unicode",
   "catch_panic",
 ]
 crashtracker = []
@@ -40,6 +41,7 @@ shared-runtime = []
 otel-thread-ctx = []
 catch_panic = []
 regex-lite = ["libdd-common/regex-lite"]
+regex-unicode = ["libdd-common/regex-unicode"]
 
 [lib]
 bench = false

--- a/libdd-agent-client/Cargo.toml
+++ b/libdd-agent-client/Cargo.toml
@@ -17,8 +17,9 @@ publish = false
 bench = false
 
 [features]
-default = ["https", "reqwest-backend"]
+default = ["https", "regex-unicode", "reqwest-backend"]
 https = ["libdd-http-client/https"]
+regex-unicode = ["libdd-common/regex-unicode"]
 reqwest-backend = ["libdd-http-client/reqwest-backend"]
 hyper-backend = ["libdd-http-client/hyper-backend"]
 

--- a/libdd-capabilities-impl/Cargo.toml
+++ b/libdd-capabilities-impl/Cargo.toml
@@ -31,6 +31,7 @@ tempfile.workspace = true
 tokio = { version = "1", features = ["fs", "macros", "rt", "time"] }
 
 [features]
-default = ["https"]
+default = ["https", "regex-unicode"]
 https = ["libdd-common/https"]
 fips = ["libdd-common/fips"]
+regex-unicode = ["libdd-common/regex-unicode"]

--- a/libdd-common/Cargo.toml
+++ b/libdd-common/Cargo.toml
@@ -28,7 +28,7 @@ multer = { version = "3.1", optional = true }
 bytes = { workspace = true, features = ["std"] }
 pin-project = "1"
 rand = { version = ">=0.8.6, <0.9", optional = true }
-regex = { workspace = true, features = ["std", "unicode", "perf"] }
+regex = { workspace = true, features = ["perf", "std"] }
 regex-lite = { version = "0.1", optional = true }
 # Use hickory-dns instead of the default system DNS resolver to avoid fork safety issues.
 # The default resolver can hold locks or other global state that can cause deadlocks
@@ -93,7 +93,7 @@ tempfile.workspace = true
 tokio = { version = "1.23", features = ["rt", "macros", "time"] }
 
 [features]
-default = ["https"]
+default = ["https", "regex-unicode"]
 http-client = [
     "dep:hyper",
     "dep:hyper-util",
@@ -112,9 +112,14 @@ use_webpki_roots = ["hyper-rustls/webpki-roots"]
 cgroup_testing = []
 # Use regex-lite instead of regex for smaller binary size
 regex-lite = ["dep:regex-lite"]
+# Force the full regex engine without Unicode tables. Cargo features are
+# additive, so builds must also omit `regex-unicode`.
+regex-ascii = []
+# Enable Unicode tables for the full regex engine.
+regex-unicode = ["regex/unicode"]
 # Consumers that handle user-provided regexes can enable this feature to force
 # the full `regex` crate, overriding `regex-lite` when both are active.
-require-regex-full = []
+require-regex-full = ["regex-unicode"]
 # FIPS mode uses the FIPS-compliant cryptographic provider (Unix only)
 fips = ["tls-core", "hyper-rustls/fips"]
 # Honor HTTP(S)_PROXY/NO_PROXY environment variables for the hyper connector,

--- a/libdd-common/src/entity_id/unix/container_id.rs
+++ b/libdd-common/src/entity_id/unix/container_id.rs
@@ -15,11 +15,11 @@ const UUID_SOURCE: &str =
 /// Distinct from `UUID_SOURCE` (8-4-4-4-12) because the last group is 4 hex.
 const PCF_UUID_SOURCE: &str = r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}";
 const CONTAINER_SOURCE: &str = r"[0-9a-f]{64}";
-const TASK_SOURCE: &str = r"[0-9a-f]{32}-\d+";
+const TASK_SOURCE: &str = r"[0-9a-f]{32}-[0-9]+";
 
 pub(crate) static LINE_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     #[allow(clippy::unwrap_used)]
-    Regex::new(r"^\d+:[^:]*:(.+)$").unwrap()
+    Regex::new(r"^[0-9]+:[^:]*:(.+)$").unwrap()
 });
 
 pub(crate) static CONTAINER_REGEX: LazyLock<Regex> = LazyLock::new(|| {

--- a/libdd-common/src/entity_id/unix/mod.rs
+++ b/libdd-common/src/entity_id/unix/mod.rs
@@ -106,7 +106,7 @@ mod tests {
     use super::*;
     use crate::regex_engine::Regex;
 
-    static IN_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"in-\d+").unwrap());
+    static IN_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"in-[0-9]+").unwrap());
     static CI_REGEX: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(&format!(r"ci-{}", container_id::CONTAINER_REGEX.as_str())).unwrap()
     });

--- a/libdd-common/src/regex_engine.rs
+++ b/libdd-common/src/regex_engine.rs
@@ -3,17 +3,53 @@
 
 //! Workspace-wide regex engine re-exports.
 //!
-//! By default this module re-exports from the full [`regex`] crate.
+//! By default this module re-exports from the full [`regex`] crate with Unicode
+//! support.
+//! Enable the **`regex-ascii`** feature without default features to keep the
+//! full regex engine and its performance optimizations while omitting Unicode
+//! tables.
 //! Enable the **`regex-lite`** feature to switch to [`regex_lite`] instead,
 //! which trades advanced features (Unicode classes, look-around, etc.) for
 //! smaller binary size and faster compile times.
 //!
-//! The **`require-regex-full`** feature forces the full `regex` crate even
-//! when `regex-lite` is enabled, for consumers that evaluate user-provided
-//! regexes requiring Unicode character class support.
+//! The **`regex-ascii`** and **`require-regex-full`** features force the full
+//! `regex` crate even when `regex-lite` is enabled. The latter also enables
+//! Unicode support for consumers that evaluate user-provided patterns.
 
-#[cfg(all(feature = "regex-lite", not(feature = "require-regex-full")))]
+#[cfg(all(
+    feature = "regex-lite",
+    not(any(feature = "regex-ascii", feature = "require-regex-full"))
+))]
 pub use regex_lite::{escape, Captures, Error, Regex, RegexBuilder, Replacer};
 
-#[cfg(not(all(feature = "regex-lite", not(feature = "require-regex-full"))))]
+#[cfg(not(all(
+    feature = "regex-lite",
+    not(any(feature = "regex-ascii", feature = "require-regex-full"))
+)))]
 pub use regex::{escape, Captures, Error, Regex, RegexBuilder, Replacer};
+
+#[cfg(test)]
+mod tests {
+    #[cfg(all(feature = "regex-ascii", not(feature = "regex-unicode")))]
+    #[test]
+    fn ascii_full_engine_supports_set_operations() {
+        use super::Regex;
+
+        assert!(Regex::new(r"[a-z&&[^aeiou]]+").unwrap().is_match("rhythm"));
+    }
+
+    #[cfg(all(
+        feature = "regex-unicode",
+        any(
+            not(feature = "regex-lite"),
+            feature = "regex-ascii",
+            feature = "require-regex-full"
+        )
+    ))]
+    #[test]
+    fn unicode_engine_includes_unicode_tables() {
+        use super::Regex;
+
+        assert!(Regex::new(r"\p{Greek}+").unwrap().is_match("Δοκιμή"));
+    }
+}

--- a/libdd-common/src/regex_engine.rs
+++ b/libdd-common/src/regex_engine.rs
@@ -11,10 +11,19 @@
 //! Enable the **`regex-lite`** feature to switch to [`regex_lite`] instead,
 //! which trades advanced features (Unicode classes, look-around, etc.) for
 //! smaller binary size and faster compile times.
+//! Builds without default features must select `regex-unicode`, `regex-ascii`,
+//! or `regex-lite` explicitly.
 //!
 //! The **`regex-ascii`** and **`require-regex-full`** features force the full
 //! `regex` crate even when `regex-lite` is enabled. The latter also enables
 //! Unicode support for consumers that evaluate user-provided patterns.
+
+#[cfg(not(any(
+    feature = "regex-ascii",
+    feature = "regex-lite",
+    feature = "regex-unicode"
+)))]
+compile_error!("enable one regex engine feature: regex-unicode, regex-ascii, or regex-lite");
 
 #[cfg(all(
     feature = "regex-lite",

--- a/libdd-common/tests/regex-ascii/.gitignore
+++ b/libdd-common/tests/regex-ascii/.gitignore
@@ -1,0 +1,2 @@
+/Cargo.lock
+/target

--- a/libdd-common/tests/regex-ascii/Cargo.toml
+++ b/libdd-common/tests/regex-ascii/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "libdd-common-regex-ascii-test"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+libdd-common = { path = "../..", default-features = false, features = ["regex-ascii", "regex-lite"] }
+
+[workspace]

--- a/libdd-common/tests/regex-ascii/Cargo.toml
+++ b/libdd-common/tests/regex-ascii/Cargo.toml
@@ -4,7 +4,9 @@ version = "0.0.0"
 edition = "2021"
 publish = false
 
-[dependencies]
-libdd-common = { path = "../..", default-features = false, features = ["regex-ascii", "regex-lite"] }
+[dependencies.libdd-common]
+path = "../.."
+default-features = false
+features = ["cgroup_testing", "regex-ascii", "regex-lite"]
 
 [workspace]

--- a/libdd-common/tests/regex-ascii/Cargo.toml
+++ b/libdd-common/tests/regex-ascii/Cargo.toml
@@ -1,3 +1,6 @@
+# Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+
 [package]
 name = "libdd-common-regex-ascii-test"
 version = "0.0.0"

--- a/libdd-common/tests/regex-ascii/src/lib.rs
+++ b/libdd-common/tests/regex-ascii/src/lib.rs
@@ -1,0 +1,13 @@
+// Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(test)]
+mod tests {
+    use libdd_common::regex_engine::Regex;
+
+    #[test]
+    fn uses_full_engine_without_unicode_tables() {
+        assert!(Regex::new(r"\p{Greek}").is_err());
+        assert!(Regex::new(r"[a-z&&[^aeiou]]+").unwrap().is_match("rhythm"));
+    }
+}

--- a/libdd-common/tests/regex-ascii/src/lib.rs
+++ b/libdd-common/tests/regex-ascii/src/lib.rs
@@ -5,9 +5,24 @@
 mod tests {
     use libdd_common::regex_engine::Regex;
 
+    #[cfg(unix)]
+    use libdd_common::entity_id;
+
     #[test]
     fn uses_full_engine_without_unicode_tables() {
         assert!(Regex::new(r"\p{Greek}").is_err());
         assert!(Regex::new(r"[a-z&&[^aeiou]]+").unwrap().is_match("rhythm"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn initializes_internal_regexes_without_unicode_tables() {
+        let cgroup_path = concat!(env!("CARGO_MANIFEST_DIR"), "/../cgroup.docker");
+        entity_id::set_cgroup_file(cgroup_path.to_string());
+
+        assert_eq!(
+            entity_id::get_container_id(),
+            Some("9d5b23edb1ba181e8910389a99906598d69ac9a0ead109ee55730cc416d95f7f")
+        );
     }
 }

--- a/libdd-crashtracker/Cargo.toml
+++ b/libdd-crashtracker/Cargo.toml
@@ -91,7 +91,11 @@ cxx-build = { workspace = true, optional = true }
 # in the build-script context. The build script only needs cc_utils, which has no TLS dependency.
 # Without this, aws-lc-sys gets compiled twice: once for the normal dep graph and once for the
 # build-script dep graph (Cargo resolver v2 keeps these contexts separate).
-libdd-common = { version = "6.0.0", path = "../libdd-common", default-features = false }
+[build-dependencies.libdd-common]
+version = "6.0.0"
+path = "../libdd-common"
+default-features = false
+features = ["regex-ascii"]
 
 [lints.clippy]
 std_instead_of_alloc = "warn"

--- a/libdd-data-pipeline-core/Cargo.toml
+++ b/libdd-data-pipeline-core/Cargo.toml
@@ -24,6 +24,8 @@ libdd-tinybytes = { version = "1.1.3", path = "../libdd-tinybytes", features = [
 zstd.workspace = true
 
 [features]
-default = []
+default = ["regex-unicode"]
 compression = ["libdd-trace-utils/compression"]
+regex-ascii = ["libdd-common/regex-ascii"]
 regex-lite = ["libdd-common/regex-lite"]
+regex-unicode = ["libdd-common/regex-unicode"]

--- a/libdd-data-pipeline-core/src/agentless/exporter.rs
+++ b/libdd-data-pipeline-core/src/agentless/exporter.rs
@@ -310,7 +310,10 @@ mod tests {
         assert!(payload_size > 0);
     }
 
-    #[cfg(feature = "regex-unicode")]
+    #[cfg(all(
+        feature = "regex-unicode",
+        any(not(feature = "regex-lite"), feature = "regex-ascii")
+    ))]
     #[test]
     fn applies_unicode_replacement_rules() {
         let capabilities = TestCapabilities::default();

--- a/libdd-data-pipeline-core/src/agentless/exporter.rs
+++ b/libdd-data-pipeline-core/src/agentless/exporter.rs
@@ -310,6 +310,34 @@ mod tests {
         assert!(payload_size > 0);
     }
 
+    #[cfg(feature = "regex-unicode")]
+    #[test]
+    fn applies_unicode_replacement_rules() {
+        let capabilities = TestCapabilities::default();
+        let mut traces = v04_traces();
+        traces[0][0].resource = BytesString::from_static("αβ endpoint");
+        let obfuscation_config = serde_json::from_str(
+            r#"{"tag_replace_rules":[{"name":"resource.name","pattern":"\\p{Greek}+","repl":"?"}]}"#,
+        )
+        .unwrap();
+        let mut config = config();
+        config.obfuscation_config = obfuscation_config;
+
+        let result = futures::executor::block_on(send_agentless_traces(
+            &capabilities,
+            traces,
+            &metadata(),
+            &config,
+            false,
+        ));
+
+        assert!(result.is_ok());
+        let requests = capabilities.requests.lock().unwrap();
+        let payload: serde_json::Value =
+            serde_json::from_slice(&request_body(&requests[0])).unwrap();
+        assert_eq!(payload["traces"][0]["spans"][0]["resource"], "? endpoint");
+    }
+
     #[test]
     fn json_request_uses_configured_api_key() {
         let capabilities = TestCapabilities::default();

--- a/libdd-data-pipeline/Cargo.toml
+++ b/libdd-data-pipeline/Cargo.toml
@@ -33,7 +33,7 @@ tokio = { workspace = true, features = [
 uuid = { workspace = true, features = ["v4", "std"] }
 tokio-util = "0.7.11"
 libdd-capabilities = { path = "../libdd-capabilities", version = "3.0.1" }
-libdd-data-pipeline-core = { path = "../libdd-data-pipeline-core", version = "1.0.0" }
+libdd-data-pipeline-core = { path = "../libdd-data-pipeline-core", version = "1.0.0", default-features = false }
 libdd-common = { version = "6.0.0", path = "../libdd-common", default-features = false }
 libdd-shared-runtime = { version = "4.0.0", path = "../libdd-shared-runtime", default-features = false }
 libdd-telemetry = { version = "8.0.0", path = "../libdd-telemetry", default-features = false, optional = true}
@@ -114,7 +114,7 @@ name = "send-traces-with-stats"
 required-features = ["stats-obfuscation"]
 
 [features]
-default = ["https", "telemetry"]
+default = ["https", "regex-unicode", "telemetry"]
 telemetry = ["libdd-telemetry", "libdd-trace-stats/telemetry"]
 https = [
     "libdd-common/https",
@@ -139,7 +139,9 @@ fips = [
     "libdd-dogstatsd-client/fips",
 ]
 test-utils = []
-regex-lite = ["libdd-common/regex-lite"]
+regex-ascii = ["libdd-common/regex-ascii", "libdd-data-pipeline-core/regex-ascii"]
+regex-lite = ["libdd-common/regex-lite", "libdd-data-pipeline-core/regex-lite"]
+regex-unicode = ["libdd-common/regex-unicode", "libdd-data-pipeline-core/regex-unicode"]
 # Enable zstd compression for the agentless trace and stats intake senders.
 compression = [
     "libdd-trace-utils/compression",

--- a/libdd-dogstatsd-client/Cargo.toml
+++ b/libdd-dogstatsd-client/Cargo.toml
@@ -23,9 +23,10 @@ tokio = { version = "1.23", features = ["sync"], optional = true }
 async-trait = { version = "0.1", optional = true }
 
 [features]
-default = ["https"]
+default = ["https", "regex-unicode"]
 https = ["libdd-common/https"]
 fips = ["libdd-common/fips"]
+regex-unicode = ["libdd-common/regex-unicode"]
 shared-runtime = ["dep:libdd-shared-runtime", "dep:tokio", "dep:async-trait"]
 
 [dev-dependencies]

--- a/libdd-http-client/Cargo.toml
+++ b/libdd-http-client/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/DataDog/libdatadog/tree/main/libdd-http-client"
 bench = false
 
 [features]
-default = ["https", "reqwest-backend"]
+default = ["https", "regex-unicode", "reqwest-backend"]
 # Use rustls-no-provider to avoid reqwest forcing aws-lc-rs. Ring provider is
 # installed explicitly by libdd-common's connector init.
 https = ["dep:reqwest", "reqwest?/rustls-no-provider", "libdd-common?/https"]
@@ -28,6 +28,7 @@ hyper-backend = [
 # Honor HTTPS_PROXY/NO_PROXY environment variables in the hyper backend.
 hyper-proxy = ["hyper-backend", "libdd-common?/hyper-proxy"]
 fips = ["dep:reqwest", "reqwest?/rustls-no-provider", "dep:rustls", "rustls?/aws-lc-rs", "libdd-common?/fips"]
+regex-unicode = ["libdd-common?/regex-unicode"]
 
 [dependencies]
 bytes = { workspace = true, features = ["std"] }

--- a/libdd-profiling/Cargo.toml
+++ b/libdd-profiling/Cargo.toml
@@ -42,7 +42,7 @@ http-body-util.workspace = true
 httparse = { workspace = true, features = ["std"] }
 indexmap = "2.11"
 libdd-alloc = { version = "1.0.0", path = "../libdd-alloc" }
-libdd-common = { version = "6.0.0", path = "../libdd-common", default-features = false, features = ["reqwest", "test-utils"] }
+libdd-common = { version = "6.0.0", path = "../libdd-common", default-features = false, features = ["regex-unicode", "reqwest", "test-utils"] }
 libdd-profiling-protobuf = { version = "2.0.0", path = "../libdd-profiling-protobuf", features = ["prost_impls"] }
 mime.workspace = true
 parking_lot = { version = "0.12", default-features = false }

--- a/libdd-remote-config/Cargo.toml
+++ b/libdd-remote-config/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/DataDog/libdatadog/tree/main/libdd-remote-confi
 description = "Datadog Remote Configuration client and config parsers"
 
 [features]
-default = ["client", "https"]
+default = ["client", "https", "regex-unicode"]
 agentless = [
     "dep:ring",
     "dep:tuf",
@@ -39,6 +39,7 @@ client = [
 ]
 
 regex-lite = ["libdd-common/regex-lite"]
+regex-unicode = ["libdd-common/regex-unicode"]
 # Enable HTTPS support in the fetcher (rustls + ring via libdd-common).
 https = ["libdd-common/https", "libdd-capabilities-impl/https"]
 # FIPS-compliant crypto provider (aws-lc-rs via libdd-common). Unix only.

--- a/libdd-sampling/Cargo.toml
+++ b/libdd-sampling/Cargo.toml
@@ -36,6 +36,8 @@ libdd-common = { path = "../libdd-common", version = "6.0.0", default-features =
 libdd-trace-utils = { path = "../libdd-trace-utils", version = "12.0.0", optional = true }
 
 [features]
+default = ["regex-unicode"]
+regex-unicode = ["libdd-common/regex-unicode"]
 v04_span = ["dep:libdd-trace-utils"]
 # Exposes internal modules (e.g. `glob_matcher`) for benchmarks. Not intended for downstream
 # consumers — enable only when running benches in this crate.

--- a/libdd-shared-runtime/Cargo.toml
+++ b/libdd-shared-runtime/Cargo.toml
@@ -26,10 +26,11 @@ libdd-capabilities = { path = "../libdd-capabilities", version = "3.0.1" }
 libdd-common = { version = "6.0.0", path = "../libdd-common", default-features = false }
 
 [features]
-default = ["https"]
+default = ["https", "regex-unicode"]
 https = ["libdd-capabilities-impl/https"]
 fips = ["libdd-capabilities-impl/fips"]
 regex-lite = ["libdd-common/regex-lite"]
+regex-unicode = ["libdd-common/regex-unicode"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libdd-capabilities-impl = { path = "../libdd-capabilities-impl", version = "5.0.0", default-features = false }

--- a/libdd-telemetry/Cargo.toml
+++ b/libdd-telemetry/Cargo.toml
@@ -12,10 +12,11 @@ license.workspace = true
 bench = false
 
 [features]
-default = ["tracing"]
+default = ["regex-unicode", "tracing"]
 tracing = ["tracing/std"]
 https = ["libdd-common/https", "libdd-shared-runtime/https"]
 fips = ["libdd-common/fips", "libdd-shared-runtime/fips"]
+regex-unicode = ["libdd-common/regex-unicode"]
 
 [dependencies]
 anyhow.workspace = true

--- a/libdd-trace-obfuscation/Cargo.toml
+++ b/libdd-trace-obfuscation/Cargo.toml
@@ -23,10 +23,12 @@ libdd-trace-utils = { version = "12.0.0", path = "../libdd-trace-utils", default
 libdd-common = { version = "6.0.0", path = "../libdd-common", default-features = false }
 
 [features]
-default = ["https"]
+default = ["https", "regex-unicode"]
 https = ["libdd-common/https", "libdd-trace-utils/https"]
 fips = ["libdd-common/fips", "libdd-trace-utils/fips"]
+regex-ascii = ["libdd-common/regex-ascii"]
 regex-lite = ["libdd-common/regex-lite"]
+regex-unicode = ["libdd-common/regex-unicode"]
 
 [dev-dependencies]
 duplicate = "0.4.1"

--- a/libdd-trace-obfuscation/Cargo.toml
+++ b/libdd-trace-obfuscation/Cargo.toml
@@ -26,7 +26,6 @@ libdd-common = { version = "6.0.0", path = "../libdd-common", default-features =
 default = ["https", "regex-unicode"]
 https = ["libdd-common/https", "libdd-trace-utils/https"]
 fips = ["libdd-common/fips", "libdd-trace-utils/fips"]
-regex-ascii = ["libdd-common/regex-ascii"]
 regex-lite = ["libdd-common/regex-lite"]
 regex-unicode = ["libdd-common/regex-unicode"]
 

--- a/libdd-trace-stats/Cargo.toml
+++ b/libdd-trace-stats/Cargo.toml
@@ -52,7 +52,7 @@ rand = ">=0.8.6, <0.9"
 tokio = { version = "1.23", features = ["rt-multi-thread", "macros", "test-util", "time"], default-features = false }
 
 [features]
-default = ["https"]
+default = ["https", "regex-unicode"]
 stats-obfuscation = []
 # Enable zstd compression for the agentless intake stats sender.
 compression = ["libdd-trace-utils/compression"]
@@ -60,3 +60,4 @@ telemetry = ["libdd-telemetry"]
 dogstatsd = ["libdd-dogstatsd-client"]
 https = ["libdd-common/https", "libdd-capabilities-impl/https", "libdd-shared-runtime/https","libdd-telemetry?/https","libdd-dogstatsd-client?/https" ]
 fips = ["libdd-common/fips", "libdd-capabilities-impl/fips", "libdd-shared-runtime/fips", "libdd-telemetry?/fips", "libdd-dogstatsd-client?/fips"]
+regex-unicode = ["libdd-common/regex-unicode"]

--- a/libdd-trace-utils/Cargo.toml
+++ b/libdd-trace-utils/Cargo.toml
@@ -91,8 +91,10 @@ libdd-trace-utils = { path = ".", features = ["test-utils"] }
 tempfile.workspace = true
 
 [features]
-default = ["https"]
+default = ["https", "regex-unicode"]
 https = ["libdd-common/https", "dep:libdd-capabilities-impl", "libdd-capabilities-impl/https"]
+regex-ascii = ["libdd-common/regex-ascii"]
+regex-unicode = ["libdd-common/regex-unicode"]
 mini_agent = [
     "compression",
     "libdd-common/http-client",

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -25,7 +25,9 @@ toml = "0.8"
 wait-timeout = "0.2"
 
 [features]
+default = ["regex-unicode"]
 regex-lite = ["libdd-common/regex-lite"]
+regex-unicode = ["libdd-common/regex-unicode"]
 
 [[bin]]
 name = "dedup_headers"


### PR DESCRIPTION
The Node WASM pipeline evaluates a closed set of ASCII patterns. `regex-lite` removes Unicode tables, but also gives up the full engine's performance optimizations.

This adds `regex-ascii` for the full engine with `perf` and `std`, without Unicode tables. Default builds and consumers that accept user-provided replacement patterns remain Unicode-capable.