### PR TITLE
ci(fuzz): restrict fuzz job to protected refs

### DIFF
--- a/.gitlab/fuzz.yml
+++ b/.gitlab/fuzz.yml
@@ -9,11 +9,16 @@ fuzz:
     name: $BASE_CI_IMAGE
   rules:
     - !reference [.untrusted_ref_guard, rules]
-    # runs on gitlab schedule and on merge to main.
-    # Also allow manual run in branches for ease of debug / testing
-    - if: '$CI_COMMIT_BRANCH == "main" && $CI_PIPELINE_SOURCE == "schedule"'
+    # runs on gitlab schedule and on merge to main (both protected refs).
+    # Manual runs are only allowed on protected refs as well: the job
+    # operates with an elevated service account and talks to the internal
+    # fuzzing platform, so it must not be reachable from arbitrary branch
+    # or merge request pipelines.
+    - if: '$CI_COMMIT_REF_PROTECTED != "true"'
+      when: never
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
       allow_failure: true
-    - if: $CI_COMMIT_BRANCH == "main"
+    - if: $CI_COMMIT_BRANCH
       allow_failure: true
     - when: manual
       allow_failure: true


### PR DESCRIPTION
# What does this PR do?

The internal fuzzing job only needs to run on scheduled pipelines and merges to main. Keep manual runs to protected refs so the job doesn't show up on branch and merge request pipelines where it isn't needed.

# Motivation

[APSMP-3123](https://datadoghq.atlassian.net/browse/APMSP-3123)

