### PR TITLE
fix(mockgen): fix dd-trace-php LTO builds

### DIFF
--- a/tools/sidecar_mockgen/src/lib.rs
+++ b/tools/sidecar_mockgen/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use object::macho::MachHeader64;
+use object::read::elf::{ElfFile64, FileHeader};
 use object::read::macho::{LoadCommandVariant, MachHeader};
 use object::{
     Endian, Endianness, File, FileKind, Object, ObjectSection, ObjectSymbol, Symbol, SymbolFlags,
@@ -147,9 +148,9 @@ pub fn weaken_object_symbols(target: &Path, binary: &Path) -> Result<(), String>
 fn weaken_symtab(obj_path: &Path, symbols: &HashSet<String>) -> Result<(), String> {
     let mut data = fs::read(obj_path).map_err(|e| format!("read {}: {e}", obj_path.display()))?;
 
-    let modified = match FileKind::parse(data.as_slice())
-        .map_err(|e| format!("parse {}: {e}", obj_path.display()))?
-    {
+    let file_kind = FileKind::parse(data.as_slice())
+        .map_err(|e| format!("parse {}: {e}", obj_path.display()))?;
+    let modified = match file_kind {
         FileKind::Elf64 => weaken_elf(&mut data, symbols, obj_path)?,
         FileKind::MachO64 => weaken_macho(&mut data, symbols, obj_path)?,
         _ => false,
@@ -162,8 +163,9 @@ fn weaken_symtab(obj_path: &Path, symbols: &HashSet<String>) -> Result<(), Strin
 }
 
 fn weaken_elf(data: &mut [u8], symbols: &HashSet<String>, obj_path: &Path) -> Result<bool, String> {
-    let patches: Vec<usize> = {
-        let elf = File::parse(&*data).map_err(|e| format!("parse {}: {e}", obj_path.display()))?;
+    let (symtab_patches, lto_patches): (Vec<usize>, Vec<usize>) = {
+        let elf = ElfFile64::<Endianness>::parse(&*data)
+            .map_err(|e| format!("parse {}: {e}", obj_path.display()))?;
 
         let symtab = match elf.section_by_name(".symtab") {
             Some(s) => s,
@@ -173,22 +175,46 @@ fn weaken_elf(data: &mut [u8], symbols: &HashSet<String>, obj_path: &Path) -> Re
             .file_range()
             .ok_or_else(|| format!("{}: .symtab has no file range", obj_path.display()))?;
 
-        elf.symbols()
+        let symtab_patches: Vec<usize> = elf
+            .symbols()
             .filter(|sym| {
                 sym.is_undefined()
                     && !sym.is_weak()
                     && sym.name().is_ok_and(|n| symbols.contains(n))
             })
             .map(|sym| (symtab_off + sym.index().0 as u64 * 24 + 4) as usize) // sizeof(Elf64_Sym)=24; st_info at +4
-            .collect()
+            .collect();
+
+        if symtab_patches.is_empty() {
+            return Ok(false);
+        }
+
+        // `-ffat-lto-objects` embeds a second, independent copy of every symbol's binding in
+        // `.gnu.lto_*` sections. The linker then recompiles from that IR instead of object data
+        // directly. Stripping the LTO sections to force the linker to use the object sections.
+        let header = elf.raw_header();
+        let endian = elf.endian();
+        let sh_off = header.e_shoff(endian) as usize;
+        let sh_entsize = header.e_shentsize(endian) as usize;
+        let lto_patches: Vec<usize> = elf
+            .sections()
+            .filter(|s| {
+                s.name()
+                    .is_ok_and(|n| n.starts_with(".gnu.lto_") || n.starts_with(".gnu.debuglto_"))
+            })
+            .map(|s| sh_off + s.index().0 * sh_entsize)
+            .collect();
+
+        (symtab_patches, lto_patches)
     };
 
-    if patches.is_empty() {
-        return Ok(false);
-    }
-    for pos in patches {
+    for pos in symtab_patches {
         let old = data[pos];
         data[pos] = (2u8 << 4) | (old & 0xf); // STB_WEAK = 2
+    }
+    for base in lto_patches {
+        // sh_name: blank to the empty string always present at offset 0 of a valid ELF string table
+        data[base..base + 4].fill(0);
     }
     Ok(true)
 }

--- a/tools/sidecar_mockgen/src/lib.rs
+++ b/tools/sidecar_mockgen/src/lib.rs
@@ -175,6 +175,20 @@ fn weaken_elf(data: &mut [u8], symbols: &HashSet<String>, obj_path: &Path) -> Re
             .file_range()
             .ok_or_else(|| format!("{}: .symtab has no file range", obj_path.display()))?;
 
+        // A slim LTO object (`-flto` without `-ffat-lto-objects`) has no real object code at all:
+        // We don't have anything we can do here. Just fail.
+        if elf
+            .symbols()
+            .any(|sym| sym.name().is_ok_and(|n| n == "__gnu_lto_slim"))
+        {
+            return Err(format!(
+                "{}: compiled as a slim LTO object (missing -ffat-lto-objects); \
+                 weaken-dynsym cannot patch symbol bindings inside GCC's LTO-only bytecode. \
+                 Recompile with -ffat-lto-objects (or without -flto).",
+                obj_path.display()
+            ));
+        }
+
         let symtab_patches: Vec<usize> = elf
             .symbols()
             .filter(|sym| {


### PR DESCRIPTION
If dd-trace-php gets compiled from source with LTO, weakened symbols will not stay weakened at final link time.