### PR TITLE
feat(crashtracking): send telemetry if instrumented application sigactions our signal

### DIFF
--- a/bin_tests/build.rs
+++ b/bin_tests/build.rs
@@ -25,6 +25,27 @@ fn main() {
     // Make the built shared object path available at compile time for tests/tools.
     println!("cargo:rustc-env=PRELOAD_LOGGER_SO={}", so_path.display());
 
+    // --- sigaction_caller shared library ---
+    // A minimal .so whose PLT/GOT entry for sigaction IS patched by the
+    // crashtracker's hook_symbol_excluding_self (unlike the statically-linked
+    // test binary). LD_PRELOAD'd in sigaction interception tests.
+    let caller_src = PathBuf::from("preload/sigaction_caller.c");
+    let caller_so = out_dir.join("libsigaction_caller.so");
+    let status = Command::new("cc")
+        .args(["-std=c11", "-fPIC", "-shared", "-Wall", "-o"])
+        .arg(&caller_so)
+        .arg(&caller_src)
+        .status()
+        .expect("failed to spawn cc for sigaction_caller.c");
+    if !status.success() {
+        panic!("compiling sigaction_caller.c failed with status {status}");
+    }
+    println!(
+        "cargo:rustc-env=SIGACTION_CALLER_SO={}",
+        caller_so.display()
+    );
+    println!("cargo:rerun-if-changed=preload/sigaction_caller.c");
+
     // --- trigger_assert static library (Linux only) ---
     #[cfg(target_os = "linux")]
     {

--- a/bin_tests/preload/sigaction_caller.c
+++ b/bin_tests/preload/sigaction_caller.c
@@ -1,0 +1,28 @@
+// Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+// Minimal shared library for bin_tests to exercise the crashtracker's sigaction
+// GOT hook.  Because this compiles as a separate .so, its PLT/GOT entry for
+// sigaction is patched by the crashtracker's hook
+
+#define _GNU_SOURCE
+#include <signal.h>
+#include <string.h>
+
+// No-op SIGSEGV handler installed by dd_test_sigaction_on_sigsegv.
+// Using a real function (not SIG_DFL / SIG_IGN) ensures the hook's
+// handler_addr > 1 check passes and telemetry is emitted.
+static void noop_sigsegv_handler(int signum) { (void)signum; }
+
+// Installs noop_sigsegv_handler for SIGSEGV and stores the previous handler
+// in *old_act.  The sigaction() call here goes through this library's
+// PLT/GOT, which is patched by the crashtracker's hook.
+// Returns 0 on success, -1 on error (errno set).
+int dd_test_sigaction_on_sigsegv(struct sigaction *old_act) {
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_handler = noop_sigsegv_handler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    return sigaction(SIGSEGV, &sa, old_act);
+}

--- a/bin_tests/src/modes/behavior.rs
+++ b/bin_tests/src/modes/behavior.rs
@@ -214,6 +214,7 @@ pub fn get_behavior(mode_str: &str) -> Box<dyn Behavior> {
         "unhandled_exception_multi_thread" => {
             Box::new(test_021_unhandled_exception_multi_thread::Test)
         }
+        "sigaction_interception" => Box::new(test_022_sigaction_interception::Test),
         "runtime_preload_logger" => Box::new(test_000_donothing::Test),
         _ => panic!("Unknown mode: {mode_str}"),
     }

--- a/bin_tests/src/modes/unix/mod.rs
+++ b/bin_tests/src/modes/unix/mod.rs
@@ -22,3 +22,4 @@ pub mod test_018_thread_limit;
 pub mod test_019_sidecar_donothing;
 pub mod test_020_sidecar_multi_thread_collection;
 pub mod test_021_unhandled_exception_multi_thread;
+pub mod test_022_sigaction_interception;

--- a/bin_tests/src/modes/unix/test_022_sigaction_interception.rs
+++ b/bin_tests/src/modes/unix/test_022_sigaction_interception.rs
@@ -1,0 +1,84 @@
+// Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+//
+// Verifies that the sigaction GOT hook fires when the test binary installs a
+// SIGSEGV handler after crashtracker init.
+//
+// Because hook_symbol (not hook_symbol_excluding_self) is used, the test
+// binary's GOT is patched at init time. Calling signal::sigaction from post()
+// therefore goes through hook_sigaction, which emits a telemetry warning.
+//
+// The installed handler chains back to the old one (crashtracker's), so the
+// crash report is still generated and the test can validate both outcomes:
+//   1. Crash report generated correctly.
+//   2. Telemetry file contains the `sigaction_intercepted` warning.
+use crate::modes::behavior::{atom_to_clone, set_atomic};
+use libc;
+use libdd_crashtracker::CrashtrackerConfiguration;
+use nix::sys::signal::{self, SaFlags, SigAction, SigHandler, SigSet};
+use std::path::Path;
+use std::sync::atomic::AtomicPtr;
+
+pub struct Test;
+
+impl crate::modes::behavior::Behavior for Test {
+    fn setup(
+        &self,
+        _output_dir: &Path,
+        _config: &mut CrashtrackerConfiguration,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn pre(&self, _output_dir: &Path) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn post(&self, _output_dir: &Path) -> anyhow::Result<()> {
+        install_handler()
+    }
+}
+
+/// Stores the handler that was active before we installed ours (crashtracker's).
+static OLD_ACTION: AtomicPtr<SigAction> = AtomicPtr::new(std::ptr::null_mut());
+
+extern "C" fn sigsegv_handler(
+    signum: i32,
+    sig_info: *mut libc::siginfo_t,
+    ucontext: *mut libc::c_void,
+) {
+    // Chain to the old handler so crashtracker receives the signal and
+    // generates a crash report.
+    let old = match atom_to_clone(&OLD_ACTION) {
+        Ok(a) => a,
+        Err(_) => return,
+    };
+    match old.handler() {
+        SigHandler::SigDfl => {
+            unsafe { signal::sigaction(signal::SIGSEGV, &old) }.ok();
+        }
+        SigHandler::SigIgn => {}
+        SigHandler::Handler(f) => f(signum),
+        SigHandler::SigAction(f) => f(signum, sig_info, ucontext),
+    }
+}
+
+fn install_handler() -> anyhow::Result<()> {
+    let sig_action = SigAction::new(
+        SigHandler::SigAction(sigsegv_handler),
+        SaFlags::empty(),
+        SigSet::empty(),
+    );
+
+    // This call goes through the test binary's patched GOT (hook_symbol patches
+    // all libraries including ours), so hook_sigaction fires and emits telemetry.
+    // The returned old_handler is the crashtracker's handle_posix_sigaction.
+    let old_handler = unsafe { signal::sigaction(signal::SIGSEGV, &sig_action) }?;
+    set_atomic(&OLD_ACTION, old_handler);
+
+    // Give the background telemetry thread time to write the warning to the
+    // telemetry file before the crash kills the process.
+    std::thread::sleep(std::time::Duration::from_millis(300));
+
+    Ok(())
+}

--- a/bin_tests/src/modes/unix/test_022_sigaction_interception.rs
+++ b/bin_tests/src/modes/unix/test_022_sigaction_interception.rs
@@ -34,8 +34,8 @@ impl crate::modes::behavior::Behavior for Test {
         Ok(())
     }
 
-    fn post(&self, _output_dir: &Path) -> anyhow::Result<()> {
-        install_handler()
+    fn post(&self, output_dir: &Path) -> anyhow::Result<()> {
+        install_handler(output_dir)
     }
 }
 
@@ -63,7 +63,7 @@ extern "C" fn sigsegv_handler(
     }
 }
 
-fn install_handler() -> anyhow::Result<()> {
+fn install_handler(output_dir: &Path) -> anyhow::Result<()> {
     let sig_action = SigAction::new(
         SigHandler::SigAction(sigsegv_handler),
         SaFlags::empty(),
@@ -76,9 +76,24 @@ fn install_handler() -> anyhow::Result<()> {
     let old_handler = unsafe { signal::sigaction(signal::SIGSEGV, &sig_action) }?;
     set_atomic(&OLD_ACTION, old_handler);
 
-    // Give the background telemetry thread time to write the warning to the
-    // telemetry file before the crash kills the process.
-    std::thread::sleep(std::time::Duration::from_millis(300));
+    // Poll here because we crash immediately after installing this. I'd rather not
+    // implement some sleep -- rather, we can just poll here and move on if we don't
+    // find the telemetry.
+    let telemetry_path = output_dir.join("crash.telemetry");
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+    loop {
+        if let Ok(content) = std::fs::read_to_string(&telemetry_path) {
+            if content.contains("sigaction_intercepted") {
+                break;
+            }
+        }
+        anyhow::ensure!(
+            std::time::Instant::now() < deadline,
+            "timed out waiting for sigaction_intercepted telemetry in {:?}",
+            telemetry_path
+        );
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
 
     Ok(())
 }

--- a/bin_tests/src/modes/unix/test_022_sigaction_interception.rs
+++ b/bin_tests/src/modes/unix/test_022_sigaction_interception.rs
@@ -1,23 +1,20 @@
 // Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 //
-// Verifies that the sigaction GOT hook fires when the test binary installs a
-// SIGSEGV handler after crashtracker init.
+// Verifies that the sigaction GOT hook fires when a dynamically-loaded library
+// installs a handler for a crashtracker-monitored signal after init, and that
+// a telemetry warning is emitted.
 //
-// Because hook_symbol (not hook_symbol_excluding_self) is used, the test
-// binary's GOT is patched at init time. Calling signal::sigaction from post()
-// therefore goes through hook_sigaction, which emits a telemetry warning.
+// The test binary statically links crashtracker, so hook_symbol_excluding_self
+// skips its GOT. libsigaction_caller.so is LD_PRELOAD'd so it is present
+// when crashtracker::init() patches GOT entries. Calling
+// dd_test_sigaction_on_sigsegv() from that library fires the hook.
 //
-// The installed handler chains back to the old one (crashtracker's), so the
-// crash report is still generated and the test can validate both outcomes:
-//   1. Crash report generated correctly.
-//   2. Telemetry file contains the `sigaction_intercepted` warning.
-use crate::modes::behavior::{atom_to_clone, set_atomic};
-use libc;
+// After the hook fires, post() restores the crashtracker's handler so the
+// crash report is still generated, then polls the telemetry file until the
+// sigaction_intercepted warning appears.
 use libdd_crashtracker::CrashtrackerConfiguration;
-use nix::sys::signal::{self, SaFlags, SigAction, SigHandler, SigSet};
 use std::path::Path;
-use std::sync::atomic::AtomicPtr;
 
 pub struct Test;
 
@@ -35,52 +32,34 @@ impl crate::modes::behavior::Behavior for Test {
     }
 
     fn post(&self, output_dir: &Path) -> anyhow::Result<()> {
-        install_handler(output_dir)
+        trigger_hook_and_restore(output_dir)
     }
 }
 
-/// Stores the handler that was active before we installed ours (crashtracker's).
-static OLD_ACTION: AtomicPtr<SigAction> = AtomicPtr::new(std::ptr::null_mut());
-
-extern "C" fn sigsegv_handler(
-    signum: i32,
-    sig_info: *mut libc::siginfo_t,
-    ucontext: *mut libc::c_void,
-) {
-    // Chain to the old handler so crashtracker receives the signal and
-    // generates a crash report.
-    let old = match atom_to_clone(&OLD_ACTION) {
-        Ok(a) => a,
-        Err(_) => return,
-    };
-    match old.handler() {
-        SigHandler::SigDfl => {
-            unsafe { signal::sigaction(signal::SIGSEGV, &old) }.ok();
-        }
-        SigHandler::SigIgn => {}
-        SigHandler::Handler(f) => f(signum),
-        SigHandler::SigAction(f) => f(signum, sig_info, ucontext),
-    }
-}
-
-fn install_handler(output_dir: &Path) -> anyhow::Result<()> {
-    let sig_action = SigAction::new(
-        SigHandler::SigAction(sigsegv_handler),
-        SaFlags::empty(),
-        SigSet::empty(),
+fn trigger_hook_and_restore(output_dir: &Path) -> anyhow::Result<()> {
+    let sym = unsafe { libc::dlsym(libc::RTLD_DEFAULT, c"dd_test_sigaction_on_sigsegv".as_ptr()) };
+    anyhow::ensure!(
+        !sym.is_null(),
+        "dd_test_sigaction_on_sigsegv not found. Is libsigaction_caller.so LD_PRELOAD'd?"
     );
 
-    // This call goes through the test binary's patched GOT (hook_symbol patches
-    // all libraries including ours), so hook_sigaction fires and emits telemetry.
-    // The returned old_handler is the crashtracker's handle_posix_sigaction.
-    let old_handler = unsafe { signal::sigaction(signal::SIGSEGV, &sig_action) }?;
-    set_atomic(&OLD_ACTION, old_handler);
+    type TestSigactionFn = unsafe extern "C" fn(*mut libc::sigaction) -> libc::c_int;
+    let call_sigaction: TestSigactionFn =
+        unsafe { std::mem::transmute::<*mut libc::c_void, TestSigactionFn>(sym) };
 
-    // Poll here because we crash immediately after installing this. I'd rather not
-    // implement some sleep -- rather, we can just poll here and move on if we don't
-    // find the telemetry.
+    // This call goes through libsigaction_caller.so's patched GOT
+    // old_act receives the crashtracker's handle_posix_sigaction.
+    let mut old_act: libc::sigaction = unsafe { std::mem::zeroed() };
+    let ret = unsafe { call_sigaction(&mut old_act) };
+    anyhow::ensure!(ret == 0, "dd_test_sigaction_on_sigsegv returned {ret}");
+
+    // Restore the crashtracker's handler so the crash is still caught and a crash report is
+    // generated.
+    unsafe { libc::sigaction(libc::SIGSEGV, &old_act, std::ptr::null_mut()) };
+
+    // Poll until the background telemetry thread writes the warning, or bail.
     let telemetry_path = output_dir.join("crash.telemetry");
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(1);
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
     loop {
         if let Ok(content) = std::fs::read_to_string(&telemetry_path) {
             if content.contains("sigaction_intercepted") {

--- a/bin_tests/src/test_types.rs
+++ b/bin_tests/src/test_types.rs
@@ -25,6 +25,7 @@ pub enum TestMode {
     SidecarDoNothing,
     SidecarMultiThreadCollection,
     UnhandledExceptionMultiThread,
+    SigactionInterception,
 }
 
 impl TestMode {
@@ -51,6 +52,7 @@ impl TestMode {
             Self::SidecarDoNothing => "sidecar_donothing",
             Self::SidecarMultiThreadCollection => "sidecar_multi_thread_collection",
             Self::UnhandledExceptionMultiThread => "unhandled_exception_multi_thread",
+            Self::SigactionInterception => "sigaction_interception",
         }
     }
 
@@ -77,6 +79,7 @@ impl TestMode {
             Self::SidecarDoNothing,
             Self::SidecarMultiThreadCollection,
             Self::UnhandledExceptionMultiThread,
+            Self::SigactionInterception,
         ]
     }
 }
@@ -112,6 +115,7 @@ impl std::str::FromStr for TestMode {
             "sidecar_donothing" => Ok(Self::SidecarDoNothing),
             "sidecar_multi_thread_collection" => Ok(Self::SidecarMultiThreadCollection),
             "unhandled_exception_multi_thread" => Ok(Self::UnhandledExceptionMultiThread),
+            "sigaction_interception" => Ok(Self::SigactionInterception),
             _ => Err(format!("Unknown test mode: {}", s)),
         }
     }

--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -196,6 +196,54 @@ fn test_crash_tracking_bin_assert_fail() {
     run_crash_test_with_artifacts(&config, &artifacts_map, &artifacts, validator).unwrap();
 }
 
+/// Tests that the sigaction GOT hook fires when the test binary calls sigaction
+/// for a monitored signal after crashtracker init, emitting a telemetry warning.
+/// The crash report is still generated because the test's handler chains back
+/// to the crashtracker handler.
+#[test]
+#[cfg(all(target_os = "linux", target_pointer_width = "64"))]
+#[cfg_attr(miri, ignore)]
+fn test_crash_tracking_bin_sigaction_interception() {
+    let config = CrashTestConfig::new(
+        BuildProfile::Release,
+        TestMode::SigactionInterception,
+        CrashType::NullDeref,
+    );
+    let artifacts = StandardArtifacts::new(config.profile);
+    let artifacts_map = fetch_built_artifacts(&artifacts.as_slice()).unwrap();
+
+    let validator: ValidatorFn = Box::new(|payload, fixtures| {
+        PayloadValidator::new(payload).validate_counters()?;
+        let sig_info = &payload["sig_info"];
+        assert_siginfo_message(sig_info, "null_deref");
+
+        validate_sigaction_interception_telemetry(&fixtures.crash_telemetry_path)?;
+
+        Ok(())
+    });
+
+    run_crash_test_with_artifacts(&config, &artifacts_map, &artifacts, validator).unwrap();
+}
+
+/// Checks that the telemetry file contains at least one entry with the
+/// `sigaction_intercepted` tag emitted by the GOT hook.
+fn validate_sigaction_interception_telemetry(telemetry_path: &Path) -> anyhow::Result<()> {
+    let content = fs::read(telemetry_path)
+        .with_context(|| format!("reading crashtracker telemetry at {:?}", telemetry_path))?;
+
+    let found = content
+        .split(|&b| b == b'\n')
+        .any(|line| String::from_utf8_lossy(line).contains("sigaction_intercepted"));
+
+    anyhow::ensure!(
+        found,
+        "expected a telemetry entry with 'sigaction_intercepted' tag in {:?}",
+        telemetry_path
+    );
+
+    Ok(())
+}
+
 /// Tests that when `collect_all_threads` is enabled and the crash is reported via
 /// `report_unhandled_exception`, the crash report contains entries in `error.threads`
 /// for background threads with valid stack traces.

--- a/bin_tests/tests/crashtracker_bin_test.rs
+++ b/bin_tests/tests/crashtracker_bin_test.rs
@@ -196,10 +196,14 @@ fn test_crash_tracking_bin_assert_fail() {
     run_crash_test_with_artifacts(&config, &artifacts_map, &artifacts, validator).unwrap();
 }
 
-/// Tests that the sigaction GOT hook fires when the test binary calls sigaction
-/// for a monitored signal after crashtracker init, emitting a telemetry warning.
-/// The crash report is still generated because the test's handler chains back
-/// to the crashtracker handler.
+/// Tests that the sigaction GOT hook fires when a dynamically-loaded library
+/// installs a handler for a monitored signal after crashtracker init, and that
+/// crash handling still works correctly afterwards.
+///
+/// libsigaction_caller.so is LD_PRELOAD'd so its GOT entry for sigaction is
+/// patched at init time. The test's post() calls dd_test_sigaction_on_sigsegv()
+/// via dlsym(RTLD_DEFAULT) to trigger the hook, then immediately restores the
+/// crashtracker's handler so the crash report is generated normally.
 #[test]
 #[cfg(all(target_os = "linux", target_pointer_width = "64"))]
 #[cfg_attr(miri, ignore)]
@@ -208,7 +212,8 @@ fn test_crash_tracking_bin_sigaction_interception() {
         BuildProfile::Release,
         TestMode::SigactionInterception,
         CrashType::NullDeref,
-    );
+    )
+    .with_env("LD_PRELOAD", env!("SIGACTION_CALLER_SO"));
     let artifacts = StandardArtifacts::new(config.profile);
     let artifacts_map = fetch_built_artifacts(&artifacts.as_slice()).unwrap();
 
@@ -216,32 +221,11 @@ fn test_crash_tracking_bin_sigaction_interception() {
         PayloadValidator::new(payload).validate_counters()?;
         let sig_info = &payload["sig_info"];
         assert_siginfo_message(sig_info, "null_deref");
-
-        validate_sigaction_interception_telemetry(&fixtures.crash_telemetry_path)?;
-
+        validate_telemetry(&fixtures.crash_telemetry_path, "null_deref")?;
         Ok(())
     });
 
     run_crash_test_with_artifacts(&config, &artifacts_map, &artifacts, validator).unwrap();
-}
-
-/// Checks that the telemetry file contains at least one entry with the
-/// `sigaction_intercepted` tag emitted by the GOT hook.
-fn validate_sigaction_interception_telemetry(telemetry_path: &Path) -> anyhow::Result<()> {
-    let content = fs::read(telemetry_path)
-        .with_context(|| format!("reading crashtracker telemetry at {:?}", telemetry_path))?;
-
-    let found = content
-        .split(|&b| b == b'\n')
-        .any(|line| String::from_utf8_lossy(line).contains("sigaction_intercepted"));
-
-    anyhow::ensure!(
-        found,
-        "expected a telemetry entry with 'sigaction_intercepted' tag in {:?}",
-        telemetry_path
-    );
-
-    Ok(())
 }
 
 /// Tests that when `collect_all_threads` is enabled and the crash is reported via

--- a/libdd-crashtracker/src/collector/crash_handler.rs
+++ b/libdd-crashtracker/src/collector/crash_handler.rs
@@ -371,6 +371,38 @@ fn handle_posix_signal_impl(
     Ok(())
 }
 
+/// Clone the current metadata out of global storage without consuming it.
+/// Returns `None` if metadata has not yet been set.
+///
+/// Not async-signal-safe
+#[cfg(all(target_os = "linux", target_pointer_width = "64"))]
+pub(crate) fn peek_metadata() -> Option<Metadata> {
+    let ptr = METADATA.load(Acquire);
+    if ptr.is_null() {
+        None
+    } else {
+        // SAFETY: non-null means it was created with Box::into_raw in update_metadata
+        // and has not been freed (free only happens on the next update_metadata call,
+        // which swaps the pointer first). We clone to avoid taking ownership.
+        Some(unsafe { &*ptr }.0.clone())
+    }
+}
+
+/// Clone the endpoint out of global config without consuming it.
+/// Returns `None` if the config has not yet been set or has no endpoint.
+///
+/// Not async-signal-safe
+#[cfg(all(target_os = "linux", target_pointer_width = "64"))]
+pub(crate) fn peek_endpoint() -> Option<libdd_common::Endpoint> {
+    let ptr = CONFIG.load(Acquire);
+    if ptr.is_null() {
+        None
+    } else {
+        // SAFETY: same reasoning as peek_metadata.
+        unsafe { &*ptr }.0.endpoint().clone()
+    }
+}
+
 /// Atomically swaps the metadata pointer to null and returns the old raw pointer.
 /// Async-signal-safe (only performs an atomic swap).
 ///

--- a/libdd-crashtracker/src/collector/crash_handler.rs
+++ b/libdd-crashtracker/src/collector/crash_handler.rs
@@ -97,7 +97,18 @@ pub enum CrashHandlerError {
 ///     No other crash-handler functions should be called concurrently.
 /// ATOMICITY:
 ///     This function uses a swap on an atomic pointer.
+/// Mutex-protected snapshot of metadata and endpoint for telemetry use by the
+/// sigaction interceptor.
+#[cfg(all(target_os = "linux", target_pointer_width = "64"))]
+static TELEMETRY_PEEK: std::sync::Mutex<(Option<Metadata>, Option<libdd_common::Endpoint>)> =
+    std::sync::Mutex::new((None, None));
+
 pub fn update_metadata(metadata: Metadata) -> anyhow::Result<()> {
+    #[cfg(all(target_os = "linux", target_pointer_width = "64"))]
+    if let Ok(mut guard) = TELEMETRY_PEEK.lock() {
+        guard.0 = Some(metadata.clone());
+    }
+
     let metadata_string = serde_json::to_string(&metadata)?;
     let box_ptr = Box::into_raw(Box::new((metadata, metadata_string)));
     let old = METADATA.swap(box_ptr, SeqCst);
@@ -204,6 +215,12 @@ fn call_previous_panic_hook(panic_info: &PanicHookInfo<'_>) {
 /// ATOMICITY:
 ///     This function uses a swap on an atomic pointer.
 pub fn update_config(config: CrashtrackerConfiguration) -> anyhow::Result<()> {
+    // Snapshot the endpoint for telemetry before consuming `config`.
+    #[cfg(all(target_os = "linux", target_pointer_width = "64"))]
+    if let Ok(mut guard) = TELEMETRY_PEEK.lock() {
+        guard.1 = config.endpoint().clone();
+    }
+
     let config_string = serde_json::to_string(&config)?;
     let box_ptr = Box::into_raw(Box::new((config, config_string)));
     let old = CONFIG.swap(box_ptr, SeqCst);
@@ -371,36 +388,18 @@ fn handle_posix_signal_impl(
     Ok(())
 }
 
-/// Clone the current metadata out of global storage without consuming it.
-/// Returns `None` if metadata has not yet been set.
-///
-/// Not async-signal-safe
+/// Return a clone of the most recently stored metadata for telemetry use.
 #[cfg(all(target_os = "linux", target_pointer_width = "64"))]
 pub(crate) fn peek_metadata() -> Option<Metadata> {
-    let ptr = METADATA.load(Acquire);
-    if ptr.is_null() {
-        None
-    } else {
-        // SAFETY: non-null means it was created with Box::into_raw in update_metadata
-        // and has not been freed (free only happens on the next update_metadata call,
-        // which swaps the pointer first). We clone to avoid taking ownership.
-        Some(unsafe { &*ptr }.0.clone())
-    }
+    let guard = TELEMETRY_PEEK.lock().ok()?;
+    guard.0.clone()
 }
 
-/// Clone the endpoint out of global config without consuming it.
-/// Returns `None` if the config has not yet been set or has no endpoint.
-///
-/// Not async-signal-safe
+/// Return a clone of the most recently stored endpoint for telemetry use.
 #[cfg(all(target_os = "linux", target_pointer_width = "64"))]
 pub(crate) fn peek_endpoint() -> Option<libdd_common::Endpoint> {
-    let ptr = CONFIG.load(Acquire);
-    if ptr.is_null() {
-        None
-    } else {
-        // SAFETY: same reasoning as peek_metadata.
-        unsafe { &*ptr }.0.endpoint().clone()
-    }
+    let guard = TELEMETRY_PEEK.lock().ok()?;
+    guard.1.clone()
 }
 
 /// Atomically swaps the metadata pointer to null and returns the old raw pointer.

--- a/libdd-crashtracker/src/collector/sigaction_interceptor.rs
+++ b/libdd-crashtracker/src/collector/sigaction_interceptor.rs
@@ -6,14 +6,17 @@
 //!
 //! During crashtracker initialization, [`install_sigaction_hook`] patches
 //! the GOT entries for `sigaction` across all loaded libraries so that
-//! calls are routed through our hook
+//! calls are routed through our hook. When the application installs a
+//! real handler for a monitored signal, a telemetry warning is emitted.
 //!
 //! This module is gated on 64-bit Linux (`mod.rs`).
 
+use crate::crash_info::UnknownValue as _;
 use core::sync::atomic::{
     AtomicU64, AtomicUsize,
     Ordering::{Acquire, Relaxed, Release},
 };
+use libdd_telemetry::data::LogLevel;
 
 /// Bit N is set if signal number N is monitored. Supports signals 0–63.
 static MONITORED_SIGNALS: AtomicU64 = AtomicU64::new(0);
@@ -28,21 +31,80 @@ static ORIG_SIGACTION_FN: AtomicUsize = AtomicUsize::new(0);
 type SigactionFn =
     unsafe extern "C" fn(libc::c_int, *const libc::sigaction, *mut libc::sigaction) -> libc::c_int;
 
-/// Our replacement for `sigaction`, installed using GOT patching.
+/// Signal name lookup for logging. Returns the signal name
+/// or "unknown" for unknown signal numbers.
+fn signal_name(signum: libc::c_int) -> &'static str {
+    match signum {
+        libc::SIGABRT => "SIGABRT",
+        libc::SIGBUS => "SIGBUS",
+        libc::SIGFPE => "SIGFPE",
+        libc::SIGILL => "SIGILL",
+        libc::SIGSEGV => "SIGSEGV",
+        libc::SIGSYS => "SIGSYS",
+        libc::SIGTRAP => "SIGTRAP",
+        libc::SIGPIPE => "SIGPIPE",
+        _ => "unknown",
+    }
+}
+
+/// Fire and forget telemetry warning when an application installs a real
+/// handler for a signal monitored by the crashtracker.
 ///
-/// For signals monitored by the crashtracker, logs a warning. In all
-/// cases, forwards the call to the real `sigaction`.
+/// Uses the existing tokio runtime if one is active; otherwise spawns a
+/// dedicated thread that creates its own runtime. Either way, the call
+/// returns immediately so the application's `sigaction` call is not stalled.
+///
+/// Must not be called from a signal handler context
+fn emit_sigaction_telemetry(signum: libc::c_int) {
+    let name = signal_name(signum);
+    let message = format!(
+        "Application called sigaction for monitored signal {signum} ({name}), \
+         crashtracker signal protection may be compromised"
+    );
+    let tags = format!("collector_issue:sigaction_intercepted,signal:{name},is_crash_debug:true");
+
+    let metadata = super::crash_handler::peek_metadata()
+        .unwrap_or_else(crate::crash_info::Metadata::unknown_value);
+    let endpoint = super::crash_handler::peek_endpoint();
+
+    let task = async move {
+        if let Ok(uploader) = crate::crash_info::TelemetryCrashUploader::new(&metadata, &endpoint) {
+            let _ = uploader
+                .upload_general_log(message, tags, LogLevel::Warn)
+                .await;
+        }
+    };
+
+    // Check if we are in a runtime so we don't block the sigaction call
+    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        handle.spawn(task);
+    } else {
+        std::thread::spawn(move || {
+            if let Ok(rt) = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                rt.block_on(task);
+            }
+        });
+    }
+}
+
+/// Our replacement for `sigaction`, installed using GOT patching.
 unsafe extern "C" fn hook_sigaction(
     signum: libc::c_int,
     act: *const libc::sigaction,
     oldact: *mut libc::sigaction,
 ) -> libc::c_int {
-    // Check if this signal is one we monitor.
     if (0..64).contains(&signum)
         && !act.is_null()
         && MONITORED_SIGNALS.load(Relaxed) & (1u64 << signum) != 0
     {
-        INTERCEPTED_SIGNALS.fetch_or(1u64 << signum, Release);
+        // Only emit for real handlers (sa_sigaction > 1).
+        let handler_addr = unsafe { (*act).sa_sigaction } as *const () as usize;
+        if handler_addr > 1 {
+            emit_sigaction_telemetry(signum);
+        }
     }
 
     // Forward to the real sigaction.
@@ -51,11 +113,10 @@ unsafe extern "C" fn hook_sigaction(
         // SAFETY: `orig` was stored by `install_sigaction_hook` from a
         // successful `hook_symbol` call which resolved the real `sigaction`.
         let func: SigactionFn = unsafe { core::mem::transmute::<usize, SigactionFn>(orig) };
-        // SAFETY: forwarding the exact arguments from the caller.
         unsafe { func(signum, act, oldact) }
     } else {
-        // Fallback: should not happen, but dont crash
-        *libc::__errno_location() = libc::ENOSYS;
+        // Fallback: should not happen, but don't crash.
+        unsafe { *libc::__errno_location() = libc::ENOSYS };
         -1
     }
 }
@@ -95,7 +156,6 @@ mod tests {
 
     #[test]
     fn test_monitored_mask_building() {
-        // Reset state for test isolation.
         MONITORED_SIGNALS.store(0, Release);
 
         let signals = [libc::SIGSEGV, libc::SIGBUS, libc::SIGABRT];
@@ -118,7 +178,6 @@ mod tests {
     #[cfg_attr(miri, ignore)]
     #[test]
     fn test_install_sigaction_hook() {
-        // Reset state so the hook can be installed in this test.
         ORIG_SIGACTION_FN.store(0, Relaxed);
 
         install_sigaction_hook(&[libc::SIGSEGV, libc::SIGBUS]);
@@ -130,7 +189,6 @@ mod tests {
                  (static libc?), GOT hook not installed"
             );
         } else {
-            // Verify the monitored mask was set correctly.
             let mask = MONITORED_SIGNALS.load(Acquire);
             assert!(mask & (1u64 << libc::SIGSEGV) != 0);
             assert!(mask & (1u64 << libc::SIGBUS) != 0);

--- a/libdd-crashtracker/src/collector/sigaction_interceptor.rs
+++ b/libdd-crashtracker/src/collector/sigaction_interceptor.rs
@@ -21,9 +21,6 @@ use libdd_telemetry::data::LogLevel;
 /// Bit N is set if signal number N is monitored. Supports signals 0–63.
 static MONITORED_SIGNALS: AtomicU64 = AtomicU64::new(0);
 
-/// Bit N is set when the hook has fired for signal N
-pub(crate) static INTERCEPTED_SIGNALS: AtomicU64 = AtomicU64::new(0);
-
 /// Resolved address of the original `sigaction`, set once during
 /// [`install_sigaction_hook`].
 static ORIG_SIGACTION_FN: AtomicUsize = AtomicUsize::new(0);
@@ -75,18 +72,20 @@ fn emit_sigaction_telemetry(signum: libc::c_int) {
         }
     };
 
-    // Check if we are in a runtime so we don't block the sigaction call
     if let Ok(handle) = tokio::runtime::Handle::try_current() {
         handle.spawn(task);
     } else {
-        std::thread::spawn(move || {
-            if let Ok(rt) = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-            {
-                rt.block_on(task);
-            }
-        });
+        // No runtime active. Swallow errors here because we don't want to panic.
+        let _ = std::thread::Builder::new()
+            .name("dd-sigaction-telemetry".into())
+            .spawn(move || {
+                if let Ok(rt) = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    rt.block_on(task);
+                }
+            });
     }
 }
 
@@ -96,20 +95,9 @@ unsafe extern "C" fn hook_sigaction(
     act: *const libc::sigaction,
     oldact: *mut libc::sigaction,
 ) -> libc::c_int {
-    if (0..64).contains(&signum)
-        && !act.is_null()
-        && MONITORED_SIGNALS.load(Relaxed) & (1u64 << signum) != 0
-    {
-        // Only emit for real handlers (sa_sigaction > 1).
-        let handler_addr = unsafe { (*act).sa_sigaction } as *const () as usize;
-        if handler_addr > 1 {
-            emit_sigaction_telemetry(signum);
-        }
-    }
-
-    // Forward to the real sigaction.
+    // Forward to the real sigaction first
     let orig = ORIG_SIGACTION_FN.load(Acquire);
-    if orig != 0 {
+    let ret = if orig != 0 {
         // SAFETY: `orig` was stored by `install_sigaction_hook` from a
         // successful `hook_symbol` call which resolved the real `sigaction`.
         let func: SigactionFn = unsafe { core::mem::transmute::<usize, SigactionFn>(orig) };
@@ -118,7 +106,20 @@ unsafe extern "C" fn hook_sigaction(
         // Fallback: should not happen, but don't crash.
         unsafe { *libc::__errno_location() = libc::ENOSYS };
         -1
+    };
+
+    if ret == 0
+        && (0..64).contains(&signum)
+        && !act.is_null()
+        && MONITORED_SIGNALS.load(Relaxed) & (1u64 << signum) != 0
+    {
+        let handler_addr = unsafe { (*act).sa_sigaction } as *const () as usize;
+        if handler_addr > 1 {
+            emit_sigaction_telemetry(signum);
+        }
     }
+
+    ret
 }
 
 /// Install the `sigaction` GOT hook across all currently loaded libraries.


### PR DESCRIPTION
[PROF-15907](https://datadoghq.atlassian.net/jira/software/c/projects/PROF/boards/11?selectedIssue=PROF-15907)
# What does this PR do?

This PR adds a fire-and-forget telemetry emission (`collector_issue:sigaction_intercepted`) to record instances where our signal handler is overwritten. We want telemetry on how common this is. We dispatches onto an existing tokio runtime if one is active, or onto a dedicated background thread with its own current-thread runtime otherwise, so the application's sigaction call is never stalled by a network write. `Metadata` and `Endpoint` are read from the crashtracker's global config with non-consuming atomic loads (`peek_metadata`/`peek_endpoint`) and are safe to call from the application thread. 

I also added a bin_test that goes thorugh the full path end-to-end by calling `sigaction` in `post()` and asserting the telemetry file contains the warning tag before the crash fires.

# Motivation

We suspect there are cases where our signal handler is overwritten, which causes us to miss out on crash telemetry

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.


[PROF-15907]: https://datadoghq.atlassian.net/browse/PROF-15907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ