### PR TITLE
fix(shared-runtime): allow disabling worker fork restart

### DIFF
--- a/libdd-shared-runtime/src/shared_runtime/fork_safe.rs
+++ b/libdd-shared-runtime/src/shared_runtime/fork_safe.rs
@@ -432,6 +432,30 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_set_fork_restart_drops_worker_without_shutdown() {
+        let shared_runtime = ForkSafeRuntime::new().unwrap();
+        let (worker, receiver) = make_test_worker();
+
+        let handle = shared_runtime.spawn_worker(worker, true).unwrap();
+
+        receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("worker did not run");
+
+        shared_runtime.before_fork();
+        while receiver.try_recv().is_ok() {}
+
+        handle.set_fork_restart(false).unwrap();
+        assert!(shared_runtime.after_fork_child().is_ok());
+
+        assert_eq!(shared_runtime.workers.lock_or_panic().len(), 0);
+        assert!(
+            receiver.recv_timeout(Duration::from_millis(200)).is_err(),
+            "worker should be dropped without running or shutting down in the fork child"
+        );
+    }
+
     /// A single `PausableWorker` in `InvalidState` must
     /// not abort the whole restart loop in `after_fork_parent`
     #[test]

--- a/libdd-shared-runtime/src/shared_runtime/mod.rs
+++ b/libdd-shared-runtime/src/shared_runtime/mod.rs
@@ -212,6 +212,26 @@ impl From<PausableWorkerError> for WorkerHandleError {
 }
 
 impl WorkerHandle {
+    /// Configure whether this worker restarts in a fork child.
+    ///
+    /// When disabled, the next [`ForkSafeRuntime::after_fork_child`] call drops the worker without
+    /// running its shutdown logic. Language runtimes can disable restart in a managed before-fork
+    /// hook, restore it in the parent hook, and replace the inherited worker in the child.
+    ///
+    /// # Errors
+    /// Returns an error if the worker has already been stopped or dropped.
+    pub fn set_fork_restart(&self, restart_on_fork: bool) -> Result<(), WorkerHandleError> {
+        let mut workers_lock = self.workers.lock_or_panic();
+        let Some(entry) = workers_lock
+            .iter_mut()
+            .find(|entry| entry.id == self.worker_id)
+        else {
+            return Err(WorkerHandleError::AlreadyStopped);
+        };
+        entry.restart_on_fork = restart_on_fork;
+        Ok(())
+    }
+
     /// Stop the worker and execute the shutdown logic.
     ///
     /// # Errors


### PR DESCRIPTION
# What does this PR do?

Adds `WorkerHandle::set_fork_restart(bool)`, allowing integrations to control whether an existing worker restarts in a fork child without stopping it.

# Motivation

Python-managed and native forks require different worker behavior. Before a Python fork, ddtrace must configure the telemetry worker so the child drops its inherited copy without running shutdown logic. The parent then restores normal native-fork restart behavior.

Changing this policy before the fork avoids locking or mutating the inherited worker registry in the child.

# Additional Notes

The [dependent ddtrace-py change](https://github.com/DataDog/dd-trace-py/pull/20066) requires this API and a libdatadog release containing it.

# How to test the change?

- `cargo fmt --all -- --check`
- `cargo check -p libdd-shared-runtime --all-targets --all-features`
- Tests cover dropping a worker without shutdown when child restart is disabled.