### PR TITLE
fix!: benchmark was doing many samples for deterministic heap usage

### DIFF
--- a/benchmark/select_bench_packages.sh
+++ b/benchmark/select_bench_packages.sh
@@ -21,17 +21,22 @@ set -eu
 node_index="${1:-1}"
 node_total="${2:-1}"
 
-# Approximate per-crate benchmark cost (~minutes of candidate wall-time) used to balance the shards.
-# Measured 2026-07-02 from a full run (all 11 benchmarked crates); only relative magnitudes matter.
-# The seven crates that fall through to the default are all <1 min (normalization ~0.7, profiling
-# ~0.6, ffe ~0.4, ipc ~0.2, trace-stats ~0.1, crashtracker ~0.1, trace-obfuscation ~1.4), so they
-# act as interchangeable filler. Retune as benchmarks are added/removed; unknown crates default to 1.
+# Approximate per-crate benchmark cost (~30 s of criterion time per pass) used to balance the shards.
+# Measured 2026-09-04 from main pipeline 8134078c4, with the allocation benchmarks discounted to
+# their cost once their sampling settings are no longer overridden. The three crates that fall
+# through to the default are ~1 unit (ipc ~35 s, trace-normalization ~30 s, trace-stats ~25 s).
+# Retune as benchmarks are added/removed; unknown crates default to 1.
 crate_weight() {
   case "$1" in
-    libdd-trace-utils) echo 9 ;;
+    libdd-trace-utils) echo 15 ;;
+    libdd-profiling-heap-allocator) echo 7 ;;
     libdd-sampling) echo 6 ;;
-    libdd-ddsketch) echo 2 ;;
-    libdd-data-pipeline) echo 2 ;;
+    libdd-ddsketch) echo 5 ;;
+    libdd-data-pipeline) echo 5 ;;
+    libdd-ffe-test-suite) echo 4 ;;
+    libdd-crashtracker) echo 2 ;;
+    libdd-profiling) echo 2 ;;
+    libdd-trace-obfuscation) echo 2 ;;
     *) echo 1 ;;
   esac
 }

--- a/libdd-common/src/bench_utils.rs
+++ b/libdd-common/src/bench_utils.rs
@@ -3,7 +3,7 @@
 
 //! Scaffolding for memory usage benchmarks.
 //!
-//! See the `ReportingAllocator` type and `memory_allocated_measurement` for usage.
+//! See the `ReportingAllocator` type and `memory_allocated_criterion` for usage.
 
 #![allow(missing_docs)]
 
@@ -22,11 +22,17 @@ impl MeasurementName for criterion::measurement::WallTime {
     }
 }
 
-pub fn memory_allocated_measurement(
+/// `Criterion` for the allocation benchmarks. Sampling is deliberately small: allocation is
+/// deterministic, so extra samples cannot refine a constant.
+///
+/// Not usable as `criterion_group!`'s `config =` -- that macro appends `.configure_from_args()`,
+/// which would let command-line flags replace the settings below.
+pub fn memory_allocated_criterion(
     global_alloc: &'static ReportingAllocator<System>,
 ) -> Criterion<AllocatedBytesMeasurement<System>> {
     Criterion::default()
         .with_measurement(AllocatedBytesMeasurement(Cell::new(false), global_alloc))
+        .configure_from_args()
         .measurement_time(Duration::from_millis(1))
         .warm_up_time(Duration::from_millis(1))
         .without_plots()

--- a/libdd-sampling/benches/glob_matcher_bench.rs
+++ b/libdd-sampling/benches/glob_matcher_bench.rs
@@ -9,7 +9,7 @@ use std::hint::black_box;
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use libdd_common::bench_utils::{
-    memory_allocated_measurement, AllocatedBytesMeasurement, ReportingAllocator,
+    memory_allocated_criterion, AllocatedBytesMeasurement, ReportingAllocator,
 };
 use libdd_sampling::glob_matcher::GlobMatcher;
 
@@ -122,9 +122,10 @@ fn bench_allocs(c: &mut Criterion<AllocatedBytesMeasurement<System>>) {
 }
 
 criterion_group!(benches, bench_wall_time);
-criterion_group!(
-    name = alloc_benches;
-    config = memory_allocated_measurement(&GLOBAL);
-    targets = bench_allocs
-);
+
+// Not `criterion_group!`: its `config =` would be overridden by the command-line flags.
+fn alloc_benches() {
+    bench_allocs(&mut memory_allocated_criterion(&GLOBAL));
+}
+
 criterion_main!(alloc_benches, benches);

--- a/libdd-sampling/benches/sampling_bench.rs
+++ b/libdd-sampling/benches/sampling_bench.rs
@@ -6,7 +6,7 @@ use std::hint::black_box;
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use libdd_common::bench_utils::{
-    memory_allocated_measurement, AllocatedBytesMeasurement, ReportingAllocator,
+    memory_allocated_criterion, AllocatedBytesMeasurement, ReportingAllocator,
 };
 use libdd_sampling::{v04_span::V04SamplingData, DatadogSampler, SamplingRule};
 use libdd_trace_utils::span::{v04::Span, SliceData};
@@ -439,9 +439,10 @@ fn criterion_benchmark_allocs(c: &mut Criterion<AllocatedBytesMeasurement<System
 }
 
 criterion_group!(benches, criterion_benchmark);
-criterion_group!(
-    name = alloc_benches;
-    config = memory_allocated_measurement(&GLOBAL);
-    targets = criterion_benchmark_allocs
-);
+
+// Not `criterion_group!`: its `config =` would be overridden by the command-line flags.
+fn alloc_benches() {
+    criterion_benchmark_allocs(&mut memory_allocated_criterion(&GLOBAL));
+}
+
 criterion_main!(alloc_benches, benches);

--- a/libdd-trace-utils/benches/deserialization.rs
+++ b/libdd-trace-utils/benches/deserialization.rs
@@ -4,7 +4,7 @@
 use std::alloc::System;
 
 use criterion::{black_box, criterion_group, Criterion};
-use libdd_common::bench_utils::{memory_allocated_measurement, AllocatedBytesMeasurement};
+use libdd_common::bench_utils::{memory_allocated_criterion, AllocatedBytesMeasurement};
 use libdd_trace_utils::msgpack_decoder;
 use libdd_trace_utils::tracer_payload::{decode_to_trace_chunks, TraceEncoding};
 use serde_json::{json, Value};
@@ -147,8 +147,9 @@ criterion_group!(
     deserialize_msgpack_to_internal,
     deserialize_msgpack_to_slice
 );
-criterion_group!(
-    name = deserialize_alloc_benches;
-    config = memory_allocated_measurement(&super::GLOBAL);
-    targets = deserialize_msgpack_to_internal_allocs, deserialize_msgpack_to_slice_allocs
-);
+// Not `criterion_group!`: its `config =` would be overridden by the command-line flags.
+pub fn deserialize_alloc_benches() {
+    let mut criterion = memory_allocated_criterion(&super::GLOBAL);
+    deserialize_msgpack_to_internal_allocs(&mut criterion);
+    deserialize_msgpack_to_slice_allocs(&mut criterion);
+}

--- a/libdd-trace-utils/benches/deserialization_v05.rs
+++ b/libdd-trace-utils/benches/deserialization_v05.rs
@@ -20,7 +20,7 @@
 use std::alloc::System;
 
 use criterion::{black_box, criterion_group, BenchmarkId, Criterion, Throughput};
-use libdd_common::bench_utils::{memory_allocated_measurement, AllocatedBytesMeasurement};
+use libdd_common::bench_utils::{memory_allocated_criterion, AllocatedBytesMeasurement};
 use libdd_tinybytes::BytesString;
 use libdd_trace_utils::msgpack_decoder;
 use libdd_trace_utils::span::v04::SpanBytes;
@@ -218,8 +218,7 @@ fn deserialize_msgpack_v05_allocs(c: &mut Criterion<AllocatedBytesMeasurement<Sy
 }
 
 criterion_group!(deserialize_v05_benches, deserialize_msgpack_v05);
-criterion_group!(
-    name = deserialize_v05_alloc_benches;
-    config = memory_allocated_measurement(&super::GLOBAL);
-    targets = deserialize_msgpack_v05_allocs
-);
+// Not `criterion_group!`: its `config =` would be overridden by the command-line flags.
+pub fn deserialize_v05_alloc_benches() {
+    deserialize_msgpack_v05_allocs(&mut memory_allocated_criterion(&super::GLOBAL));
+}


### PR DESCRIPTION
# What does this PR do?

Make a deterministic benchmark do less samples.

# Motivation

Time it takes for this benchmark to complete (about 80s), when you have the deterministic results in 2s.

# Additional Notes

It was because the args overrode the inline config by how the bench was setup.

# How to test the change?

pipeline logs