### PR TITLE
fix(build): build script change detection

### DIFF
--- a/libdd-ffe-ffi/build.rs
+++ b/libdd-ffe-ffi/build.rs
@@ -5,7 +5,7 @@ extern crate build_common;
 use build_common::generate_and_configure_header;
 
 fn main() {
-    println!("cargo:rerun-if-changed=src/*");
+    println!("cargo:rerun-if-changed=src");
     println!("cargo:rerun-if-changed=cbindgen.toml");
     println!("cargo:rerun-if-changed=build.rs");
     let header_name = "ffe.h";

--- a/libdd-profiling-heap-gotter-ffi/build.rs
+++ b/libdd-profiling-heap-gotter-ffi/build.rs
@@ -9,7 +9,7 @@ extern crate build_common;
 use build_common::generate_and_configure_header;
 
 fn main() {
-    println!("cargo:rerun-if-changed=src/*");
+    println!("cargo:rerun-if-changed=src");
     println!("cargo:rerun-if-changed=cbindgen.toml");
     println!("cargo:rerun-if-changed=build.rs");
     generate_and_configure_header("heap_gotter.h");

--- a/libdd-trace-protobuf/build.rs
+++ b/libdd-trace-protobuf/build.rs
@@ -10,6 +10,7 @@ use {
 
 // to re-generate protobuf structs, run cargo build --features generate-protobuf
 fn main() -> Result<()> {
+    println!("cargo:rerun-if-changed=build.rs");
     #[cfg(feature = "generate-protobuf")]
     {
         // protoc is required to compile proto files. This uses protobuf_src to compile protoc
@@ -18,10 +19,6 @@ fn main() -> Result<()> {
 
         // compiles the .proto files into rust structs
         generate_protobuf();
-    }
-    #[cfg(not(feature = "generate-protobuf"))]
-    {
-        println!("cargo:rerun-if-changed=build.rs");
     }
 
     Ok(())
@@ -354,6 +351,7 @@ fn generate_protobuf() {
 
     config.include_file("_includes.rs");
 
+    println!("cargo:rerun-if-changed=src/pb");
     config
         .compile_protos(
             &[


### PR DESCRIPTION
# What does this PR do?

Fix incorrect change detection directives in build scripts

# Motivation

When running build, tests, clippy etc... some crates are systematically rebuilt when they don't need to be.

This is because we are misusung change directives in a couple locations:

* Wildcard don't work. specifying a directory will already recusrsively check files for changes (since 1.50 https://github.com/rust-lang/cargo/pull/8973)
* Missing directives in the trace-protobuf crate meant it always was rebuilt if all features were enabled

