### PR TITLE
chore(ci): create crashtracking reviewers pack

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,7 +20,7 @@ CLAUDE.md                            @DataDog/apm-common-components-core
 .gitlab/fuzz.yml                     @DataDog/chaos-engineering
 .gitlab/impacted-crates.yml          @DataDog/apm-common-components-core
 benchmark/                           @DataDog/apm-common-components-core
-bin_tests/                           @DataDog/libdatadog-profiling
+bin_tests/                           @DataDog/libdatadog-profiling @DataDog/libdatadog-crashtracking-reviewers
 build-common/                        @DataDog/apm-common-components-core
 builder                              @DataDog/apm-common-components-core
 Cargo.*                              @DataDog/libdatadog
@@ -46,7 +46,7 @@ libdd-agent-client                   @DataDog/apm-common-components-core
 libdd-alloc/                         @DataDog/libdatadog-profiling
 libdd-capabilities*/                 @DataDog/apm-common-components-core
 libdd-common*/                       @DataDog/libdatadog
-libdd-crashtracker*/                 @DataDog/libdatadog-profiling
+libdd-crashtracker*/                 @DataDog/libdatadog-profiling @DataDog/libdatadog-crashtracking-reviewers
 libdd-data-pipeline*/                @DataDog/apm-common-components-core
 libdd-ddsketch*/                     @DataDog/libdatadog-apm @DataDog/apm-common-components-core
 libdd-dogstatsd-client               @DataDog/apm-common-components-core


### PR DESCRIPTION
# What does this PR do?

Add [libdatadog-crashtracking-reviewers](https://mosaic.us1.ddbuild.io/packs/libdatadog-crashtracking-reviewers), which consists of libdatadog-profiling and apm-common-components-core to be bin_tests (crashtracking integration tests) and general crashtracking reviewers

# Motivation

We are often blocked by non-crashtracker logic specific issues (bin tests, infra issues), that require code changes in what was previously owned by libdatadog-profiling. Creating this pack which includes apm common components ownership will improve unblocking and the velocity of this repository 

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
