### PR TITLE
chore: move all remaining external deps to workspace-level dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide 0.8.8",
- "object 0.36.5",
+ "object",
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
@@ -465,7 +465,6 @@ dependencies = [
  "anyhow",
  "current_platform",
  "errno",
- "hex",
  "libc",
  "libdd-common",
  "libdd-crashtracker",
@@ -475,7 +474,6 @@ dependencies = [
  "os_info",
  "serde_json",
  "serial_test",
- "strum",
  "tempfile",
 ]
 
@@ -812,7 +810,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "975982cdb7ad6a142be15bdf84aea7ec6a9e5d4d797c004d43185b24cfe4e684"
 dependencies = [
  "clap",
- "heck 0.5.0",
+ "heck",
  "indexmap 2.12.1",
  "log",
  "proc-macro2",
@@ -952,7 +950,7 @@ version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -1583,21 +1581,11 @@ checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "duplicate"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a4be4cd710e92098de6ad258e6e7c24af11c29c5142f3c6f2a545652480ff8"
-dependencies = [
- "heck 0.4.1",
- "proc-macro-error",
-]
-
-[[package]]
-name = "duplicate"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e92f10a49176cbffacaedabfaa11d51db1ea0f80a83c26e1873b43cd1742c24"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "proc-macro2-diagnostics",
 ]
@@ -1635,7 +1623,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -1783,7 +1771,6 @@ checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
 dependencies = [
  "borrow-or-share",
  "ref-cast",
- "serde",
 ]
 
 [[package]]
@@ -2093,8 +2080,6 @@ version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -2156,12 +2141,6 @@ checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
  "http 1.1.0",
 ]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -2785,7 +2764,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.1.0",
- "thiserror 1.0.68",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -2841,7 +2820,7 @@ dependencies = [
  "serde",
  "static_assertions",
  "tempfile",
- "thiserror 1.0.68",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2898,7 +2877,7 @@ dependencies = [
  "symbolic-common",
  "symbolic-demangle",
  "tempfile",
- "thiserror 1.0.68",
+ "thiserror 2.0.17",
  "tokio",
  "uuid",
  "windows 0.59.0",
@@ -2933,7 +2912,7 @@ dependencies = [
  "bytes",
  "clap",
  "criterion",
- "duplicate 2.0.1",
+ "duplicate",
  "either",
  "futures",
  "getrandom 0.2.15",
@@ -2989,7 +2968,7 @@ dependencies = [
  "libdd-trace-obfuscation",
  "libdd-trace-utils",
  "serde_json",
- "thiserror 1.0.68",
+ "thiserror 2.0.17",
  "zstd",
 ]
 
@@ -3165,7 +3144,7 @@ dependencies = [
 name = "libdd-ipc-macros"
 version = "1.0.1"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -3281,7 +3260,7 @@ dependencies = [
  "anyhow",
  "elf",
  "libdd-otel-thread-ctx",
- "object 0.36.5",
+ "object",
 ]
 
 [[package]]
@@ -3310,7 +3289,7 @@ dependencies = [
  "cxx",
  "cxx-build",
  "futures",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "http 1.1.0",
  "http-body-util",
  "httparse",
@@ -3452,7 +3431,7 @@ dependencies = [
  "sha2",
  "strum",
  "strum_macros",
- "thiserror 1.0.68",
+ "thiserror 2.0.17",
  "time",
  "tokio",
  "tokio-util",
@@ -3507,7 +3486,7 @@ dependencies = [
  "bytes",
  "futures",
  "getrandom 0.2.15",
- "hashbrown 0.15.1",
+ "hashbrown 0.17.1",
  "http 1.1.0",
  "httpmock",
  "libc",
@@ -3567,7 +3546,7 @@ dependencies = [
  "anyhow",
  "arbitrary",
  "criterion",
- "duplicate 0.4.1",
+ "duplicate",
  "libdd-trace-protobuf",
  "rand 0.8.8",
 ]
@@ -3578,7 +3557,7 @@ version = "8.0.0"
 dependencies = [
  "anyhow",
  "criterion",
- "duplicate 0.4.1",
+ "duplicate",
  "fluent-uri",
  "libdd-common",
  "libdd-tinybytes",
@@ -3613,7 +3592,7 @@ dependencies = [
  "async-trait",
  "criterion",
  "futures",
- "hashbrown 0.15.1",
+ "hashbrown 0.17.1",
  "http 1.1.0",
  "httpmock",
  "libdd-capabilities",
@@ -4070,15 +4049,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nu-ansi-term"
-version = "0.50.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4265,22 +4235,13 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
-dependencies = [
- "flate2",
- "memchr",
- "ruzstd",
-]
-
-[[package]]
-name = "object"
 version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
+ "flate2",
  "memchr",
+ "ruzstd",
 ]
 
 [[package]]
@@ -4317,7 +4278,6 @@ dependencies = [
  "objc2",
  "objc2-foundation",
  "objc2-ui-kit",
- "serde",
  "windows-sys 0.61.2",
 ]
 
@@ -4656,7 +4616,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "itertools",
  "log",
  "multimap",
@@ -4799,7 +4759,7 @@ version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
@@ -5239,12 +5199,10 @@ dependencies = [
 
 [[package]]
 name = "ruzstd"
-version = "0.3.1"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a15e661f0f9dac21f3494fe5d23a6338c0ac116a2d22c2b63010acd89467ffe"
+checksum = "fad02996bfc73da3e301efe90b1837be9ed8f4a462b6ed410aa35d00381de89f"
 dependencies = [
- "byteorder",
- "thiserror 1.0.68",
  "twox-hash",
 ]
 
@@ -5543,8 +5501,6 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
 dependencies = [
- "futures",
- "log",
  "once_cell",
  "parking_lot",
  "scc",
@@ -5603,7 +5559,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 name = "sidecar_mockgen"
 version = "0.1.0"
 dependencies = [
- "object 0.31.1",
+ "object",
 ]
 
 [[package]]
@@ -5746,7 +5702,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -5958,7 +5914,6 @@ checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",
- "xattr",
 ]
 
 [[package]]
@@ -6444,17 +6399,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
- "nu-ansi-term",
  "once_cell",
  "regex-automata",
  "serde",
  "serde_json",
  "sharded-slab",
- "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
  "tracing-serde",
 ]
 
@@ -7340,17 +7292,6 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
-name = "xattr"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
-dependencies = [
- "libc",
- "linux-raw-sys 0.4.14",
- "rustix 0.38.39",
-]
 
 [[package]]
 name = "yansi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,26 +92,68 @@ authors = ["Datadog Inc. <info@datadoghq.com>"]
 # crate so that present and future crates opt into exactly what they use,
 # reducing unintentional bloat. Exceptions must be justified.
 allocator-api2 = { version = "0.2.21", default-features = false }
-arc-swap = { version = "1.7.1", default-features = false }
 anyhow = { version = "1.0", default-features = false }
+arbitrary = { version = "1.3", default-features = false }
+arc-swap = { version = "1.7.1", default-features = false }
+arrayref = { version = "0.3.7", default-features = false }
+assert_no_alloc = { version = "1.1.2", default-features = false }
+async-trait = { version = "0.1", default-features = false }
 base64 = { version = "0.22", default-features = false }
+bincode = { version = "1.3.3", default-features = false }
+bindgen = { version = "0.71", default-features = false }
+bitmaps = { version = "3.2.0", default-features = false }
+blazesym = { version = "=0.2.3", default-features = false }
 bolero = { version = "0.13.4", default-features = false }
+byteorder = { version = "1.5", default-features = false }
 bytes = { version = "1.11", default-features = false }
+cadence = { version = "1.3.0", default-features = false }
+cargo-platform = { version = "=0.1.7", default-features = false }
+cargo_metadata = { version = "0.18.1", default-features = false }
+cc = { version = "1.1.31", default-features = false }
 chrono = { version = "0.4.38", default-features = false }
 clap = { version = "4.3.21", default-features = false }
+cmake = { version = "0.1.50", default-features = false }
+colored = { version = "2", default-features = false }
+console-subscriber = { version = "0.5", default-features = false }
+const_format = { version = "0.2.34", default-features = false }
+constcat = { version = "0.4.1", default-features = false }
 # Some default features are necessary: without `cargo_bench_support` the
 # harness refuses to run under a plain `cargo bench`, and `plotters`/`rayon`
 # are required for report plots. All benches want them, and criterion is a
 # dev-dependency anyway, which doesn't impact release binary size.
 criterion = { version = "0.5.1", default-features = true }
+crossbeam-channel = { version = "0.5.15", default-features = false }
+crossbeam-queue = { version = "0.3.11", default-features = false }
+crossbeam-utils = { version = "0.8.21", default-features = false }
+current_platform = { version = "0.2.0", default-features = false }
+cxx = { version = "1.0", default-features = false }
 cxx-build = { version = "1.0", default-features = false }
+derive_more = { version = "2.0.0", default-features = false }
+duplicate = { version = "2.0.1", default-features = false }
+either = { version = "1.13.0", default-features = false }
 elf = { version = "0.7", default-features = false }
+env_logger = { version = "0.10", default-features = false }
+errno = { version = "0.3", default-features = false }
 fastrand = { version = "2", default-features = false }
+faststr = { version = "0.2.23", default-features = false }
 # flate2 without a backend feature is unusable (no compression backend at all).
 # `rust_backend` (pure Rust, no C dependency) is the baseline we want everywhere.
 flate2 = { version = "1.0", default-features = false, features = ["rust_backend"] }
+fluent-uri = { version = "0.4.1", default-features = false }
+function_name = { version = "0.3.0", default-features = false }
 futures = { version = "0.3", default-features = false }
+futures-channel = { version = "0.3", default-features = false }
+futures-core = { version = "0.3.0", default-features = false }
+futures-util = { version = "0.3.0", default-features = false }
+getrandom = { version = "0.2", default-features = false }
+glibc_version = { version = "0.1.2", default-features = false }
+goblin = { version = "0.9.3", default-features = false }
+h2 = { version = "0.4", default-features = false }
+hashbrown = { version = "0.17", default-features = false }
+heck = { version = "0.5", default-features = false }
+hex = { version = "0.4", default-features = false }
 http = { version = "1.1", default-features = false }
+http-body = { version = "1", default-features = false }
 http-body-util = { version = "0.1", default-features = false }
 # httpmock 0.8.0-alpha.1 does not compile without the `cookies` feature: its
 # own `readers.rs` calls `req.cookies()` unconditionally while that method is
@@ -119,39 +161,128 @@ http-body-util = { version = "0.1", default-features = false }
 httpmock = { version = "0.8.0-alpha.1", default-features = false, features = ["cookies"] }
 httparse = { version = "1.9", default-features = false }
 hyper = { version = "1.11", default-features = false }
+hyper-rustls = { version = "0.27.7", default-features = false }
 hyper-util = { version = "0.1.10", default-features = false }
+indexmap = { version = "2.11", default-features = false }
 io-lifetimes = { version = "1.0", default-features = false }
+itoa = { version = "1.0", default-features = false }
 # libc's only default feature is `std`, which is needed by virtually every
 # consumer (libc itself says that not using this feature to link libc in a
 # `no-std` environment is not the recommended way, and that this possibility
 # will be gone in future versions). We enable it by default for everyone.
 libc = { version = "0.2", default-features = true }
+libdd-libunwind-sys = { version = "1.0.3", default-features = false }
+log = { version = "0.4.21", default-features = false }
+lru = { version = "0.16.3", default-features = false }
+manual_future = { version = "0.1.1", default-features = false }
+maplit = { version = "1.0", default-features = false }
+md5 = { version = "0.7.0", default-features = false }
+memfd = { version = "0.6", default-features = false }
+memory-stats = { version = "1.2.0", default-features = false }
+microseh = { version = "0.1.1", default-features = false }
 mime = { version = "0.3.16", default-features = false }
+multer = { version = "3.1", default-features = false }
+nix = { version = "0.29", default-features = false }
+num-derive = { version = "0.4.2", default-features = false }
+num-traits = { version = "0.2.19", default-features = false }
+object = { version = "0.36", default-features = false }
 once_cell = { version = "1.18", default-features = false }
+os_info = { version = "3.14.0", default-features = false }
+page_size = { version = "0.6.0", default-features = false }
+parking_lot = { version = "0.12", default-features = false }
+paste = { version = "1", default-features = false }
 percent-encoding = { version = "2.1", default-features = false }
+pico-args = { version = "0.5.0", default-features = false }
+pin-project = { version = "1", default-features = false }
+portable-atomic = { version = "1.6.0", default-features = false }
+prctl = { version = "1.0.0", default-features = false }
+pretty_assertions = { version = "1.3", default-features = false }
+priority-queue = { version = "2.1.1", default-features = false }
+proc-macro2 = { version = "1", default-features = false }
+proptest = { version = "1", default-features = false }
+prost = { version = "0.14.1", default-features = false }
 prost-build = { version = "0.14.1", default-features = false }
 protoc-bin-vendored = { version = "3.0.0", default-features = false }
+pyo3 = { version = "0.28", default-features = false }
+quick-xml = { version = "0.37", default-features = false }
+quote = { version = "1", default-features = false }
+rand = { version = "0.8", default-features = false }
+rand_chacha = { version = "0.3.1", default-features = false }
 regex = { version = "1.5", default-features = false }
+regex-lite = { version = "0.1", default-features = false }
 reqwest = { version = "0.13", default-features = false }
+ring = { version = "0.17", default-features = false }
+rlimit = { version = "0.9", default-features = false }
+rmp = { version = "0.8.14", default-features = false }
+rmp-serde = { version = "1.3.0", default-features = false }
+rmpv = { version = "1.3.0", default-features = false }
+rustc-hash = { version = "2.1.1", default-features = false }
 rustls = { version = "0.23", default-features = false }
+rustls-native-certs = { version = ">=0.8.1, <0.8.3", default-features = false }
 rustls-platform-verifier = { version = "0.6", default-features = false }
+rustls-webpki = { version = ">=0.103.13", default-features = false }
+schemars = { version = "0.8.21", default-features = false }
+semver = { version = "1.0", default-features = false }
+sendfd = { version = "0.4", default-features = false }
 serde = { version = "1.0", default-features = false }
+serde-bool = { version = "0.1.3", default-features = false }
+serde-transcode = { version = "1.1", default-features = false }
+serde_bytes = { version = "0.11.9", default-features = false }
 # serde_json requires at least one of `std` or `alloc`. We set `alloc` here as
 # the minimal working baseline, and to avoid repeating alloc everywhere.
 # Enabling `std` on top of it is fine.
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
+serde_with = { version = "3.11.0", default-features = false }
+serde_yaml = { version = "0.9.34", default-features = false }
+serial_test = { version = "3.2", default-features = false }
 sha2 = { version = "0.10", default-features = false }
+simd-json = { version = "=0.14", default-features = false }
+smallvec = { version = "1.13.2", default-features = false }
+static_assertions = { version = "1.1.0", default-features = false }
+strum = { version = "0.26.2", default-features = false }
+strum_macros = { version = "0.26", default-features = false }
+symbolic-common = { version = "12.8.0", default-features = false }
+symbolic-demangle = { version = "12.8.0", default-features = false }
 syn = { version = "^2", default-features = false }
+sys-info = { version = "0.9.0", default-features = false }
+sysinfo = { version = "0.29.8", default-features = false }
+tar = { version = "0.4.45", default-features = false }
+target-triple = { version = "0.1.4", default-features = false }
 # Without `getrandom`, tempfile seeds its temp-name RNG weakly and its own docs
 # flag that an attacker may then be able to predict the file names. We enable
 # it by default for security reasons.
 tempfile = { version = "3.13", default-features = false, features = [
     "getrandom",
 ] }
-tokio = { version = "1.36", default-features = false }
+test-case = { version = "2.2", default-features = false }
+thin-vec = { version = "0.2", default-features = false }
+thiserror = { version = "2.0.3", default-features = false }
+thread_local = { version = "1.1", default-features = false }
+time = { version = "0.3", default-features = false }
+tokio = { version = "1.49", default-features = false }
+tokio-rustls = { version = "0.26", default-features = false }
+tokio-util = { version = "0.7.11", default-features = false }
+toml = { version = "0.8.19", default-features = false }
+tonic = { version = "0.14", default-features = false }
+tower-service = { version = "0.3", default-features = false }
 tracing = { version = "0.1", default-features = false }
+tracing-appender = { version = "0.2.3", default-features = false }
+tracing-log = { version = "0.2.0", default-features = false }
+tracing-subscriber = { version = "0.3.22", default-features = false }
+tuf = { package = "libdd-tuf", version = "0.3.1", default-features = false }
+url = { version = "2.5.0", default-features = false }
+urlencoding = { version = "2.1.3", default-features = false }
 uuid = { version = "1.7.0", default-features = false }
+wait-timeout = { version = "0.2", default-features = false }
+walkdir = { version = "2.4", default-features = false }
+wasm-bindgen-futures = { version = "0.4", default-features = false }
+wasm-bindgen-test = { version = "=0.3.50", default-features = false }
+web-time = { version = "1", default-features = false }
+winver = { version = "1.0.0", default-features = false }
+zip = { version = "4.0.0", default-features = false }
+zrip = { version = "=0.6.0", default-features = false }
 zstd = { version = "0.13", default-features = false }
+zwohash = { version = "0.1.2", default-features = false }
 
 [profile.dev]
 debug = 2 # full debug info

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -174,7 +174,6 @@ hdrhistogram,https://github.com/HdrHistogram/HdrHistogram_rust,MIT OR Apache-2.0
 headers,https://github.com/hyperium/headers,MIT,Sean McArthur <sean@seanmonstar.com>
 headers-core,https://github.com/hyperium/headers,MIT,Sean McArthur <sean@seanmonstar.com>
 heck,https://github.com/withoutboats/heck,MIT OR Apache-2.0,The heck Authors
-heck,https://github.com/withoutboats/heck,MIT OR Apache-2.0,Without Boats <woboats@gmail.com>
 hermit-abi,https://github.com/hermit-os/hermit-rs,MIT OR Apache-2.0,Stefan Lankes
 hex,https://github.com/KokaKiwi/rust-hex,MIT OR Apache-2.0,KokaKiwi <kokakiwi@kokakiwi.net>
 hickory-proto,https://github.com/hickory-dns/hickory-dns,MIT OR Apache-2.0,The contributors to Hickory DNS
@@ -257,7 +256,6 @@ multimap,https://github.com/havarnov/multimap,MIT OR Apache-2.0,Håvar Nøvik <h
 nix,https://github.com/nix-rust/nix,MIT,The nix-rust Project Developers
 nom,https://github.com/Geal/nom,MIT,contact@geoffroycouprie.com
 ntapi,https://github.com/MSxDOS/ntapi,Apache-2.0 OR MIT,MSxDOS <melcodos@gmail.com>
-nu-ansi-term,https://github.com/nushell/nu-ansi-term,MIT,"ogham@bsago.me, Ryan Scheel (Havvy) <ryan.havvy@gmail.com>, Josh Triplett <josh@joshtriplett.org>, The Nushell Project Developers"
 num-conv,https://github.com/jhpratt/num-conv,MIT OR Apache-2.0,Jacob Pratt <jacob@jhpratt.dev>
 num-derive,https://github.com/rust-num/num-derive,MIT OR Apache-2.0,The Rust Project Developers
 num-traits,https://github.com/rust-num/num-traits,MIT OR Apache-2.0,The Rust Project Developers
@@ -537,7 +535,6 @@ winver,https://github.com/rhysd/winver,MIT,rhysd <lin90162@yahoo.co.jp>
 wit-bindgen-rt,https://github.com/bytecodealliance/wit-bindgen,Apache-2.0 WITH LLVM-exception OR Apache-2.0 OR MIT,The wit-bindgen-rt Authors
 write16,https://github.com/hsivonen/write16,Apache-2.0 OR MIT,The write16 Authors
 writeable,https://github.com/unicode-org/icu4x,Unicode-3.0,The ICU4X Project Developers
-xattr,https://github.com/Stebalien/xattr,MIT OR Apache-2.0,Steven Allen <steven@stebalien.com>
 yansi,https://github.com/SergioBenitez/yansi,MIT OR Apache-2.0,Sergio Benitez <sb@sergio.bz>
 yoke,https://github.com/unicode-org/icu4x,Unicode-3.0,Manish Goregaokar <manishsmail@gmail.com>
 yoke-derive,https://github.com/unicode-org/icu4x,Unicode-3.0,Manish Goregaokar <manishsmail@gmail.com>

--- a/bin_tests/Cargo.toml
+++ b/bin_tests/Cargo.toml
@@ -12,22 +12,20 @@ build = "build.rs"
 
 [dependencies]
 once_cell = { workspace = true, features = ["std"] }
-anyhow = "1.0"
-current_platform = "0.2.0"
+anyhow = { workspace = true, default-features = true }
+current_platform.workspace = true
 libdd-profiling = { path = "../libdd-profiling" }
 libdd-crashtracker = { path = "../libdd-crashtracker" }
 libdd-common = { path = "../libdd-common" }
 tempfile.workspace = true
 serde_json.workspace = true
-strum = { version = "0.26.2", features = ["derive"] }
 libc.workspace = true
-errno = "0.3"
-nix = { version = "0.29", features = ["signal", "socket"] }
-hex = "0.4"
-os_info = "3.14.0"
+errno = { workspace = true, default-features = true }
+nix = { workspace = true, features = ["signal", "socket"] }
+os_info = { workspace = true, default-features = false }
 
 [dev-dependencies]
-serial_test = "3.2"
+serial_test = { workspace = true, default-features = false }
 
 [features]
 regex-lite = ["libdd-common/regex-lite"]

--- a/bin_tests/Cargo.toml
+++ b/bin_tests/Cargo.toml
@@ -22,10 +22,10 @@ serde_json.workspace = true
 libc.workspace = true
 errno = { workspace = true, default-features = true }
 nix = { workspace = true, features = ["signal", "socket"] }
-os_info = { workspace = true, default-features = false }
+os_info.workspace = true
 
 [dev-dependencies]
-serial_test = { workspace = true, default-features = false }
+serial_test.workspace = true
 
 [features]
 regex-lite = ["libdd-common/regex-lite"]

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -53,7 +53,7 @@ pico-args.workspace = true
 # Only reads/writes tar archives; no extended-attribute handling needed.
 tar.workspace = true
 tools = { path = "../tools" }
-toml = { workspace = true, default-features = false, features = ["parse"] }
+toml = { workspace = true, features = ["parse"] }
 serde.workspace = true
 libdd-common = { path = "../libdd-common", default-features = false }
 

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -48,11 +48,12 @@ doctest = false
 [dependencies]
 anyhow.workspace = true
 build_common = { path = "../build-common", features = ["cbindgen"] }
-cmake = "0.1.50"
-pico-args = "0.5.0"
-tar = "0.4.45"
+cmake.workspace = true
+pico-args.workspace = true
+# Only reads/writes tar archives; no extended-attribute handling needed.
+tar.workspace = true
 tools = { path = "../tools" }
-toml = "0.8.19"
+toml = { workspace = true, default-features = false, features = ["parse"] }
 serde.workspace = true
 libdd-common = { path = "../libdd-common", default-features = false }
 

--- a/datadog-profiling-replayer/Cargo.toml
+++ b/datadog-profiling-replayer/Cargo.toml
@@ -13,8 +13,8 @@ anyhow.workspace = true
 clap = { workspace = true, default-features = true, features = ["cargo", "derive"] }
 libdd-profiling = { path = "../libdd-profiling" }
 libdd-profiling-protobuf = { path = "../libdd-profiling-protobuf", features = ["prost_impls"] }
-prost = "0.14.1"
-sysinfo = { version = "0.29.8", default-features = false }
+prost = { workspace = true, default-features = false, features = ["std"] }
+sysinfo.workspace = true
 
 [[bin]]
 name = "datadog-profiling-replayer"

--- a/datadog-profiling-replayer/Cargo.toml
+++ b/datadog-profiling-replayer/Cargo.toml
@@ -13,7 +13,7 @@ anyhow.workspace = true
 clap = { workspace = true, default-features = true, features = ["cargo", "derive"] }
 libdd-profiling = { path = "../libdd-profiling" }
 libdd-profiling-protobuf = { path = "../libdd-profiling-protobuf", features = ["prost_impls"] }
-prost = { workspace = true, default-features = false, features = ["std"] }
+prost = { workspace = true, features = ["std"] }
 sysinfo.workspace = true
 
 [[bin]]

--- a/datadog-sidecar-ffi/Cargo.toml
+++ b/datadog-sidecar-ffi/Cargo.toml
@@ -23,10 +23,10 @@ libdd-remote-config = { path = "../libdd-remote-config" }
 libdd-live-debugger = { path = "../libdd-live-debugger" }
 libdd-dogstatsd-client = { path = "../libdd-dogstatsd-client" }
 libdd-tinybytes = { path = "../libdd-tinybytes", features = ["bytes_string"] }
-paste = "1"
+paste.workspace = true
 libc.workspace = true
 tracing.workspace = true
-rmp-serde = "1.1.1"
+rmp-serde.workspace = true
 serde_json.workspace = true
 
 

--- a/datadog-sidecar-macros/Cargo.toml
+++ b/datadog-sidecar-macros/Cargo.toml
@@ -10,5 +10,5 @@ proc-macro = true
 bench = false
 
 [dependencies]
-syn = { workspace = true, default-features = false, features = ["full", "parsing", "printing", "proc-macro"] }
+syn = { workspace = true, features = ["full", "parsing", "printing", "proc-macro"] }
 quote = { workspace = true, default-features = true }

--- a/datadog-sidecar-macros/Cargo.toml
+++ b/datadog-sidecar-macros/Cargo.toml
@@ -10,5 +10,5 @@ proc-macro = true
 bench = false
 
 [dependencies]
-syn = { workspace = true, default-features = true, features = ["full"] }
-quote = "^1"
+syn = { workspace = true, default-features = false, features = ["full", "parsing", "printing", "proc-macro"] }
+quote = { workspace = true, default-features = true }

--- a/datadog-sidecar/Cargo.toml
+++ b/datadog-sidecar/Cargo.toml
@@ -15,10 +15,10 @@ tokio-console = ["tokio/full", "tokio/tracing", "console-subscriber"]
 stats-obfuscation = ["libdd-trace-stats/stats-obfuscation", "libdd-data-pipeline/stats-obfuscation", "arc-swap"]
 
 [dependencies]
-anyhow = { version = "1.0" }
+anyhow = { workspace = true, default-features = true }
 arc-swap = { workspace = true, optional = true }
-arrayref = "0.3.7"
-priority-queue = "2.1.1"
+arrayref.workspace = true
+priority-queue = { workspace = true, default-features = true }
 libdd-common = { path = "../libdd-common" }
 libdd-capabilities = { path = "../libdd-capabilities", version = "3.0.1" }
 datadog-sidecar-macros = { path = "../datadog-sidecar-macros" }
@@ -35,48 +35,38 @@ libdd-dogstatsd-client = { path = "../libdd-dogstatsd-client" }
 libdd-tinybytes = { path = "../libdd-tinybytes" }
 
 futures.workspace = true
-manual_future = "0.1.1"
+manual_future.workspace = true
 http = { workspace = true, features = ["std"] }
 http-body-util.workspace = true
 
 libdd-ipc = { path = "../libdd-ipc", features = ["tiny-bytes"] }
 libdd-ipc-macros = { path = "../libdd-ipc-macros" }
 
-rand = "0.8.3"
-rmp-serde = "1.3.0"
-serde = { version = "1.0", features = ["derive", "rc"] }
-serde_with = "3.6.0"
-bincode = { version = "1.3.3" }
+rand = { workspace = true, default-features = true }
+rmp-serde.workspace = true
+serde = { workspace = true, default-features = true, features = ["derive", "rc"] }
+serde_with = { workspace = true, default-features = true }
+bincode.workspace = true
 serde_json.workspace = true
 base64 = { workspace = true, features = ["std"] }
 spawn_worker = { path = "../spawn_worker" }
-zwohash = "0.1.2"
+zwohash = { workspace = true, default-features = true }
 sha2 = { workspace = true, features = ["std"] }
-tokio = { version = "1.49.0", features = [
-    "fs",
-    "sync",
-    "io-util",
-    "signal",
-    "rt-multi-thread",
-] }
-tokio-util = { version = "0.7", features = ["codec"] }
+tokio = { workspace = true, features = ["fs", "sync", "io-util", "signal", "rt-multi-thread"] }
+tokio-util = { workspace = true, features = ["codec"] }
 
-prctl = "1.0.0"
-sys-info = { version = "0.9.0" }
-tracing = { version = "0.1", default-features = false }
-tracing-log = { version = "0.2.0", optional = true }
-tracing-subscriber = { version = "0.3.22", default-features = false, features = [
-    "std",
-    "fmt",
-    "env-filter",
-], optional = true }
+prctl.workspace = true
+sys-info.workspace = true
+tracing.workspace = true
+tracing-log = { workspace = true, default-features = true, optional = true }
+tracing-subscriber = { workspace = true, features = ["std", "fmt", "env-filter"], optional = true }
 chrono = { workspace = true, features = ["clock", "std"] }
-console-subscriber = { version = "0.5", optional = true }
-crossbeam-utils = "0.8.21"
+console-subscriber = { workspace = true, default-features = true, optional = true }
+crossbeam-utils = { workspace = true, default-features = true }
 libc.workspace = true
 
 # watchdog and self telemetry
-memory-stats = { version = "1.2.0", features = ["always_use_statm"] }
+memory-stats = { workspace = true, features = ["always_use_statm"] }
 
 [target.'cfg(windows)'.dependencies.windows]
 features = [
@@ -88,20 +78,19 @@ features = [
 version = "0.51.0"
 
 # unstable-only feature
-[target.'cfg(all(tokio_unstable, target_os = "linux"))'.dependencies.tokio]
-features = ["taskdump"]
-version = "1.49.0"
+[target.'cfg(all(tokio_unstable, target_os = "linux"))'.dependencies]
+tokio = { workspace = true, features = ["taskdump"] }
 
 # simd-json v0.15 uses Rust 2024 Edition, so it needs Rust 1.85+.
 [target.'cfg(not(target_arch = "x86"))'.dependencies]
-simd-json = "=0.14"
+simd-json = { workspace = true, default-features = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libdd-capabilities-impl = { path = "../libdd-capabilities-impl" }
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.29", features = ["socket", "mman"] }
-sendfd = { version = "0.4", features = ["tokio"] }
+nix = { workspace = true, features = ["socket", "mman"] }
+sendfd = { workspace = true, features = ["tokio"] }
 
 [target.'cfg(windows)'.dependencies]
 libdd-common-ffi = { path = "../libdd-common-ffi", default-features = false }
@@ -110,7 +99,7 @@ winapi = { version = "0.3.9", features = ["securitybaseapi", "sddl", "winerror",
 windows-sys = { version = "0.52.0", features = ["Win32_System_SystemInformation"] }
 
 [target.'cfg(windows_seh_wrapper)'.dependencies]
-microseh = "0.1.1"
+microseh.workspace = true
 
 [dev-dependencies]
 libc.workspace = true

--- a/libdd-agent-client/Cargo.toml
+++ b/libdd-agent-client/Cargo.toml
@@ -36,5 +36,5 @@ tracing.workspace = true
 [dev-dependencies]
 httpmock.workspace = true
 rustls = { workspace = true, features = ["ring"] }
-serial_test = { workspace = true, default-features = false }
+serial_test.workspace = true
 tokio = { workspace = true, features = ["rt", "macros"] }

--- a/libdd-agent-client/Cargo.toml
+++ b/libdd-agent-client/Cargo.toml
@@ -27,7 +27,7 @@ bytes = { workspace = true, features = ["std"] }
 flate2.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-thiserror = "2"
+thiserror = { workspace = true, default-features = true }
 tokio = { workspace = true, features = ["rt"] }
 libdd-http-client = { path = "../libdd-http-client", default-features = false }
 libdd-common = { version = "6.0", path = "../libdd-common", default-features = false }
@@ -36,5 +36,5 @@ tracing.workspace = true
 [dev-dependencies]
 httpmock.workspace = true
 rustls = { workspace = true, features = ["ring"] }
-serial_test = "3.2"
-tokio = { version = "1.23", features = ["rt", "macros"] }
+serial_test = { workspace = true, default-features = false }
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/libdd-alloc/Cargo.toml
+++ b/libdd-alloc/Cargo.toml
@@ -14,8 +14,8 @@ license.workspace = true
 [dependencies]
 allocator-api2.workspace = true
 
-[target.'cfg(unix)'.dependencies.libc]
-version = "0.2.153"
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.52"

--- a/libdd-capabilities-impl/Cargo.toml
+++ b/libdd-capabilities-impl/Cargo.toml
@@ -28,7 +28,7 @@ http-body-util.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
-tokio = { version = "1", features = ["fs", "macros", "rt", "time"] }
+tokio = { workspace = true, features = ["fs", "macros", "rt", "time"] }
 
 [features]
 default = ["https"]

--- a/libdd-capabilities/Cargo.toml
+++ b/libdd-capabilities/Cargo.toml
@@ -18,7 +18,7 @@ bench = false
 [dependencies]
 http = { workspace = true, features = ["std"] }
 bytes = { workspace = true, features = ["std"] }
-anyhow = "1.0"
-thiserror = "1.0"
-futures-channel = { version = "0.3", default-features = false, features = ["std"] }
-futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
+anyhow = { workspace = true, default-features = true }
+thiserror = { workspace = true, default-features = true }
+futures-channel = { workspace = true, features = ["std"] }
+futures-util = { workspace = true, features = ["alloc"] }

--- a/libdd-common-ffi/Cargo.toml
+++ b/libdd-common-ffi/Cargo.toml
@@ -23,15 +23,15 @@ build_common = { path = "../build-common" }
 [dependencies]
 anyhow.workspace = true
 chrono = { workspace = true, features = ["clock", "std"] }
-crossbeam-queue = "0.3.11"
+crossbeam-queue = { workspace = true, default-features = true }
 libdd-common = { path = "../libdd-common" }
 hyper = { workspace = true, features = ["http1", "client"] }
 serde.workspace = true
 
 [dev-dependencies]
 bolero = { workspace = true, features = ["std"] }
-assert_no_alloc = "1.1.2"
-function_name = "0.3.0"
+assert_no_alloc.workspace = true
+function_name.workspace = true
 
 [lints.clippy]
 std_instead_of_alloc = "warn"

--- a/libdd-common/Cargo.toml
+++ b/libdd-common/Cargo.toml
@@ -18,18 +18,18 @@ bench = false
 [dependencies]
 anyhow.workspace = true
 futures = { workspace = true, features = ["alloc", "executor"] }
-futures-core = { version = "0.3.0", default-features = false }
-futures-util = { version = "0.3.0", default-features = false }
-hex = "0.4"
+futures-core.workspace = true
+futures-util.workspace = true
+hex = { workspace = true, default-features = true }
 httparse = { workspace = true, features = ["std"], optional = true }
 http = { workspace = true, features = ["std"] }
 mime = { workspace = true, optional = true }
-multer = { version = "3.1", optional = true }
+multer = { workspace = true, optional = true }
 bytes = { workspace = true, features = ["std"] }
-pin-project = "1"
-rand = { version = ">=0.8.6, <0.9", optional = true }
+pin-project.workspace = true
+rand = { workspace = true, default-features = true, optional = true }
 regex = { workspace = true, features = ["std", "unicode", "perf"] }
-regex-lite = { version = "0.1", optional = true }
+regex-lite = { workspace = true, default-features = true, optional = true }
 # Use hickory-dns instead of the default system DNS resolver to avoid fork safety issues.
 # The default resolver can hold locks or other global state that can cause deadlocks
 # or corruption when the process forks (e.g., in PHP-FPM or other forking environments).
@@ -37,33 +37,30 @@ regex-lite = { version = "0.1", optional = true }
 # backend. We install the ring provider explicitly in connector/mod.rs instead.
 reqwest = { workspace = true, features = ["rustls-no-provider", "hickory-dns"], optional = true }
 criterion = { workspace = true, optional = true }
-rustls-native-certs = { version = ">=0.8.1, <0.8.3", optional = true }
+rustls-native-certs = { workspace = true, optional = true }
 rustls-platform-verifier = { workspace = true, optional = true }
-thiserror = "1.0"
-tokio-rustls = { version = "0.26", default-features = false, optional = true }
+thiserror = { workspace = true, default-features = true }
+tokio-rustls = { workspace = true, optional = true }
 serde = { workspace = true, default-features = true, features = ["derive"] }
-static_assertions = "1.1.0"
-const_format = "0.2.34"
+static_assertions.workspace = true
+const_format.workspace = true
 # Declare rustls and hyper-rustls without a crypto provider. The provider is
 # selected via features: `https` enables ring, `fips` enables aws-lc-rs.
 rustls = { workspace = true, optional = true }
-hyper-rustls = { version = "0.27.7", default-features = false, features = [
-    "http1",
-    "tls12",
-], optional = true }
+hyper-rustls = { workspace = true, features = ["http1", "tls12"], optional = true }
 # Unused; pins a floor on this transitive-only dep since rustls itself only requires ^0.103.5.
-rustls-webpki = { version = ">=0.103.13", optional = true }
+rustls-webpki = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # Target gating keeps these dependencies out of WASM. They are also optional so
 # native callers using host-managed capabilities do not pull in an HTTP runtime.
 hyper = { workspace = true, features = ["http1", "client"], optional = true }
 hyper-util = { workspace = true, features = ["http1", "client", "client-legacy"], optional = true }
-http-body = { version = "1.0", optional = true }
+http-body = { workspace = true, optional = true }
 http-body-util = {workspace = true, optional = true }
-tower-service = { version = "0.3", optional = true }
-cc = "1.1.31"
-pin-project = "1"
+tower-service = { workspace = true, optional = true }
+cc.workspace = true
+pin-project.workspace = true
 libc.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread", "macros", "net", "io-util", "fs", "time"], optional = true }
 
@@ -78,19 +75,19 @@ features = [
 ]
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.29", features = ["process"] }
+nix = { workspace = true, features = ["process"] }
 
 [dev-dependencies]
 bytes = { workspace = true, features = ["std"] }
 httparse = { workspace = true, features = ["std"] }
-indexmap = "2.11"
-maplit = "1.0"
+indexmap = { workspace = true, default-features = true }
+maplit.workspace = true
 mime.workspace = true
-multer = "3.1"
-proptest = "1"
-rand = ">=0.8.6, <0.9"
+multer.workspace = true
+proptest = { workspace = true, default-features = true }
+rand = { workspace = true, default-features = true }
 tempfile.workspace = true
-tokio = { version = "1.23", features = ["rt", "macros", "time"] }
+tokio = { workspace = true, features = ["rt", "macros", "time"] }
 
 [features]
 default = ["https"]

--- a/libdd-crashtracker-ffi/Cargo.toml
+++ b/libdd-crashtracker-ffi/Cargo.toml
@@ -41,12 +41,14 @@ anyhow.workspace = true
 libdd-crashtracker = { path = "../libdd-crashtracker" }
 libdd-common = { path = "../libdd-common" }
 libdd-common-ffi = { path = "../libdd-common-ffi", default-features = false }
-symbolic-demangle = { version = "12.8.0", default-features = false, features = ["rust", "cpp", "msvc"], optional = true }
-symbolic-common = { version = "12.8.0", default-features = false, optional = true }
-function_name = "0.3.0"
+symbolic-demangle = { workspace = true, features = ["rust", "cpp", "msvc"], optional = true }
+symbolic-common = { workspace = true, optional = true }
+function_name.workspace = true
 libc.workspace = true
 serde_json.workspace = true
-serde = { version = "1.0.214", features = ["derive"] }
+# serde is not referenced by this crate's code; keep only the `derive` feature
+# (serde_json in tests pulls in the rest transitively).
+serde = { workspace = true, features = ["derive"] }
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.59.0", features = ["Win32_System_Diagnostics_Debug", "Win32_System_ErrorReporting"] }

--- a/libdd-crashtracker/Cargo.toml
+++ b/libdd-crashtracker/Cargo.toml
@@ -62,7 +62,7 @@ num-derive.workspace = true
 num-traits.workspace = true
 # os_info::get() is converted into our own OsInfo type before serialization,
 # so os_info's own `serde` default feature is unnecessary.
-os_info = { workspace = true, default-features = false }
+os_info.workspace = true
 page_size.workspace = true
 portable-atomic = { workspace = true, default-features = true, features = ["serde"] }
 rand = { workspace = true, default-features = true }
@@ -80,7 +80,7 @@ windows = { version = "0.59.0", features = ["Win32_System_Diagnostics_Debug", "W
 
 [dev-dependencies]
 criterion.workspace = true
-goblin = { workspace = true, default-features = false, features = ["std", "pe32", "pe64"] }
+goblin = { workspace = true, features = ["std", "pe32", "pe64"] }
 tempfile.workspace = true
 
 [target.'cfg(windows)'.dev-dependencies]

--- a/libdd-crashtracker/Cargo.toml
+++ b/libdd-crashtracker/Cargo.toml
@@ -38,46 +38,49 @@ benchmarking = ["generate-unit-test-files"]
 cxx = ["dep:cxx", "dep:cxx-build"]
 
 [target.'cfg(unix)'.dependencies]
-# Should be kept in sync with the libdatadog symbolizer crate (also using blasesym)
-blazesym = "=0.2.3"
+# Should be kept in sync with the libdatadog symbolizer crate (also using blazesym)
+# Symbolization needs DWARF info, name demangling, and compressed debug sections.
+blazesym = { workspace = true, default-features = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libdd-gotter = { version = "1.1.0", path = "../libdd-gotter" }
-libdd-libunwind-sys = { version = "1.0.3" }
+libdd-libunwind-sys.workspace = true
 
 [dependencies]
 anyhow.workspace = true
 chrono = { workspace = true, features = ["std", "clock", "serde"] }
-cxx = { version = "1.0", optional = true }
-errno = "0.3"
+cxx = { workspace = true, default-features = true, optional = true }
+errno = { workspace = true, default-features = true }
 libdd-capabilities = { version = "3.0.1", path = "../libdd-capabilities" }
 libdd-capabilities-impl = { version = "5.0.0", path = "../libdd-capabilities-impl" }
 libdd-common = { version = "6.0.0", path = "../libdd-common", features = ["hyper-proxy"] }
 libdd-telemetry = { version = "8.0.0", path = "../libdd-telemetry" }
 http = { workspace = true, features = ["std"] }
 libc.workspace = true
-nix = { version = "0.29", features = ["poll", "signal", "socket"] }
-num-derive = "0.4.2"
-num-traits = "0.2.19"
-os_info = "3.14.0"
-page_size = "0.6.0"
-portable-atomic = { version = "1.6.0", features = ["serde"] }
-rand = "0.8.5"
-schemars = "0.8.21"
+nix = { workspace = true, features = ["poll", "signal", "socket"] }
+num-derive.workspace = true
+num-traits.workspace = true
+# os_info::get() is converted into our own OsInfo type before serialization,
+# so os_info's own `serde` default feature is unnecessary.
+os_info = { workspace = true, default-features = false }
+page_size.workspace = true
+portable-atomic = { workspace = true, default-features = true, features = ["serde"] }
+rand = { workspace = true, default-features = true }
+schemars = { workspace = true, default-features = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
-symbolic-demangle = { version = "12.8.0", default-features = false, features = ["rust", "cpp", "msvc"] }
-symbolic-common = { version = "12.8.0", default-features = false }
+symbolic-demangle = { workspace = true, features = ["rust", "cpp", "msvc"] }
+symbolic-common.workspace = true
 tokio = { workspace = true, features = ["rt", "macros", "io-std", "io-util"] }
 uuid = { workspace = true, features = ["v4", "serde", "std"] }
-thiserror = "1.0"
+thiserror = { workspace = true, default-features = true }
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.59.0", features = ["Win32_System_Diagnostics_Debug", "Win32_System_Diagnostics_ToolHelp", "Win32_System_ErrorReporting", "Win32_System_Kernel", "Win32_System_ProcessStatus", "Win32_System_Registry", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_Security"] }
 
 [dev-dependencies]
 criterion.workspace = true
-goblin = "0.9.3"
+goblin = { workspace = true, default-features = false, features = ["std", "pe32", "pe64"] }
 tempfile.workspace = true
 
 [target.'cfg(windows)'.dev-dependencies]
@@ -85,7 +88,7 @@ windows = { version = "0.59.0", features = ["Win32_System_LibraryLoader"] }
 
 [build-dependencies]
 # If we use a newer version of cc, CI fails on alpine.
-cc = "1.1.31"
+cc.workspace = true
 cxx-build = { workspace = true, optional = true }
 # Use default-features = false to avoid pulling in the `https` feature (rustls/aws-lc-rs/aws-lc-sys)
 # in the build-script context. The build script only needs cc_utils, which has no TLS dependency.

--- a/libdd-data-pipeline-core/Cargo.toml
+++ b/libdd-data-pipeline-core/Cargo.toml
@@ -11,7 +11,7 @@ license.workspace = true
 [dependencies]
 http.workspace = true
 serde_json.workspace = true
-thiserror = "1.0"
+thiserror = { workspace = true, default-features = true }
 libdd-capabilities = { version = "3.0.1", path = "../libdd-capabilities" }
 libdd-common = { version = "6.0.0", path = "../libdd-common", default-features = false }
 libdd-trace-utils = { version = "12.0.0", path = "../libdd-trace-utils", default-features = false }

--- a/libdd-data-pipeline-ffi/Cargo.toml
+++ b/libdd-data-pipeline-ffi/Cargo.toml
@@ -32,7 +32,7 @@ build_common = { path = "../build-common" }
 
 [dev-dependencies]
 httpmock.workspace = true
-rmp-serde = "1.3.0"
+rmp-serde.workspace = true
 libdd-trace-utils = { path = "../libdd-trace-utils" }
 
 [dependencies]
@@ -42,8 +42,8 @@ libdd-shared-runtime = { version = "4.0.0", path = "../libdd-shared-runtime" }
 libdd-common-ffi = { path = "../libdd-common-ffi", default-features = false }
 libdd-tinybytes = { path = "../libdd-tinybytes" }
 libdd-trace-utils = { path = "../libdd-trace-utils" }
-rmp = { version = "0.8.14", default-features = false }
-tokio-util = "0.7.11"
+rmp.workspace = true
+tokio-util.workspace = true
 tracing.workspace = true
-serde_json = { workspace = true }
+serde_json.workspace = true
 libdd-trace-obfuscation = { version = "8.0.0", path = "../libdd-trace-obfuscation", default-features = false }

--- a/libdd-data-pipeline/Cargo.toml
+++ b/libdd-data-pipeline/Cargo.toml
@@ -14,16 +14,16 @@ autobenches = false
 [dependencies]
 arc-swap.workspace = true
 anyhow.workspace = true
-async-trait = "0.1"
+async-trait.workspace = true
 http = { workspace = true, features = ["std"] }
 http-body-util.workspace = true
 tracing.workspace = true
-rmp-serde = "1.3.0"
+rmp-serde.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 bytes = { workspace = true, features = ["std"] }
 sha2 = { workspace = true, features = ["std"] }
-either = "1.13.0"
+either = { workspace = true, default-features = true }
 futures = { workspace = true, features = ["alloc"] }
 tokio = { workspace = true, features = [
     "rt",
@@ -31,7 +31,7 @@ tokio = { workspace = true, features = [
     "time",
 ], default-features = false }
 uuid = { workspace = true, features = ["v4", "std"] }
-tokio-util = "0.7.11"
+tokio-util.workspace = true
 libdd-capabilities = { path = "../libdd-capabilities", version = "3.0.1" }
 libdd-data-pipeline-core = { path = "../libdd-data-pipeline-core", version = "1.0.0" }
 libdd-common = { version = "6.0.0", path = "../libdd-common", default-features = false }
@@ -48,22 +48,20 @@ libdd-tinybytes = { version = "1.1.3", path = "../libdd-tinybytes", features = [
     "bytes_string",
     "serialization",
 ] }
-web-time = "1"
+web-time.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1.23", features = ["time", "test-util", "net"], default-features = false }
+tokio = { workspace = true, features = ["time", "test-util", "net"] }
 libdd-capabilities-impl = { version = "5.0.0", path = "../libdd-capabilities-impl", default-features = false }
-# OTLP gRPC transport: a custom GrpcService over hyper h2c. tonic's transport
-# (hyper/tokio/socket2) does not build for wasm32, so the whole gRPC path is gated off.
-tonic = { version = "0.14", default-features = false }
-prost = "0.14.1"
-h2 = "0.4"
+tonic.workspace = true
+prost = { workspace = true, default-features = false, features = ["std"] }
+h2.workspace = true
 hyper = { workspace = true, features = ["client", "http2"] }
 hyper-util = { workspace = true, features = ["tokio"] }
 rand = "0.8.5"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2", features = ["js"] }
+getrandom = { workspace = true, features = ["js"] }
 uuid = { workspace = true, features = ["js", "std"] }
 
 [lib]
@@ -88,22 +86,18 @@ libdd-trace-utils = { path = "../libdd-trace-utils", features = [
     "test-utils",
 ] }
 httpmock.workspace = true
-prost = "0.14.1"
-rand = ">=0.8.6, <0.9"
+prost = { workspace = true, default-features = false, features = ["std"] }
+rand = { workspace = true, default-features = true }
 tempfile.workspace = true
-tokio = { version = "1.23", features = [
-    "rt",
-    "time",
-    "test-util",
-], default-features = false }
-duplicate = "2.0.1"
+tokio = { workspace = true, features = ["rt", "time", "test-util"] }
+duplicate = { workspace = true, default-features = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-h2 = ">=0.4.19, <0.5"
+h2.workspace = true
 zstd.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-zrip = { version = "=0.6.0", default-features = false, features = ["alloc"] }
+zrip = { workspace = true, features = ["alloc"] }
 
 [[test]]
 name = "test_agentless_stats"

--- a/libdd-data-pipeline/Cargo.toml
+++ b/libdd-data-pipeline/Cargo.toml
@@ -29,7 +29,7 @@ tokio = { workspace = true, features = [
     "rt",
     "sync",
     "time",
-], default-features = false }
+] }
 uuid = { workspace = true, features = ["v4", "std"] }
 tokio-util.workspace = true
 libdd-capabilities = { path = "../libdd-capabilities", version = "3.0.1" }
@@ -54,11 +54,11 @@ web-time.workspace = true
 tokio = { workspace = true, features = ["time", "test-util", "net"] }
 libdd-capabilities-impl = { version = "5.0.0", path = "../libdd-capabilities-impl", default-features = false }
 tonic.workspace = true
-prost = { workspace = true, default-features = false, features = ["std"] }
 h2.workspace = true
+prost = { workspace = true, features = ["std"] }
 hyper = { workspace = true, features = ["client", "http2"] }
 hyper-util = { workspace = true, features = ["tokio"] }
-rand = "0.8.5"
+rand.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { workspace = true, features = ["js"] }
@@ -86,7 +86,7 @@ libdd-trace-utils = { path = "../libdd-trace-utils", features = [
     "test-utils",
 ] }
 httpmock.workspace = true
-prost = { workspace = true, default-features = false, features = ["std"] }
+prost = { workspace = true, features = ["std"] }
 rand = { workspace = true, default-features = true }
 tempfile.workspace = true
 tokio = { workspace = true, features = ["rt", "time", "test-util"] }

--- a/libdd-ddsketch/Cargo.toml
+++ b/libdd-ddsketch/Cargo.toml
@@ -12,7 +12,7 @@ autobenches = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-prost = "0.14.1"
+prost = { workspace = true, default-features = true }
 
 [build-dependencies]
 prost-build = { workspace = true, features = ["format"], optional = true }
@@ -20,8 +20,10 @@ protoc-bin-vendored = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion.workspace = true
-rand = ">=0.8.6, <0.9"
-rand_chacha = "0.3.1"
+# Bench only uses gen_range + seed_from_u64 (ChaCha8Rng); no thread_rng/StdRng,
+# so the default `std_rng` feature is unneeded.
+rand = { workspace = true, default-features = false, features = ["std"] }
+rand_chacha = { workspace = true, default-features = false }
 
 [features]
 generate-protobuf = ["dep:prost-build", "dep:protoc-bin-vendored"]

--- a/libdd-ddsketch/Cargo.toml
+++ b/libdd-ddsketch/Cargo.toml
@@ -22,8 +22,8 @@ protoc-bin-vendored = { workspace = true, optional = true }
 criterion.workspace = true
 # Bench only uses gen_range + seed_from_u64 (ChaCha8Rng); no thread_rng/StdRng,
 # so the default `std_rng` feature is unneeded.
-rand = { workspace = true, default-features = false, features = ["std"] }
-rand_chacha = { workspace = true, default-features = false }
+rand = { workspace = true, features = ["std"] }
+rand_chacha.workspace = true
 
 [features]
 generate-protobuf = ["dep:prost-build", "dep:protoc-bin-vendored"]

--- a/libdd-dogstatsd-client/Cargo.toml
+++ b/libdd-dogstatsd-client/Cargo.toml
@@ -13,14 +13,14 @@ bench = false
 
 [dependencies]
 libdd-common = { version = "6.0.0", path = "../libdd-common", default-features = false }
-cadence = "1.3.0"
+cadence.workspace = true
 serde = { workspace = true, features = ["derive", "rc"] }
 tracing.workspace = true
 anyhow.workspace = true
 http = { workspace = true, features = ["std"] }
 libdd-shared-runtime = { version = "4.0.0", path = "../libdd-shared-runtime", default-features = false, optional = true }
-tokio = { version = "1.23", features = ["sync"], optional = true }
-async-trait = { version = "0.1", optional = true }
+tokio = { workspace = true, features = ["sync"], optional = true }
+async-trait = { workspace = true, optional = true }
 
 [features]
 default = ["https"]

--- a/libdd-ffe-ffi/Cargo.toml
+++ b/libdd-ffe-ffi/Cargo.toml
@@ -21,9 +21,10 @@ cbindgen = ["build_common/cbindgen", "libdd-common-ffi/cbindgen"]
 build_common = { path = "../build-common" }
 
 [dependencies]
-anyhow = "1.0.103"
+# Only the `ensure!` macro is used; no std-specific anyhow APIs needed.
+anyhow = { workspace = true, default-features = false }
 libdd-ffe = { path = "../libdd-ffe", version = "=2.0.0" }
 libdd-common-ffi = { path = "../libdd-common-ffi", default-features = false }
-function_name = "0.3.0"
+function_name.workspace = true
 
 [dev-dependencies]

--- a/libdd-ffe-ffi/Cargo.toml
+++ b/libdd-ffe-ffi/Cargo.toml
@@ -22,7 +22,7 @@ build_common = { path = "../build-common" }
 
 [dependencies]
 # Only the `ensure!` macro is used; no std-specific anyhow APIs needed.
-anyhow = { workspace = true, default-features = false }
+anyhow.workspace = true
 libdd-ffe = { path = "../libdd-ffe", version = "=2.0.0" }
 libdd-common-ffi = { path = "../libdd-common-ffi", default-features = false }
 function_name.workspace = true

--- a/libdd-ffe-test-suite/Cargo.toml
+++ b/libdd-ffe-test-suite/Cargo.toml
@@ -14,7 +14,8 @@ bench = false
 libdd-ffe = { path = "../libdd-ffe", features = ["flagevaluation-evp"] }
 chrono = { workspace = true, features = ["now", "serde"] }
 criterion = { workspace = true, features = ["html_reports"] }
-env_logger = "0.10"
+# Only builder().is_test().try_init() used; colored timestamps/regex filter syntax not needed.
+env_logger = { workspace = true, default-features = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true, features = ["std", "raw_value"] }
 

--- a/libdd-ffe/Cargo.toml
+++ b/libdd-ffe/Cargo.toml
@@ -26,7 +26,7 @@ libdd-capabilities = { path = "../libdd-capabilities", version = "3.0.1", option
 http = { workspace = true, features = ["std"], optional = true }
 tokio = { workspace = true, features = ["time"], optional = true }
 # Uses semver::Version::parse in runtime code; parse is available without std (alloc fallback).
-semver = { workspace = true, default-features = false }
+semver.workspace = true
 serde-bool.workspace = true
 serde_with = { workspace = true, features = ["base64", "hex", "macros"] }
 thiserror.workspace = true

--- a/libdd-ffe/Cargo.toml
+++ b/libdd-ffe/Cargo.toml
@@ -14,32 +14,34 @@ bench = false
 
 [dependencies]
 libdd-remote-config = { version = "5.0.0", path = "../libdd-remote-config", default-features = false, optional = true }
-faststr = { version = "0.2.23", default-features = false, features = ["serde"] }
+faststr = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true, features = ["std", "raw_value"] }
 chrono = { workspace = true, features = ["now", "serde"] }
-derive_more = { version = "2.0.0", default-features = false, features = ["from", "into"] }
-log = { version = "0.4.21", default-features = false, features = ["kv", "kv_serde"] }
-md5 = { version = "0.7.0", default-features = false }
+derive_more = { workspace = true, features = ["from", "into"] }
+log = { workspace = true, features = ["kv", "kv_serde"] }
+md5.workspace = true
 libdd-common = { version = "6.0.0", path = "../libdd-common", default-features = false, features = ["require-regex-full"] }
 libdd-capabilities = { path = "../libdd-capabilities", version = "3.0.1", optional = true }
 http = { workspace = true, features = ["std"], optional = true }
-tokio = { version = "1.49.0", features = ["time"], optional = true }
-semver = "1.0"
-serde-bool = { version = "0.1.3", default-features = false }
-serde_with = { version = "3.11.0", default-features = false, features = ["base64", "hex", "macros"] }
-thiserror = { version = "2.0.3", default-features = false }
-url = { version = "2.5.0", default-features = false, features = ["std"] }
-lru = { version = "0.16.3", optional = true }
+tokio = { workspace = true, features = ["time"], optional = true }
+# Uses semver::Version::parse in runtime code; parse is available without std (alloc fallback).
+semver = { workspace = true, default-features = false }
+serde-bool.workspace = true
+serde_with = { workspace = true, features = ["base64", "hex", "macros"] }
+thiserror.workspace = true
+url = { workspace = true, features = ["std"] }
+lru = { workspace = true, default-features = true, optional = true }
 libdd-trace-protobuf = { version = "5.0.0", path = "../libdd-trace-protobuf", optional = true }
-prost = { version = "0.14.1", optional = true }
-pyo3 = { version = "0.28", optional = true, default-features = false, features = ["macros"] }
+# Hand-written generated-style code uses #[derive(::prost::Message)] and ::prost::alloc types.
+prost = { workspace = true, default-features = true, optional = true }
+pyo3 = { workspace = true, features = ["macros"], optional = true }
 
 [dev-dependencies]
 # Matches the sidecar's bincode version. Used by the flagevaluation bincode
 # round-trip test, which guards against `skip_serializing_if` reintroducing the
 # worker→sidecar IPC field-misalignment bug (bincode is non-self-describing).
-bincode = { version = "1.3.3" }
+bincode.workspace = true
 httpmock.workspace = true
 libdd-capabilities-impl = { path = "../libdd-capabilities-impl" }
 

--- a/libdd-http-client/Cargo.toml
+++ b/libdd-http-client/Cargo.toml
@@ -31,7 +31,7 @@ fips = ["dep:reqwest", "reqwest?/rustls-no-provider", "dep:rustls", "rustls?/aws
 
 [dependencies]
 bytes = { workspace = true, features = ["std"] }
-thiserror = "2"
+thiserror = { workspace = true, default-features = true }
 fastrand = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["rt", "time"] }
 reqwest = { workspace = true, optional = true }
@@ -45,5 +45,5 @@ http-body-util = { workspace = true, optional = true }
 [dev-dependencies]
 httpmock.workspace = true
 rustls = { workspace = true, features = ["ring"] }
-tokio = { version = "1.23", features = ["rt", "macros", "io-util", "net"] }
+tokio = { workspace = true, features = ["rt", "macros", "io-util", "net"] }
 tempfile.workspace = true

--- a/libdd-ipc-macros/Cargo.toml
+++ b/libdd-ipc-macros/Cargo.toml
@@ -13,7 +13,14 @@ proc-macro = true
 bench = false
 
 [dependencies]
-proc-macro2 = "1"
-quote = "^1"
-syn = { workspace = true, default-features = true, features = ["full"] }
-heck = "0.5"
+proc-macro2 = { workspace = true, default-features = true }
+quote = { workspace = true, default-features = true }
+# Needs full (ItemTrait, Pat), parsing, printing, clone-impls, proc-macro; derive not used.
+syn = { workspace = true, default-features = false, features = [
+    "full",
+    "parsing",
+    "printing",
+    "clone-impls",
+    "proc-macro",
+] }
+heck.workspace = true

--- a/libdd-ipc-macros/Cargo.toml
+++ b/libdd-ipc-macros/Cargo.toml
@@ -16,7 +16,7 @@ bench = false
 proc-macro2 = { workspace = true, default-features = true }
 quote = { workspace = true, default-features = true }
 # Needs full (ItemTrait, Pat), parsing, printing, clone-impls, proc-macro; derive not used.
-syn = { workspace = true, default-features = false, features = [
+syn = { workspace = true, features = [
     "full",
     "parsing",
     "printing",

--- a/libdd-ipc/Cargo.toml
+++ b/libdd-ipc/Cargo.toml
@@ -12,12 +12,12 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-zwohash = "0.1.2"
-bincode = { version = "1" }
+zwohash.workspace = true
+bincode.workspace = true
 futures.workspace = true
 io-lifetimes = { workspace = true, features = ["close"] }
-page_size = "0.6.0"
-memfd = { version = "0.6" }
+page_size.workspace = true
+memfd.workspace = true
 serde = { workspace = true, features = ["derive"] }
 libc.workspace = true
 libdd-tinybytes = { path = "../libdd-tinybytes", version = "1.1.3", optional = true }
@@ -32,7 +32,8 @@ tracing.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true
-pretty_assertions = "1.3"
+# Unused in this crate's sources; kept with defaults (the crate needs its own `std` to compile).
+pretty_assertions = { workspace = true, default-features = true }
 tempfile.workspace = true
 tokio = { workspace = true, features = [
     "macros",
@@ -42,22 +43,23 @@ tokio = { workspace = true, features = [
     "fs",
     "io-util",
 ] }
-tracing = { version = "0.1" }
-tracing-subscriber = { version = "0.3.22" }
+# Both appear unused in this crate's tests/benches; keep them with no default features.
+tracing.workspace = true
+tracing-subscriber.workspace = true
 spawn_worker = { path = "../spawn_worker" }
 
 [target.'cfg(not(windows))'.dependencies]
-nix = { version = "0.29", features = ["fs", "mman", "process", "poll", "socket", "uio", "user"] }
-sendfd = { version = "0.4", features = ["tokio"] }
-tokio = { version = "1.23", features = ["sync", "io-util"] }
+nix = { workspace = true, features = ["fs", "mman", "process", "poll", "socket", "uio", "user"] }
+sendfd = { workspace = true, features = ["tokio"] }
+tokio = { workspace = true, features = ["sync", "io-util"] }
 
 [target.'cfg(target_env = "gnu")'.build-dependencies]
-glibc_version = "0.1.2"
+glibc_version.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["handleapi", "memoryapi", "winbase", "winnt", "winerror", "processthreadsapi", "fileapi", "minwinbase"] }
 windows-sys = { version = "0.48.0", features = ["Win32_System", "Win32_System_WindowsProgramming", "Win32_Foundation", "Win32_System_Pipes", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Threading"] }
-tokio = { version = "1.23", features = ["sync", "io-util", "net", "rt-multi-thread", "rt"] }
+tokio = { workspace = true, features = ["sync", "io-util", "net", "rt-multi-thread", "rt"] }
 
 [lib]
 bench = false

--- a/libdd-library-config-ffi/Cargo.toml
+++ b/libdd-library-config-ffi/Cargo.toml
@@ -16,7 +16,7 @@ libdd-common = { path = "../libdd-common" }
 libdd-common-ffi = { path = "../libdd-common-ffi", default-features = false }
 libdd-library-config = { path = "../libdd-library-config", default-features = false, features = ["process-context-writer"] }
 anyhow.workspace = true
-constcat = "0.4.1"
+constcat.workspace = true
 
 [features]
 default = ["cbindgen", "catch_panic"]

--- a/libdd-library-config/Cargo.toml
+++ b/libdd-library-config/Cargo.toml
@@ -22,21 +22,23 @@ process-context-writer = []
 
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
-serde_yaml = "0.9.34"
-prost = "0.14.1"
+serde_yaml.workspace = true
+# Only the `Message` trait is used (types come from libdd-trace-protobuf); no derive here.
+prost = { workspace = true, default-features = false, features = ["std"] }
 anyhow.workspace = true
-rand = "0.8.3"
-rmp = "0.8.14"
-rmp-serde = "1.3.0"
+rand = { workspace = true, default-features = true }
+# Direct dep unused in sources (only rmp-serde is used, which pulls rmp itself).
+rmp = { workspace = true, default-features = false }
+rmp-serde.workspace = true
 
 libdd-trace-protobuf = { version = "5.0.0", path = "../libdd-trace-protobuf" }
 
 [dev-dependencies]
 tempfile.workspace = true
-serial_test = "3.2"
+serial_test = { workspace = true, default-features = false }
 
 [target.'cfg(unix)'.dependencies]
-memfd = { version = "0.6" }
+memfd.workspace = true
 libc.workspace = true
 
 [lints.clippy]

--- a/libdd-library-config/Cargo.toml
+++ b/libdd-library-config/Cargo.toml
@@ -24,18 +24,18 @@ process-context-writer = []
 serde = { workspace = true, features = ["derive"] }
 serde_yaml.workspace = true
 # Only the `Message` trait is used (types come from libdd-trace-protobuf); no derive here.
-prost = { workspace = true, default-features = false, features = ["std"] }
+prost = { workspace = true, features = ["std"] }
 anyhow.workspace = true
 rand = { workspace = true, default-features = true }
 # Direct dep unused in sources (only rmp-serde is used, which pulls rmp itself).
-rmp = { workspace = true, default-features = false }
+rmp.workspace = true
 rmp-serde.workspace = true
 
 libdd-trace-protobuf = { version = "5.0.0", path = "../libdd-trace-protobuf" }
 
 [dev-dependencies]
 tempfile.workspace = true
-serial_test = { workspace = true, default-features = false }
+serial_test.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 memfd.workspace = true

--- a/libdd-live-debugger-ffi/Cargo.toml
+++ b/libdd-live-debugger-ffi/Cargo.toml
@@ -17,9 +17,9 @@ libdd-common-ffi = { path = "../libdd-common-ffi", default-features = false }
 percent-encoding = { workspace = true, features = ["std"] }
 uuid = { workspace = true, features = ["v4", "std"] }
 serde_json.workspace = true
-tokio = "1.36.0"
-tokio-util = { version = "0.7", features = ["rt"] }
-log = "0.4.21"
+tokio.workspace = true
+tokio-util = { workspace = true, features = ["rt"] }
+log.workspace = true
 
 [features]
 default = ["cbindgen"]

--- a/libdd-live-debugger/Cargo.toml
+++ b/libdd-live-debugger/Cargo.toml
@@ -21,13 +21,13 @@ futures.workspace = true
 percent-encoding = { workspace = true, features = ["std"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-sys-info = { version = "0.9.0" }
+sys-info.workspace = true
 uuid = { workspace = true, features = ["v4", "std"] }
-smallvec = "1.13.2"
-constcat = "0.4.1"
-strum = { version = "0.26", default-features = false }
-strum_macros = "0.26"
-tokio = "1.36.0"
+smallvec.workspace = true
+constcat.workspace = true
+strum.workspace = true
+strum_macros.workspace = true
+tokio.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libdd-capabilities-impl = { version = "5.0.0", path = "../libdd-capabilities-impl" }

--- a/libdd-log/Cargo.toml
+++ b/libdd-log/Cargo.toml
@@ -13,8 +13,8 @@ bench = false
 
 [dependencies]
 tracing = { workspace = true, features = ["std"] }
-tracing-subscriber = { version = "0.3.22", default-features = false, features = ["json"] }
-tracing-appender = "0.2.3"
+tracing-subscriber = { workspace = true, features = ["json"] }
+tracing-appender.workspace = true
 chrono = { workspace = true, features = ["clock", "std"] }
 
 [dev-dependencies]

--- a/libdd-otel-thread-ctx/Cargo.toml
+++ b/libdd-otel-thread-ctx/Cargo.toml
@@ -18,7 +18,7 @@ bench = false
 [dependencies]
 anyhow = { workspace = true, optional = true }
 elf = { workspace = true, features = ["std"], optional = true }
-object = { version = "0.36", default-features = false, features = ["archive", "read_core"], optional = true }
+object = { workspace = true, features = ["archive", "read_core"], optional = true }
 
 [features]
 sanity-check = ["dep:elf", "dep:anyhow"]

--- a/libdd-profiling-ffi/Cargo.toml
+++ b/libdd-profiling-ffi/Cargo.toml
@@ -79,15 +79,15 @@ libdd-common-ffi = { path = "../libdd-common-ffi", default-features = false, opt
 libdd-telemetry-ffi = { path = "../libdd-telemetry-ffi", default-features = false, optional = true, features = ["expanded_builder_macros"] }
 libdd-ddsketch-ffi = { path = "../libdd-ddsketch-ffi", default-features = false, optional = true }
 libdd-log-ffi = { path = "../libdd-log-ffi", default-features = false, optional = true }
-function_name = "0.3.0"
+function_name.workspace = true
 futures.workspace = true
 http-body-util.workspace = true
 hyper = { workspace = true, features = ["http1", "client"] }
 libc.workspace = true
 serde_json.workspace = true
 symbolizer-ffi = { path = "../symbolizer-ffi", optional = true, default-features = false }
-thiserror = "2"
-tokio-util = "0.7.1"
+thiserror = { workspace = true, default-features = true }
+tokio-util.workspace = true
 libdd-ffe-ffi = { path = "../libdd-ffe-ffi", default-features = false, optional = true }
 libdd-shared-runtime-ffi = { path = "../libdd-shared-runtime-ffi", default-features = false, optional = true }
 libdd-otel-thread-ctx-ffi = { path = "../libdd-otel-thread-ctx-ffi", default-features = false, optional = true }

--- a/libdd-profiling-heap-gotter-ffi/Cargo.toml
+++ b/libdd-profiling-heap-gotter-ffi/Cargo.toml
@@ -25,8 +25,8 @@ live-heap = ["libdd-profiling-heap-gotter/live-heap"]
 build_common = { path = "../build-common" }
 
 [dependencies]
-anyhow = "1.0"
-function_name = "0.3.0"
+anyhow = { workspace = true, default-features = true }
+function_name.workspace = true
 libdd-common-ffi = { path = "../libdd-common-ffi", default-features = false }
 # libdd-profiling-heap-gotter exposes the same public surface on every target
 # (no-ops on non-Linux), so this dependency is unconditional and the

--- a/libdd-profiling-heap-gotter/Cargo.toml
+++ b/libdd-profiling-heap-gotter/Cargo.toml
@@ -32,4 +32,4 @@ libdd-profiling-heap-sampler = { version = "1.0.0", path = "../libdd-profiling-h
 libc.workspace = true
 libdd-profiling-heap-sampler = { version = "1.0.0", path = "../libdd-profiling-heap-sampler" }
 # Only sync #[serial] is used; `logging`/`async` defaults are unneeded.
-serial_test = { workspace = true, default-features = false }
+serial_test.workspace = true

--- a/libdd-profiling-heap-gotter/Cargo.toml
+++ b/libdd-profiling-heap-gotter/Cargo.toml
@@ -31,4 +31,5 @@ libdd-profiling-heap-sampler = { version = "1.0.0", path = "../libdd-profiling-h
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 libc.workspace = true
 libdd-profiling-heap-sampler = { version = "1.0.0", path = "../libdd-profiling-heap-sampler" }
-serial_test = "3.2"
+# Only sync #[serial] is used; `logging`/`async` defaults are unneeded.
+serial_test = { workspace = true, default-features = false }

--- a/libdd-profiling-heap-sampler/Cargo.toml
+++ b/libdd-profiling-heap-sampler/Cargo.toml
@@ -27,11 +27,11 @@ sanity-check = ["dep:elf", "dep:anyhow"]
 
 # Only used by the `sanity-check` feature; the crate has no runtime deps otherwise.
 [dependencies]
-anyhow = { version = "1.0", optional = true }
+anyhow = { workspace = true, default-features = true, optional = true }
 elf = { workspace = true, features = ["std"], optional = true }
 
 [build-dependencies]
-cc = "1.1.31"
+cc.workspace = true
 # `bindgen` is only *invoked* when the env var LIBDD_PROFILING_HEAP_SAMPLER_REGEN
 # is set (see build.rs); it is otherwise pulled in as a build-dep so
 # that regen works without a cargo feature. Cargo features would be
@@ -39,4 +39,6 @@ cc = "1.1.31"
 # which would silently trigger a bindgen regen on hosts that lack
 # libclang. An env var side-steps
 # that (see README's "Regenerating bindings" section).
-bindgen = "0.71"
+# bindgen is only invoked when LIBDD_PROFILING_HEAP_SAMPLER_REGEN is set
+# (see above); `logging` is purely diagnostic output and is dropped.
+bindgen = { workspace = true, default-features = true }

--- a/libdd-profiling-protobuf/Cargo.toml
+++ b/libdd-profiling-protobuf/Cargo.toml
@@ -19,7 +19,7 @@ bolero = ["dep:bolero"]
 prost_impls = ["dep:prost"]
 
 [dependencies]
-prost = { version = "0.14", optional = true }
+prost = { workspace = true, default-features = true, optional = true }
 bolero = { workspace = true, optional = true }
 
 [dev-dependencies]

--- a/libdd-profiling/Cargo.toml
+++ b/libdd-profiling/Cargo.toml
@@ -29,9 +29,9 @@ harness = false
 allocator-api2 = { workspace = true, features = ["alloc"] }
 anyhow.workspace = true
 bitmaps = { workspace = true, default-features = true }
-# std is byteorder's only default feature; listed explicitly to keep the
-# workspace's default-features = false policy honest.
-byteorder = { workspace = true, default-features = false, features = ["std"] }
+# std is byteorder's only default feature; the workspace disables default
+# features, so enable std explicitly.
+byteorder = { workspace = true, features = ["std"] }
 bytes = { workspace = true, features = ["std"] }
 chrono = { workspace = true, features = ["std", "clock"] }
 crossbeam-channel = { workspace = true, default-features = true }
@@ -50,7 +50,7 @@ mime.workspace = true
 parking_lot.workspace = true
 # Only the prost::Message trait is used here; the Message derives live in
 # libdd-profiling-protobuf (which enables prost/derive for its generated code).
-prost = { workspace = true, default-features = false, features = ["std"] }
+prost = { workspace = true, features = ["std"] }
 # Use rustls to align with the rest of the workspace (libdd-common, libdd-telemetry, etc.)
 # Non-FIPS builds use ring as the crypto provider; FIPS builds use aws-lc-rs.
 # Use hickory-dns instead of the default system DNS resolver to avoid fork safety issues.
@@ -87,7 +87,7 @@ libdd-profiling = { path = ".", features = ["test-utils"] }
 # thread RNG, i.e. both `std` and `std_rng` defaults.
 rand = { workspace = true, default-features = true }
 proptest = { workspace = true, default-features = true }
-strum = { workspace = true, default-features = false, features = ["derive"] }
+strum = { workspace = true, features = ["derive"] }
 tempfile.workspace = true
 
 [build-dependencies]

--- a/libdd-profiling/Cargo.toml
+++ b/libdd-profiling/Cargo.toml
@@ -28,26 +28,29 @@ harness = false
 [dependencies]
 allocator-api2 = { workspace = true, features = ["alloc"] }
 anyhow.workspace = true
-bitmaps = "3.2.0"
-byteorder = { version = "1.5", features = ["std"] }
+bitmaps = { workspace = true, default-features = true }
+# std is byteorder's only default feature; listed explicitly to keep the
+# workspace's default-features = false policy honest.
+byteorder = { workspace = true, default-features = false, features = ["std"] }
 bytes = { workspace = true, features = ["std"] }
 chrono = { workspace = true, features = ["std", "clock"] }
-crossbeam-channel = "0.5.15"
-crossbeam-utils = { version = "0.8.21" }
-cxx = { version = "1.0", optional = true }
+crossbeam-channel = { workspace = true, default-features = true }
+crossbeam-utils = { workspace = true, default-features = true }
+cxx = { workspace = true, default-features = true, optional = true }
 futures.workspace = true
-hashbrown = { version = "0.16", default-features = false }
+hashbrown.workspace = true
 http = { workspace = true, features = ["std"] }
 http-body-util.workspace = true
 httparse = { workspace = true, features = ["std"] }
-indexmap = "2.11"
+indexmap = { workspace = true, default-features = true }
 libdd-alloc = { version = "1.0.0", path = "../libdd-alloc" }
 libdd-common = { version = "6.0.0", path = "../libdd-common", default-features = false, features = ["reqwest", "test-utils"] }
 libdd-profiling-protobuf = { version = "2.0.0", path = "../libdd-profiling-protobuf", features = ["prost_impls"] }
 mime.workspace = true
-parking_lot = { version = "0.12", default-features = false }
-prost = "0.14.1"
-rand = "0.8"
+parking_lot.workspace = true
+# Only the prost::Message trait is used here; the Message derives live in
+# libdd-profiling-protobuf (which enables prost/derive for its generated code).
+prost = { workspace = true, default-features = false, features = ["std"] }
 # Use rustls to align with the rest of the workspace (libdd-common, libdd-telemetry, etc.)
 # Non-FIPS builds use ring as the crypto provider; FIPS builds use aws-lc-rs.
 # Use hickory-dns instead of the default system DNS resolver to avoid fork safety issues.
@@ -57,13 +60,13 @@ rand = "0.8"
 # backend. We install the ring provider explicitly via tls.rs / libdd-common instead.
 reqwest = { workspace = true, features = ["multipart", "rustls-no-provider", "hickory-dns"] }
 rustls-platform-verifier.workspace = true
-rustc-hash = { version = "2.1", default-features = false }
+rustc-hash.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-target-triple = "0.1.4"
-thiserror = "2"
-tokio = {version = "1.23", features = ["rt", "macros", "net", "io-util", "fs"]}
-tokio-util = { version = "0.7.1", default-features = false }
+target-triple.workspace = true
+thiserror = { workspace = true, default-features = true }
+tokio = { workspace = true, features = ["rt", "macros", "net", "io-util", "fs"] }
+tokio-util.workspace = true
 # ring is the crypto provider for non-FIPS builds on all platforms.
 # FIPS builds activate aws-lc-rs via the rustls/fips feature instead.
 rustls = { workspace = true, features = ["ring"] }
@@ -72,15 +75,19 @@ rustls = { workspace = true, features = ["ring"] }
 zstd.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-zrip = { version = "=0.6.0", default-features = false, features = ["frame"] }
+zrip = { workspace = true, features = ["frame"] }
 
 [dev-dependencies]
 bolero = { workspace = true, features = ["std"] }
 criterion.workspace = true
 libdd-common = { path = "../libdd-common", features = ["test-utils"] }
 libdd-profiling = { path = ".", features = ["test-utils"] }
-proptest = "1"
-strum = { version = "0.26", features = ["derive"] }
+# rand is only used by tests/exporter_e2e.rs (rand::random), never by the
+# library itself, so it lives in dev-dependencies. `rand::random` needs the
+# thread RNG, i.e. both `std` and `std_rng` defaults.
+rand = { workspace = true, default-features = true }
+proptest = { workspace = true, default-features = true }
+strum = { workspace = true, default-features = false, features = ["derive"] }
 tempfile.workspace = true
 
 [build-dependencies]

--- a/libdd-remote-config/Cargo.toml
+++ b/libdd-remote-config/Cargo.toml
@@ -56,33 +56,27 @@ http-body-util = { workspace = true, optional = true }
 http = { workspace = true, features = ["std"], optional = true }
 base64 = { workspace = true, features = ["std"], optional = true }
 sha2 = { workspace = true, features = ["std"], optional = true }
-getrandom = { version = "0.2", optional = true }
+getrandom = { workspace = true, optional = true }
 uuid = { workspace = true, features = ["std"], optional = true }
-futures-util = { version = "0.3", optional = true }
+futures-util = { workspace = true, default-features = false, features = ["std"], optional = true }
 tokio = { workspace = true, optional = true, features = ["macros"] }
-tokio-util = { version = "0.7.10", optional = true }
-manual_future = { version = "0.1.1", optional = true }
-time = { version = "0.3", features = [
-    "parsing",
-    "serde",
-    "formatting",
-], optional = true }
+tokio-util = { workspace = true, optional = true }
+manual_future = { workspace = true, optional = true }
+time = { workspace = true, default-features = false, features = ["parsing", "serde", "formatting"], optional = true }
 tracing = { workspace = true, optional = true }
-serde = { workspace = true }
+serde.workspace = true
 serde_json = { workspace = true, features = ["raw_value"] }
-serde_with = "3"
-rand = { version = "0.8.5", optional = true }
-thiserror = "1"
-hashbrown = "0.17"
-tuf = { package = "libdd-tuf", version = "0.3.1", default-features = false, optional = true }
-chrono = { version = "0.4", default-features = false, features = [
-    "clock",
-], optional = true }
-prost = { version = "0.14.1", optional = true }
-futures = { version = "0.3", optional = true }
+serde_with = { workspace = true, default-features = false }
+rand = { workspace = true, default-features = true, optional = true }
+thiserror = { workspace = true, default-features = true }
+hashbrown = { workspace = true, default-features = true }
+tuf = { workspace = true, optional = true }
+chrono = { workspace = true, features = ["clock"], optional = true }
+prost = { workspace = true, default-features = false, features = ["std"], optional = true }
+futures = { workspace = true, default-features = false, features = ["std", "async-await"], optional = true }
 # `EnumIter` for external consumers to make struct available to runtime
-strum = { version = "0.26", default-features = false }
-strum_macros = "0.26"
+strum.workspace = true
+strum_macros.workspace = true
 
 # Test feature
 hyper-util = { workspace = true, features = [
@@ -93,9 +87,9 @@ hyper-util = { workspace = true, features = [
 ], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2", features = ["js"] }
+getrandom = { workspace = true, features = ["js"] }
 # For `tuf` ring needs this feature for `SystemRandom` on wasm.
-ring = { version = "0.17", features = ["wasm32_unknown_unknown_js"], optional = true }
+ring = { workspace = true, default-features = true, features = ["wasm32_unknown_unknown_js"], optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libdd-capabilities-impl = { path = "../libdd-capabilities-impl", version = "5.0.0", default-features = false }

--- a/libdd-remote-config/Cargo.toml
+++ b/libdd-remote-config/Cargo.toml
@@ -58,22 +58,22 @@ base64 = { workspace = true, features = ["std"], optional = true }
 sha2 = { workspace = true, features = ["std"], optional = true }
 getrandom = { workspace = true, optional = true }
 uuid = { workspace = true, features = ["std"], optional = true }
-futures-util = { workspace = true, default-features = false, features = ["std"], optional = true }
+futures-util = { workspace = true, features = ["std"], optional = true }
 tokio = { workspace = true, optional = true, features = ["macros"] }
 tokio-util = { workspace = true, optional = true }
 manual_future = { workspace = true, optional = true }
-time = { workspace = true, default-features = false, features = ["parsing", "serde", "formatting"], optional = true }
+time = { workspace = true, features = ["parsing", "serde", "formatting"], optional = true }
 tracing = { workspace = true, optional = true }
 serde.workspace = true
 serde_json = { workspace = true, features = ["raw_value"] }
-serde_with = { workspace = true, default-features = false }
+serde_with.workspace = true
 rand = { workspace = true, default-features = true, optional = true }
 thiserror = { workspace = true, default-features = true }
 hashbrown = { workspace = true, default-features = true }
 tuf = { workspace = true, optional = true }
 chrono = { workspace = true, features = ["clock"], optional = true }
-prost = { workspace = true, default-features = false, features = ["std"], optional = true }
-futures = { workspace = true, default-features = false, features = ["std", "async-await"], optional = true }
+prost = { workspace = true, features = ["std"], optional = true }
+futures = { workspace = true, features = ["std", "async-await"], optional = true }
 # `EnumIter` for external consumers to make struct available to runtime
 strum.workspace = true
 strum_macros.workspace = true

--- a/libdd-sampling/Cargo.toml
+++ b/libdd-sampling/Cargo.toml
@@ -31,7 +31,7 @@ required-features = ["bench-internals"]
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-lru = "0.16.3"
+lru = { workspace = true, default-features = true }
 libdd-common = { path = "../libdd-common", version = "6.0.0", default-features = false }
 libdd-trace-utils = { path = "../libdd-trace-utils", version = "12.0.0", optional = true }
 

--- a/libdd-shared-runtime/Cargo.toml
+++ b/libdd-shared-runtime/Cargo.toml
@@ -16,11 +16,11 @@ crate-type = ["lib"]
 bench = false
 
 [dependencies]
-async-trait = "0.1"
+async-trait.workspace = true
 futures = { workspace = true, features = ["alloc"] }
-futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
+futures-util = { workspace = true, features = ["alloc"] }
 tokio = { workspace = true, features = ["rt", "macros", "time"] }
-tokio-util = "0.7.11"
+tokio-util.workspace = true
 tracing.workspace = true
 libdd-capabilities = { path = "../libdd-capabilities", version = "3.0.1" }
 libdd-common = { version = "6.0.0", path = "../libdd-common", default-features = false }
@@ -33,11 +33,11 @@ regex-lite = ["libdd-common/regex-lite"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libdd-capabilities-impl = { path = "../libdd-capabilities-impl", version = "5.0.0", default-features = false }
-tokio = { version = "1.23", features = ["rt-multi-thread"] }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen-futures = "0.4"
-futures-util = { version = "0.3", default-features = false, features = ["alloc", "channel"] }
+wasm-bindgen-futures = { workspace = true, default-features = true }
+futures-util = { workspace = true, features = ["alloc", "channel"] }
 
 [dev-dependencies]
 futures = { workspace = true, features = ["executor"] }

--- a/libdd-telemetry-ffi/Cargo.toml
+++ b/libdd-telemetry-ffi/Cargo.toml
@@ -27,9 +27,9 @@ libdd-capabilities-impl = { path = "../libdd-capabilities-impl" }
 libdd-telemetry = { path = "../libdd-telemetry" }
 libdd-common = { path = "../libdd-common" }
 libdd-common-ffi = { path = "../libdd-common-ffi", default-features = false }
-function_name = "0.3"
+function_name.workspace = true
 libc.workspace = true
-paste = "1"
+paste.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/libdd-telemetry/Cargo.toml
+++ b/libdd-telemetry/Cargo.toml
@@ -55,7 +55,7 @@ winver.workspace = true
 
 [dev-dependencies]
 # Examples only call fmt(); ansi/tracing-log/smallvec extras not needed.
-tracing-subscriber = { workspace = true, default-features = false, features = ["fmt"] }
+tracing-subscriber = { workspace = true, features = ["fmt"] }
 tokio = { workspace = true, features = ["sync", "io-util", "rt-multi-thread"] }
 libdd-capabilities-impl = { path = "../libdd-capabilities-impl" }
 libdd-common = { path = "../libdd-common", features = ["test-utils"] }

--- a/libdd-telemetry/Cargo.toml
+++ b/libdd-telemetry/Cargo.toml
@@ -19,42 +19,44 @@ fips = ["libdd-common/fips", "libdd-shared-runtime/fips"]
 
 [dependencies]
 anyhow.workspace = true
-async-trait = "0.1"
+async-trait.workspace = true
 base64 = { workspace = true, features = ["std"] }
 futures.workspace = true
 http = { workspace = true, features = ["std"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
-strum = { version = "0.26", default-features = false }
-strum_macros = "0.26"
+strum.workspace = true
+strum_macros.workspace = true
 tokio = { workspace = true, features = ["sync", "io-util"] }
-tokio-util = { version = "0.7", features = ["codec"] }
+tokio-util = { workspace = true, features = ["codec"] }
 tracing.workspace = true
 uuid = { workspace = true, features = ["v4", "std"] }
-hashbrown = "0.15"
+# Only HashTable (ungated) and DefaultHashBuilder (default-hasher) are used.
+hashbrown = { workspace = true, default-features = true }
 bytes = { workspace = true, features = ["std"] }
 libdd-capabilities = { version = "3.0.1", path = "../libdd-capabilities" }
 libdd-common = { version = "6.0.0", path = "../libdd-common", default-features = false }
 libdd-shared-runtime = { version = "4.0.0", path = "../libdd-shared-runtime", default-features = false }
 libdd-ddsketch = { version = "1.1.1", path = "../libdd-ddsketch" }
-web-time = "1" # cross-platform Instant/SystemTime; shims via js-sys on wasm32
+web-time.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-sys-info = { version = "0.9.0" }
+sys-info.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2", features = ["js"] }
+getrandom = { workspace = true, features = ["js"] }
 uuid = { workspace = true, features = ["js", "std"] }
 
 [target."cfg(unix)".dependencies]
 libc.workspace = true
 
 [target."cfg(windows)".dependencies]
-winver = "1.0.0"
+winver.workspace = true
 
 [dev-dependencies]
-tracing-subscriber = "0.3.22"
-tokio = { version = "1.23", features = ["sync", "io-util", "rt-multi-thread"] }
+# Examples only call fmt(); ansi/tracing-log/smallvec extras not needed.
+tracing-subscriber = { workspace = true, default-features = false, features = ["fmt"] }
+tokio = { workspace = true, features = ["sync", "io-util", "rt-multi-thread"] }
 libdd-capabilities-impl = { path = "../libdd-capabilities-impl" }
 libdd-common = { path = "../libdd-common", features = ["test-utils"] }
 httpmock.workspace = true

--- a/libdd-tinybytes/Cargo.toml
+++ b/libdd-tinybytes/Cargo.toml
@@ -13,12 +13,12 @@ bench = false
 
 [dev-dependencies]
 once_cell = { workspace = true, features = ["std"] }
-pretty_assertions = "1.3"
-proptest = {version = "1.5", features = ["std"], default-features = false}
-test-case = "2.2"
+pretty_assertions = { workspace = true, default-features = true }
+proptest = { workspace = true, default-features = true }
+test-case.workspace = true
 serde_json.workspace = true
 libdd-tinybytes = { path = ".", features = ["bytes_string", "serialization"] }
-rmp-serde = "1.3.0"
+rmp-serde.workspace = true
 
 [dependencies]
 serde = { workspace = true, optional = true }

--- a/libdd-trace-normalization/Cargo.toml
+++ b/libdd-trace-normalization/Cargo.toml
@@ -15,14 +15,14 @@ bench = false
 [dependencies]
 anyhow.workspace = true
 libdd-trace-protobuf = { version = "5.0.0", path = "../libdd-trace-protobuf" }
-arbitrary = { version = "1.3", features = ["derive"], optional = true }
+arbitrary = { workspace = true, features = ["derive"], optional = true }
 
 [features]
 fuzzing = ["arbitrary"]
 
 [dev-dependencies]
-rand = ">=0.8.6, <0.9"
-duplicate = "0.4.1"
+rand = { workspace = true, default-features = true }
+duplicate = { workspace = true, default-features = true }
 criterion.workspace = true
 
 [[bench]]

--- a/libdd-trace-obfuscation/Cargo.toml
+++ b/libdd-trace-obfuscation/Cargo.toml
@@ -16,8 +16,8 @@ anyhow.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
 percent-encoding = { workspace = true, features = ["std"] }
-log = "0.4"
-fluent-uri = "0.4.1"
+log.workspace = true
+fluent-uri = { workspace = true, default-features = false }
 libdd-trace-protobuf = { version = "5.0.0", path = "../libdd-trace-protobuf" }
 libdd-trace-utils = { version = "12.0.0", path = "../libdd-trace-utils", default-features = false }
 libdd-common = { version = "6.0.0", path = "../libdd-common", default-features = false }
@@ -29,7 +29,7 @@ fips = ["libdd-common/fips", "libdd-trace-utils/fips"]
 regex-lite = ["libdd-common/regex-lite"]
 
 [dev-dependencies]
-duplicate = "0.4.1"
+duplicate = { workspace = true, default-features = true }
 criterion = { workspace = true, features = ["csv_output"] }
 libdd-trace-utils = { path = "../libdd-trace-utils", features = ["test-utils"] }
 libdd-tinybytes = { version = "1.1.3", path = "../libdd-tinybytes" }

--- a/libdd-trace-obfuscation/Cargo.toml
+++ b/libdd-trace-obfuscation/Cargo.toml
@@ -17,7 +17,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["preserve_order"] }
 percent-encoding = { workspace = true, features = ["std"] }
 log.workspace = true
-fluent-uri = { workspace = true, default-features = false }
+fluent-uri.workspace = true
 libdd-trace-protobuf = { version = "5.0.0", path = "../libdd-trace-protobuf" }
 libdd-trace-utils = { version = "12.0.0", path = "../libdd-trace-utils", default-features = false }
 libdd-common = { version = "6.0.0", path = "../libdd-common", default-features = false }

--- a/libdd-trace-obfuscation/src/http.rs
+++ b/libdd-trace-obfuscation/src/http.rs
@@ -302,509 +302,78 @@ mod tests {
     use super::obfuscate_url_string;
 
     #[duplicate_item(
-        [
-            test_name           [remove_query_string_1]
-            remove_query_string [true]
-            remove_path_digits  [false]
-            input               ["http://foo.com/"]
-            expected_output     ["http://foo.com/"];
-        ]
-        [
-            test_name           [remove_query_string_2]
-            remove_query_string [true]
-            remove_path_digits  [false]
-            input               ["http://foo.com/123"]
-            expected_output     ["http://foo.com/123"];
-        ]
-        [
-            test_name           [remove_query_string_3]
-            remove_query_string [true]
-            remove_path_digits  [false]
-            input               ["http://foo.com/id/123/page/1?search=bar&page=2"]
-            expected_output     ["http://foo.com/id/123/page/1?"];
-        ]
-        [
-            test_name           [remove_query_string_4]
-            remove_query_string [true]
-            remove_path_digits  [false]
-            input               ["http://foo.com/id/123/page/1?search=bar&page=2#fragment"]
-            expected_output     ["http://foo.com/id/123/page/1?#fragment"];
-        ]
-        [
-            test_name           [remove_query_string_5]
-            remove_query_string [true]
-            remove_path_digits  [false]
-            input               ["http://foo.com/id/123/page/1?blabla"]
-            expected_output     ["http://foo.com/id/123/page/1?"];
-        ]
-        [
-            test_name           [remove_query_string_6]
-            remove_query_string [true]
-            remove_path_digits  [false]
-            input               ["http://foo.com/id/123/pa%3Fge/1?blabla"]
-            expected_output     ["http://foo.com/id/123/pa%3Fge/1?"];
-        ]
-        [
-            test_name           [remove_query_string_7]
-            remove_query_string [true]
-            remove_path_digits  [false]
-            input               ["http://user:password@foo.com/1/2/3?q=james"]
-            expected_output     ["http://foo.com/1/2/3?"];
-        ]
-        [
-            test_name           [remove_path_digits_1]
-            remove_query_string [false]
-            remove_path_digits  [true]
-            input               ["http://foo.com/"]
-            expected_output     ["http://foo.com/"];
-        ]
-        [
-            test_name           [remove_path_digits_2]
-            remove_query_string [false]
-            remove_path_digits  [true]
-            input               ["http://foo.com/name?query=search"]
-            expected_output     ["http://foo.com/name?query=search"];
-        ]
-        [
-            test_name           [remove_path_digits_3]
-            remove_query_string [false]
-            remove_path_digits  [true]
-            input               ["http://foo.com/id/123/page/1?search=bar&page=2"]
-            expected_output     ["http://foo.com/id/?/page/??search=bar&page=2"];
-        ]
-        [
-            test_name           [remove_path_digits_4]
-            remove_query_string [false]
-            remove_path_digits  [true]
-            input               ["http://foo.com/id/a1/page/1qwe233?search=bar&page=2#fragment-123"]
-            expected_output     ["http://foo.com/id/?/page/??search=bar&page=2#fragment-123"];
-        ]
-        [
-            test_name           [remove_path_digits_5]
-            remove_query_string [false]
-            remove_path_digits  [true]
-            input               ["http://foo.com/123"]
-            expected_output     ["http://foo.com/?"];
-        ]
-        [
-            test_name           [remove_path_digits_6]
-            remove_query_string [false]
-            remove_path_digits  [true]
-            input               ["http://foo.com/123/abcd9"]
-            expected_output     ["http://foo.com/?/?"];
-        ]
-        [
-            test_name           [remove_path_digits_7]
-            remove_query_string [false]
-            remove_path_digits  [true]
-            input               ["http://foo.com/123/name/abcd9"]
-            expected_output     ["http://foo.com/?/name/?"];
-        ]
-        [
-            test_name           [remove_path_digits_8]
-            remove_query_string [false]
-            remove_path_digits  [true]
-            input               ["http://foo.com/1%3F3/nam%3Fe/abcd9"]
-            expected_output     ["http://foo.com/?/nam%3Fe/?"];
-        ]
-        [
-            test_name           [empty_input]
-            remove_query_string [false]
-            remove_path_digits  [false]
-            input               [""]
-            expected_output     [""];
-        ]
-        [
-            test_name           [non_printable_chars]
-            remove_query_string [false]
-            remove_path_digits  [false]
-            input               ["\u{10}"]
-            // When both options false, Go returns original (obfuscateUserInfo passthrough)
-            expected_output     ["\u{10}"];
-        ]
-        [
-            test_name           [non_printable_chars_and_unicode]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["\u{10}ჸ"]
-            expected_output     ["?"];
-        ]
-        [
-            test_name           [hashtag]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["#"]
-            expected_output     [""];
-        ]
-        [
-            test_name           [fuzzing_1050521893]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["ჸ"]
-            expected_output     ["%E1%83%B8"];
-        ]
-        [
-            test_name           [fuzzing_594901251]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["%"]
-            expected_output     ["?"];
-        ]
-        [
-            test_name           [fuzzing_3638045804]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["."]
-            expected_output     ["."];
-        ]
-        [
-            test_name           [fuzzing_1928485962]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["0"]
-            expected_output     ["?"];
-        ]
-        [
-            test_name           [fuzzing_4273565798]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["!ჸ"]
-            expected_output     ["%21%E1%83%B8"];
-        ]
-        [
-            test_name           [fuzzing_1457007156]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["!"]
-            expected_output     ["!"];
-        ]
-        [
-            test_name           [fuzzing_3119724369]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               [":"]
-            expected_output     ["?"];
-        ]
-        [
-            test_name           [fuzzing_1092426409]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["#ჸ"]
-            expected_output     ["#%E1%83%B8"];
-        ]
-        [
-            test_name           [fuzzing_1323831861]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["#\u{01}"]
-            expected_output     ["#%01"];
-        ]
-        [
-            test_name           [fuzzing_35626170]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["#\u{01}ჸ"]
-            expected_output     ["#%01%E1%83%B8"];
-        ]
-        [
-            test_name           [fuzzing_618280270]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["\\"]
-            expected_output     ["%5C"];
-        ]
-        [
-            test_name           [fuzzing_1505427946]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["[ჸ"]
-            expected_output     ["%5B%E1%83%B8"];
-        ]
-        [
-            test_name           [fuzzing_backslash_unicode]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["\\ჸ"]
-            expected_output     ["%5C%E1%83%B8"];
-        ]
-        [
-            test_name           [fuzzing_2438023093]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["ჸ#"]
-            expected_output     ["%E1%83%B8"];
-        ]
-        [
-            test_name           [fuzzing_2729083127]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["!#ჸ"]
-            expected_output     ["!#%E1%83%B8"];
-        ]
-        [
-            test_name           [fuzzing_slash_unicode]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["/ჸ"]
-            expected_output     ["/%E1%83%B8"];
-        ]
-        [
-            test_name           [fuzzing_3710129001]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["##"]
-            expected_output     ["#%23"];
-        ]
-        [
-            test_name           [fuzzing_1009954227]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["ჸ#\u{10}"]
-            expected_output     ["%E1%83%B8#%10"];
-        ]
-        [
-            test_name           [fuzzing_hash_exclamation]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["ჸ#!"]
-            expected_output     ["%E1%83%B8#!"];
-        ]
-        [
-            test_name           [fuzzing_578834728]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["#%"]
-            expected_output     ["?"];
-        ]
-        [
-            test_name           [fuzzing_3991369296]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["#'ჸ"]
-            expected_output     ["#%27%E1%83%B8"];
-        ]
-        [
-            test_name           [fuzzing_path_frag_quote]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["ჸ#'ჸ"]
-            expected_output     ["%E1%83%B8#%27%E1%83%B8"];
-        ]
-        [
-            test_name           [fuzzing_hash_excl_unicode]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["#!ჸ"]
-            expected_output     ["#!%E1%83%B8"];
-        ]
-        [
-            // Cat1 char (<) triggers full escape(), which also encodes Cat2 char (!)
-            test_name           [fuzzing_2455396347_cat1_triggers_cat2]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["<!"]
-            expected_output     ["%3C%21"];
-        ]
-        [
-            // Fragment has invalid percent-encoding (%\u{1}) AND control char — Go rejects
-            test_name           [fuzzing_3886417401]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["ჸ#%\u{1}"]
-            expected_output     ["?"];
-        ]
-        [
-            test_name           [parity_double_quote_cat1]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["\"!"]
-            expected_output     ["%22%21"];
-        ]
-        [
-            test_name           [parity_dot_hash_unicode]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               [".#ჸ"]
-            expected_output     [".#%E1%83%B8"];
-        ]
-        [
-            test_name           [parity_dot_hash]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               [".#"]
-            expected_output     ["."];
-        ]
-        [
-            test_name           [parity_unicode_hash_digit]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["ჸ#0"]
-            expected_output     ["%E1%83%B8#0"];
-        ]
-        [
-            test_name           [parity_scheme_empty_frag]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["C:#"]
-            expected_output     ["c:"];
-        ]
-        [
-            test_name           [parity_relative_dotdot_unicode]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["../ჸ"]
-            expected_output     ["../%E1%83%B8"];
-        ]
-        [
-            test_name           [parity_query_hash_unicode_both]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["?#ჸ"]
-            expected_output     ["?#%E1%83%B8"];
-        ]
-        [
-            test_name           [parity_query_hash_unicode_digits]
-            remove_query_string [false]
-            remove_path_digits  [true]
-            input               ["?#ჸ"]
-            expected_output     ["?#%E1%83%B8"];
-        ]
-        [
-            test_name           [parity_excl_query_unicode]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["!?ჸ"]
-            expected_output     ["!?"];
-        ]
-        [
-            test_name           [parity_query_unicode_keep]
-            remove_query_string [false]
-            remove_path_digits  [true]
-            input               ["?ჸ"]
-            expected_output     ["?ჸ"];
-        ]
-        [
-            test_name           [parity_space_unicode]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               [" ჸ"]
-            expected_output     ["%20%E1%83%B8"];
-        ]
-        [
-            test_name           [parity_unicode_query_unicode_keep]
-            remove_query_string [false]
-            remove_path_digits  [true]
-            input               ["ჸ?ჸ"]
-            expected_output     ["%E1%83%B8?ჸ"];
-        ]
-        [
-            test_name           [parity_unicode_query_hash_both]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["?ჸ#ჸ"]
-            expected_output     ["?#%E1%83%B8"];
-        ]
-        [
-            test_name           [parity_unicode_query_empty_hash]
-            remove_query_string [false]
-            remove_path_digits  [true]
-            input               ["ჸ?#"]
-            expected_output     ["%E1%83%B8?"];
-        ]
-        [
-            test_name           [parity_pct_unreserved_normalize]
-            remove_query_string [true]
-            remove_path_digits  [false]
-            input               ["%30ჸ"]
-            expected_output     ["0%E1%83%B8"];
-        ]
-        [
-            test_name           [parity_unicode_query_invalid_pct]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["ჸ?%"]
-            expected_output     ["%E1%83%B8?"];
-        ]
-        [
-            test_name           [parity_not_a_url_both_false]
-            remove_query_string [false]
-            remove_path_digits  [false]
-            input               ["this is not a valid url"]
-            expected_output     ["this%20is%20not%20a%20valid%20url"];
-        ]
-        [
-            test_name           [parity_not_a_url_both_true]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["this is not a valid url"]
-            expected_output     ["this%20is%20not%20a%20valid%20url"];
-        ]
-        [
-            test_name           [parity_disabled_userinfo]
-            remove_query_string [false]
-            remove_path_digits  [false]
-            input               ["http://user:password@foo.com/1/2/3?q=james"]
-            expected_output     ["http://foo.com/1/2/3?q=james"];
-        ]
-        [
-            test_name           [parity_colon_both_false]
-            remove_query_string [false]
-            remove_path_digits  [false]
-            input               [":"]
-            expected_output     [":"];
-        ]
-        [
-            test_name           [parity_pct_both_false]
-            remove_query_string [false]
-            remove_path_digits  [false]
-            input               ["%"]
-            expected_output     ["%"];
-        ]
-        [
-            test_name           [parity_ctrl_in_scheme_both_false]
-            remove_query_string [false]
-            remove_path_digits  [false]
-            input               ["C:\u{1}"]
-            expected_output     ["C:\u{1}"];
-        ]
-        [
-            test_name           [parity_ctrl_both_false]
-            remove_query_string [false]
-            remove_path_digits  [false]
-            input               ["\u{1}"]
-            expected_output     ["\u{1}"];
-        ]
-        [
-            test_name           [parity_frag_curly_brace]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["ჸ#{ჸ"]
-            expected_output     ["%E1%83%B8#%7B%E1%83%B8"];
-        ]
-        [
-            // Opaque URL: Go keeps the opaque part verbatim (not percent-encoded)
-            test_name           [parity_opaque_url_unicode]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["A:ჸ"]
-            expected_output     ["a:ჸ"];
-        ]
-        [
-            test_name           [no_decode_dash]
-            remove_query_string [false]
-            remove_path_digits  [false]
-            input               ["http://foo.com/foo%20bar/"]
-            expected_output     ["http://foo.com/foo%20bar/"];
-        ]
-        [
-            // Fragment with chars outside RFC 3987 ucschar ranges (U+10EF4F, U+10FFFF, etc.)
-            // These must be percent-encoded, not cause a parse failure returning "?"
-            test_name           [parity_fuzzing_supp_unicode_frag]
-            remove_query_string [true]
-            remove_path_digits  [true]
-            input               ["\u{91cb8}\u{9232f}झ\u{44db0}#\u{3}\n\u{5bb50}\u{925d9}\u{925d5}\u{925d5}\u{925d5}\u{925d5}䕞\u{9a70d}\u{3d2ff}\u{10ef4f}\u{87307}\u{6}\u{10ef0a}\u{10ffff}\u{ad7e5}\u{33f}筚\u{361}➑\u{2}{\u{10de13}\u{10ffff}\u{10ffff}'"]
-            expected_output     ["%F2%91%B2%B8%F2%92%8C%AF%E0%A4%9D%F1%84%B6%B0#%03%0A%F1%9B%AD%90%F2%92%97%99%F2%92%97%95%F2%92%97%95%F2%92%97%95%F2%92%97%95%E4%95%9E%F2%9A%9C%8D%F0%BD%8B%BF%F4%8E%BD%8F%F2%87%8C%87%06%F4%8E%BC%8A%F4%8F%BF%BF%F2%AD%9F%A5%CC%BF%E7%AD%9A%CD%A1%E2%9E%91%02%7B%F4%8D%B8%93%F4%8F%BF%BF%F4%8F%BF%BF%27"];
-        ]
+    test_name remove_query_string remove_path_digits input expected_output;
+    [remove_query_string_1] [true] [false] ["http://foo.com/"] ["http://foo.com/"];
+    [remove_query_string_2] [true] [false] ["http://foo.com/123"] ["http://foo.com/123"];
+    [remove_query_string_3] [true] [false] ["http://foo.com/id/123/page/1?search=bar&page=2"] ["http://foo.com/id/123/page/1?"];
+    [remove_query_string_4] [true] [false] ["http://foo.com/id/123/page/1?search=bar&page=2#fragment"] ["http://foo.com/id/123/page/1?#fragment"];
+    [remove_query_string_5] [true] [false] ["http://foo.com/id/123/page/1?blabla"] ["http://foo.com/id/123/page/1?"];
+    [remove_query_string_6] [true] [false] ["http://foo.com/id/123/pa%3Fge/1?blabla"] ["http://foo.com/id/123/pa%3Fge/1?"];
+    [remove_query_string_7] [true] [false] ["http://user:password@foo.com/1/2/3?q=james"] ["http://foo.com/1/2/3?"];
+    [remove_path_digits_1] [false] [true] ["http://foo.com/"] ["http://foo.com/"];
+    [remove_path_digits_2] [false] [true] ["http://foo.com/name?query=search"] ["http://foo.com/name?query=search"];
+    [remove_path_digits_3] [false] [true] ["http://foo.com/id/123/page/1?search=bar&page=2"] ["http://foo.com/id/?/page/??search=bar&page=2"];
+    [remove_path_digits_4] [false] [true] ["http://foo.com/id/a1/page/1qwe233?search=bar&page=2#fragment-123"] ["http://foo.com/id/?/page/??search=bar&page=2#fragment-123"];
+    [remove_path_digits_5] [false] [true] ["http://foo.com/123"] ["http://foo.com/?"];
+    [remove_path_digits_6] [false] [true] ["http://foo.com/123/abcd9"] ["http://foo.com/?/?"];
+    [remove_path_digits_7] [false] [true] ["http://foo.com/123/name/abcd9"] ["http://foo.com/?/name/?"];
+    [remove_path_digits_8] [false] [true] ["http://foo.com/1%3F3/nam%3Fe/abcd9"] ["http://foo.com/?/nam%3Fe/?"];
+    [empty_input] [false] [false] [""] [""];
+    [non_printable_chars] [false] [false] ["\u{10}"] ["\u{10}"];
+    [non_printable_chars_and_unicode] [true] [true] ["\u{10}ჸ"] ["?"];
+    [hashtag] [true] [true] ["#"] [""];
+    [fuzzing_1050521893] [true] [true] ["ჸ"] ["%E1%83%B8"];
+    [fuzzing_594901251] [true] [true] ["%"] ["?"];
+    [fuzzing_3638045804] [true] [true] ["."] ["."];
+    [fuzzing_1928485962] [true] [true] ["0"] ["?"];
+    [fuzzing_4273565798] [true] [true] ["!ჸ"] ["%21%E1%83%B8"];
+    [fuzzing_1457007156] [true] [true] ["!"] ["!"];
+    [fuzzing_3119724369] [true] [true] [":"] ["?"];
+    [fuzzing_1092426409] [true] [true] ["#ჸ"] ["#%E1%83%B8"];
+    [fuzzing_1323831861] [true] [true] ["#\u{01}"] ["#%01"];
+    [fuzzing_35626170] [true] [true] ["#\u{01}ჸ"] ["#%01%E1%83%B8"];
+    [fuzzing_618280270] [true] [true] ["\\"] ["%5C"];
+    [fuzzing_1505427946] [true] [true] ["[ჸ"] ["%5B%E1%83%B8"];
+    [fuzzing_backslash_unicode] [true] [true] ["\\ჸ"] ["%5C%E1%83%B8"];
+    [fuzzing_2438023093] [true] [true] ["ჸ#"] ["%E1%83%B8"];
+    [fuzzing_2729083127] [true] [true] ["!#ჸ"] ["!#%E1%83%B8"];
+    [fuzzing_slash_unicode] [true] [true] ["/ჸ"] ["/%E1%83%B8"];
+    [fuzzing_3710129001] [true] [true] ["##"] ["#%23"];
+    [fuzzing_1009954227] [true] [true] ["ჸ#\u{10}"] ["%E1%83%B8#%10"];
+    [fuzzing_hash_exclamation] [true] [true] ["ჸ#!"] ["%E1%83%B8#!"];
+    [fuzzing_578834728] [true] [true] ["#%"] ["?"];
+    [fuzzing_3991369296] [true] [true] ["#'ჸ"] ["#%27%E1%83%B8"];
+    [fuzzing_path_frag_quote] [true] [true] ["ჸ#'ჸ"] ["%E1%83%B8#%27%E1%83%B8"];
+    [fuzzing_hash_excl_unicode] [true] [true] ["#!ჸ"] ["#!%E1%83%B8"];
+    [fuzzing_2455396347_cat1_triggers_cat2] [true] [true] ["<!"] ["%3C%21"];
+    [fuzzing_3886417401] [true] [true] ["ჸ#%\u{1}"] ["?"];
+    [parity_double_quote_cat1] [true] [true] ["\"!"] ["%22%21"];
+    [parity_dot_hash_unicode] [true] [true] [".#ჸ"] [".#%E1%83%B8"];
+    [parity_dot_hash] [true] [true] [".#"] ["."];
+    [parity_unicode_hash_digit] [true] [true] ["ჸ#0"] ["%E1%83%B8#0"];
+    [parity_scheme_empty_frag] [true] [true] ["C:#"] ["c:"];
+    [parity_relative_dotdot_unicode] [true] [true] ["../ჸ"] ["../%E1%83%B8"];
+    [parity_query_hash_unicode_both] [true] [true] ["?#ჸ"] ["?#%E1%83%B8"];
+    [parity_query_hash_unicode_digits] [false] [true] ["?#ჸ"] ["?#%E1%83%B8"];
+    [parity_excl_query_unicode] [true] [true] ["!?ჸ"] ["!?"];
+    [parity_query_unicode_keep] [false] [true] ["?ჸ"] ["?ჸ"];
+    [parity_space_unicode] [true] [true] [" ჸ"] ["%20%E1%83%B8"];
+    [parity_unicode_query_unicode_keep] [false] [true] ["ჸ?ჸ"] ["%E1%83%B8?ჸ"];
+    [parity_unicode_query_hash_both] [true] [true] ["?ჸ#ჸ"] ["?#%E1%83%B8"];
+    [parity_unicode_query_empty_hash] [false] [true] ["ჸ?#"] ["%E1%83%B8?"];
+    [parity_pct_unreserved_normalize] [true] [false] ["%30ჸ"] ["0%E1%83%B8"];
+    [parity_unicode_query_invalid_pct] [true] [true] ["ჸ?%"] ["%E1%83%B8?"];
+    [parity_not_a_url_both_false] [false] [false] ["this is not a valid url"] ["this%20is%20not%20a%20valid%20url"];
+    [parity_not_a_url_both_true] [true] [true] ["this is not a valid url"] ["this%20is%20not%20a%20valid%20url"];
+    [parity_disabled_userinfo] [false] [false] ["http://user:password@foo.com/1/2/3?q=james"] ["http://foo.com/1/2/3?q=james"];
+    [parity_colon_both_false] [false] [false] [":"] [":"];
+    [parity_pct_both_false] [false] [false] ["%"] ["%"];
+    [parity_ctrl_in_scheme_both_false] [false] [false] ["C:\u{1}"] ["C:\u{1}"];
+    [parity_ctrl_both_false] [false] [false] ["\u{1}"] ["\u{1}"];
+    [parity_frag_curly_brace] [true] [true] ["ჸ#{ჸ"] ["%E1%83%B8#%7B%E1%83%B8"];
+    [parity_opaque_url_unicode] [true] [true] ["A:ჸ"] ["a:ჸ"];
+    [no_decode_dash] [false] [false] ["http://foo.com/foo%20bar/"] ["http://foo.com/foo%20bar/"];
+    [parity_fuzzing_supp_unicode_frag] [true] [true] ["\u{91cb8}\u{9232f}झ\u{44db0}#\u{3}\n\u{5bb50}\u{925d9}\u{925d5}\u{925d5}\u{925d5}\u{925d5}䕞\u{9a70d}\u{3d2ff}\u{10ef4f}\u{87307}\u{6}\u{10ef0a}\u{10ffff}\u{ad7e5}\u{33f}筚\u{361}➑\u{2}{\u{10de13}\u{10ffff}\u{10ffff}'"] ["%F2%91%B2%B8%F2%92%8C%AF%E0%A4%9D%F1%84%B6%B0#%03%0A%F1%9B%AD%90%F2%92%97%99%F2%92%97%95%F2%92%97%95%F2%92%97%95%F2%92%97%95%E4%95%9E%F2%9A%9C%8D%F0%BD%8B%BF%F4%8E%BD%8F%F2%87%8C%87%06%F4%8E%BC%8A%F4%8F%BF%BF%F2%AD%9F%A5%CC%BF%E7%AD%9A%CD%A1%E2%9E%91%02%7B%F4%8D%B8%93%F4%8F%BF%BF%F4%8F%BF%BF%27"];
     )]
     #[test]
     fn test_name() {

--- a/libdd-trace-obfuscation/src/redis.rs
+++ b/libdd-trace-obfuscation/src/redis.rs
@@ -371,127 +371,31 @@ mod tests {
     use super::{obfuscate_redis_string, quantize_redis_string, remove_all_redis_args};
 
     #[duplicate_item(
-        [
-            test_name   [test_quantize_redis_string_client]
-            input       ["CLIENT"]
-            expected    ["CLIENT"];
-        ]
-        [
-            test_name   [test_quantize_redis_string_client_list]
-            input       ["CLIENT LIST"]
-            expected    ["CLIENT LIST"];
-        ]
-        [
-            test_name   [test_quantize_redis_string_client_truncated]
-            input       ["CLIENT ..."]
-            expected    ["..."];
-        ]
-        [
-            test_name   [test_quantize_redis_string_get_lowercase]
-            input       ["get my_key"]
-            expected    ["GET"];
-        ]
-        [
-            test_name   [test_quantize_redis_string_set]
-            input       ["SET le_key le_value"]
-            expected    ["SET"];
-        ]
-        [
-            test_name   [test_quantize_redis_string_set_with_newlines]
-            input       ["\n\n  \nSET foo bar  \n  \n\n  "]
-            expected    ["SET"];
-        ]
-        [
-            test_name   [test_quantize_redis_string_config_set]
-            input       ["CONFIG SET parameter value"]
-            expected    ["CONFIG SET"];
-        ]
-        [
-            test_name   [test_quantize_redis_string_two_cmds]
-            input       ["SET toto tata \n \n  EXPIRE toto 15  "]
-            expected    ["SET EXPIRE"];
-        ]
-        [
-            test_name   [test_quantize_redis_string_mset]
-            input       ["MSET toto tata toto tata toto tata \n "]
-            expected    ["MSET"];
-        ]
-        [
-            test_name   [test_quantize_redis_string_max_cmds]
-            input       ["MULTI\nSET k1 v1\nSET k2 v2\nSET k3 v3\nSET k4 v4\nDEL to_del\nEXEC"]
-            expected    ["MULTI SET SET ..."];
-        ]
-        [
-            test_name   [test_quantize_redis_string_truncation_first]
-            input       ["GET..."]
-            expected    ["..."];
-        ]
-        [
-            test_name   [test_quantize_redis_string_truncation_arg]
-            input       ["GET k..."]
-            expected    ["GET"];
-        ]
-        [
-            test_name   [test_quantize_redis_string_truncation_third]
-            input       ["GET k1\nGET k2\nG..."]
-            expected    ["GET GET ..."];
-        ]
-        [
-            test_name   [test_quantize_redis_string_truncation_after_max]
-            input       ["GET k1\nGET k2\nDEL k3\nGET k..."]
-            expected    ["GET GET DEL ..."];
-        ]
-        [
-            test_name   [test_quantize_redis_string_truncation_hdel]
-            input       ["GET k1\nGET k2\nHDEL k3 a\nG..."]
-            expected    ["GET GET HDEL ..."];
-        ]
-        [
-            test_name   [test_quantize_redis_string_truncation_mid]
-            input       ["GET k...\nDEL k2\nMS..."]
-            expected    ["GET DEL ..."];
-        ]
-        [
-            test_name   [test_quantize_redis_string_truncation_early]
-            input       ["GET k...\nDE...\nMS..."]
-            expected    ["GET ..."];
-        ]
-        [
-            test_name   [test_quantize_redis_string_truncation_then_cmd]
-            input       ["GET k1\nDE...\nGET k2"]
-            expected    ["GET GET"];
-        ]
-        [
-            test_name   [test_quantize_redis_string_truncation_complex]
-            input       ["GET k1\nDE...\nGET k2\nHDEL k3 a\nGET k4\nDEL k5"]
-            expected    ["GET GET HDEL ..."];
-        ]
-        [
-            test_name   [test_quantize_redis_string_unknown]
-            input       ["UNKNOWN 123"]
-            expected    ["UNKNOWN"];
-        ]
-        [
-            test_name   [fuzzing_3286489773]
-            input       ["ꭺ"]
-            expected    ["Ꭺ"];
-        ]
-        [
-            test_name   [fuzzing_2812552373]
-            input       ["\t"]
-            expected    ["\t"];
-        ]
-        [
-            test_name   [fuzzing_crlf]
-            input       ["\r\n"]
-            // Split on \n specifically, not newlines, to copy agent's behaviour
-            expected    ["\r"];
-        ]
-        [
-            test_name   [fuzzing_box_char]
-            input       ["𖺻"]
-            expected    ["𖺻"];
-        ]
+    test_name input expected;
+    [test_quantize_redis_string_client] ["CLIENT"] ["CLIENT"];
+    [test_quantize_redis_string_client_list] ["CLIENT LIST"] ["CLIENT LIST"];
+    [test_quantize_redis_string_client_truncated] ["CLIENT ..."] ["..."];
+    [test_quantize_redis_string_get_lowercase] ["get my_key"] ["GET"];
+    [test_quantize_redis_string_set] ["SET le_key le_value"] ["SET"];
+    [test_quantize_redis_string_set_with_newlines] ["\n\n  \nSET foo bar  \n  \n\n  "] ["SET"];
+    [test_quantize_redis_string_config_set] ["CONFIG SET parameter value"] ["CONFIG SET"];
+    [test_quantize_redis_string_two_cmds] ["SET toto tata \n \n  EXPIRE toto 15  "] ["SET EXPIRE"];
+    [test_quantize_redis_string_mset] ["MSET toto tata toto tata toto tata \n "] ["MSET"];
+    [test_quantize_redis_string_max_cmds] ["MULTI\nSET k1 v1\nSET k2 v2\nSET k3 v3\nSET k4 v4\nDEL to_del\nEXEC"] ["MULTI SET SET ..."];
+    [test_quantize_redis_string_truncation_first] ["GET..."] ["..."];
+    [test_quantize_redis_string_truncation_arg] ["GET k..."] ["GET"];
+    [test_quantize_redis_string_truncation_third] ["GET k1\nGET k2\nG..."] ["GET GET ..."];
+    [test_quantize_redis_string_truncation_after_max] ["GET k1\nGET k2\nDEL k3\nGET k..."] ["GET GET DEL ..."];
+    [test_quantize_redis_string_truncation_hdel] ["GET k1\nGET k2\nHDEL k3 a\nG..."] ["GET GET HDEL ..."];
+    [test_quantize_redis_string_truncation_mid] ["GET k...\nDEL k2\nMS..."] ["GET DEL ..."];
+    [test_quantize_redis_string_truncation_early] ["GET k...\nDE...\nMS..."] ["GET ..."];
+    [test_quantize_redis_string_truncation_then_cmd] ["GET k1\nDE...\nGET k2"] ["GET GET"];
+    [test_quantize_redis_string_truncation_complex] ["GET k1\nDE...\nGET k2\nHDEL k3 a\nGET k4\nDEL k5"] ["GET GET HDEL ..."];
+    [test_quantize_redis_string_unknown] ["UNKNOWN 123"] ["UNKNOWN"];
+    [fuzzing_3286489773] ["ꭺ"] ["Ꭺ"];
+    [fuzzing_2812552373] ["\t"] ["\t"];
+    [fuzzing_crlf] ["\r\n"] ["\r"];
+    [fuzzing_box_char] ["𖺻"] ["𖺻"];
     )]
     #[test]
     fn test_name() {
@@ -500,425 +404,94 @@ mod tests {
     }
 
     #[duplicate_item(
-        [
-            test_name   [test_obfuscate_redis_string_1]
-            input       ["AUTH my-secret-password"]
-            expected    ["AUTH ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_2]
-            input       ["AUTH james my-secret-password"]
-            expected    ["AUTH ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_3]
-            input       ["AUTH"]
-            expected    ["AUTH"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_migrate_basic]
-            input       ["MIGRATE host port key destination-db timeout"]
-            expected    ["MIGRATE ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_migrate_with_flags]
-            input       ["MIGRATE host port key destination-db timeout COPY REPLACE"]
-            expected    ["MIGRATE ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_migrate_with_keys]
-            input       [r#"MIGRATE host port "" destination-db timeout KEYS key1 key2 key3"#]
-            expected    ["MIGRATE ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_migrate_no_args]
-            input       ["MIGRATE"]
-            expected    ["MIGRATE"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_hello_version]
-            input       ["HELLO 3"]
-            expected    ["HELLO ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_hello_auth]
-            input       ["HELLO 3 AUTH username password"]
-            expected    ["HELLO ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_hello_auth_setname]
-            input       ["HELLO 3 AUTH username password SETNAME clientname"]
-            expected    ["HELLO ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_hello_no_args]
-            input       ["HELLO"]
-            expected    ["HELLO"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_acl_setuser]
-            input       ["ACL SETUSER alice on >password ~* &* +@all"]
-            expected    ["ACL SETUSER ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_acl_setuser_complex]
-            input       ["ACL SETUSER bob on >mysecretpassword ~keys:* resetchannels &channel:* +@all -@dangerous"]
-            expected    ["ACL SETUSER ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_acl_getuser]
-            input       ["ACL GETUSER alice"]
-            expected    ["ACL GETUSER ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_acl_deluser]
-            input       ["ACL DELUSER alice"]
-            expected    ["ACL DELUSER ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_acl_deluser_multi]
-            input       ["ACL DELUSER alice bob charlie"]
-            expected    ["ACL DELUSER ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_acl_list]
-            input       ["ACL LIST"]
-            expected    ["ACL LIST"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_acl_whoami]
-            input       ["ACL WHOAMI"]
-            expected    ["ACL WHOAMI"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_acl_no_args]
-            input       ["ACL"]
-            expected    ["ACL"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_4]
-            input       ["APPEND key value"]
-            expected    ["APPEND key ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_5]
-            input       ["GETSET key value"]
-            expected    ["GETSET key ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_6]
-            input       ["LPUSHX key value"]
-            expected    ["LPUSHX key ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_7]
-            input       ["GEORADIUSBYMEMBER key member radius m|km|ft|mi [WITHCOORD] [WITHDIST] [WITHHASH] [COUNT count] [ASC|DESC] [STORE key] [STOREDIST key]"]
-            expected    ["GEORADIUSBYMEMBER key ? radius m|km|ft|mi [WITHCOORD] [WITHDIST] [WITHHASH] [COUNT count] [ASC|DESC] [STORE key] [STOREDIST key]"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_8]
-            input       ["RPUSHX key value"]
-            expected    ["RPUSHX key ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_9]
-            input       ["SET key value"]
-            expected    ["SET key ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_10]
-            input       ["SET key value [expiration EX seconds|PX milliseconds] [NX|XX]"]
-            expected    ["SET key ? [expiration EX seconds|PX milliseconds] [NX|XX]"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_11]
-            input       ["SETNX key value"]
-            expected    ["SETNX key ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_12]
-            input       ["SISMEMBER key member"]
-            expected    ["SISMEMBER key ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_13]
-            input       ["ZRANK key member"]
-            expected    ["ZRANK key ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_14]
-            input       ["ZREVRANK key member"]
-            expected    ["ZREVRANK key ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_15]
-            input       ["ZSCORE key member"]
-            expected    ["ZSCORE key ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_16]
-            input       ["BITFIELD key GET type offset SET type offset value INCRBY type"]
-            expected    ["BITFIELD key GET type offset SET type offset ? INCRBY type"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_17]
-            input       ["BITFIELD key SET type offset value INCRBY type"]
-            expected    ["BITFIELD key SET type offset ? INCRBY type"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_18]
-            input       ["BITFIELD key GET type offset INCRBY type"]
-            expected    ["BITFIELD key GET type offset INCRBY type"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_19]
-            input       ["BITFIELD key SET type offset"]
-            expected    ["BITFIELD key SET type offset"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_20]
-            input       ["CONFIG SET parameter value"]
-            expected    ["CONFIG SET parameter ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_21]
-            input       ["CONFIG foo bar baz"]
-            expected    ["CONFIG foo bar baz"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_22]
-            input       ["GEOADD key longitude latitude member longitude latitude member longitude latitude member"]
-            expected    ["GEOADD key longitude latitude ? longitude latitude ? longitude latitude ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_23]
-            input       ["GEOADD key longitude latitude member longitude latitude member"]
-            expected    ["GEOADD key longitude latitude ? longitude latitude ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_24]
-            input       ["GEOADD key longitude latitude member"]
-            expected    ["GEOADD key longitude latitude ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_25]
-            input       ["GEOADD key longitude latitude"]
-            expected    ["GEOADD key longitude latitude"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_26]
-            input       ["GEOADD key"]
-            expected    ["GEOADD key"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_27]
-            input       ["GEOHASH key\nGEOPOS key\n GEODIST key"]
-            expected    ["GEOHASH key\nGEOPOS key\nGEODIST key"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_28]
-            input       ["GEOHASH key member\nGEOPOS key member\nGEODIST key member\n"]
-            expected    ["GEOHASH key ?\nGEOPOS key ?\nGEODIST key ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_29]
-            input       ["GEOHASH key member member member\nGEOPOS key member member \n  GEODIST key member member member"]
-            expected    ["GEOHASH key ?\nGEOPOS key ?\nGEODIST key ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_30]
-            input       ["GEOPOS key member [member ...]"]
-            expected    ["GEOPOS key ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_31]
-            input       ["SREM key member [member ...]"]
-            expected    ["SREM key ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_32]
-            input       ["ZREM key member [member ...]"]
-            expected    ["ZREM key ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_33]
-            input       ["SADD key member [member ...]"]
-            expected    ["SADD key ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_34]
-            input       ["GEODIST key member1 member2 [unit]"]
-            expected    ["GEODIST key ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_35]
-            input       ["LPUSH key value [value ...]"]
-            expected    ["LPUSH key ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_36]
-            input       ["RPUSH key value [value ...]"]
-            expected    ["RPUSH key ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_37]
-            input       ["HSET key field value \nHSETNX key field value\nBLAH"]
-            expected    ["HSET key field ?\nHSETNX key field ?\nBLAH"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_38]
-            input       ["HSET key field value"]
-            expected    ["HSET key field ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_39]
-            input       ["HSETNX key field value"]
-            expected    ["HSETNX key field ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_40]
-            input       ["LREM key count value"]
-            expected    ["LREM key count ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_41]
-            input       ["LSET key index value"]
-            expected    ["LSET key index ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_42]
-            input       ["SETBIT key offset value"]
-            expected    ["SETBIT key offset ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_43]
-            input       ["SETRANGE key offset value"]
-            expected    ["SETRANGE key offset ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_44]
-            input       ["SETEX key seconds value"]
-            expected    ["SETEX key seconds ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_45]
-            input       ["PSETEX key milliseconds value"]
-            expected    ["PSETEX key milliseconds ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_46]
-            input       ["ZINCRBY key increment member"]
-            expected    ["ZINCRBY key increment ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_47]
-            input       ["SMOVE source destination member"]
-            expected    ["SMOVE source destination ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_48]
-            input       ["RESTORE key ttl serialized-value [REPLACE]"]
-            expected    ["RESTORE key ttl ? [REPLACE]"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_49]
-            input       ["LINSERT key BEFORE pivot value"]
-            expected    ["LINSERT key BEFORE pivot ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_50]
-            input       ["LINSERT key AFTER pivot value"]
-            expected    ["LINSERT key AFTER pivot ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_51]
-            input       ["HMSET key field value field value"]
-            expected    ["HMSET key field ? field ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_52]
-            input       ["HMSET key field value \n HMSET key field value\n\n "]
-            expected    ["HMSET key field ?\nHMSET key field ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_53]
-            input       ["HMSET key field"]
-            expected    ["HMSET key field"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_54]
-            input       ["MSET key value key value"]
-            expected    ["MSET key ? key ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_55]
-            input       ["HMSET key field"]
-            expected    ["HMSET key field"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_56]
-            input       ["MSET\nMSET key value"]
-            expected    ["MSET\nMSET key ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_57]
-            input       ["MSET key value"]
-            expected    ["MSET key ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_58]
-            input       ["MSETNX key value key value"]
-            expected    ["MSETNX key ? key ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_59]
-            input       ["ZADD key score member score member"]
-            expected    ["ZADD key score ? score ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_60]
-            input       ["ZADD key NX score member score member"]
-            expected    ["ZADD key NX score ? score ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_61]
-            input       ["ZADD key NX CH score member score member"]
-            expected    ["ZADD key NX CH score ? score ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_62]
-            input       ["ZADD key NX CH INCR score member score member"]
-            expected    ["ZADD key NX CH INCR score ? score ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_63]
-            input       ["ZADD key XX INCR score member score member"]
-            expected    ["ZADD key XX INCR score ? score ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_64]
-            input       ["ZADD key XX INCR score member"]
-            expected    ["ZADD key XX INCR score ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_65]
-            input       ["ZADD key XX INCR score"]
-            expected    ["ZADD key XX INCR score"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_66]
-            input       [r"
+    test_name input expected;
+    [test_obfuscate_redis_string_1] ["AUTH my-secret-password"] ["AUTH ?"];
+    [test_obfuscate_redis_string_2] ["AUTH james my-secret-password"] ["AUTH ?"];
+    [test_obfuscate_redis_string_3] ["AUTH"] ["AUTH"];
+    [test_obfuscate_redis_string_migrate_basic] ["MIGRATE host port key destination-db timeout"] ["MIGRATE ?"];
+    [test_obfuscate_redis_string_migrate_with_flags] ["MIGRATE host port key destination-db timeout COPY REPLACE"] ["MIGRATE ?"];
+    [test_obfuscate_redis_string_migrate_with_keys] [r#"MIGRATE host port "" destination-db timeout KEYS key1 key2 key3"#] ["MIGRATE ?"];
+    [test_obfuscate_redis_string_migrate_no_args] ["MIGRATE"] ["MIGRATE"];
+    [test_obfuscate_redis_string_hello_version] ["HELLO 3"] ["HELLO ?"];
+    [test_obfuscate_redis_string_hello_auth] ["HELLO 3 AUTH username password"] ["HELLO ?"];
+    [test_obfuscate_redis_string_hello_auth_setname] ["HELLO 3 AUTH username password SETNAME clientname"] ["HELLO ?"];
+    [test_obfuscate_redis_string_hello_no_args] ["HELLO"] ["HELLO"];
+    [test_obfuscate_redis_string_acl_setuser] ["ACL SETUSER alice on >password ~* &* +@all"] ["ACL SETUSER ?"];
+    [test_obfuscate_redis_string_acl_setuser_complex] ["ACL SETUSER bob on >mysecretpassword ~keys:* resetchannels &channel:* +@all -@dangerous"] ["ACL SETUSER ?"];
+    [test_obfuscate_redis_string_acl_getuser] ["ACL GETUSER alice"] ["ACL GETUSER ?"];
+    [test_obfuscate_redis_string_acl_deluser] ["ACL DELUSER alice"] ["ACL DELUSER ?"];
+    [test_obfuscate_redis_string_acl_deluser_multi] ["ACL DELUSER alice bob charlie"] ["ACL DELUSER ?"];
+    [test_obfuscate_redis_string_acl_list] ["ACL LIST"] ["ACL LIST"];
+    [test_obfuscate_redis_string_acl_whoami] ["ACL WHOAMI"] ["ACL WHOAMI"];
+    [test_obfuscate_redis_string_acl_no_args] ["ACL"] ["ACL"];
+    [test_obfuscate_redis_string_4] ["APPEND key value"] ["APPEND key ?"];
+    [test_obfuscate_redis_string_5] ["GETSET key value"] ["GETSET key ?"];
+    [test_obfuscate_redis_string_6] ["LPUSHX key value"] ["LPUSHX key ?"];
+    [test_obfuscate_redis_string_7] ["GEORADIUSBYMEMBER key member radius m|km|ft|mi [WITHCOORD] [WITHDIST] [WITHHASH] [COUNT count] [ASC|DESC] [STORE key] [STOREDIST key]"] ["GEORADIUSBYMEMBER key ? radius m|km|ft|mi [WITHCOORD] [WITHDIST] [WITHHASH] [COUNT count] [ASC|DESC] [STORE key] [STOREDIST key]"];
+    [test_obfuscate_redis_string_8] ["RPUSHX key value"] ["RPUSHX key ?"];
+    [test_obfuscate_redis_string_9] ["SET key value"] ["SET key ?"];
+    [test_obfuscate_redis_string_10] ["SET key value [expiration EX seconds|PX milliseconds] [NX|XX]"] ["SET key ? [expiration EX seconds|PX milliseconds] [NX|XX]"];
+    [test_obfuscate_redis_string_11] ["SETNX key value"] ["SETNX key ?"];
+    [test_obfuscate_redis_string_12] ["SISMEMBER key member"] ["SISMEMBER key ?"];
+    [test_obfuscate_redis_string_13] ["ZRANK key member"] ["ZRANK key ?"];
+    [test_obfuscate_redis_string_14] ["ZREVRANK key member"] ["ZREVRANK key ?"];
+    [test_obfuscate_redis_string_15] ["ZSCORE key member"] ["ZSCORE key ?"];
+    [test_obfuscate_redis_string_16] ["BITFIELD key GET type offset SET type offset value INCRBY type"] ["BITFIELD key GET type offset SET type offset ? INCRBY type"];
+    [test_obfuscate_redis_string_17] ["BITFIELD key SET type offset value INCRBY type"] ["BITFIELD key SET type offset ? INCRBY type"];
+    [test_obfuscate_redis_string_18] ["BITFIELD key GET type offset INCRBY type"] ["BITFIELD key GET type offset INCRBY type"];
+    [test_obfuscate_redis_string_19] ["BITFIELD key SET type offset"] ["BITFIELD key SET type offset"];
+    [test_obfuscate_redis_string_20] ["CONFIG SET parameter value"] ["CONFIG SET parameter ?"];
+    [test_obfuscate_redis_string_21] ["CONFIG foo bar baz"] ["CONFIG foo bar baz"];
+    [test_obfuscate_redis_string_22] ["GEOADD key longitude latitude member longitude latitude member longitude latitude member"] ["GEOADD key longitude latitude ? longitude latitude ? longitude latitude ?"];
+    [test_obfuscate_redis_string_23] ["GEOADD key longitude latitude member longitude latitude member"] ["GEOADD key longitude latitude ? longitude latitude ?"];
+    [test_obfuscate_redis_string_24] ["GEOADD key longitude latitude member"] ["GEOADD key longitude latitude ?"];
+    [test_obfuscate_redis_string_25] ["GEOADD key longitude latitude"] ["GEOADD key longitude latitude"];
+    [test_obfuscate_redis_string_26] ["GEOADD key"] ["GEOADD key"];
+    [test_obfuscate_redis_string_27] ["GEOHASH key\nGEOPOS key\n GEODIST key"] ["GEOHASH key\nGEOPOS key\nGEODIST key"];
+    [test_obfuscate_redis_string_28] ["GEOHASH key member\nGEOPOS key member\nGEODIST key member\n"] ["GEOHASH key ?\nGEOPOS key ?\nGEODIST key ?"];
+    [test_obfuscate_redis_string_29] ["GEOHASH key member member member\nGEOPOS key member member \n  GEODIST key member member member"] ["GEOHASH key ?\nGEOPOS key ?\nGEODIST key ?"];
+    [test_obfuscate_redis_string_30] ["GEOPOS key member [member ...]"] ["GEOPOS key ?"];
+    [test_obfuscate_redis_string_31] ["SREM key member [member ...]"] ["SREM key ?"];
+    [test_obfuscate_redis_string_32] ["ZREM key member [member ...]"] ["ZREM key ?"];
+    [test_obfuscate_redis_string_33] ["SADD key member [member ...]"] ["SADD key ?"];
+    [test_obfuscate_redis_string_34] ["GEODIST key member1 member2 [unit]"] ["GEODIST key ?"];
+    [test_obfuscate_redis_string_35] ["LPUSH key value [value ...]"] ["LPUSH key ?"];
+    [test_obfuscate_redis_string_36] ["RPUSH key value [value ...]"] ["RPUSH key ?"];
+    [test_obfuscate_redis_string_37] ["HSET key field value \nHSETNX key field value\nBLAH"] ["HSET key field ?\nHSETNX key field ?\nBLAH"];
+    [test_obfuscate_redis_string_38] ["HSET key field value"] ["HSET key field ?"];
+    [test_obfuscate_redis_string_39] ["HSETNX key field value"] ["HSETNX key field ?"];
+    [test_obfuscate_redis_string_40] ["LREM key count value"] ["LREM key count ?"];
+    [test_obfuscate_redis_string_41] ["LSET key index value"] ["LSET key index ?"];
+    [test_obfuscate_redis_string_42] ["SETBIT key offset value"] ["SETBIT key offset ?"];
+    [test_obfuscate_redis_string_43] ["SETRANGE key offset value"] ["SETRANGE key offset ?"];
+    [test_obfuscate_redis_string_44] ["SETEX key seconds value"] ["SETEX key seconds ?"];
+    [test_obfuscate_redis_string_45] ["PSETEX key milliseconds value"] ["PSETEX key milliseconds ?"];
+    [test_obfuscate_redis_string_46] ["ZINCRBY key increment member"] ["ZINCRBY key increment ?"];
+    [test_obfuscate_redis_string_47] ["SMOVE source destination member"] ["SMOVE source destination ?"];
+    [test_obfuscate_redis_string_48] ["RESTORE key ttl serialized-value [REPLACE]"] ["RESTORE key ttl ? [REPLACE]"];
+    [test_obfuscate_redis_string_49] ["LINSERT key BEFORE pivot value"] ["LINSERT key BEFORE pivot ?"];
+    [test_obfuscate_redis_string_50] ["LINSERT key AFTER pivot value"] ["LINSERT key AFTER pivot ?"];
+    [test_obfuscate_redis_string_51] ["HMSET key field value field value"] ["HMSET key field ? field ?"];
+    [test_obfuscate_redis_string_52] ["HMSET key field value \n HMSET key field value\n\n "] ["HMSET key field ?\nHMSET key field ?"];
+    [test_obfuscate_redis_string_53] ["HMSET key field"] ["HMSET key field"];
+    [test_obfuscate_redis_string_54] ["MSET key value key value"] ["MSET key ? key ?"];
+    [test_obfuscate_redis_string_55] ["HMSET key field"] ["HMSET key field"];
+    [test_obfuscate_redis_string_56] ["MSET\nMSET key value"] ["MSET\nMSET key ?"];
+    [test_obfuscate_redis_string_57] ["MSET key value"] ["MSET key ?"];
+    [test_obfuscate_redis_string_58] ["MSETNX key value key value"] ["MSETNX key ? key ?"];
+    [test_obfuscate_redis_string_59] ["ZADD key score member score member"] ["ZADD key score ? score ?"];
+    [test_obfuscate_redis_string_60] ["ZADD key NX score member score member"] ["ZADD key NX score ? score ?"];
+    [test_obfuscate_redis_string_61] ["ZADD key NX CH score member score member"] ["ZADD key NX CH score ? score ?"];
+    [test_obfuscate_redis_string_62] ["ZADD key NX CH INCR score member score member"] ["ZADD key NX CH INCR score ? score ?"];
+    [test_obfuscate_redis_string_63] ["ZADD key XX INCR score member score member"] ["ZADD key XX INCR score ? score ?"];
+    [test_obfuscate_redis_string_64] ["ZADD key XX INCR score member"] ["ZADD key XX INCR score ?"];
+    [test_obfuscate_redis_string_65] ["ZADD key XX INCR score"] ["ZADD key XX INCR score"];
+    [test_obfuscate_redis_string_66] [r"
 CONFIG command
 SET k v
-                        "]
-            expected    [r"CONFIG command
+                        "] [r"CONFIG command
 SET k ?"];
-        ]
-        [
-            test_name   [test_obfuscate_redis_string_67]
-            input       ["HSET key field value field value"]
-            expected    ["HSET key field ? field ?"];
-        ]
+    [test_obfuscate_redis_string_67] ["HSET key field value field value"] ["HSET key field ? field ?"];
     )]
     #[test]
     fn test_name() {
@@ -927,101 +500,26 @@ SET k ?"];
     }
 
     #[duplicate_item(
-        [
-            test_name   [test_obfuscate_all_redis_args_1]
-            input       [""]
-            expected    [""];
-        ]
-        [
-            test_name   [test_obfuscate_all_redis_args_2]
-            input       ["SET key value"]
-            expected    ["SET ?"];
-        ]
-        [
-            test_name   [test_obfuscate_all_redis_args_3]
-            input       ["GET k"]
-            expected    ["GET ?"];
-        ]
-        [
-            test_name   [test_obfuscate_all_redis_args_4]
-            input       ["FAKECMD key value hash"]
-            expected    ["FAKECMD ?"];
-        ]
-        [
-            test_name   [test_obfuscate_all_redis_args_5]
-            input       ["AUTH password"]
-            expected    ["AUTH ?"];
-        ]
-        [
-            test_name   [test_obfuscate_all_redis_args_6]
-            input       ["GET"]
-            expected    ["GET"];
-        ]
-        [
-            test_name   [test_obfuscate_all_redis_args_7]
-            input       ["CONFIG SET key value"]
-            expected    ["CONFIG SET ?"];
-        ]
-        [
-            test_name   [test_obfuscate_all_redis_args_8]
-            input       ["CONFIG GET key"]
-            expected    ["CONFIG GET ?"];
-        ]
-        [
-            test_name   [test_obfuscate_all_redis_args_9]
-            input       ["CONFIG key"]
-            expected    ["CONFIG ?"];
-        ]
-        [
-            test_name   [test_obfuscate_all_redis_args_10]
-            input       ["BITFIELD key SET key value GET key"]
-            expected    ["BITFIELD ? SET ? GET ?"];
-        ]
-        [
-            test_name   [test_obfuscate_all_redis_args_11]
-            input       ["BITFIELD key INCRBY value"]
-            expected    ["BITFIELD ? INCRBY ?"];
-        ]
-        [
-            test_name   [test_obfuscate_all_redis_args_12]
-            input       ["BITFIELD secret key"]
-            expected    ["BITFIELD ?"];
-        ]
-        [
-            test_name   [test_obfuscate_all_redis_args_13]
-            input       ["set key value"]
-            expected    ["set ?"];
-        ]
-        [
-            test_name   [test_obfuscate_all_redis_args_14]
-            input       ["Get key"]
-            expected    ["Get ?"];
-        ]
-        [
-            test_name   [test_obfuscate_all_redis_args_15]
-            input       ["config key"]
-            expected    ["config ?"];
-        ]
-        [
-            test_name   [test_obfuscate_all_redis_args_16]
-            input       ["CONFIG get key"]
-            expected    ["CONFIG get ?"];
-        ]
-        [
-            test_name   [test_obfuscate_all_redis_args_17]
-            input       ["bitfield key SET key value incrby 3"]
-            expected    ["bitfield ? SET ? incrby ?"];
-        ]
-        [
-            test_name   [test_obfuscate_fuzzing_unicode]
-            input       ["\u{00b}ჸ"]
-            expected    ["ჸ"];
-        ]
-        [
-            test_name   [test_obfuscate_fuzzing_whitespaces]
-            input       ["ჸ\n\tჸ"]
-            expected    ["ჸ ?"];
-        ]
+    test_name input expected;
+    [test_obfuscate_all_redis_args_1] [""] [""];
+    [test_obfuscate_all_redis_args_2] ["SET key value"] ["SET ?"];
+    [test_obfuscate_all_redis_args_3] ["GET k"] ["GET ?"];
+    [test_obfuscate_all_redis_args_4] ["FAKECMD key value hash"] ["FAKECMD ?"];
+    [test_obfuscate_all_redis_args_5] ["AUTH password"] ["AUTH ?"];
+    [test_obfuscate_all_redis_args_6] ["GET"] ["GET"];
+    [test_obfuscate_all_redis_args_7] ["CONFIG SET key value"] ["CONFIG SET ?"];
+    [test_obfuscate_all_redis_args_8] ["CONFIG GET key"] ["CONFIG GET ?"];
+    [test_obfuscate_all_redis_args_9] ["CONFIG key"] ["CONFIG ?"];
+    [test_obfuscate_all_redis_args_10] ["BITFIELD key SET key value GET key"] ["BITFIELD ? SET ? GET ?"];
+    [test_obfuscate_all_redis_args_11] ["BITFIELD key INCRBY value"] ["BITFIELD ? INCRBY ?"];
+    [test_obfuscate_all_redis_args_12] ["BITFIELD secret key"] ["BITFIELD ?"];
+    [test_obfuscate_all_redis_args_13] ["set key value"] ["set ?"];
+    [test_obfuscate_all_redis_args_14] ["Get key"] ["Get ?"];
+    [test_obfuscate_all_redis_args_15] ["config key"] ["config ?"];
+    [test_obfuscate_all_redis_args_16] ["CONFIG get key"] ["CONFIG get ?"];
+    [test_obfuscate_all_redis_args_17] ["bitfield key SET key value incrby 3"] ["bitfield ? SET ? incrby ?"];
+    [test_obfuscate_fuzzing_unicode] ["\u{00b}ჸ"] ["ჸ"];
+    [test_obfuscate_fuzzing_whitespaces] ["ჸ\n\tჸ"] ["ჸ ?"];
     )]
     #[test]
     fn test_name() {

--- a/libdd-trace-obfuscation/src/redis_tokenizer.rs
+++ b/libdd-trace-obfuscation/src/redis_tokenizer.rs
@@ -144,113 +144,63 @@ mod tests {
     use super::RedisTokenizer;
 
     #[duplicate_item(
-        [
-            test_name   [test_redis_tokenizer_1]
-            input       [""]
-            expected    [[r#"{ token: "", token_type: RedisTokenCommand, done: true }"#]];
-        ]
-        [
-            test_name   [test_redis_tokenizer_2]
-            input       ["BAD\"\"INPUT\" \"boo\n  Weird13\\Stuff"]
-            expected    [
+    test_name input expected;
+    [test_redis_tokenizer_1] [""] [[r#"{ token: "", token_type: RedisTokenCommand, done: true }"#]];
+    [test_redis_tokenizer_2] ["BAD\"\"INPUT\" \"boo\n  Weird13\\Stuff"] [
                 [
                     r#"{ token: "BAD\"\"INPUT\"", token_type: RedisTokenCommand, done: false }"#,
                     r#"{ token: "\"boo\n  Weird13\\Stuff", token_type: RedisTokenArgument, done: true }"#
                 ]
             ];
-        ]
-        [
-            test_name   [test_redis_tokenizer_3]
-            input       ["CMD"]
-            expected    [[r#"{ token: "CMD", token_type: RedisTokenCommand, done: true }"#]];
-        ]
-        [
-            test_name   [test_redis_tokenizer_4]
-            input       ["\n  \nCMD\n  \n"]
-            expected    [[r#"{ token: "CMD", token_type: RedisTokenCommand, done: true }"#]];
-        ]
-        [
-            test_name   [test_redis_tokenizer_5]
-            input       ["  CMD  "]
-            expected    [[r#"{ token: "CMD", token_type: RedisTokenCommand, done: true }"#]];
-        ]
-        [
-            test_name   [test_redis_tokenizer_6]
-            input       ["CMD1\nCMD2"]
-            expected    [
+    [test_redis_tokenizer_3] ["CMD"] [[r#"{ token: "CMD", token_type: RedisTokenCommand, done: true }"#]];
+    [test_redis_tokenizer_4] ["\n  \nCMD\n  \n"] [[r#"{ token: "CMD", token_type: RedisTokenCommand, done: true }"#]];
+    [test_redis_tokenizer_5] ["  CMD  "] [[r#"{ token: "CMD", token_type: RedisTokenCommand, done: true }"#]];
+    [test_redis_tokenizer_6] ["CMD1\nCMD2"] [
                 [
                     r#"{ token: "CMD1", token_type: RedisTokenCommand, done: false }"#,
                     r#"{ token: "CMD2", token_type: RedisTokenCommand, done: true }"#
                 ]
             ];
-        ]
-        [
-            test_name   [test_redis_tokenizer_7]
-            input       ["  CMD1  \n  CMD2  "]
-            expected    [
+    [test_redis_tokenizer_7] ["  CMD1  \n  CMD2  "] [
                 [
                     r#"{ token: "CMD1", token_type: RedisTokenCommand, done: false }"#,
                     r#"{ token: "CMD2", token_type: RedisTokenCommand, done: true }"#
                 ]
             ];
-        ]
-        [
-            test_name   [test_redis_tokenizer_8]
-            input       ["CMD1\nCMD2\nCMD3"]
-            expected    [
+    [test_redis_tokenizer_8] ["CMD1\nCMD2\nCMD3"] [
                 [
                     r#"{ token: "CMD1", token_type: RedisTokenCommand, done: false }"#,
                     r#"{ token: "CMD2", token_type: RedisTokenCommand, done: false }"#,
                     r#"{ token: "CMD3", token_type: RedisTokenCommand, done: true }"#
                 ]
             ];
-        ]
-        [
-            test_name   [test_redis_tokenizer_9]
-            input       ["CMD arg"]
-            expected    [
+    [test_redis_tokenizer_9] ["CMD arg"] [
                 [
                     r#"{ token: "CMD", token_type: RedisTokenCommand, done: false }"#,
                     r#"{ token: "arg", token_type: RedisTokenArgument, done: true }"#
                 ]
             ];
-        ]
-        [
-            test_name   [test_redis_tokenizer_10]
-            input       ["  CMD  arg  "]
-            expected    [
+    [test_redis_tokenizer_10] ["  CMD  arg  "] [
                 [
                     r#"{ token: "CMD", token_type: RedisTokenCommand, done: false }"#,
                     r#"{ token: "arg", token_type: RedisTokenArgument, done: true }"#
                 ]
             ];
-        ]
-        [
-            test_name   [test_redis_tokenizer_11]
-            input       ["CMD arg1 arg2"]
-            expected    [
+    [test_redis_tokenizer_11] ["CMD arg1 arg2"] [
                 [
                     r#"{ token: "CMD", token_type: RedisTokenCommand, done: false }"#,
                     r#"{ token: "arg1", token_type: RedisTokenArgument, done: false }"#,
                     r#"{ token: "arg2", token_type: RedisTokenArgument, done: true }"#
                 ]
             ];
-        ]
-        [
-            test_name   [test_redis_tokenizer_12]
-            input       [" 	 CMD   arg1 	  arg2 "]
-            expected    [
+    [test_redis_tokenizer_12] [" 	 CMD   arg1 	  arg2 "] [
                 [
                     r#"{ token: "CMD", token_type: RedisTokenCommand, done: false }"#,
                     r#"{ token: "arg1", token_type: RedisTokenArgument, done: false }"#,
                     r#"{ token: "arg2", token_type: RedisTokenArgument, done: true }"#
                 ]
             ];
-        ]
-        [
-            test_name   [test_redis_tokenizer_13]
-            input       ["CMD arg1\nCMD2 arg2"]
-            expected    [
+    [test_redis_tokenizer_13] ["CMD arg1\nCMD2 arg2"] [
                 [
                     r#"{ token: "CMD", token_type: RedisTokenCommand, done: false }"#,
                     r#"{ token: "arg1", token_type: RedisTokenArgument, done: false }"#,
@@ -258,11 +208,7 @@ mod tests {
                     r#"{ token: "arg2", token_type: RedisTokenArgument, done: true }"#
                 ]
             ];
-        ]
-        [
-            test_name   [test_redis_tokenizer_14]
-            input       ["CMD arg1 arg2\nCMD2 arg3\nCMD3\nCMD4 arg4 arg5 arg6"]
-            expected    [
+    [test_redis_tokenizer_14] ["CMD arg1 arg2\nCMD2 arg3\nCMD3\nCMD4 arg4 arg5 arg6"] [
                 [
                     r#"{ token: "CMD", token_type: RedisTokenCommand, done: false }"#,
                     r#"{ token: "arg1", token_type: RedisTokenArgument, done: false }"#,
@@ -276,11 +222,7 @@ mod tests {
                     r#"{ token: "arg6", token_type: RedisTokenArgument, done: true }"#
                 ]
             ];
-        ]
-        [
-            test_name   [test_redis_tokenizer_15]
-            input       ["CMD arg1   arg2  \n CMD2  arg3 \n CMD3 \n  CMD4 arg4 arg5 arg6\nCMD5 "]
-            expected    [
+    [test_redis_tokenizer_15] ["CMD arg1   arg2  \n CMD2  arg3 \n CMD3 \n  CMD4 arg4 arg5 arg6\nCMD5 "] [
                 [
                     r#"{ token: "CMD", token_type: RedisTokenCommand, done: false }"#,
                     r#"{ token: "arg1", token_type: RedisTokenArgument, done: false }"#,
@@ -295,42 +237,26 @@ mod tests {
                     r#"{ token: "CMD5", token_type: RedisTokenCommand, done: true }"#,
                 ]
             ];
-        ]
-        [
-            test_name   [test_redis_tokenizer_16]
-            input       [r#"CMD """#]
-            expected    [
+    [test_redis_tokenizer_16] [r#"CMD """#] [
                 [
                     r#"{ token: "CMD", token_type: RedisTokenCommand, done: false }"#,
                     r#"{ token: "\"\"", token_type: RedisTokenArgument, done: true }"#
                 ]
             ];
-        ]
-        [
-            test_name   [test_redis_tokenizer_17]
-            input       [r#"CMD "foo bar""#]
-            expected    [
+    [test_redis_tokenizer_17] [r#"CMD "foo bar""#] [
                 [
                     r#"{ token: "CMD", token_type: RedisTokenCommand, done: false }"#,
                     r#"{ token: "\"foo bar\"", token_type: RedisTokenArgument, done: true }"#
                 ]
             ];
-        ]
-        [
-            test_name   [test_redis_tokenizer_18]
-            input       [r#"CMD "foo bar\ " baz"#]
-            expected    [
+    [test_redis_tokenizer_18] [r#"CMD "foo bar\ " baz"#] [
                 [
                     r#"{ token: "CMD", token_type: RedisTokenCommand, done: false }"#,
                     r#"{ token: "\"foo bar\\ \"", token_type: RedisTokenArgument, done: false }"#,
                     r#"{ token: "baz", token_type: RedisTokenArgument, done: true }"#
                 ]
             ];
-        ]
-        [
-            test_name   [test_redis_tokenizer_19]
-            input       ["CMD \"foo \n bar\" \"\"  baz "]
-            expected    [
+    [test_redis_tokenizer_19] ["CMD \"foo \n bar\" \"\"  baz "] [
                 [
                     r#"{ token: "CMD", token_type: RedisTokenCommand, done: false }"#,
                     r#"{ token: "\"foo \n bar\"", token_type: RedisTokenArgument, done: false }"#,
@@ -338,33 +264,21 @@ mod tests {
                     r#"{ token: "baz", token_type: RedisTokenArgument, done: true }"#
                 ]
             ];
-        ]
-        [
-            test_name   [test_redis_tokenizer_20]
-            input       ["CMD \"foo \\\" bar\" baz"]
-            expected    [
+    [test_redis_tokenizer_20] ["CMD \"foo \\\" bar\" baz"] [
                 [
                     r#"{ token: "CMD", token_type: RedisTokenCommand, done: false }"#,
                     r#"{ token: "\"foo \\\" bar\"", token_type: RedisTokenArgument, done: false }"#,
                     r#"{ token: "baz", token_type: RedisTokenArgument, done: true }"#
                 ]
             ];
-        ]
-        [
-            test_name   [test_redis_tokenizer_21]
-            input       [r#"CMD "foo bar" baz"#]
-            expected    [
+    [test_redis_tokenizer_21] [r#"CMD "foo bar" baz"#] [
                 [
                     r#"{ token: "CMD", token_type: RedisTokenCommand, done: false }"#,
                     r#"{ token: "\"foo bar\"", token_type: RedisTokenArgument, done: false }"#,
                     r#"{ token: "baz", token_type: RedisTokenArgument, done: true }"#
                 ]
             ];
-        ]
-        [
-            test_name   [test_redis_tokenizer_22]
-            input       ["CMD \"foo bar\" baz\nCMD2 \"baz\\\\bar\""]
-            expected    [
+    [test_redis_tokenizer_22] ["CMD \"foo bar\" baz\nCMD2 \"baz\\\\bar\""] [
                 [
                     r#"{ token: "CMD", token_type: RedisTokenCommand, done: false }"#,
                     r#"{ token: "\"foo bar\"", token_type: RedisTokenArgument, done: false }"#,
@@ -373,11 +287,7 @@ mod tests {
                     r#"{ token: "\"baz\\\\bar\"", token_type: RedisTokenArgument, done: true }"#
                 ]
             ];
-        ]
-        [
-            test_name   [test_redis_tokenizer_23]
-            input       [" CMD  \"foo bar\"  baz \n CMD2  \"baz\\\\bar\"  "]
-            expected    [
+    [test_redis_tokenizer_23] [" CMD  \"foo bar\"  baz \n CMD2  \"baz\\\\bar\"  "] [
                 [
                     r#"{ token: "CMD", token_type: RedisTokenCommand, done: false }"#,
                     r#"{ token: "\"foo bar\"", token_type: RedisTokenArgument, done: false }"#,
@@ -386,7 +296,6 @@ mod tests {
                     r#"{ token: "\"baz\\\\bar\"", token_type: RedisTokenArgument, done: true }"#
                 ]
             ];
-        ]
     )]
     #[test]
     fn test_name() {

--- a/libdd-trace-obfuscation/src/replacer.rs
+++ b/libdd-trace-obfuscation/src/replacer.rs
@@ -318,44 +318,36 @@ mod tests {
     }
 
     #[duplicate_item(
-        [
-        test_name   [test_replace_tags]
-        rules       [r#"[
+    test_name rules input expected;
+    [test_replace_tags] [r#"[
                         {"name": "http.url", "pattern": "(token/)([^/]*)", "repl": "${1}?"},
                         {"name": "http.url", "pattern": "guid", "repl": "[REDACTED]"},
                         {"name": "custom.tag", "pattern": "(/foo/bar/).*", "repl": "${1}extra"}
-                    ]"#]
-        input       [
+                    ]"#] [
                         HashMap::from([
                             ("http.url", "some/guid/token/abcdef/abc"),
                             ("custom.tag", "/foo/bar/foo"),
                         ])
-                    ]
-        expected    [
+                    ] [
                         HashMap::from([
                             ("http.url", "some/[REDACTED]/token/?/abc"),
                             ("custom.tag", "/foo/bar/extra"),
                         ])
                     ];
-        ]
-        [
-        test_name   [test_replace_tags_with_exceptions]
-        rules       [r#"[
+    [test_replace_tags_with_exceptions] [r#"[
                         {"name": "*", "pattern": "(token/)([^/]*)", "repl": "${1}?"},
                         {"name": "*", "pattern": "this", "repl": "that"},
                         {"name": "http.url", "pattern": "guid", "repl": "[REDACTED]"},
                         {"name": "custom.tag", "pattern": "(/foo/bar/).*", "repl": "${1}extra"},
                         {"name": "resource.name", "pattern": "prod", "repl": "stage"}
-                    ]"#]
-        input       [
+                    ]"#] [
                         HashMap::from([
                             ("resource.name", "this is prod"),
                             ("http.url", "some/[REDACTED]/token/abcdef/abc"),
                             ("other.url", "some/guid/token/abcdef/abc"),
                             ("custom.tag", "/foo/bar/foo"),
                         ])
-                    ]
-        expected    [
+                    ] [
                         HashMap::from([
                             ("resource.name", "that is stage"),
                             ("http.url", "some/[REDACTED]/token/?/abc"),
@@ -363,7 +355,6 @@ mod tests {
                             ("custom.tag", "/foo/bar/extra"),
                         ])
                     ];
-        ]
     )]
     #[test]
     #[cfg_attr(miri, ignore)]

--- a/libdd-trace-protobuf/Cargo.toml
+++ b/libdd-trace-protobuf/Cargo.toml
@@ -15,8 +15,10 @@ bench = false
 bolero = { workspace = true, features = ["std"], optional = true }
 prost = { workspace = true, default-features = true }
 serde = { workspace = true, features = ["derive"] }
-# `std` is required: it gates the alloc-backed `ByteBuf`/`Vec<u8>` serde impls used by
-# `#[serde(with = "serde_bytes")]` in the generated code.
+# We tend to prefer the smaller `alloc` feature over `std` for crates that
+# expose both, as does `serde_bytes`. However, switching to `alloc` only here
+# removes the (required) `Deserialize` implementations of some basic types.
+# There might be a way to migrate, but for now, we stay with default-features.
 serde_bytes = { workspace = true, default-features = true }
 
 [build-dependencies]

--- a/libdd-trace-protobuf/Cargo.toml
+++ b/libdd-trace-protobuf/Cargo.toml
@@ -13,9 +13,11 @@ bench = false
 
 [dependencies]
 bolero = { workspace = true, features = ["std"], optional = true }
-prost = "0.14.1"
+prost = { workspace = true, default-features = true }
 serde = { workspace = true, features = ["derive"] }
-serde_bytes = "0.11.9"
+# `std` is required: it gates the alloc-backed `ByteBuf`/`Vec<u8>` serde impls used by
+# `#[serde(with = "serde_bytes")]` in the generated code.
+serde_bytes = { workspace = true, default-features = true }
 
 [build-dependencies]
 prost-build = { workspace = true, features = ["format"], optional = true }

--- a/libdd-trace-stats/Cargo.toml
+++ b/libdd-trace-stats/Cargo.toml
@@ -21,16 +21,16 @@ libdd-telemetry = { version = "8.0.0", path = "../libdd-telemetry", default-feat
 libdd-trace-protobuf = { version = "5.0.0", path = "../libdd-trace-protobuf" }
 libdd-trace-obfuscation = { version = "8.0.0", path = "../libdd-trace-obfuscation", default-features = false }
 libdd-trace-utils = { version = "12.0.0", path = "../libdd-trace-utils", default-features = false }
-hashbrown = { version = "0.15" }
+hashbrown = { workspace = true, default-features = true }
 http = { workspace = true, features = ["std"] }
-rmp-serde = "1.3.0"
+rmp-serde.workspace = true
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["macros", "time"] }
-tokio-util = "0.7.11"
+tokio-util.workspace = true
 tracing.workspace = true
-async-trait = "0.1.85"
+async-trait.workspace = true
 # Cross-platform `SystemTime`; `std::time::SystemTime::now()` panics on wasm32.
-web-time = "1"
+web-time.workspace = true
 futures = { workspace = true, features = ["alloc"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -48,8 +48,8 @@ path = "benches/main.rs"
 criterion.workspace = true
 httpmock.workspace = true
 libdd-trace-utils = { path = "../libdd-trace-utils", features = ["test-utils"] }
-rand = ">=0.8.6, <0.9"
-tokio = { version = "1.23", features = ["rt-multi-thread", "macros", "test-util", "time"], default-features = false }
+rand = { workspace = true, default-features = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util", "time"] }
 
 [features]
 default = ["https"]

--- a/libdd-trace-stats/src/span_concentrator/aggregation.rs
+++ b/libdd-trace-stats/src/span_concentrator/aggregation.rs
@@ -674,7 +674,7 @@ impl StatsBucket {
                     return;
                 }
                 // Within the max entry limit, admit key as a new distinct entry.
-                e.insert(GroupedStats::default())
+                e.insert_with_key(OwnedAggregationKey::from(&key), GroupedStats::default())
                     .insert(duration, is_error, is_top_level);
             }
         }

--- a/libdd-trace-utils/Cargo.toml
+++ b/libdd-trace-utils/Cargo.toml
@@ -45,7 +45,7 @@ bytes = { workspace = true, features = ["std"] }
 rmpv.workspace = true
 rmp.workspace = true
 rustc-hash = { workspace = true, default-features = true }
-crossbeam-channel.workspace = true
+crossbeam-channel = { workspace = true, features = ["std"] }
 thread_local.workspace = true 
 
 libdd-capabilities = { path = "../libdd-capabilities", version = "3.0.1" }

--- a/libdd-trace-utils/Cargo.toml
+++ b/libdd-trace-utils/Cargo.toml
@@ -34,7 +34,7 @@ http-body.workspace = true
 http-body-util.workspace = true
 serde = { workspace = true, features = ["derive"] }
 # Only uses the prost::Message trait on generated types; no local derives.
-prost = { workspace = true, default-features = false, features = ["std"] }
+prost = { workspace = true, features = ["std"] }
 rmp-serde.workspace = true
 tracing.workspace = true
 serde_json = { workspace = true, features = ["std"] }

--- a/libdd-trace-utils/Cargo.toml
+++ b/libdd-trace-utils/Cargo.toml
@@ -26,26 +26,27 @@ required-features = ["bench-internals"]
 [dependencies]
 anyhow.workspace = true
 base64 = { workspace = true, features = ["std"] }
-hex = "0.4"
-itoa = "1.0"
+hex = { workspace = true, default-features = true }
+itoa.workspace = true
 hyper = { workspace = true, optional = true, features = ["http1", "client"] }
 "http" = { workspace = true, features = ["std"] }
-"http-body" = "1"
+http-body.workspace = true
 http-body-util.workspace = true
 serde = { workspace = true, features = ["derive"] }
-prost = "0.14.1"
-rmp-serde = "1.3.0"
+# Only uses the prost::Message trait on generated types; no local derives.
+prost = { workspace = true, default-features = false, features = ["std"] }
+rmp-serde.workspace = true
 tracing.workspace = true
 serde_json = { workspace = true, features = ["std"] }
-serde-transcode = "1.1"
+serde-transcode.workspace = true
 futures.workspace = true
-rand = { version = "0.8.6", features = ["small_rng"] }
+rand = { workspace = true, default-features = true, features = ["small_rng"] }
 bytes = { workspace = true, features = ["std"] }
-rmpv = { version = "1.3.0", default-features = false }
-rmp = { version = "0.8.14", default-features = false }
-rustc-hash = "2.1.1"
-crossbeam-channel = "0.5.16"
-thread_local = "1.1"
+rmpv.workspace = true
+rmp.workspace = true
+rustc-hash = { workspace = true, default-features = true }
+crossbeam-channel.workspace = true
+thread_local.workspace = true 
 
 libdd-capabilities = { path = "../libdd-capabilities", version = "3.0.1" }
 libdd-common = { version = "6.0.0", path = "../libdd-common", default-features = false }
@@ -55,27 +56,27 @@ libdd-tinybytes = { version = "1.1.3", path = "../libdd-tinybytes", features = [
     "bytes_string",
     "serialization",
 ] }
-indexmap = "2.11"
-thin-vec = "0.2"
+indexmap = { workspace = true, default-features = true }
+thin-vec = { workspace = true, default-features = true }
 
 # Compression feature
 flate2 = { workspace = true, optional = true }
 
 # test-utils feature
-cargo_metadata = { version = "0.18.1", optional = true }
+cargo_metadata = { workspace = true, optional = true }
 # Dependency of cargo metadata, but 0.1.8 requires too new of a rust version.
-cargo-platform = { version = "=0.1.7", optional = true }
+cargo-platform = { workspace = true, optional = true }
 httpmock = { workspace = true, optional = true }
-urlencoding = { version = "2.1.3", optional = true }
+urlencoding = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libdd-capabilities-impl = { version = "5.0.0", path = "../libdd-capabilities-impl", default-features = false, optional = true }
-tokio = { version = "1", features = ["time"], optional = true }
+tokio = { workspace = true, features = ["time"], optional = true }
 zstd = {workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.2", features = ["js"] }
-zrip = { version = "=0.6.0", default-features = false, features = ["frame"], optional = true }
+getrandom = { workspace = true, features = ["js"] }
+zrip = { workspace = true, features = ["frame"], optional = true }
 
 [dev-dependencies]
 libdd-capabilities-impl = { version = "5.0.0", path = "../libdd-capabilities-impl" }
@@ -86,7 +87,7 @@ bolero = { workspace = true, features = ["std"] }
 criterion.workspace = true
 httpmock.workspace = true
 serde_json.workspace = true
-tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 libdd-trace-utils = { path = ".", features = ["test-utils"] }
 tempfile.workspace = true
 

--- a/libdd-tracer-flare/Cargo.toml
+++ b/libdd-tracer-flare/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/DataDog/libdatadog/tree/main/libdd-tracer-flare"
 repository = "https://github.com/DataDog/libdatadog/tree/main/libdd-tracer-flare"
 
 [dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true, default-features = true }
 libdd-remote-config = { version = "5.0.0", path = "../libdd-remote-config", default-features = false }
 libdd-common = { version = "6.0.0", path = "../libdd-common" }
 libdd-trace-utils = { version = "12.0.0", path = "../libdd-trace-utils" }
@@ -19,8 +19,8 @@ http = { workspace = true, features = ["std"] }
 bytes = { workspace = true, features = ["std"] }
 tokio = { workspace = true, features = ["time"] }
 serde_json.workspace = true
-zip = { version = "4.0.0", default-features = false, features = ["deflate"] }
-walkdir = "2.4"
+zip = { workspace = true, features = ["deflate"] }
+walkdir.workspace = true
 tempfile.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -33,7 +33,7 @@ bench = false
 libdd-remote-config = { path = "../libdd-remote-config", features = ["test"] }
 httpmock.workspace = true
 libdd-trace-utils = { path = "../libdd-trace-utils", features = ["test-utils"] }
-tokio = { version = "1.36.0", features = ["time", "macros", "rt"] }
+tokio = { workspace = true, features = ["time", "macros", "rt"] }
 
 [features]
 default = ["listener"]

--- a/spawn_worker/Cargo.toml
+++ b/spawn_worker/Cargo.toml
@@ -32,15 +32,15 @@ winapi = { version = "=0.2.8" }
 kernel32-sys = "0.2.2"
 
 [target.'cfg(not(windows))'.dependencies]
-memfd = { version = "0.6" }
-nix = { version = "0.29", features = ["dir", "process"] }
+memfd.workspace = true
+nix = { workspace = true, features = ["dir", "process"] }
 tempfile.workspace = true
 
 [target.'cfg(windows)'.dev-dependencies]
 tempfile.workspace = true
 
 [target.'cfg(not(windows))'.dev-dependencies]
-rlimit = {version = "0.9"}
+rlimit.workspace = true
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage,coverage_nightly)'] }

--- a/tests/spawn_from_lib/Cargo.toml
+++ b/tests/spawn_from_lib/Cargo.toml
@@ -16,7 +16,7 @@ prefer-dynamic = []
 
 [dependencies]
 libc.workspace = true
-anyhow = { version = "1.0" }
+anyhow = { workspace = true, default-features = true }
 spawn_worker = { path = "../../spawn_worker" }
 tempfile.workspace = true
 io-lifetimes = { workspace = true, features = ["close"] }

--- a/tests/wasm/Cargo.toml
+++ b/tests/wasm/Cargo.toml
@@ -15,6 +15,6 @@ default = ["compression"]
 compression = []
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-http = "1"
-wasm-bindgen-test = "=0.3.50"
-zrip = { version = "=0.6.0", default-features = false, features = ["frame"] }
+http = { workspace = true, default-features = true }
+wasm-bindgen-test = { workspace = true, default-features = true }
+zrip = { workspace = true, features = ["frame"] }

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -21,7 +21,7 @@ clap = { workspace = true, default-features = true, features = ["derive"] }
 colored.workspace = true
 quick-xml.workspace = true
 libdd-common = { path = "../libdd-common", default-features = false }
-toml = { workspace = true, default-features = false, features = ["parse"] }
+toml = { workspace = true, features = ["parse"] }
 wait-timeout.workspace = true
 
 [features]

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -16,13 +16,13 @@ bench = false
 
 [dependencies]
 anyhow.workspace = true
-cargo_metadata = "0.18"
+cargo_metadata.workspace = true
 clap = { workspace = true, default-features = true, features = ["derive"] }
-colored = "2"
-quick-xml = "0.37"
+colored.workspace = true
+quick-xml.workspace = true
 libdd-common = { path = "../libdd-common", default-features = false }
-toml = "0.8"
-wait-timeout = "0.2"
+toml = { workspace = true, default-features = false, features = ["parse"] }
+wait-timeout.workspace = true
 
 [features]
 regex-lite = ["libdd-common/regex-lite"]

--- a/tools/cc_utils/Cargo.toml
+++ b/tools/cc_utils/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 anyhow.workspace = true
-cc = {version = "1.0"}
+cc.workspace = true
 
 [lib]
 bench = false

--- a/tools/sidecar_mockgen/Cargo.toml
+++ b/tools/sidecar_mockgen/Cargo.toml
@@ -8,7 +8,8 @@ publish = false
 bench = false
 
 [dependencies]
-object = {version = "0.31.0"}
+# Reads ELF/Mach-O symbol tables.
+object = { workspace = true, default-features = true }
 
 [[bin]]
 name = "sidecar_mockgen"

--- a/tools/sidecar_mockgen/src/lib.rs
+++ b/tools/sidecar_mockgen/src/lib.rs
@@ -206,7 +206,7 @@ fn weaken_elf(data: &mut [u8], symbols: &HashSet<String>, obj_path: &Path) -> Re
         // `-ffat-lto-objects` embeds a second, independent copy of every symbol's binding in
         // `.gnu.lto_*` sections. The linker then recompiles from that IR instead of object data
         // directly. Stripping the LTO sections to force the linker to use the object sections.
-        let header = elf.raw_header();
+        let header = elf.elf_header();
         let endian = elf.endian();
         let sh_off = header.e_shoff(endian) as usize;
         let sh_entsize = header.e_shentsize(endian) as usize;


### PR DESCRIPTION
# What does this PR do?

Follow-up of #2350. Migrate all of the remaining external dependencies to the workspace level. `duplicate` was used with incompatible major versions. Mostly the macro syntax changed. Files are updated to use the latest version's syntax.

# Motivation

As for the other workspace-level deps: use a single source of truth and version, for each dependency, in the whole workspace. Force leaf crates to opt-in features they need instead of blindly enabling default features.