### PR TITLE
feat(profiling): rename ddheap USDT provider to otel_memory

### DIFF
--- a/libdd-profiling-heap-allocator/examples/usdt_demo.rs
+++ b/libdd-profiling-heap-allocator/examples/usdt_demo.rs
@@ -5,7 +5,7 @@
 //!
 //! Install `SampledAllocator<System>` globally, then loop producing
 //! allocations (strings joined into a single buffer) so a tracer attached
-//! to the `ddheap:alloc` USDT probe sees samples fire periodically.
+//! to the `otel_memory:alloc` USDT probe sees samples fire periodically.
 //!
 //! Run (Linux, inside the crate's Lima VM):
 //! ```
@@ -13,7 +13,7 @@
 //! ```
 //! and in another shell, attach a tracer, e.g.
 //! ```
-//! sudo bpftrace -p <pid> -e 'usdt:*:ddheap:alloc { printf("alloc %p %d %d\n", arg0, arg1, arg2); }'
+//! sudo bpftrace -p <pid> -e 'usdt:*:otel_memory:alloc { printf("alloc %p %d %d\n", arg0, arg1, arg2); }'
 //! ```
 //!
 //! `SampledAllocator` is Linux-only; on other targets the example
@@ -40,7 +40,7 @@ mod linux {
 
     pub fn main() {
         println!(
-            "pid={}; attach a tracer on 'usdt:*:ddheap:alloc'",
+            "pid={}; attach a tracer on 'usdt:*:otel_memory:alloc'",
             std::process::id()
         );
 

--- a/libdd-profiling-heap-allocator/src/lib.rs
+++ b/libdd-profiling-heap-allocator/src/lib.rs
@@ -44,7 +44,7 @@ mod allocator;
 pub use allocator::SampledAllocator;
 
 /// Returns true when an external profiler is currently attached to the
-/// allocator's `ddheap:alloc` USDT.
+/// allocator's `otel_memory:alloc` USDT.
 ///
 /// This is a point-in-time read of the USDT semaphore. A profiler can attach
 /// or detach immediately after this returns. Use it as a diagnostic/readiness

--- a/libdd-profiling-heap-gotter-ffi/examples/cdylib_demo.rs
+++ b/libdd-profiling-heap-gotter-ffi/examples/cdylib_demo.rs
@@ -141,7 +141,7 @@ mod linux {
         println!("pre-install is_installed={}", unsafe { is_installed() });
         check(unsafe { install() }, "ddog_heap_gotter_install")?;
         println!("post-install is_installed={}", unsafe { is_installed() });
-        println!("attach a tracer on `usdt:*:ddheap:*`; producing allocation pressure...");
+        println!("attach a tracer on `usdt:*:otel_memory:*`; producing allocation pressure...");
 
         for i in 0..30_u64 {
             let parts: Vec<String> = (0..1000)

--- a/libdd-profiling-heap-gotter-ffi/tests/usdt_notes.rs
+++ b/libdd-profiling-heap-gotter-ffi/tests/usdt_notes.rs
@@ -1,14 +1,14 @@
 // Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-//! Verify the ddheap USDT probes appear exactly once in the built shared
+//! Verify the otel_memory USDT probes appear exactly once in the built shared
 //! library's `.note.stapsdt`. A duplicate entry (e.g. from `static inline` +
 //! bindgen's `wrap_static_fns`, or LTO inlining across TUs) would make an
 //! attached consumer fire twice, so this guards the "one note per probe"
 //! invariant documented in the sampler's `probes.c`.
 //!
 //! Split into two tests because the two probes have different lifetimes:
-//! `ddheap:alloc` is expected in every build, while `ddheap:free` only
+//! `otel_memory:alloc` is expected in every build, while `otel_memory:free` only
 //! exists when compiled with live-heap tracking (the `live-heap` feature) —
 //! its absence otherwise is intentional, so it's covered by its own
 //! feature-gated test rather than folded into a single "all probes present"
@@ -32,22 +32,22 @@ fn cdylib_path() -> PathBuf {
         .join("liblibdd_profiling_heap_gotter_ffi.so")
 }
 
-/// `ddheap:alloc` is unconditional: every build samples allocations, so its
+/// `otel_memory:alloc` is unconditional: every build samples allocations, so its
 /// note must always be present exactly once.
 #[test]
 #[cfg_attr(miri, ignore)]
-fn ddheap_alloc_probe_has_one_note() {
+fn otel_memory_alloc_probe_has_one_note() {
     let path = cdylib_path();
     libdd_profiling_heap_sampler::usdt_check::check_usdt_probes_in(&path, &["alloc"]).unwrap();
 }
 
-/// `ddheap:free` only exists when built with live-heap tracking. Gated on the
+/// `otel_memory:free` only exists when built with live-heap tracking. Gated on the
 /// `live-heap` feature (forwarded to the sampler crate) so this test only
 /// runs, and only asserts the note is present, in builds that opt in.
 #[cfg(feature = "live-heap")]
 #[test]
 #[cfg_attr(miri, ignore)]
-fn ddheap_free_probe_has_one_note() {
+fn otel_memory_free_probe_has_one_note() {
     let path = cdylib_path();
     libdd_profiling_heap_sampler::usdt_check::check_usdt_probes_in(&path, &["free"]).unwrap();
 }

--- a/libdd-profiling-heap-gotter/examples/gotter_usdt_demo.rs
+++ b/libdd-profiling-heap-gotter/examples/gotter_usdt_demo.rs
@@ -24,8 +24,8 @@
 //! Attach a tracer in another shell, e.g.:
 //! ```
 //! sudo bpftrace -p <pid> -e '
-//!   usdt:*:ddheap:alloc { @allocs = count(); }
-//!   usdt:*:ddheap:free  { @frees  = count(); }
+//!   usdt:*:otel_memory:alloc { @allocs = count(); }
+//!   usdt:*:otel_memory:free  { @frees  = count(); }
 //!   interval:s:1 { print(@allocs); print(@frees); }'
 //! ```
 //!
@@ -356,7 +356,7 @@ mod linux {
             .unwrap_or(4);
 
         println!(
-            "pid={}; pre-install. Attach a tracer on 'usdt:*:ddheap:*'. \
+            "pid={}; pre-install. Attach a tracer on 'usdt:*:otel_memory:*'. \
              threads={threads} stress={stress} secs={:?}",
             std::process::id(),
             secs,

--- a/libdd-profiling-heap-gotter/src/lib.rs
+++ b/libdd-profiling-heap-gotter/src/lib.rs
@@ -28,7 +28,7 @@
 //! install_heap_overrides();
 //! // ... application runs for the rest of its life; malloc/free/calloc/
 //! //     realloc/etc. flow through libdd-profiling-heap-sampler and emit
-//! //     ddheap:alloc / ddheap:free USDTs ...
+//! //     otel_memory:alloc / otel_memory:free USDTs ...
 //! ```
 //!
 //! # Installation is permanent (there is no uninstall)

--- a/libdd-profiling-heap-sampler/Cargo.toml
+++ b/libdd-profiling-heap-sampler/Cargo.toml
@@ -19,7 +19,7 @@ bench = false
 default = []
 # Live-heap tracking: flag each sampled allocation so frees can be balanced
 # against allocs for retained/live-heap profiling, and sample
-# frees to emit ddheap:free.
+# frees to emit otel_memory:free.
 live-heap = []
 # Runtime ELF self-inspection of the USDT notes (see src/usdt_check.rs). Opt-in
 # so the crate keeps zero runtime deps by default; only pulls in elf/anyhow.

--- a/libdd-profiling-heap-sampler/README.md
+++ b/libdd-profiling-heap-sampler/README.md
@@ -54,10 +54,10 @@ They are responsible for deciding whether or not to sample, and storing the info
 
 The actual USDTs emitted are:
 
-* `ddheap:alloc(void *user, uint64_t size, uint64_t weight)` — fired on sampled allocations; `user` is the user-visible pointer, `size` in bytes, `weight` is the unbiased size estimator (`nsamples * interval`)
-* `ddheap:free(void *ptr)` — fired when a previously-sampled allocation is freed
-* `ddheap:mmap` - TODO 
-* `ddheap:munmap` - TODO
+* `otel_memory:alloc(void *user, uint64_t size, uint64_t weight)` — fired on sampled allocations; `user` is the user-visible pointer, `size` in bytes, `weight` is the unbiased size estimator (`nsamples * interval`)
+* `otel_memory:free(void *ptr)` — fired when a previously-sampled allocation is freed
+* `otel_memory:mmap` - TODO 
+* `otel_memory:munmap` - TODO
 
 **Allocations**
 

--- a/libdd-profiling-heap-sampler/docs/realloc.md
+++ b/libdd-profiling-heap-sampler/docs/realloc.md
@@ -63,6 +63,6 @@ For the sampled-old case:
   `memmove` them down to the front. It has to be `memmove`, not `memcpy`,
   because when realloc grows a block in place, `new_raw` and `old_raw` are
   the same address and the ranges overlap.
-* We fire the `ddheap:free` USDT for the old address, since as far as the
+* We fire the `otel_memory:free` USDT for the old address, since as far as the
   profiler is concerned that allocation no longer exists.
 * We return `new_raw` as a plain, unsampled pointer.

--- a/libdd-profiling-heap-sampler/include/datadog/heap/allocation_created.h
+++ b/libdd-profiling-heap-sampler/include/datadog/heap/allocation_created.h
@@ -1,13 +1,13 @@
 /**
  * @file allocation_created.h
  *
- * Post-allocation hook for the ddheap sampler.
+ * Post-allocation hook for the otel_memory sampler.
  *
  * Call dd_allocation_created() immediately after the underlying allocator
  * returns. On the common (unsampled) fast path this is a single branch on
  * req.weight and an immediate return of the raw pointer. On the sampled slow
  * path it applies the architecture-specific sample flag to the raw pointer,
- * emits the ddheap:alloc USDT, and closes the reentry guard that was opened
+ * emits the otel_memory:alloc USDT, and closes the reentry guard that was opened
  * by the paired dd_allocation_requested() call.
  *
  * Always call this even when the allocator returns NULL: the reentry guard
@@ -37,7 +37,7 @@ void *dd_allocation_created_slow(void *raw, dd_alloc_req_t req)
  *
  * Fast path (not sampled): returns raw unchanged.
  * Slow path (sampled): applies the architecture-specific flag, emits
- * the ddheap:alloc USDT, closes the reentry guard opened by the paired
+ * the otel_memory:alloc USDT, closes the reentry guard opened by the paired
  * requested() call, returns the user-visible pointer.
  *
  * Safe when raw == NULL (allocator failed): no USDT, guard still closed.

--- a/libdd-profiling-heap-sampler/include/datadog/heap/allocation_freed.h
+++ b/libdd-profiling-heap-sampler/include/datadog/heap/allocation_freed.h
@@ -1,13 +1,13 @@
 /**
  * @file allocation_freed.h
  *
- * Pre-free hook for the ddheap sampler.
+ * Pre-free hook for the otel_memory sampler.
  *
  * Call dd_allocation_freed() before forwarding to the underlying deallocator.
  * On the fast path it checks whether the pointer carries the architecture-
  * specific sample flag (a top-byte tag on arm64, a magic header word on
  * x86-64); unsampled pointers return immediately with their inputs unchanged.
- * On the slow path it emits the ddheap:free USDT and returns the raw pointer
+ * On the slow path it emits the otel_memory:free USDT and returns the raw pointer
  * and adjusted size that the caller must pass to the real free.
  *
  * The caller must use the ptr and size from the returned dd_alloc_freed_t
@@ -49,7 +49,7 @@ dd_alloc_freed_t dd_allocation_freed_slow(void *ptr, void *raw, size_t size,
  * Wraps free, operator delete (sized and unsized), sdallocx, etc.
  *
  * Checks whether the allocation at `ptr` was previously sampled and
- * emits the matching `ddheap:free` USDT if so, then returns the
+ * emits the matching `otel_memory:free` USDT if so, then returns the
  * (ptr, size) the caller must forward to the underlying deallocator
  * verbatim.
  *

--- a/libdd-profiling-heap-sampler/include/datadog/heap/allocation_realloc.h
+++ b/libdd-profiling-heap-sampler/include/datadog/heap/allocation_realloc.h
@@ -18,7 +18,7 @@
  *
  * For a sampled old allocation, a successful realloc is reported as:
  *
- *   ddheap:free(old sampled) + new unsampled allocation
+ *   otel_memory:free(old sampled) + new unsampled allocation
  *
  * New blocks from realloc(NULL, size) use the normal allocation sampling
  * path. Existing unsampled blocks pass through unchanged. Existing
@@ -87,7 +87,7 @@ dd_realloc_prep_t dd_allocation_realloc_prepare(void *old_user, size_t new_size)
  * returns the possibly tagged user pointer.
  *
  * On the sampled-old path: shifts old user contents from [old_offset, ...)
- * down to [0, ...), fires ddheap:free(old_user), and returns new_raw as
+ * down to [0, ...), fires otel_memory:free(old_user), and returns new_raw as
  * an unsampled pointer.
  *
  * On the unsampled/passthrough and realloc(ptr, 0) paths: returns new_raw

--- a/libdd-profiling-heap-sampler/include/datadog/heap/allocation_requested.h
+++ b/libdd-profiling-heap-sampler/include/datadog/heap/allocation_requested.h
@@ -1,7 +1,7 @@
 /**
  * @file allocation_requested.h
  *
- * Pre-allocation hook for the ddheap sampler.
+ * Pre-allocation hook for the otel_memory sampler.
  *
  * Call dd_allocation_requested() immediately before invoking the underlying
  * allocator. It runs the Poisson sampling decision for this allocation:
@@ -16,7 +16,7 @@
  *                store the sample flag in a 16-byte header before the user
  *                pointer).
  *   - user_size: the original application-requested size, reported to
- *                the profiler via the ddheap:alloc USDT.
+ *                the profiler via the otel_memory:alloc USDT.
  *   - alignment: passed through so dd_allocation_created can place the
  *                user pointer correctly relative to the raw pointer.
  *   - weight:    0 if not sampled; otherwise the unbiased size
@@ -46,7 +46,7 @@
  *               alignment slack.
  *   user_size - the size the application originally asked for. This is
  *               the value that gets reported to the profiler via the
- *               ddheap:alloc USDT, so that heap-size distributions are
+ *               otel_memory:alloc USDT, so that heap-size distributions are
  *               not skewed by the sampler's per-allocation overhead.
  *   alignment - alignment the wrapper MUST pass to its underlying
  *               allocator. Equals the alignment the caller passed to
@@ -108,8 +108,8 @@ static inline __attribute__((always_inline, warn_unused_result))
 dd_alloc_req_t dd_allocation_requested(size_t size, size_t alignment) {
     dd_alloc_req_t out = { size, size, alignment, 0 };
 
-    // If no tracer is attached to ddheap, skip all sampling logic.
-    if (__builtin_expect(!USDT_SEMA_IS_ACTIVE(ddheap_alloc), 1)) return out;
+    // If no tracer is attached to otel_memory, skip all sampling logic.
+    if (__builtin_expect(!USDT_SEMA_IS_ACTIVE(otel_memory_alloc), 1)) return out;
 
     // If we don't have TLS yet (this is defensive and should never happen), or
     // the reentry guard is set (meaning a sampled allocation is already in

--- a/libdd-profiling-heap-sampler/include/datadog/heap/probes.h
+++ b/libdd-profiling-heap-sampler/include/datadog/heap/probes.h
@@ -1,5 +1,5 @@
 /*
- * USDT probe emission functions for the ddheap provider.
+ * USDT probe emission functions for the otel_memory provider.
  *
  * Defined in probes.c as regular non-inline functions so that each probe
  * site has a single, stable address in the final binary. This matters
@@ -20,18 +20,18 @@
     * the variadic USDT() macro that emits the same v3 ELF-note format
     * that bpftrace, systemtap, and BPF tracers all consume. */
 #  include <usdt.h>
-   /* Shared explicit semaphore for the ddheap provider. Defined in probes.c;
+   /* Shared explicit semaphore for the otel_memory provider. Defined in probes.c;
     * declared here so that other TUs (e.g. allocation_requested.h) can check
-    * USDT_SEMA_IS_ACTIVE(ddheap_alloc) without emitting their own implicit
+    * USDT_SEMA_IS_ACTIVE(otel_memory_alloc) without emitting their own implicit
     * semaphore definitions. */
-   USDT_DECLARE_SEMA(ddheap_alloc);
+   USDT_DECLARE_SEMA(otel_memory_alloc);
 #else
 #  define USDT(provider, name, ...) ((void)0)
 #  define USDT_SEMA_IS_ACTIVE(sema) (1)
 #endif
 
 /*
- * Emits the `ddheap:alloc` USDT.
+ * Emits the `otel_memory:alloc` USDT.
  *   user   - user-visible allocation pointer
  *   size   - allocation size in bytes
  *   weight - unbiased size estimator (nsamples * interval)
@@ -39,11 +39,11 @@
 void dd_probe_alloc(void *user, uint64_t size, uint64_t weight);
 
 /*
- * Emits the `ddheap:free` USDT.
+ * Emits the `otel_memory:free` USDT.
  *   ptr - user-visible pointer being freed
  *
  * The symbol always exists, but the USDT is only emitted when compiled
- * with live-heap tracking. The absence of the `ddheap:free` note in
+ * with live-heap tracking. The absence of the `otel_memory:free` note in
  * .note.stapsdt signals to external profilers that this binary does not
  * support live-heap correlation.
  */
@@ -51,7 +51,7 @@ void dd_probe_free(void *ptr);
 
 /*
  * Returns true when an external profiler is currently attached to the
- * ddheap:alloc USDT in this object file.
+ * otel_memory:alloc USDT in this object file.
  *
  * This is a point-in-time read of the alloc probe's USDT semaphore. A profiler
  * can attach or detach immediately after this returns. Use it as a
@@ -60,7 +60,7 @@ void dd_probe_free(void *ptr);
 bool dd_heap_profiler_attached(void);
 
 /*
- * Test-only: manually activate the ddheap:alloc USDT semaphore so that
+ * Test-only: manually activate the otel_memory:alloc USDT semaphore so that
  * dd_allocation_requested's fast-path guard allows sampling in a process
  * where no real profiler is attached. Call with `active=true` before
  * exercising the sampler and `active=false` to restore the default state.

--- a/libdd-profiling-heap-sampler/src/allocation_created.c
+++ b/libdd-profiling-heap-sampler/src/allocation_created.c
@@ -14,7 +14,7 @@
  *
  * Applies the architecture-specific sample flag to raw (tagging the pointer
  * on arm64, writing a header magic word on x86-64) to produce the
- * user-visible pointer, then fires the ddheap:alloc USDT so an attached
+ * user-visible pointer, then fires the otel_memory:alloc USDT so an attached
  * profiler can record the sample. Finally closes the reentry guard that
  * dd_allocation_requested_slow opened.
  *
@@ -24,7 +24,7 @@
  * TODO: on x86-64, consider abandoning the sample when raw falls within
  * DD_HEADER_BYTES of a page boundary. The free-side fast path already bails
  * in that case (to avoid reading before the page), so those allocations will
- * never emit a ddheap:free. Dropping them at alloc time would keep the
+ * never emit a otel_memory:free. Dropping them at alloc time would keep the
  * alloc/free pair balanced at the cost of occasionally missing a sample.
  *
  * (ddprof: AllocTrackerHelper::track / AllocationTracker push_alloc_sample)

--- a/libdd-profiling-heap-sampler/src/allocation_freed.c
+++ b/libdd-profiling-heap-sampler/src/allocation_freed.c
@@ -12,7 +12,7 @@
  * dd_sample_flag_check_and_clear confirmed that ptr carries the sample flag,
  * meaning this allocation was previously sampled.
  *
- * Fires the ddheap:free USDT (when live-heap tracking is enabled) with the
+ * Fires the otel_memory:free USDT (when live-heap tracking is enabled) with the
  * user-visible pointer, then returns
  * the raw pointer and adjusted size that the caller must forward to the
  * real deallocator. On x86-64 the size grows by DD_HEADER_BYTES to cover

--- a/libdd-profiling-heap-sampler/src/allocation_realloc.c
+++ b/libdd-profiling-heap-sampler/src/allocation_realloc.c
@@ -152,7 +152,7 @@ void *dd_allocation_realloc_commit(void *old_user, void *new_raw, dd_realloc_pre
 
     /* Report the free of the OLD sampled allocation (the address the
      * profiler last saw as live). No matching alloc is fired: the new
-     * block is unsampled. dd_probe_free just emits the ddheap:free
+     * block is unsampled. dd_probe_free just emits the otel_memory:free
      * USDT so the profiler can close the live-heap entry. */
     dd_probe_free(old_user);
     return new_raw;

--- a/libdd-profiling-heap-sampler/src/lib.rs
+++ b/libdd-profiling-heap-sampler/src/lib.rs
@@ -53,7 +53,7 @@ pub fn set_default_sampling_distance(distance_bytes: u64) {
 }
 
 /// Returns true when an external profiler is currently attached to the
-/// `ddheap:alloc` USDT in this object file.
+/// `otel_memory:alloc` USDT in this object file.
 ///
 /// This is a point-in-time read of the alloc probe's USDT semaphore. A profiler
 /// can attach or detach immediately after this returns. Use it as a
@@ -246,7 +246,7 @@ mod tests {
 
     // With live-heap tracking compiled out, dd_allocation_freed is a
     // straight passthrough: it never inspects the sample-flag header and
-    // never fires ddheap:free. Verify this even when the underlying
+    // never fires otel_memory:free. Verify this even when the underlying
     // memory happens to contain the magic pattern that *would* trigger
     // the slow path if live-heap were enabled.
     #[cfg(not(feature = "live-heap"))]

--- a/libdd-profiling-heap-sampler/src/probes.c
+++ b/libdd-profiling-heap-sampler/src/probes.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
- * USDT emission for the ddheap provider.
+ * USDT emission for the otel_memory provider.
  *
  * Kept as non-inline functions in a separate translation unit so that each
  * probe has one USDT() expansion and one .note.stapsdt entry. The intent
@@ -23,23 +23,23 @@
 #include <errno.h>
 #include <stdbool.h>
 
-/* Single definition of the shared ddheap USDT semaphore. Both the alloc and
+/* Single definition of the shared otel_memory USDT semaphore. Both the alloc and
  * free probes reference this semaphore, so attaching to either one activates
  * sampling for the whole provider. Other TUs access it via
- * USDT_DECLARE_SEMA(ddheap_alloc) in probes.h. */
-USDT_DEFINE_SEMA(ddheap_alloc);
+ * USDT_DECLARE_SEMA(otel_memory_alloc) in probes.h. */
+USDT_DEFINE_SEMA(otel_memory_alloc);
 
 /* Save / restore errno: an attached USDT consumer may perturb it. */
 void dd_probe_alloc(void *user, uint64_t size, uint64_t weight) {
     int saved_errno = errno;
-    USDT_WITH_EXPLICIT_SEMA(ddheap_alloc, ddheap, alloc, user, size, weight);
+    USDT_WITH_EXPLICIT_SEMA(otel_memory_alloc, otel_memory, alloc, user, size, weight);
     errno = saved_errno;
 }
 
 void dd_probe_free(void *ptr) {
 #if DD_HEAP_LIVE_TRACKING
     int saved_errno = errno;
-    USDT_WITH_EXPLICIT_SEMA(ddheap_alloc, ddheap, free, ptr);
+    USDT_WITH_EXPLICIT_SEMA(otel_memory_alloc, otel_memory, free, ptr);
     errno = saved_errno;
 #else
     (void)ptr;
@@ -47,9 +47,9 @@ void dd_probe_free(void *ptr) {
 }
 
 bool dd_heap_profiler_attached(void) {
-    return USDT_SEMA_IS_ACTIVE(ddheap_alloc);
+    return USDT_SEMA_IS_ACTIVE(otel_memory_alloc);
 }
 
 void dd_test_set_profiler_active(bool active) {
-    USDT_SEMA(ddheap_alloc).active = active ? 1 : 0;
+    USDT_SEMA(otel_memory_alloc).active = active ? 1 : 0;
 }

--- a/libdd-profiling-heap-sampler/src/usdt_check.rs
+++ b/libdd-profiling-heap-sampler/src/usdt_check.rs
@@ -1,7 +1,7 @@
 // Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
 // SPDX-License-Identifier: Apache-2.0
 
-//! Runtime ELF self-inspection for the ddheap USDT probes. Verifies that each
+//! Runtime ELF self-inspection for the otel_memory USDT probes. Verifies that each
 //! probe has exactly one `.note.stapsdt` entry, so an attached consumer
 //! (bpftrace / eBPF) sees one probe per site rather than attaching twice.
 //!
@@ -10,7 +10,7 @@
 //! note; a regression (e.g. `static inline` + bindgen's `wrap_static_fns`, or
 //! LTO inlining across TUs) could duplicate the entry. This check catches that.
 //!
-//! `ddheap:alloc` is expected in every build. `ddheap:free` is only expected
+//! `otel_memory:alloc` is expected in every build. `otel_memory:free` is only expected
 //! when compiled with live-heap tracking (the `live-heap` feature): its
 //! absence is how external profilers detect that a binary doesn't support
 //! live-heap correlation (see `probes.h`), so callers must pass the probe
@@ -28,12 +28,12 @@ use elf::{endian::AnyEndian, ElfBytes};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-/// USDT provider name emitted by `probes.c` (`USDT(ddheap, ...)`).
-const PROVIDER: &str = "ddheap";
+/// USDT provider name emitted by `probes.c` (`USDT(otel_memory, ...)`).
+const PROVIDER: &str = "otel_memory";
 
 /// As [`sanity_check`], but takes the object file as an argument. Useful for a
 /// test setting where the test code is separate from the artifact to
-/// validate. `expected_probes` lists the probe names (without the `ddheap:`
+/// validate. `expected_probes` lists the probe names (without the `otel_memory:`
 /// provider prefix) that must each appear exactly once.
 pub fn check_usdt_probes_in(path: &Path, expected_probes: &[&str]) -> anyhow::Result<()> {
     let data = std::fs::read(path).with_context(|| format!("failed to read {}", path.display()))?;
@@ -44,7 +44,7 @@ pub fn check_usdt_probes_in(path: &Path, expected_probes: &[&str]) -> anyhow::Re
 }
 
 /// Check that the current running module carries exactly one `.note.stapsdt`
-/// entry per ddheap probe expected in this build (`alloc` always, `free`
+/// entry per otel_memory probe expected in this build (`alloc` always, `free`
 /// only when the `live-heap` feature is enabled).
 pub fn sanity_check() -> anyhow::Result<()> {
     let mut expected = vec!["alloc"];


### PR DESCRIPTION
Updating to reflect upstream profiler changes; we should land this once that has been merged.