### PR TITLE
chore(deps): bump zrip to 0.8.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7503,9 +7503,9 @@ dependencies = [
 
 [[package]]
 name = "zrip"
-version = "0.6.0"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964fe9f1ea10a0d183fc143a7525266cbe16978883dbe304725da34b314c04cf"
+checksum = "edd02f990082191d398ad4ffb08dc3d92174f275b0b5e8b76d12eddd3e486bcf"
 dependencies = [
  "zrip-core",
  "zrip-decode",
@@ -7514,24 +7514,24 @@ dependencies = [
 
 [[package]]
 name = "zrip-core"
-version = "0.6.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc201ba56175f86e67cc88bdaf1a7af9c061815c7dde719c7a6a1ed5aaa186b"
+checksum = "d0122e5712041938e8a1a4db57975da142f9b9cd1aab24cf8a94bb2ce4b79774"
 
 [[package]]
 name = "zrip-decode"
-version = "0.6.0"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038f795e49887bdeaab197fff84c8165644484a98dc3f2354e5df3d2e5f4f978"
+checksum = "8a21823fd3263a53b26c082461bd411006652fa3e0d7842c5bac552ac5498bab"
 dependencies = [
  "zrip-core",
 ]
 
 [[package]]
 name = "zrip-encode"
-version = "0.6.0"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3dfdcbb503db2045716492d5ab31cd82f2852d0d93d8edf6a9235653d9da685"
+checksum = "233b9d977003b9c1e3aaaf95ea1863a2e6263c37c9050b001d69152058b58735"
 dependencies = [
  "zrip-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ resolver = "2"
 # The RHEL restrictions are for the dd-trace-php repository. Someone in the
 # community, Remi Collet, packages the extension for these systems.
 [workspace.package]
-rust-version = "1.87.0"
+rust-version = "1.89.0"
 edition = "2021"
 version = "43.0.0"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cargo run --bin release -- --out output-folder
 
 #### Build dependencies
 
-- Rust 1.87.0 or newer with cargo. The exact version is pinned in `rust-toolchain.toml` at the workspace root and rustup installs it automatically. See the comment near `rust-version` in `Cargo.toml` for the constraints to check when bumping this version.
+- Rust 1.89.0 or newer with cargo. The exact version is pinned in `rust-toolchain.toml` at the workspace root and rustup installs it automatically. See the comment near `rust-version` in `Cargo.toml` for the constraints to check when bumping this version.
 - `cbindgen` 0.29
 - `cmake` and `protoc`
 

--- a/libdd-data-pipeline/Cargo.toml
+++ b/libdd-data-pipeline/Cargo.toml
@@ -101,7 +101,7 @@ h2 = "0.4"
 zstd.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
-zrip = { version = "=0.6.0", default-features = false, features = ["alloc"] }
+zrip = { version = "=0.8.7", default-features = false, features = ["alloc"] }
 
 [[test]]
 name = "test_agentless_stats"

--- a/libdd-profiling/Cargo.toml
+++ b/libdd-profiling/Cargo.toml
@@ -72,7 +72,7 @@ rustls = { workspace = true, features = ["ring"] }
 zstd.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-zrip = { version = "=0.6.0", default-features = false, features = ["frame"] }
+zrip = { version = "=0.8.7", default-features = false, features = ["frame"] }
 
 [dev-dependencies]
 bolero = { workspace = true, features = ["std"] }

--- a/libdd-trace-utils/Cargo.toml
+++ b/libdd-trace-utils/Cargo.toml
@@ -73,7 +73,7 @@ zstd = {workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
-zrip = { version = "=0.6.0", default-features = false, features = ["frame"], optional = true }
+zrip = { version = "=0.8.7", default-features = false, features = ["frame"], optional = true }
 
 [dev-dependencies]
 libdd-capabilities-impl = { version = "4.0.0", path = "../libdd-capabilities-impl" }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.87.0"
+channel = "1.89.0"
 components = ["rustfmt", "clippy"]
 profile = "minimal"

--- a/tests/wasm/Cargo.toml
+++ b/tests/wasm/Cargo.toml
@@ -17,4 +17,4 @@ compression = []
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 http = "1"
 wasm-bindgen-test = "=0.3.50"
-zrip = { version = "=0.6.0", default-features = false, features = ["frame"] }
+zrip = { version = "=0.8.7", default-features = false, features = ["frame"] }


### PR DESCRIPTION
zrip 0.8.7 requires Rust 1.89, so this moves the dependency and workspace MSRV together. It lets downstream WASM consumers use one zrip version instead of retaining the 0.6.0 stack.

Refs: https://github.com/DataDog/libdatadog-nodejs/pull/270