### PR TITLE
feat(crashtracking)!: API to unpatch crashtracker GOT patches

### DIFF
--- a/libdd-crashtracker/src/collector/api.rs
+++ b/libdd-crashtracker/src/collector/api.rs
@@ -95,6 +95,37 @@ pub fn init(
     Ok(())
 }
 
+/// Remove the GOT hooks installed by [`init`] for `sigaction` and
+/// `__assert_fail`, restoring every patched slot to its pre-hook value.
+///
+/// After this call, `sigaction` and `__assert_fail` calls in all
+/// previously-patched libraries go directly to whatever implementation
+/// was in their GOT before [`init`] ran — typically the real libc
+/// function, or an LD_PRELOAD interposer if one was loaded first.
+///
+/// # Return value
+///
+/// Returns a combined [`UnhookResult`]. If [`slots_failed`] is non-zero,
+/// one or more GOT entries still point into libdatadog's code. The caller
+/// **must not** unload the library until all slots are restored, or a later
+/// call through those entries will fault. The hook state is preserved on
+/// partial failure so this function may be retried.
+///
+/// Safe to call if [`init`] was never called (no-op in that case). Not
+/// reentrant; do not call concurrently with [`init`] or the hooked functions.
+///
+/// [`slots_failed`]: libdd_gotter::UnhookResult::slots_failed
+/// [`UnhookResult`]: libdd_gotter::UnhookResult
+#[cfg(all(target_os = "linux", target_pointer_width = "64"))]
+pub fn uninstall_hooks() -> libdd_gotter::UnhookResult {
+    let assert_result = super::assert_interceptor::uninstall_assert_hook();
+    let sigaction_result = super::sigaction_interceptor::uninstall_sigaction_hook();
+    libdd_gotter::UnhookResult {
+        slots_restored: assert_result.slots_restored + sigaction_result.slots_restored,
+        slots_failed: assert_result.slots_failed + sigaction_result.slots_failed,
+    }
+}
+
 /// Reconfigure the crash-tracking infrastructure.
 ///
 /// PRECONDITIONS:

--- a/libdd-crashtracker/src/collector/assert_interceptor.rs
+++ b/libdd-crashtracker/src/collector/assert_interceptor.rs
@@ -25,6 +25,11 @@ use core::sync::atomic::{
     Ordering::{Acquire, Relaxed, Release},
 };
 
+/// Per-slot `(GOT_address, original_value)` pairs captured at hook time,
+/// needed by [`uninstall_assert_hook`] to restore the exact pre-hook values.
+static ASSERT_HOOK_RESULT: std::sync::Mutex<Option<libdd_gotter::HookResult>> =
+    std::sync::Mutex::new(None);
+
 const ASSERT_BUF_CAP: usize = 1024;
 
 /// Fixed-size buffer for the formatted assert message.
@@ -224,7 +229,41 @@ pub(crate) fn install_assert_hook() {
         let our_hook = hook_assert_fail as *const () as usize;
         if hook.orig_addr != our_hook {
             ORIG_ASSERT_FN.store(hook.orig_addr, Release);
+            // Store the full HookResult so uninstall_assert_hook can restore
+            // each GOT slot to its exact pre-hook value.
+            if let Ok(mut guard) = ASSERT_HOOK_RESULT.lock() {
+                *guard = Some(hook);
+            }
         }
+    }
+}
+
+/// Remove the `__assert_fail` GOT hook installed by [`install_assert_hook`],
+/// restoring every patched slot to the value it held before hooking.
+///
+/// Safe to call when the hook was never installed (no-op in that case).
+///
+/// Returns an [`UnhookResult`] describing how many slots were restored and
+/// how many failed. If [`UnhookResult::slots_failed`] is non-zero, some GOT
+/// entries still point at `hook_assert_fail`; the caller must not unload
+/// libdatadog until all slots are restored.
+///
+/// On partial failure the hook state is left intact so a retry is possible.
+///
+/// [`UnhookResult`]: libdd_gotter::UnhookResult
+pub(crate) fn uninstall_assert_hook() -> libdd_gotter::UnhookResult {
+    let mut guard = ASSERT_HOOK_RESULT.lock().unwrap_or_else(|e| e.into_inner());
+
+    if let Some(result) = guard.as_ref() {
+        // SAFETY: all libraries patched at hook time are still loaded.
+        let unhook = unsafe { libdd_gotter::unhook_symbol(result) };
+        if unhook.is_complete() {
+            *guard = None;
+            ORIG_ASSERT_FN.store(0, Release);
+        }
+        unhook
+    } else {
+        libdd_gotter::UnhookResult::default()
     }
 }
 

--- a/libdd-crashtracker/src/collector/sigaction_interceptor.rs
+++ b/libdd-crashtracker/src/collector/sigaction_interceptor.rs
@@ -18,12 +18,19 @@ use core::sync::atomic::{
 /// Bit N is set if signal number N is monitored. Supports signals 0–63.
 static MONITORED_SIGNALS: AtomicU64 = AtomicU64::new(0);
 
-/// Bit N is set when the hook has fired for signal N
+/// Bit N is set when the hook has fired for signal N.
+/// Atomically swap to zero with [`take_intercepted_signals`] to consume it.
 pub(crate) static INTERCEPTED_SIGNALS: AtomicU64 = AtomicU64::new(0);
 
 /// Resolved address of the original `sigaction`, set once during
-/// [`install_sigaction_hook`].
+/// [`install_sigaction_hook`], cleared by [`uninstall_sigaction_hook`].
 static ORIG_SIGACTION_FN: AtomicUsize = AtomicUsize::new(0);
+
+/// Per-slot `(GOT_address, original_value)` pairs captured at hook time,
+/// needed by [`uninstall_sigaction_hook`] to restore the exact pre-hook
+/// values (including IFUNC-resolved addresses and RELA addends).
+static SIGACTION_HOOK_RESULT: std::sync::Mutex<Option<libdd_gotter::HookResult>> =
+    std::sync::Mutex::new(None);
 
 type SigactionFn =
     unsafe extern "C" fn(libc::c_int, *const libc::sigaction, *mut libc::sigaction) -> libc::c_int;
@@ -85,7 +92,47 @@ pub(crate) fn install_sigaction_hook(monitored_signals: &[i32]) {
         let our_hook = hook_sigaction as *const () as usize;
         if hook.orig_addr != our_hook {
             ORIG_SIGACTION_FN.store(hook.orig_addr, Release);
+            // Store the full HookResult so uninstall_sigaction_hook can
+            // restore each GOT slot to its exact pre-hook value.
+            if let Ok(mut guard) = SIGACTION_HOOK_RESULT.lock() {
+                *guard = Some(hook);
+            }
         }
+    }
+}
+
+/// Remove the `sigaction` GOT hook installed by [`install_sigaction_hook`],
+/// restoring every patched slot to the value it held before hooking.
+///
+/// Safe to call when the hook was never installed (no-op in that case).
+///
+/// Returns an [`UnhookResult`] describing how many slots were restored and
+/// how many failed. If [`UnhookResult::slots_failed`] is non-zero, some GOT
+/// entries still point at `hook_sigaction`; the caller must not unload
+/// libdatadog until all slots are restored.
+///
+/// On partial failure the hook state is left intact so a retry is possible.
+///
+/// [`UnhookResult`]: libdd_gotter::UnhookResult
+pub(crate) fn uninstall_sigaction_hook() -> libdd_gotter::UnhookResult {
+    let mut guard = SIGACTION_HOOK_RESULT
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+
+    if let Some(result) = guard.as_ref() {
+        // Restore every GOT entry to the value captured before patching.
+        // SAFETY: all libraries patched at hook time are still loaded
+        // (the crashtracker itself is live, so the process hasn't exited).
+        // The caller must ensure sigaction is not called concurrently.
+        let unhook = unsafe { libdd_gotter::unhook_symbol(result) };
+        if unhook.is_complete() {
+            *guard = None;
+            ORIG_SIGACTION_FN.store(0, Release);
+            MONITORED_SIGNALS.store(0, Release);
+        }
+        unhook
+    } else {
+        libdd_gotter::UnhookResult::default()
     }
 }
 

--- a/libdd-crashtracker/src/lib.rs
+++ b/libdd-crashtracker/src/lib.rs
@@ -82,6 +82,13 @@ pub use collector::{
     set_expected_receiver_pid, update_config, update_metadata, OpTypes, DEFAULT_SYMBOLS,
 };
 
+#[cfg(all(
+    feature = "collector",
+    target_os = "linux",
+    target_pointer_width = "64"
+))]
+pub use {collector::uninstall_hooks, libdd_gotter::UnhookResult};
+
 #[cfg(all(windows, feature = "collector_windows"))]
 pub use collector_windows::api::{exception_event_callback, init_crashtracking_windows};
 


### PR DESCRIPTION
# What does this PR do?

Provides an API to unpatch the two symbols that crashtracker patches -- `assert_fail` and `sigaction`.

# Motivation

Some tracers unload extensions. Unloading libdatadog after its already updated the GOT entries means that symbols now point to now-unmapped areas. We should provide an API for users to call before unloading.

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
