### PR TITLE
chore(codeowners): make common component co-codeowner of otlp exporter in data-pipeline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -112,9 +112,9 @@ bin_tests/tests/test_the_tests.rs    @DataDog/libdatadog-core
 bin_tests/src/bin/test_the_tests.rs  @DataDog/libdatadog-core
 tools/cc_utils/                      @DataDog/libdatadog-php
 tools/sidecar_mockgen/               @DataDog/libdatadog-php
-libdd-data-pipeline/src/otlp/                           @DataDog/apm-sdk-capabilities-rust
-libdd-data-pipeline/tests/test_trace_exporter_otlp_export.rs @DataDog/apm-sdk-capabilities-rust
-libdd-trace-utils/src/otlp_encoder/                     @DataDog/apm-sdk-capabilities-rust
+libdd-data-pipeline/src/otlp/                           @DataDog/apm-sdk-capabilities-rust @DataDog/apm-common-components-core
+libdd-data-pipeline/tests/test_trace_exporter_otlp_export.rs @DataDog/apm-sdk-capabilities-rust @DataDog/apm-common-components-core
+libdd-trace-utils/src/otlp_encoder/                     @DataDog/apm-sdk-capabilities-rust @DataDog/apm-common-components-core
 datadog-sidecar/src/service/ffe_exposures_flusher.rs    @DataDog/libdatadog-php @DataDog/libdatadog-apm @DataDog/feature-flagging-and-experimentation-sdk
 datadog-sidecar/src/service/ffe_metrics_flusher.rs      @DataDog/libdatadog-php @DataDog/libdatadog-apm @DataDog/feature-flagging-and-experimentation-sdk
 .github/workflows/nix.yml                               @DataDog/nix-guild @DataDog/apm-common-components-core


### PR DESCRIPTION

# What does this PR do?

Make common component co-codeowner of otlp exporter in data-pipeline

# Motivation

We sometimes have to refactor this file, and now that all codeowners have to approve, this is unnecessary friction to have to ask for a review every time

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
