### PR TITLE
feat(crashtracking): GOT patch sigaction

### DIFF
--- a/libdd-crashtracker/src/collector/api.rs
+++ b/libdd-crashtracker/src/collector/api.rs
@@ -87,7 +87,10 @@ pub fn init(
     register_crash_handlers(&config)?;
     register_panic_hook()?;
     #[cfg(all(target_os = "linux", target_pointer_width = "64"))]
-    super::assert_interceptor::install_assert_hook();
+    {
+        super::assert_interceptor::install_assert_hook();
+        super::sigaction_interceptor::install_sigaction_hook(config.signals());
+    }
     enable();
     Ok(())
 }

--- a/libdd-crashtracker/src/collector/mod.rs
+++ b/libdd-crashtracker/src/collector/mod.rs
@@ -13,6 +13,8 @@ mod emitters;
 mod process_handle;
 mod receiver_manager;
 mod saguard;
+#[cfg(all(target_os = "linux", target_pointer_width = "64"))]
+mod sigaction_interceptor;
 mod signal_handler_manager;
 mod spans;
 

--- a/libdd-crashtracker/src/collector/sigaction_interceptor.rs
+++ b/libdd-crashtracker/src/collector/sigaction_interceptor.rs
@@ -1,0 +1,139 @@
+// Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0
+
+//! Intercepts `sigaction` calls to detect when an application overwrites
+//! signal handlers installed by the crashtracker.
+//!
+//! During crashtracker initialization, [`install_sigaction_hook`] patches
+//! the GOT entries for `sigaction` across all loaded libraries so that
+//! calls are routed through our hook
+//!
+//! This module is gated on 64-bit Linux (`mod.rs`).
+
+use core::sync::atomic::{
+    AtomicU64, AtomicUsize,
+    Ordering::{Acquire, Relaxed, Release},
+};
+
+/// Bit N is set if signal number N is monitored. Supports signals 0–63.
+static MONITORED_SIGNALS: AtomicU64 = AtomicU64::new(0);
+
+/// Bit N is set when the hook has fired for signal N
+pub(crate) static INTERCEPTED_SIGNALS: AtomicU64 = AtomicU64::new(0);
+
+/// Resolved address of the original `sigaction`, set once during
+/// [`install_sigaction_hook`].
+static ORIG_SIGACTION_FN: AtomicUsize = AtomicUsize::new(0);
+
+type SigactionFn =
+    unsafe extern "C" fn(libc::c_int, *const libc::sigaction, *mut libc::sigaction) -> libc::c_int;
+
+/// Our replacement for `sigaction`, installed using GOT patching.
+///
+/// For signals monitored by the crashtracker, logs a warning. In all
+/// cases, forwards the call to the real `sigaction`.
+unsafe extern "C" fn hook_sigaction(
+    signum: libc::c_int,
+    act: *const libc::sigaction,
+    oldact: *mut libc::sigaction,
+) -> libc::c_int {
+    // Check if this signal is one we monitor.
+    if (0..64).contains(&signum)
+        && !act.is_null()
+        && MONITORED_SIGNALS.load(Relaxed) & (1u64 << signum) != 0
+    {
+        INTERCEPTED_SIGNALS.fetch_or(1u64 << signum, Release);
+    }
+
+    // Forward to the real sigaction.
+    let orig = ORIG_SIGACTION_FN.load(Acquire);
+    if orig != 0 {
+        // SAFETY: `orig` was stored by `install_sigaction_hook` from a
+        // successful `hook_symbol` call which resolved the real `sigaction`.
+        let func: SigactionFn = unsafe { core::mem::transmute::<usize, SigactionFn>(orig) };
+        // SAFETY: forwarding the exact arguments from the caller.
+        unsafe { func(signum, act, oldact) }
+    } else {
+        // Fallback: should not happen, but dont crash
+        *libc::__errno_location() = libc::ENOSYS;
+        -1
+    }
+}
+
+/// Install the `sigaction` GOT hook across all currently loaded libraries.
+///
+/// Safe to call multiple times; only the first call patches.
+pub(crate) fn install_sigaction_hook(monitored_signals: &[i32]) {
+    if ORIG_SIGACTION_FN.load(Relaxed) != 0 {
+        return;
+    }
+
+    let mut mask: u64 = 0;
+    for &sig in monitored_signals {
+        if (0..64).contains(&sig) {
+            mask |= 1u64 << sig;
+        }
+    }
+    MONITORED_SIGNALS.store(mask, Release);
+
+    // SAFETY: hook_sigaction has the same signature as sigaction.
+    let result = unsafe {
+        libdd_gotter::hook_symbol_excluding_self(c"sigaction", hook_sigaction as *const () as usize)
+    };
+
+    if let Ok(hook) = result {
+        let our_hook = hook_sigaction as *const () as usize;
+        if hook.orig_addr != our_hook {
+            ORIG_SIGACTION_FN.store(hook.orig_addr, Release);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_monitored_mask_building() {
+        // Reset state for test isolation.
+        MONITORED_SIGNALS.store(0, Release);
+
+        let signals = [libc::SIGSEGV, libc::SIGBUS, libc::SIGABRT];
+        let mut mask: u64 = 0;
+        for &sig in &signals {
+            if (0..64).contains(&sig) {
+                mask |= 1u64 << sig;
+            }
+        }
+
+        for &sig in &signals {
+            assert!(mask & (1u64 << sig) != 0, "signal {sig} should be set");
+        }
+        assert!(
+            mask & (1u64 << libc::SIGTERM) == 0,
+            "SIGTERM should not be set"
+        );
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[test]
+    fn test_install_sigaction_hook() {
+        // Reset state so the hook can be installed in this test.
+        ORIG_SIGACTION_FN.store(0, Relaxed);
+
+        install_sigaction_hook(&[libc::SIGSEGV, libc::SIGBUS]);
+
+        let orig = ORIG_SIGACTION_FN.load(Acquire);
+        if orig == 0 {
+            eprintln!(
+                "note: sigaction not found in dynamic symbol table \
+                 (static libc?), GOT hook not installed"
+            );
+        } else {
+            // Verify the monitored mask was set correctly.
+            let mask = MONITORED_SIGNALS.load(Acquire);
+            assert!(mask & (1u64 << libc::SIGSEGV) != 0);
+            assert!(mask & (1u64 << libc::SIGBUS) != 0);
+        }
+    }
+}


### PR DESCRIPTION
bringing [feat(crashtracking): GOT patch sigaction](https://github.com/DataDog/libdatadog/pull/2448) back

# What does this PR do?
Intercepts sigaction calls with `hook_symbol` GOT patching so the crashtracker can detect when application code overwrites a monitored signal handler after initialization.

The hook covers all callers including the statically-linked test binary; internal `sigaction` calls from `chain_signal_handler` (which runs inside the signal handler) are safe because SIG_DFL/SIG_IGN handlers are filtered out before any async work is attempted (this is done before the `hook_symbol` anyways), and the hook always forwards using the stored original function pointer rather than through a GOT entry so there.

# Motivation

Some runtimes may overwrite our handlers. It would be good to know when this is happening. 

# Additional Notes

This is a stacked PR. This change is minimal -- just adding the patch, and flipping a flag that isnt read anywhere. Sending actual telemetry is done [feat(crashtracking): send telemetry if instrumented application sigactions our signal](https://github.com/DataDog/libdatadog/pull/2461)

# How to test the change?

Describe here in detail how the change can be validated.
