### PR TITLE
chore(benchmarks): remove batched-loop sampling noise

### DIFF
--- a/libdd-sampling/benches/glob_matcher_bench.rs
+++ b/libdd-sampling/benches/glob_matcher_bench.rs
@@ -7,7 +7,7 @@
 use std::alloc::System;
 use std::hint::black_box;
 
-use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use libdd_common::bench_utils::{
     memory_allocated_criterion, AllocatedBytesMeasurement, ReportingAllocator,
 };
@@ -92,13 +92,7 @@ fn bench_wall_time(c: &mut Criterion) {
     for case in cases() {
         let matcher = GlobMatcher::new(case.pattern);
         c.bench_function(&format!("glob_matcher/{}/wall_time", case.name), |b| {
-            b.iter_batched(
-                || (),
-                |_| {
-                    black_box(matcher.matches(black_box(case.subject)));
-                },
-                BatchSize::SmallInput,
-            )
+            b.iter(|| black_box(matcher.matches(black_box(case.subject))))
         });
     }
 }
@@ -109,13 +103,7 @@ fn bench_allocs(c: &mut Criterion<AllocatedBytesMeasurement<System>>) {
         c.bench_function(
             &format!("glob_matcher/{}/allocated_bytes", case.name),
             |b| {
-                b.iter_batched(
-                    || (),
-                    |_| {
-                        black_box(matcher.matches(black_box(case.subject)));
-                    },
-                    BatchSize::SmallInput,
-                )
+                b.iter(|| black_box(matcher.matches(black_box(case.subject))))
             },
         );
     }

--- a/libdd-sampling/benches/glob_matcher_bench.rs
+++ b/libdd-sampling/benches/glob_matcher_bench.rs
@@ -102,9 +102,7 @@ fn bench_allocs(c: &mut Criterion<AllocatedBytesMeasurement<System>>) {
         let matcher = GlobMatcher::new(case.pattern);
         c.bench_function(
             &format!("glob_matcher/{}/allocated_bytes", case.name),
-            |b| {
-                b.iter(|| black_box(matcher.matches(black_box(case.subject))))
-            },
+            |b| b.iter(|| black_box(matcher.matches(black_box(case.subject)))),
         );
     }
 }

--- a/libdd-sampling/benches/sampling_bench.rs
+++ b/libdd-sampling/benches/sampling_bench.rs
@@ -4,7 +4,7 @@
 use std::alloc::System;
 use std::hint::black_box;
 
-use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use libdd_common::bench_utils::{
     memory_allocated_criterion, AllocatedBytesMeasurement, ReportingAllocator,
 };
@@ -399,17 +399,13 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         c.bench_function(
             &format!("datadog_sample_span/{}/wall_time", config.name),
             |b| {
-                b.iter_batched(
-                    || (),
-                    |_| {
-                        let data = V04SamplingData {
-                            is_parent_sampled: config.is_parent_sampled,
-                            span: &config.span,
-                        };
-                        black_box(config.sampler.sample(black_box(&data)));
-                    },
-                    BatchSize::SmallInput,
-                )
+                b.iter(|| {
+                    let data = V04SamplingData {
+                        is_parent_sampled: config.is_parent_sampled,
+                        span: &config.span,
+                    };
+                    black_box(config.sampler.sample(black_box(&data)));
+                })
             },
         );
     }
@@ -422,17 +418,13 @@ fn criterion_benchmark_allocs(c: &mut Criterion<AllocatedBytesMeasurement<System
         c.bench_function(
             &format!("datadog_sample_span/{}/allocated_bytes", config.name),
             |b| {
-                b.iter_batched(
-                    || (),
-                    |_| {
-                        let data = V04SamplingData {
-                            is_parent_sampled: config.is_parent_sampled,
-                            span: &config.span,
-                        };
-                        black_box(config.sampler.sample(black_box(&data)));
-                    },
-                    BatchSize::SmallInput,
-                )
+                b.iter(|| {
+                    let data = V04SamplingData {
+                        is_parent_sampled: config.is_parent_sampled,
+                        span: &config.span,
+                    };
+                    black_box(config.sampler.sample(black_box(&data)));
+                })
             },
         );
     }


### PR DESCRIPTION
Criterion times output collection inside batched loops. The glob matcher and sampler benchmarks used that API with an empty setup, which made harness bookkeeping part of their short measurements.

On Apple Silicon with Rust 1.87.0, ten fresh-process measurements of the worst wildcard case narrowed from a 10.4-19.2 ns non-outlier range to 10.7-12.5 ns. The remaining outlier fell from 80.1 ns to 27.4 ns.