### PR TITLE
perf(ci): rebalance benchmark shards via measured per-crate weights

### DIFF
--- a/benchmark/bench-weights.json
+++ b/benchmark/bench-weights.json
@@ -1,0 +1,18 @@
+{
+  "$comment": "Per-crate benchmark shard-balancing weights, consumed by benchmark/select_bench_packages.sh. Values approximate per-crate benchmark-execution wall-time in seconds (single candidate pass) measured from complete main pipelines; only relative magnitude matters, for packing crates into parallel shards via longest-processing-time. Crates absent here fall back to default_weight.",
+  "default_weight": 1,
+  "weights": {
+    "libdd-trace-utils": 349,
+    "libdd-sampling": 290,
+    "libdd-profiling-heap-allocator": 150,
+    "libdd-ddsketch": 137,
+    "libdd-data-pipeline": 108,
+    "libdd-ffe-test-suite": 58,
+    "libdd-trace-obfuscation": 54,
+    "libdd-profiling": 47,
+    "libdd-trace-normalization": 21,
+    "libdd-crashtracker": 12,
+    "libdd-ipc": 10,
+    "libdd-trace-stats": 7
+  }
+}

--- a/benchmark/select_bench_packages.sh
+++ b/benchmark/select_bench_packages.sh
@@ -21,23 +21,20 @@ set -eu
 node_index="${1:-1}"
 node_total="${2:-1}"
 
-# Approximate per-crate benchmark cost (~30 s of criterion time per pass) used to balance the shards.
-# Measured 2026-09-04 from main pipeline 8134078c4, with the allocation benchmarks discounted to
-# their cost once their sampling settings are no longer overridden. The three crates that fall
-# through to the default are ~1 unit (ipc ~35 s, trace-normalization ~30 s, trace-stats ~25 s).
-# Retune as benchmarks are added/removed; unknown crates default to 1.
+# Per-crate benchmark cost used to balance the parallel shards. Weights live in
+# benchmark/bench-weights.json (approximate per-crate benchmark-execution seconds); only relative
+WEIGHTS_FILE="$(cd -- "$(dirname -- "${BASH_SOURCE[0]:-$0}")" >/dev/null 2>&1 && pwd)/bench-weights.json"
+_default_weight="$(jq -r '.default_weight // 1' "$WEIGHTS_FILE" 2>/dev/null || echo 1)"
+case "$_default_weight" in ''|*[!0-9]*) _default_weight=1 ;; esac
+
 crate_weight() {
-  case "$1" in
-    libdd-trace-utils) echo 15 ;;
-    libdd-profiling-heap-allocator) echo 7 ;;
-    libdd-sampling) echo 6 ;;
-    libdd-ddsketch) echo 5 ;;
-    libdd-data-pipeline) echo 5 ;;
-    libdd-ffe-test-suite) echo 4 ;;
-    libdd-crashtracker) echo 2 ;;
-    libdd-profiling) echo 2 ;;
-    libdd-trace-obfuscation) echo 2 ;;
-    *) echo 1 ;;
+  local w=""
+  if [ -f "$WEIGHTS_FILE" ]; then
+    w="$(jq -r --arg c "$1" '.weights[$c] // empty' "$WEIGHTS_FILE" 2>/dev/null || echo "")"
+  fi
+  case "$w" in
+    ''|*[!0-9]*) echo "$_default_weight" ;;
+    *) echo "$w" ;;
   esac
 }
 


### PR DESCRIPTION
# What does this PR do?

Since the addition of sccache to our Gitlab pipeline, the original weights are no longer correct as they over-emphasize compilation time, this has led to a runtime imbalance between the two parallel benchmark jobs.

Also, the weights were moved into a json file. A future PR will implement a scheduled CI job to update these weights at a regular cadence automatically. 

# Motivation

Observation of one benchmark job finishing much earlier than the second one. 

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Observe in gitlab
