### PR TITLE
chore: update AGENTS.md to not suggest license headers for json files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ Common types: `feat`, `fix`, `docs`, `refactor`, `perf`, `test`, `build`, `ci`, 
 Breaking changes: append `!` — e.g. `feat!: remove deprecated API`
 
 ### Licenses
-All source files must have Apache 2.0 license headers (except `symbolizer-ffi`). Use `./scripts/reformat_copyright.sh` to add or fix headers automatically. The third-party license CSV (`LICENSE-3rdparty.csv`) is validated in CI. To regenerate:
+All code source files (e.g. `.rs`, `.sh`) and TOML files (e.g. `Cargo.toml`) must have Apache 2.0 license headers (except `symbolizer-ffi`). Use `./scripts/reformat_copyright.sh` to add or fix headers automatically. JSON files do **not** get license headers (JSON has no comment syntax); do not add them. The third-party license CSV (`LICENSE-3rdparty.csv`) is validated in CI. To regenerate:
 ```bash
 ./scripts/update_license_3rdparty.sh
 ```


### PR DESCRIPTION
# What does this PR do?

[In a separate PR codex suggested that I add a license header to a json file in accordance with AGENTS.md](https://github.com/DataDog/libdatadog/pull/2501#discussion_r3974755302). The AGENTs.md file has been scoped to only suggest the license headers on code files and toml.

# Motivation

What inspired you to submit this pull request?

# Additional Notes

Anything else we should know when reviewing?

# How to test the change?

Describe here in detail how the change can be validated.
