### PR TITLE
test(data-pipeline): fix flaky OTLP gRPC exporter integration tests

### DIFF
--- a/libdd-data-pipeline/src/otlp/grpc_exporter.rs
+++ b/libdd-data-pipeline/src/otlp/grpc_exporter.rs
@@ -736,32 +736,41 @@ mod integration_tests {
         let (socket, _) = listener.accept().await.unwrap();
         let mut conn = server::handshake(socket).await.unwrap();
         let (req, mut respond) = conn.accept().await.unwrap().unwrap();
-        let mut body = req.into_body();
-        let mut buf = Vec::new();
-        while let Some(chunk) = body.data().await {
-            let chunk = chunk.unwrap();
-            buf.extend_from_slice(&chunk);
-            body.flow_control().release_capacity(chunk.len()).unwrap();
-        }
-        let decoded = ExportTraceServiceRequest::decode(&buf[5..]).unwrap();
+        // `respond`/`body` only touch h2's in-memory state: the connection itself has to keep
+        // being polled for request DATA to be read and for the response to reach the socket.
+        // Handle the stream on a separate task so the accept loop below can drive it.
+        let handler = tokio::spawn(async move {
+            let mut body = req.into_body();
+            let mut buf = Vec::new();
+            while let Some(chunk) = body.data().await {
+                let chunk = chunk.unwrap();
+                buf.extend_from_slice(&chunk);
+                body.flow_control().release_capacity(chunk.len()).unwrap();
+            }
+            let decoded = ExportTraceServiceRequest::decode(&buf[5..]).unwrap();
 
-        let resp = http::Response::builder()
-            .status(200)
-            .header("content-type", "application/grpc")
-            .body(())
-            .unwrap();
-        let mut send = respond.send_response(resp, false).unwrap();
-        let msg = ExportTraceServiceResponse::default();
-        let mut framed = vec![0u8; 5];
-        msg.encode(&mut framed).unwrap();
-        let len = u32::try_from(framed.len() - 5).expect("response exceeds gRPC frame length");
-        framed[1..5].copy_from_slice(&len.to_be_bytes());
-        send.send_data(Bytes::from(framed), false).unwrap();
-        let mut trailers = http::HeaderMap::new();
-        trailers.insert("grpc-status", "0".parse().unwrap());
-        send.send_trailers(trailers).unwrap();
-        let _ = tokio::time::timeout(Duration::from_secs(2), conn.accept()).await;
-        decoded
+            let resp = http::Response::builder()
+                .status(200)
+                .header("content-type", "application/grpc")
+                .body(())
+                .unwrap();
+            let mut send = respond.send_response(resp, false).unwrap();
+            let msg = ExportTraceServiceResponse::default();
+            let mut framed = vec![0u8; 5];
+            msg.encode(&mut framed).unwrap();
+            let len = u32::try_from(framed.len() - 5).expect("response exceeds gRPC frame length");
+            framed[1..5].copy_from_slice(&len.to_be_bytes());
+            send.send_data(Bytes::from(framed), false).unwrap();
+            let mut trailers = http::HeaderMap::new();
+            trailers.insert("grpc-status", "0".parse().unwrap());
+            send.send_trailers(trailers).unwrap();
+            decoded
+        });
+        let _ = tokio::time::timeout(Duration::from_secs(2), async {
+            while conn.accept().await.is_some() {}
+        })
+        .await;
+        handler.await.unwrap()
     }
 
     #[cfg_attr(miri, ignore)]
@@ -792,28 +801,40 @@ mod integration_tests {
             let (socket, _) = listener.accept().await.unwrap();
             let mut conn = server::handshake(socket).await.unwrap();
             let (req, mut respond) = conn.accept().await.unwrap().unwrap();
-            let mut body = req.into_body();
-            while let Some(chunk) = body.data().await {
-                let chunk = chunk.unwrap();
-                body.flow_control().release_capacity(chunk.len()).unwrap();
-            }
+            // The connection has to stay polled while the stream is served, otherwise the
+            // request DATA frame may never be read off the socket. See the comment in
+            // `run_one_shot_grpc_server`.
+            let handler = tokio::spawn(async move {
+                let mut body = req.into_body();
+                while let Some(chunk) = body.data().await {
+                    let chunk = chunk.unwrap();
+                    body.flow_control().release_capacity(chunk.len()).unwrap();
+                }
 
-            let response = http::Response::builder()
-                .status(200)
-                .header("content-type", "application/grpc")
-                .body(())
-                .unwrap();
-            let mut send = respond.send_response(response, false).unwrap();
-            send.send_data(Bytes::from_static(&[0, 0, 0, 0, 0]), false)
-                .unwrap();
-            let mut trailers = http::HeaderMap::new();
-            trailers.insert("grpc-status", "0".parse().unwrap());
-            send.send_trailers(trailers).unwrap();
+                let response = http::Response::builder()
+                    .status(200)
+                    .header("content-type", "application/grpc")
+                    .body(())
+                    .unwrap();
+                let mut send = respond.send_response(response, false).unwrap();
+                send.send_data(Bytes::from_static(&[0, 0, 0, 0, 0]), false)
+                    .unwrap();
+                let mut trailers = http::HeaderMap::new();
+                trailers.insert("grpc-status", "0".parse().unwrap());
+                send.send_trailers(trailers).unwrap();
+            });
+            tokio::pin!(handler);
+            // Drive the connection until the whole response has been queued...
+            tokio::select! {
+                res = &mut handler => res.unwrap(),
+                _ = async { while conn.accept().await.is_some() {} } => {}
+            }
+            // ...then give those frames a window to reach the socket before tearing down.
             let flush_deadline = tokio::time::sleep(Duration::from_millis(25));
             tokio::pin!(flush_deadline);
             tokio::select! {
                 _ = &mut flush_deadline => {}
-                _ = conn.accept() => {}
+                _ = async { while conn.accept().await.is_some() {} } => {}
             }
             conn.abrupt_shutdown(h2::Reason::INTERNAL_ERROR);
             while conn.accept().await.is_some() {}


### PR DESCRIPTION
## What

Fixes the `otlp::grpc_exporter::integration_tests` flake that has been failing `cargo test #macos-15` on `main`, in the merge queue, and across unrelated PRs.

## Why

The h2 `server::Connection` is the only thing that touches the socket, and it only makes progress while something polls it (in practice, `conn.accept()`). `RecvStream::data()` and `SendStream::send_data()` just move bytes in and out of h2's in-memory state.

Both test servers polled the connection exactly once — the `accept()` that yields the request — and then handled the stream inline, reading the request body and sending the response without ever polling the connection again:

```rust
let (req, mut respond) = conn.accept().await.unwrap().unwrap();  // last poll of conn
let mut body = req.into_body();
while let Some(chunk) = body.data().await { ... }                // nothing is driving conn
```

That works only when the client's `HEADERS` and `DATA`+`END_STREAM` happen to be parsed by that same `accept()` call, which is the common case on loopback with a small unary payload. When the `DATA` frame lands in a later read, nothing pulls it off the socket, `body.data().await` parks forever, and the client fails its 2s deadline:

```
thread '...::sends_and_server_decodes_request' panicked at libdd-data-pipeline/src/otlp/grpc_exporter.rs:780:14:
send should succeed: Retryable { error: Io(Kind(TimedOut)), retry_after: None }
```

The failing runs take ~2.18s, matching the 2s client timeout exactly. Whether the two frames coalesce is a TCP/scheduler accident, which is why the slower macOS runners are hit far more often than the Linux ones.

## How

Serve the stream on its own task so the accept loop can drive the connection concurrently. `successful_response_wins_over_connection_teardown` had the identical latent bug and is fixed the same way; its abrupt-shutdown sequencing is preserved by waiting for the response to be queued before opening the flush window.

## Testing

Stress-run locally on macOS (aarch64):

| Test | Before | After |
| --- | --- | --- |
| `sends_and_server_decodes_request` | 3 / 100 failures | 0 / 300 |
| `successful_response_wins_over_connection_teardown` | 1 / 200 failures | 0 / 300 |

Plus `cargo nextest run -p libdd-data-pipeline` (204 passed), `cargo +nightly fmt --all --check`, and `cargo clippy -p libdd-data-pipeline --all-targets -- -D warnings`.

Test-only change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
