### PR TITLE
feat(release): score dependency floors and cargo features in semver-level

### DIFF
--- a/.github/workflows/pr-title-semver-check.yml
+++ b/.github/workflows/pr-title-semver-check.yml
@@ -257,15 +257,19 @@ jobs:
           VALIDATION_FAILED="false"
           FAILURE_REASONS=()
 
-          # Rule: ci/docs/style/test/build cannot change the public API
+          # Rule: ci/docs/style/test cannot change what a consumer sees
+          #
+          # 'build' is deliberately NOT in this list. Conventional Commits defines it as
+          # changes to the build system *or external dependencies*, and semver-level.sh
+          # scores a raised dependency floor as a minor
           case "$TYPE" in
-            ci|docs|style|test|build)
+            ci|docs|style|test)
               if [[ "$SEMVER_LEVEL" == "major" ]] || [[ "$SEMVER_LEVEL" == "minor" ]]; then
                 VALIDATION_FAILED="true"
-                FAILURE_REASONS+=("'$TYPE' cannot have major or minor API changes. Use a different PR type, or avoid public API changes.")
+                FAILURE_REASONS+=("'$TYPE' cannot change the public API, a dependency requirement floor, or the cargo feature surface. Use a different PR type ('build' for a dependency change), or leave those alone.")
               fi
               ;;
-            feat|fix|refactor|chore|perf|revert)
+            feat|fix|refactor|chore|perf|revert|build)
               # These can be any semver level (subject to breaking change rules below)
               ;;
             *)
@@ -306,9 +310,11 @@ jobs:
             echo "--------------------------------------------"
             echo "VALID COMBINATIONS:"
             echo "--------------------------------------------"
-            echo "  ci/docs/style/test/build -> patch or none only (no public API changes)"
-            echo "  all other types          -> any level allowed"
-            echo "  major changes            -> must have '!' or 'BREAKING CHANGE:' footer"
+            echo "  ci/docs/style/test -> patch or none only (no change to the public API,"
+            echo "                        a dependency requirement floor, or the feature surface)"
+            echo "  all other types    -> any level allowed ('build' included: it is the"
+            echo "                        conventional type for a dependency change)"
+            echo "  major changes      -> must have '!' or 'BREAKING CHANGE:' footer"
             echo ""
             exit 1
           else

--- a/.github/workflows/pr-title-semver-check.yml
+++ b/.github/workflows/pr-title-semver-check.yml
@@ -71,6 +71,9 @@ jobs:
           # Find all changed files
           CHANGED_FILES=$(git diff --name-only "origin/$BASE_REF"...HEAD)
 
+          MANIFEST_AFFECTED=$(./scripts/semver-level.sh --list-affected "$BASE_REF")
+          echo "Crates whose manifest facts moved: ${MANIFEST_AFFECTED:-<none>}"
+
           # Get workspace members metadata using cargo-metadata
           # Filter to only workspace members that are publishable (publish != false and publish != [])
           # Extract workspace root and convert manifest paths to relative paths
@@ -94,6 +97,9 @@ jobs:
             # Check if any files in this crate directory changed
             if echo "$CHANGED_FILES" | grep -q "^${CRATE_DIR}/"; then
               echo "Detected change in published crate: $CRATE_NAME ($CRATE_DIR)"
+              CHANGED_CRATES+=("$CRATE_NAME")
+            elif grep -qxF "$CRATE_NAME" <<< "$MANIFEST_AFFECTED"; then
+              echo "Detected manifest change reaching published crate: $CRATE_NAME (no file of its own changed)"
               CHANGED_CRATES+=("$CRATE_NAME")
             fi
           done < <(echo "$WORKSPACE_CRATES")

--- a/scripts/semver-level.sh
+++ b/scripts/semver-level.sh
@@ -159,6 +159,115 @@ crate_target_kinds_at_rev() {
     echo "$kinds"
 }
 
+# Echo one tab-separated row per manifest fact about crate $1 at revision $2, read once
+# per revision for both manifest passes below:
+#
+#   dep      <name> <alias> <kind> <target> <req>   one per dependency a consumer resolves
+#   feature  <name> default|optional                one per declared feature
+#
+# Read via `cargo metadata` rather than the crate's own Cargo.toml, which would see
+# neither the version behind a `{ workspace = true }` inheritance marker nor the implicit
+# feature an `optional = true` dependency creates.
+#
+# <alias> is `.rename`, defaulting to the package name. It is in the row because a crate
+# may alias two versions of one package (`foo1`/`foo2` both `package = "foo"`), for which
+# cargo metadata reports an identical name, kind and target; keyed without it, the second
+# alias matches the first's baseline requirement and an unchanged pair reads as a raise.
+crate_manifest_facts_at_rev() {
+    local crate=$1 rev=$2
+    local tree meta cargo_status
+    tree=$(mktemp -d) || return 1
+    if ! git archive "$rev" | tar -x -C "$tree"; then
+        echo "Error: could not extract $rev to read the manifest for $crate" >&2
+        rm -rf "$tree"
+        return 1
+    fi
+    # Captured before jq: without pipefail a failing cargo would surface as jq's clean
+    # exit over empty input, and a broken manifest would read as "declares nothing".
+    meta=$(cargo metadata --format-version=1 --no-deps --manifest-path "$tree/Cargo.toml" 2>/dev/null)
+    cargo_status=$?
+    rm -rf "$tree"
+    if [[ $cargo_status -ne 0 || -z "$meta" ]]; then
+        echo "Error: could not read the manifest for $crate at $rev" >&2
+        return 1
+    fi
+    jq -r --arg crate "$crate" '
+        .packages[]
+        | select(.name == $crate)
+        | . as $p
+        | (
+            ( $p.dependencies[]
+              | select((.kind // "normal") != "dev")
+              | ["dep", .name, (.rename // .name), (.kind // "normal"), (.target // "any"), .req] ),
+            ( ($p.features // {}) as $f
+              | ($f.default // []) as $d
+              | ($f | keys[]) as $n
+              | select($n != "default")
+              | ["feature", $n, (if ($d | index($n)) then "default" else "optional" end)] )
+          )
+        | @tsv' <<< "$meta"
+}
+
+# version_gt A B — true when the dotted numeric tuple A is strictly greater than B.
+# Four components: req_min appends an exclusivity flag to the X.Y.Z triple.
+# Compared in the shell rather than with `sort -V`, a GNU extension.
+version_gt() {
+    local -a a=() b=()
+    local i x y
+    IFS='.' read -r -a a <<< "$1"
+    IFS='.' read -r -a b <<< "$2"
+    for i in 0 1 2 3; do
+        x=${a[i]:-0}
+        y=${b[i]:-0}
+        if (( 10#$x > 10#$y )); then
+            return 0
+        elif (( 10#$x < 10#$y )); then
+            return 1
+        fi
+    done
+    return 1
+}
+
+# Echo the lowest version requirement $1 admits, as `X.Y.Z.E` with E=1 when the bound
+# EXCLUDES that version. `>1.2.3` and `>=1.2.3` are different floors, so without E the
+# two compare equal and narrowing one into the other passes as a patch. E is an ordering
+# device only; the report quotes requirements verbatim.
+#
+# Echo nothing when there is no lower bound (`*`, `<2`) or it cannot be parsed: callers
+# treat that as "no opinion", so an exotic requirement can never invent a bump. A
+# pre-release bound is compared as its release version (`1.0.0-rc.1` -> `1.0.0`), which
+# can only understate a raise.
+req_min() {
+    local req=$1
+    local -a parts=() v=()
+    local part bound best="" exclusive
+    read -r -a parts <<< "${req//,/ }"
+    for part in "${parts[@]}"; do
+        exclusive=0
+        case "$part" in
+            ''|'*'|'<'*|'!='*) continue ;;
+            '>='*)  bound=${part#>=} ;;
+            '>'*)   bound=${part#>}; exclusive=1 ;;
+            '^'*)   bound=${part#^} ;;
+            '~'*)   bound=${part#\~} ;;
+            '='*)   bound=${part#=} ;;
+            [0-9]*) bound=$part ;;
+            *)      continue ;;
+        esac
+        bound=${bound%%[-+]*}   # drop pre-release and build metadata
+        bound=${bound//\*/0}    # `1.*` admits 1.0.0
+        [[ "$bound" =~ ^[0-9]+(\.[0-9]+)*$ ]] || continue
+        IFS='.' read -r -a v <<< "$bound"
+        bound="${v[0]:-0}.${v[1]:-0}.${v[2]:-0}.${exclusive}"
+        if [[ -z "$best" ]] || version_gt "$bound" "$best"; then
+            best=$bound
+        fi
+    done
+    if [[ -n "$best" ]]; then
+        printf '%s\n' "$best"
+    fi
+}
+
 compute_semver_results() {
     local crate=$1
     local baseline=$2
@@ -437,15 +546,175 @@ compute_semver_results() {
     fi
 
     # ----------------------------------------------------------------
-    # 3) Combine signals: take the higher of cargo-semver-checks and cargo-public-api.
+    # 2b) Dependency requirement floors
+    #
+    # Neither tool above reads a manifest. Raising the lowest version a requirement
+    # admits (`http = "1"` -> `"1.1"`) leaves every rustdoc signature byte-identical, so
+    # both report nothing and the level comes out patch — yet a consumer pinned to the
+    # old version can no longer resolve this crate, conventionally a minor.
+    #
+    # Deliberately NOT scored: dev-dependencies (not part of what a consumer resolves);
+    # a widened requirement; a dependency added or removed outright. Nor a raised MAJOR
+    # floor, capped at minor here on purpose — whether that forces the dependent to
+    # major is release-version-major-bumps.sh's call, made with the dependency graph
+    # this script cannot see, and max_level() lets it win from there.
+    # ----------------------------------------------------------------
+    local dep_level="none"
+    local dep_reason=""
+    local dep_details=""
+    local feature_level="none"
+    local feature_reason=""
+    local feature_details=""
+
+    # The passes have different ceilings, so they stop at different points: (2b) can
+    # only report minor, so minor ends it; (2c) can report major, so it runs on until
+    # major. They share one extraction per revision, gated by (2c)'s wider ceiling.
+    #
+    # Stopping (2c) at minor too would save that extraction, since (1)'s
+    # `feature_missing` / `feature_not_enabled_by_default` cover its major findings —
+    # but only while those lints exist, and the failure mode is silent. Second opinion
+    # kept on purpose.
+    local level_so_far
+    level_so_far=$(max_level "$semver_level" "$public_api_level")
+
+    local base_facts="" now_facts="" manifest_compared=false
+    if $crate_is_new; then
+        log_verbose "Skipping manifest diff: new crate (no baseline)"
+    elif [[ "$level_so_far" == "major" ]]; then
+        log_verbose "Skipping manifest diff: already at major"
+    else
+        if ! base_facts=$(crate_manifest_facts_at_rev "$crate" "$baseline"); then
+            exit 1
+        fi
+        if ! now_facts=$(crate_manifest_facts_at_rev "$crate" "$current"); then
+            exit 1
+        fi
+        manifest_compared=true
+    fi
+
+    if $manifest_compared && [[ "$level_so_far" == "minor" ]]; then
+        log_verbose "Skipping dependency requirement diff: already at minor, which is this pass's ceiling"
+    elif $manifest_compared; then
+        local base_reqs now_reqs raised=""
+        base_reqs=$(awk -F'\t' '$1 == "dep" { print substr($0, index($0, "\t") + 1) }' <<< "$base_facts")
+        now_reqs=$(awk -F'\t' '$1 == "dep" { print substr($0, index($0, "\t") + 1) }' <<< "$now_facts")
+
+        local dep_name dep_alias dep_kind dep_target dep_req dep_label old_req old_min new_min
+        while IFS=$'\t' read -r dep_name dep_alias dep_kind dep_target dep_req; do
+            [[ -z "$dep_name" ]] && continue
+            # Name, alias, kind and target together: see crate_manifest_facts_at_rev for
+            # why the alias belongs in the key.
+            old_req=$(awk -F'\t' -v n="$dep_name" -v a="$dep_alias" -v k="$dep_kind" -v t="$dep_target" \
+                '$1 == n && $2 == a && $3 == k && $4 == t { print $5; exit }' <<< "$base_reqs")
+            # Absent from the baseline: a dependency newly added, or one whose alias
+            # changed. Either way not a raised floor.
+            [[ -z "$old_req" ]] && continue
+            [[ "$old_req" == "$dep_req" ]] && continue
+
+            dep_label="$dep_name"
+            [[ "$dep_alias" != "$dep_name" ]] && dep_label="$dep_name as $dep_alias"
+
+            old_min=$(req_min "$old_req")
+            new_min=$(req_min "$dep_req")
+            if [[ -z "$old_min" || -z "$new_min" ]]; then
+                log_verbose "Not judging $dep_label: unparsed requirement ($old_req -> $dep_req)"
+                continue
+            fi
+            if version_gt "$new_min" "$old_min"; then
+                raised+="$dep_label ($dep_kind): $old_req -> $dep_req"$'\n'
+                log_verbose "$dep_label floor raised: $old_req -> $dep_req"
+            fi
+        done <<< "$now_reqs"
+
+        if [[ -n "$raised" ]]; then
+            dep_level="minor"
+            dep_reason="Dependency requirement floor raised"
+            dep_details=$(truncate_details 50 <<< "${raised%$'\n'}")
+        fi
+    fi
+
+    # ----------------------------------------------------------------
+    # 2c) Cargo feature surface
+    #
+    # Features are public API — downstream writes `features = ["x"]` — so adding one is
+    # a minor and removing one, or dropping it from the default set, breaks consumers
+    # that named it.
+    #
+    # An ADDED feature is the gap: cargo-semver-checks has no lint for it (0.47/0.48
+    # offer feature_missing, feature_not_enabled_by_default and the two
+    # *_enables_feature lints, nothing for an addition) and it adds no rustdoc item
+    # unless it gates one, so it used to come out patch.
+    #
+    # The removal cases are a backstop. For a library crate feature_missing and
+    # feature_not_enabled_by_default get there first (verified to fail the run, not
+    # merely warn) and this block is skipped once a pass said major; it earns its keep
+    # on a crate with no library target, where (1) is skipped entirely.
+    #
+    # Not scored: a change to what a feature *enables* — the two *_enables_feature
+    # lints' job, and judging it needs the feature graph rather than a name set.
+    # ----------------------------------------------------------------
+    if $manifest_compared; then
+        local base_features now_features
+        local feat_name feat_default removed="" added="" undefaulted=""
+        base_features=$(awk -F'\t' '$1 == "feature" { print $2 "\t" $3 }' <<< "$base_facts")
+        now_features=$(awk -F'\t' '$1 == "feature" { print $2 "\t" $3 }' <<< "$now_facts")
+
+        while IFS=$'\t' read -r feat_name feat_default; do
+            [[ -z "$feat_name" ]] && continue
+            if ! awk -F'\t' -v n="$feat_name" '$1 == n { found = 1 } END { exit !found }' <<< "$now_features"; then
+                removed+="$feat_name"$'\n'
+                continue
+            fi
+            # Still declared, but no longer reached by `default`.
+            if [[ "$feat_default" == "default" ]] \
+               && ! awk -F'\t' -v n="$feat_name" '$1 == n && $2 == "default" { found = 1 } END { exit !found }' <<< "$now_features"; then
+                undefaulted+="$feat_name"$'\n'
+            fi
+        done <<< "$base_features"
+
+        while IFS=$'\t' read -r feat_name feat_default; do
+            [[ -z "$feat_name" ]] && continue
+            if ! awk -F'\t' -v n="$feat_name" '$1 == n { found = 1 } END { exit !found }' <<< "$base_features"; then
+                added+="$feat_name"$'\n'
+            fi
+        done <<< "$now_features"
+
+        if [[ -n "$removed" || -n "$undefaulted" ]]; then
+            feature_level="major"
+            feature_reason="Cargo feature removed or no longer enabled by default"
+            feature_details=$(truncate_details 50 <<< "$(
+                [[ -n "$removed" ]] && printf 'removed: %s\n' "${removed//$'\n'/ }"
+                [[ -n "$undefaulted" ]] && printf 'no longer default: %s\n' "${undefaulted//$'\n'/ }"
+            )")
+            log_verbose "features removed: ${removed//$'\n'/ } undefaulted: ${undefaulted//$'\n'/ }"
+        elif [[ -n "$added" ]]; then
+            feature_level="minor"
+            feature_reason="Cargo feature added"
+            feature_details=$(truncate_details 50 <<< "added: ${added//$'\n'/ }")
+            log_verbose "features added: ${added//$'\n'/ }"
+        fi
+    fi
+
+    # ----------------------------------------------------------------
+    # 3) Combine: the highest level any pass reported. The reason comes from the pass
+    # that decided it, and on a tie from the one that describes the change most
+    # concretely — a removed item says more than "a dependency floor moved".
     # ----------------------------------------------------------------
     LEVEL=$(max_level "$semver_level" "$public_api_level")
-    if [[ "$LEVEL" == "$public_api_level" && "$public_api_level" != "$semver_level" ]]; then
-        REASON="$public_api_reason"
-        DETAILS="$public_api_details"
-    else
+    LEVEL=$(max_level "$LEVEL" "$feature_level")
+    LEVEL=$(max_level "$LEVEL" "$dep_level")
+    if [[ "$semver_level" == "$LEVEL" ]]; then
         REASON="$semver_reason"
         DETAILS="$semver_details"
+    elif [[ "$public_api_level" == "$LEVEL" ]]; then
+        REASON="$public_api_reason"
+        DETAILS="$public_api_details"
+    elif [[ "$feature_level" == "$LEVEL" ]]; then
+        REASON="$feature_reason"
+        DETAILS="$feature_details"
+    else
+        REASON="$dep_reason"
+        DETAILS="$dep_details"
     fi
 
     if [[ "$LEVEL" == "none" ]]; then

--- a/scripts/semver-level.sh
+++ b/scripts/semver-level.sh
@@ -5,6 +5,7 @@
 
 
 VERBOSE=false
+LIST_AFFECTED=false
 
 # Use GITHUB_OUTPUT from environment or default to /dev/stdout for local testing
 if [ -z "$GITHUB_OUTPUT" ]; then
@@ -17,8 +18,20 @@ while [[ $# -gt 0 ]]; do
             VERBOSE=true
             shift
             ;;
+        --list-affected)
+            LIST_AFFECTED=true
+            shift
+            ;;
         -h|--help)
             echo "Usage: $0 [-v] [-h] CRATE BASE_REF CURRENT_REF"
+            echo "       $0 [-v] --list-affected BASE_REF CURRENT_REF"
+            echo ""
+            echo "Without --list-affected: print the semver level CRATE needs, as JSON."
+            echo "With it: print, one per line, every workspace member whose dependency"
+            echo "requirements or feature surface moved between the two revisions --"
+            echo "the crates worth running the first form on, including those a"
+            echo "changed-file-path search cannot find because the edit was to the root"
+            echo "manifest's [workspace.dependencies]."
             exit 0
             ;;
         -*)
@@ -32,9 +45,15 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-CRATE="${1:?ERROR: CRATE is required}"
-BASE_REF="${2:-main}"
-CURRENT_REF="${3:-HEAD}"
+if $LIST_AFFECTED; then
+    CRATE=""
+    BASE_REF="${1:-main}"
+    CURRENT_REF="${2:-HEAD}"
+else
+    CRATE="${1:?ERROR: CRATE is required}"
+    BASE_REF="${2:-main}"
+    CURRENT_REF="${3:-HEAD}"
+fi
 
 log_verbose() {
     if [ "$VERBOSE" = true ]; then
@@ -160,10 +179,14 @@ crate_target_kinds_at_rev() {
 }
 
 # Echo one tab-separated row per manifest fact about crate $1 at revision $2, read once
-# per revision for both manifest passes below:
+# per revision for both manifest passes below. Every workspace member is read when $1 is
+# empty, which is how list_affected_crates gets the whole workspace for one extraction.
 #
-#   dep      <name> <alias> <kind> <target> <req>   one per dependency a consumer resolves
-#   feature  <name> default|optional                one per declared feature
+#   <crate> dep      <name> <alias> <kind> <target> <req>  one per dependency a consumer resolves
+#   <crate> feature  <name> default|optional               one per declared feature
+#
+# The crate leads every row so that rows from different members stay apart; the passes
+# below, which ask for one crate, cut it back off.
 #
 # Read via `cargo metadata` rather than the crate's own Cargo.toml, which would see
 # neither the version behind a `{ workspace = true }` inheritance marker nor the implicit
@@ -173,12 +196,12 @@ crate_target_kinds_at_rev() {
 # may alias two versions of one package (`foo1`/`foo2` both `package = "foo"`), for which
 # cargo metadata reports an identical name, kind and target; keyed without it, the second
 # alias matches the first's baseline requirement and an unchanged pair reads as a raise.
-crate_manifest_facts_at_rev() {
+manifest_facts_at_rev() {
     local crate=$1 rev=$2
-    local tree meta cargo_status
+    local tree meta cargo_status label=${crate:-the workspace}
     tree=$(mktemp -d) || return 1
     if ! git archive "$rev" | tar -x -C "$tree"; then
-        echo "Error: could not extract $rev to read the manifest for $crate" >&2
+        echo "Error: could not extract $rev to read the manifest for $label" >&2
         rm -rf "$tree"
         return 1
     fi
@@ -188,24 +211,53 @@ crate_manifest_facts_at_rev() {
     cargo_status=$?
     rm -rf "$tree"
     if [[ $cargo_status -ne 0 || -z "$meta" ]]; then
-        echo "Error: could not read the manifest for $crate at $rev" >&2
+        echo "Error: could not read the manifest for $label at $rev" >&2
         return 1
     fi
     jq -r --arg crate "$crate" '
         .packages[]
-        | select(.name == $crate)
+        | select($crate == "" or .name == $crate)
         | . as $p
         | (
             ( $p.dependencies[]
               | select((.kind // "normal") != "dev")
-              | ["dep", .name, (.rename // .name), (.kind // "normal"), (.target // "any"), .req] ),
+              | [$p.name, "dep", .name, (.rename // .name), (.kind // "normal"), (.target // "any"), .req] ),
             ( ($p.features // {}) as $f
               | ($f.default // []) as $d
               | ($f | keys[]) as $n
               | select($n != "default")
-              | ["feature", $n, (if ($d | index($n)) then "default" else "optional" end)] )
+              | [$p.name, "feature", $n, (if ($d | index($n)) then "default" else "optional" end)] )
           )
         | @tsv' <<< "$meta"
+}
+
+# Echo the name of every workspace member whose manifest facts moved between revisions
+# $1 and $2, one per line, so a caller can run the passes below on each.
+#
+# This exists because the facts are *resolved* ones: an edit to the root manifest's
+# [workspace.dependencies] raises the floor of every member that inherits the entry
+# while touching no file under any member's directory. A caller selecting crates by
+# changed file path sees nothing to check and would score such a PR as no change at all.
+#
+# Publishability is the caller's business: a member it does not release never comes up.
+list_affected_crates() {
+    local baseline=$1 current=$2
+    local base_facts now_facts
+    if ! base_facts=$(manifest_facts_at_rev "" "$baseline"); then
+        return 1
+    fi
+    if ! now_facts=$(manifest_facts_at_rev "" "$current"); then
+        return 1
+    fi
+    # A row present in exactly one of the two revisions is a fact that moved, which
+    # `uniq -u` keeps and the unchanged pairs it drops. A member added or removed
+    # between the revisions has every row on one side only, so it reads as affected.
+    printf '%s\n%s\n' "$base_facts" "$now_facts" \
+        | grep -v '^$' \
+        | sort \
+        | uniq -u \
+        | cut -f1 \
+        | sort -u
 }
 
 # version_gt A B — true when the dotted numeric tuple A is strictly greater than B.
@@ -268,15 +320,10 @@ req_min() {
     fi
 }
 
-compute_semver_results() {
-    local crate=$1
-    local baseline=$2
-    local current=$3
-
-    # If current is not provided set it to the tip of the branch
-    if [ -z "$current" ]; then
-        current="HEAD"
-    fi
+# Fetch baseline ref $1 and echo the revision to read it by. Shared so that both entry
+# points resolve a caller's ref identically.
+resolve_baseline() {
+    local baseline=$1
 
     # Fetch base commit
     git fetch origin "$baseline" --quiet
@@ -289,6 +336,25 @@ compute_semver_results() {
     # Ensure baseline has origin/ prefix if it doesn't already (skip for tags: refs/tags/...)
     if [[ ! "$baseline" =~ ^origin/ ]] && [[ "$baseline" != *"refs/tags"* ]]; then
         baseline="origin/$baseline"
+    fi
+    printf '%s\n' "$baseline"
+}
+
+compute_semver_results() {
+    local crate=$1
+    local baseline=$2
+    local current=$3
+
+    # If current is not provided set it to the tip of the branch
+    if [ -z "$current" ]; then
+        current="HEAD"
+    fi
+
+    local resolve_status
+    baseline=$(resolve_baseline "$baseline")
+    resolve_status=$?
+    if [[ $resolve_status -ne 0 ]]; then
+        return "$resolve_status"
     fi
 
     log_verbose "========================================"
@@ -583,10 +649,10 @@ compute_semver_results() {
     elif [[ "$level_so_far" == "major" ]]; then
         log_verbose "Skipping manifest diff: already at major"
     else
-        if ! base_facts=$(crate_manifest_facts_at_rev "$crate" "$baseline"); then
+        if ! base_facts=$(manifest_facts_at_rev "$crate" "$baseline"); then
             exit 1
         fi
-        if ! now_facts=$(crate_manifest_facts_at_rev "$crate" "$current"); then
+        if ! now_facts=$(manifest_facts_at_rev "$crate" "$current"); then
             exit 1
         fi
         manifest_compared=true
@@ -596,13 +662,15 @@ compute_semver_results() {
         log_verbose "Skipping dependency requirement diff: already at minor, which is this pass's ceiling"
     elif $manifest_compared; then
         local base_reqs now_reqs raised=""
-        base_reqs=$(awk -F'\t' '$1 == "dep" { print substr($0, index($0, "\t") + 1) }' <<< "$base_facts")
-        now_reqs=$(awk -F'\t' '$1 == "dep" { print substr($0, index($0, "\t") + 1) }' <<< "$now_facts")
+        # Field 1 is the crate, identical on every row here, so the key below starts at
+        # the dependency name.
+        base_reqs=$(awk -F'\t' '$2 == "dep" { print $3 "\t" $4 "\t" $5 "\t" $6 "\t" $7 }' <<< "$base_facts")
+        now_reqs=$(awk -F'\t' '$2 == "dep" { print $3 "\t" $4 "\t" $5 "\t" $6 "\t" $7 }' <<< "$now_facts")
 
         local dep_name dep_alias dep_kind dep_target dep_req dep_label old_req old_min new_min
         while IFS=$'\t' read -r dep_name dep_alias dep_kind dep_target dep_req; do
             [[ -z "$dep_name" ]] && continue
-            # Name, alias, kind and target together: see crate_manifest_facts_at_rev for
+            # Name, alias, kind and target together: see manifest_facts_at_rev for
             # why the alias belongs in the key.
             old_req=$(awk -F'\t' -v n="$dep_name" -v a="$dep_alias" -v k="$dep_kind" -v t="$dep_target" \
                 '$1 == n && $2 == a && $3 == k && $4 == t { print $5; exit }' <<< "$base_reqs")
@@ -656,8 +724,8 @@ compute_semver_results() {
     if $manifest_compared; then
         local base_features now_features
         local feat_name feat_default removed="" added="" undefaulted=""
-        base_features=$(awk -F'\t' '$1 == "feature" { print $2 "\t" $3 }' <<< "$base_facts")
-        now_features=$(awk -F'\t' '$1 == "feature" { print $2 "\t" $3 }' <<< "$now_facts")
+        base_features=$(awk -F'\t' '$2 == "feature" { print $3 "\t" $4 }' <<< "$base_facts")
+        now_features=$(awk -F'\t' '$2 == "feature" { print $3 "\t" $4 }' <<< "$now_facts")
 
         while IFS=$'\t' read -r feat_name feat_default; do
             [[ -z "$feat_name" ]] && continue
@@ -729,6 +797,27 @@ compute_semver_results() {
         --arg details "$DETAILS" \
         '{"name": $name, "level": $level, "reason": $reason, "details": $details}'
 }
+
+# --list-affected stops here: it names the crates to check rather than checking one, so
+# none of the per-crate machinery below runs.
+if $LIST_AFFECTED; then
+    if ! BASE_REF=$(resolve_baseline "$BASE_REF"); then
+        exit 1
+    fi
+    # Compared from where the branch left the baseline, the way a changed-file search
+    # uses `git diff base...HEAD`: a fact that moved on the baseline *since* then is not
+    # this branch's doing, and selecting its crate would put another branch's change on
+    # this branch's report. A clone too shallow to hold a merge base falls back to the
+    # baseline tip, erring towards checking too much.
+    FORK_POINT=$(git merge-base "$BASE_REF" "$CURRENT_REF" 2>/dev/null)
+    if [[ -z "$FORK_POINT" ]]; then
+        echo "Warning: no merge base for $BASE_REF and $CURRENT_REF; comparing against the baseline tip" >&2
+        FORK_POINT="$BASE_REF"
+    fi
+    log_verbose "Listing crates whose manifest facts moved between $FORK_POINT and $CURRENT_REF"
+    list_affected_crates "$FORK_POINT" "$CURRENT_REF"
+    exit $?
+fi
 
 # Run the computation and capture JSON output.
 #


### PR DESCRIPTION
# What does this PR do?

`semver-level.sh` combined cargo-semver-checks and cargo-public-api. Both read rustdoc and neither reads a manifest, so two semver-relevant manifest changes came out as `patch`:

- a **raised dependency requirement floor** (`http = "1"` → `"1.1"`): every rustdoc signature is byte-identical, yet a consumer pinned to the old version can no longer resolve the crate — conventionally a minor;
- an **added cargo feature**: cargo-semver-checks has no lint for an addition at all, and a feature adds no rustdoc item unless it happens to gate one.

Two passes are added, both reading the manifest through `cargo metadata`:

| pass | reports |
| --- | --- |
| 2b) dependency requirement floors | `minor` when the lowest version a requirement admits goes up |
| 2c) cargo feature surface | `minor` on an added feature; `major` on one removed, or dropped from the set `default` reaches |

The second commit is a consequence of the first: `build` moves into the permissive PR-title type list, because scoring a dependency floor as minor would otherwise make `build(deps): bump foo from 1.0 to 1.1` — the conventional title for a dependency change — fail the type rule.

The third commit is what lets CI reach any of it. `detect-changes` selected a crate only when a file under its own directory changed, so a PR editing just the root manifest's `[workspace.dependencies]` selected nothing: `has_rust_changes` came out `false`, both the `semver-check` and `validate` jobs were skipped, and every PR title was accepted — a `docs:` title included. Since this workspace declares dependencies version-only at the root and members inherit them with `workspace = true`, that is the ordinary shape of a floor raise here, which left the pass above unreachable from CI. `semver-level.sh` grows a `--list-affected` mode naming every member whose dependency requirements, dependency feature selections or own feature surface moved between two revisions, and `detect-changes` adds those crates to the ones it finds by path.

The last three commits answer review findings against the manifest readers. None of them changes what any pass scores on this workspace today:

- **Default membership is the closure, not a direct listing.** 2c asked whether `default` *lists* a feature. So a behaviour-preserving refactor — `default = ["foo"]` becoming `default = ["bundle"]` with `bundle = ["foo"]` — read as `foo` losing its default and scored major, while the inverse, emptying a `bundle` that `default` still lists, is a real break that read as no change at all. Rows now carry the closure over the feature graph, which is what a consumer writing `default-features = true` actually gets.
- **Dependency rows now carry the feature selection.** They recorded only the requirement, so a root entry that merely gained a feature, or stopped disabling default features, left every inheriting member's facts identical: `--list-affected` named nobody and, with only the root manifest touched, the jobs were skipped again — the same shape of gap the third commit fixes for floors.
- **Exclusive bounds are normalized, not tagged.** `req_min` appended an exclusivity bit to the version a bound states rather than advancing past it, so `>` was read as admitting the version it excludes. `>1.2` admits nothing below 1.3.0, so `>=1.2.1` → `>1.2` read as a lowering rather than the raise it is; and `>1.2.3` → the equivalent `>=1.2.4` read as a raise. Bounds now advance to the first version they admit, which drops the flag and returns `version_gt` to a plain triple.

# Motivation

Reviewing release proposal #2482 surfaced `libdd-capabilities` proposed as `patch`, when #2350 had moved its `http` requirement from `^1` to the workspace entry at `^1.1`. That is a minor, and nothing in the pipeline could see it: the version had moved *into* `[workspace.dependencies]`, so even a textual diff of the crate's own `Cargo.toml` shows only `{ workspace = true }` with no version in it.

# Additional Notes

Points reviewers may want to weigh:

- **Read through `cargo metadata`, not `Cargo.toml`.** That is what resolves `{ workspace = true }` to the version the root manifest declares, and what surfaces the implicit feature an `optional = true` dependency creates.
- **Dependencies are keyed by `.rename` as well as name/kind/target.** A crate aliasing two versions of one package emits an identical name, kind and target for both; keyed without the alias, the second matches the first's baseline requirement and an unchanged pair reads as a raise.
- **An exclusive bound is advanced to the first version it admits**, `>` excluding everything up to and including the components it states: `>1.2.3` starts at 1.2.4, `>1.2` at 1.3.0 and `>1` at 2.0.0. So `>=1.2.3` → `>1.2.3` reads as the narrowing it is, `>=1.2.1` → `>1.2` as the raise it is, and `>1.2.3` → the equivalent `>=1.2.4` as no change at all. A pre-release bound is the exception and stays where it is: `>1.2.3-rc.1` admits 1.2.3 itself, so the release version this reader already compares is that bound's exact floor, and advancing it would overstate the requirement. `req_min` was checked against `semver` 1.0.28's own `VersionReq::matches` over 33 requirement forms — every operator at one, two and three components, the four shapes this workspace uses, and both pre-release cases — and agrees on all of them.
- **A raised *major* floor is capped at `minor` on purpose.** Whether that forces the dependent to major is `release-version-major-bumps.sh`'s decision, made with the dependency graph this script cannot see; `max_level()` lets it win from there.
- **The two passes stop at different points.** 2b can only report minor, so minor ends it. 2c can report major, so it runs on until major — which matters for a crate with no library target, where cargo-semver-checks is skipped entirely and nothing else watches the feature table.
- **Feature removals are a backstop, not the primary check.** For a library crate `feature_missing` and `feature_not_enabled_by_default` get there first; both were verified to *fail* the run rather than merely warn, using a two-crate repro against the pinned invocation. The closure above is what keeps the backstop from contradicting them: cargo-semver-checks resolves the default set transitively, so keyed on direct membership this pass would have reported major over a refactor the lint passes.
- **Dependency feature facts are selected on, not scored.** Enabling a feature in a dependency can change this crate's own API — an item reached through a glob re-export appears — but the manifest cannot say whether it did, and the passes that read rustdoc can. So the columns widen what `--list-affected` names and assign no level of their own; 2b's key stops before them, so a feature move never reads as a requirement change.
- **Deliberately not scored:** dev-dependencies, a widened requirement, a dependency added or removed outright, and a change to what a feature *enables* for its own sake (the two `*_enables_feature` lints' job) — that last reaches 2c only where it moves the set `default` reaches.

On the detection commit:

- **`--list-affected` lives in `semver-level.sh` rather than a script of its own**, because it reuses `manifest_facts_at_rev` — now able to read the whole workspace in one extraction — so what the detector considers a manifest fact cannot drift from what the passes score. A detector considering *fewer* facts silently selects nothing and reports "no change", which is the failure this commit fixes; there are no shell tests to catch that drift. 19 lines are new, the 51 they lean on are shared.
- **The mode compares from `git merge-base`**, matching the `base...HEAD` the changed-file search uses. Measured from the baseline tip instead, a branch behind the baseline reports every crate that moved *on* the baseline since the fork, putting another branch's changes on this one's report — and since scoring uses the tip, a feature added on the baseline would read as a removal, i.e. a spurious major.
- **Publishability stays the caller's business.** The mode lists workspace members; `detect-changes` keeps its own `publish` filter, so a `publish = false` member such as `libdd-agent-client` shows up in the list and is dropped where that filter already lives.
- **Cost.** A crate selected only by moved facts still gets the full treatment, cargo-semver-checks and cargo-public-api both building rustdoc, so a one-line root bump now costs ~12 of those instead of zero, and a root entry that only gains a feature costs one per inheritor too — 20 for `serde_json`. That is deliberate: a changed floor or a newly enabled dependency feature can alter a crate's API through re-exports. If it bites, the cheap follow-up is a mode running only passes 2b/2c for those crates. Release-proposal PRs are unaffected — they carry `skip-pr-title-semver-check`, and each member's `version` is literal, so the path search already finds them.
- **The release path reports the same change rather than releasing for it.** `commits-since-release.sh` selects a crate's commits with `git log "$COMMIT_RANGE" -- "$CRATE_PATH"`, so a root-only floor raise leaves every inheriting crate with no commits and `release-version-bumps.sh` defers it. That is the right outcome, not a second instance of the bug above: the crate's code is unchanged, the requirement its published version states is still true of that code, and requirements are minimums, so a consumer combining it with a freshly published sibling that asks for the raised floor resolves the newer dependency anyway. Deferring moves neither the version nor the tag, so the raise stays in range and the crate's next release is still scored a minor for it — late, not wrong — while the case where a crate's code does need the raised version always arrives with a change to a file of its own, which the path search already finds. What is missing there is only the saying so: a deferred crate is recorded as level `none` and reads as "nothing happened". A follow-up reports those moves at the deferral point instead of releasing 12 crates that needed nothing.

Selection, each case a root-manifest edit and nothing else:

| root edit | before | after |
| --- | --- | --- |
| `bytes` floor `1.11` → `1.12` (12 members inherit it) | 0, both jobs skipped | exactly the 12 inheritors |
| + a feature added to one crate | that crate, by path | same, plus the 12 |
| `serde_json` gains a feature (20 members inherit it outside dev-dependencies) | 0, both jobs skipped | exactly those 20 |
| `serde_json` stops disabling default features | 0, both jobs skipped | exactly those 20 |
| baseline unchanged | — | none |

Scoring, over the same revisions, is unmoved by any of the three follow-ups: 2b's projection is byte-identical across all 698 dependency rows of the workspace, the 217 feature rows are byte-identical too, and all 149 distinct requirement strings in the workspace keep the floors they had — every bound here being inclusive with a full triple, the normalization has nothing to advance. So the floor and feature passes see exactly what they saw before. Both manifest passes also produce byte-identical output after the field shift in the shared reader (`bytes (normal): ^1.11 -> ^1.12`; `Cargo feature added / added: new-thing`). Scoring one of the 20 selected crates end to end reports `patch` — "No public API changes detected" — rather than a level invented from the new columns.

The closure was checked against cargo-semver-checks 0.47.0 and 0.48.0, the pinned version, on a two-crate repro: `feature_not_enabled_by_default` passes the behaviour-preserving refactor and fails the inverse, exactly as the closure does, and on `libdd-common`'s real feature graph the pass and the lint name the same eight features. The refactor now scores `minor` for the genuinely new feature name rather than `major`.

Everything above runs under `RUSTUP_TOOLCHAIN=1.92.0` as the workflow does. `shellcheck` on the script and on the extracted `run:` block (actionlint's `-e SC2086` profile) reports nothing that was not already there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
