### PR TITLE
test(release): add a bats suite for the release-proposal scripts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -91,6 +91,7 @@ scripts/release-generate-changelogs.sh  @DataDog/apm-common-components-core
 scripts/release-version-bumps.sh     @DataDog/apm-common-components-core
 scripts/release-version-major-bumps.sh  @DataDog/apm-common-components-core
 scripts/semver-level.sh              @DataDog/apm-common-components-core
+scripts/tests/                       @DataDog/apm-common-components-core
 scripts/update_license_3rdparty.sh   @DataDog/apm-common-components-core
 scripts/Dockerfile.license           @DataDog/libdatadog-core
 spawn_worker/                        @DataDog/libdatadog-php @DataDog/libdatadog-apm

--- a/.github/workflows/pr-title-semver-check.yml
+++ b/.github/workflows/pr-title-semver-check.yml
@@ -257,15 +257,19 @@ jobs:
           VALIDATION_FAILED="false"
           FAILURE_REASONS=()
 
-          # Rule: ci/docs/style/test/build cannot change the public API
+          # Rule: ci/docs/style/test cannot change what a consumer sees
+          #
+          # 'build' is deliberately NOT in this list. Conventional Commits defines it as
+          # changes to the build system *or external dependencies*, and semver-level.sh
+          # scores a raised dependency floor as a minor
           case "$TYPE" in
-            ci|docs|style|test|build)
+            ci|docs|style|test)
               if [[ "$SEMVER_LEVEL" == "major" ]] || [[ "$SEMVER_LEVEL" == "minor" ]]; then
                 VALIDATION_FAILED="true"
-                FAILURE_REASONS+=("'$TYPE' cannot have major or minor API changes. Use a different PR type, or avoid public API changes.")
+                FAILURE_REASONS+=("'$TYPE' cannot change the public API, a dependency requirement floor, or the cargo feature surface. Use a different PR type ('build' for a dependency change), or leave those alone.")
               fi
               ;;
-            feat|fix|refactor|chore|perf|revert)
+            feat|fix|refactor|chore|perf|revert|build)
               # These can be any semver level (subject to breaking change rules below)
               ;;
             *)
@@ -306,9 +310,11 @@ jobs:
             echo "--------------------------------------------"
             echo "VALID COMBINATIONS:"
             echo "--------------------------------------------"
-            echo "  ci/docs/style/test/build -> patch or none only (no public API changes)"
-            echo "  all other types          -> any level allowed"
-            echo "  major changes            -> must have '!' or 'BREAKING CHANGE:' footer"
+            echo "  ci/docs/style/test -> patch or none only (no change to the public API,"
+            echo "                        a dependency requirement floor, or the feature surface)"
+            echo "  all other types    -> any level allowed ('build' included: it is the"
+            echo "                        conventional type for a dependency change)"
+            echo "  major changes      -> must have '!' or 'BREAKING CHANGE:' footer"
             echo ""
             exit 1
           else

--- a/.github/workflows/release-scripts.yml
+++ b/.github/workflows/release-scripts.yml
@@ -50,6 +50,12 @@ jobs:
         with:
           tool: cargo-release
 
+      # release-generate-changelogs.bats renders with the repository's real cliff.toml,
+      # so the entries it asserts are the ones a release would publish.
+      - uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7 # 2.3.1
+        with:
+          tool: git-cliff
+
       - name: Install bats-core
         run: |
           set -euo pipefail

--- a/.github/workflows/release-scripts.yml
+++ b/.github/workflows/release-scripts.yml
@@ -43,6 +43,13 @@ jobs:
         with:
           toolchain: 1.92.0
 
+      # release-version-bumps.bats runs cargo-release for real against a throwaway
+      # workspace, so the versions it asserts are the ones a release would land on.
+      # Without it those tests skip rather than fail.
+      - uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7 # 2.3.1
+        with:
+          tool: cargo-release
+
       - name: Install bats-core
         run: |
           set -euo pipefail

--- a/.github/workflows/release-scripts.yml
+++ b/.github/workflows/release-scripts.yml
@@ -29,7 +29,8 @@ jobs:
           shellcheck --version
           shellcheck -e SC2086 --severity=warning scripts/*.sh scripts/tests/run.sh
           shellcheck -e SC2086 --severity=warning -s bash \
-            scripts/tests/helpers/*.bash scripts/tests/helpers/cargo-stub/cargo
+            scripts/tests/helpers/*.bash \
+            scripts/tests/helpers/cargo-stub/cargo scripts/tests/helpers/jq-stub/jq
 
   bats:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-scripts.yml
+++ b/.github/workflows/release-scripts.yml
@@ -13,6 +13,9 @@ on:
       - main
       - mq-working-branch-*
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-scripts.yml
+++ b/.github/workflows/release-scripts.yml
@@ -1,0 +1,59 @@
+name: Release scripts
+
+# Unit tests and lint for the scripts that drive the release-proposal workflows
+# (scripts/*.sh) plus structural guards on release-proposal-dispatch.yml itself.
+#
+# The dispatch workflow can only be exercised end to end by running a real release,
+# so these are the only checks that catch a regression in it before it ships.
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - mq-working-branch-*
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+      # actionlint (lint.yml) shellchecks the `run:` blocks inside workflows, but
+      # nothing covers the standalone scripts they call.
+      # SC2086 is excluded to match the actionlint job's shellcheck options.
+      - name: Run shellcheck on the release scripts
+        run: |
+          shellcheck --version
+          shellcheck -e SC2086 --severity=warning scripts/*.sh scripts/tests/run.sh
+          shellcheck -e SC2086 --severity=warning -s bash \
+            scripts/tests/helpers/*.bash scripts/tests/helpers/cargo-stub/cargo
+
+  bats:
+    runs-on: ubuntu-latest
+    env:
+      BATS_VERSION: 1.11.1
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
+        with:
+          # The suites build their own throwaway git repositories, but bats itself
+          # is run from this checkout.
+          fetch-depth: 1
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.92.0
+
+      - name: Install bats-core
+        run: |
+          set -euo pipefail
+          curl -sSfL "https://github.com/bats-core/bats-core/archive/refs/tags/v${BATS_VERSION}.tar.gz" \
+            -o /tmp/bats.tar.gz
+          tar -xzf /tmp/bats.tar.gz -C /tmp
+          "/tmp/bats-core-${BATS_VERSION}/install.sh" "$HOME/.local"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Ensure PyYAML is available
+        run: python3 -c 'import yaml' || python3 -m pip install --quiet pyyaml
+
+      - name: Run the release-script test suite
+        run: ./scripts/tests/run.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,18 @@ Iterate fastest with `cargo check -p <crate>` while editing; validate each affec
   ```
 - **test_spawn_from_lib**: `cargo nextest run --package test_spawn_from_lib --features prefer-dynamic`.
 
+### If `scripts/` or the release-proposal workflows were touched
+
+`scripts/*.sh` and `.github/workflows/release-proposal-dispatch.yml` have a bats suite
+(`scripts/tests/`), because a real release is otherwise the only way to exercise them:
+
+```bash
+./scripts/tests/run.sh                                   # needs bats-core >= 1.5.0
+shellcheck -e SC2086 --severity=warning scripts/*.sh     # CI enforces this
+```
+
+See `scripts/tests/README.md` for what is covered and what is not.
+
 ### Code exploration
 
 When searching for code with `grep` or `find`, always exclude the `./target` directory. Only search in it if specifically looking for build artifacts

--- a/scripts/semver-level.sh
+++ b/scripts/semver-level.sh
@@ -159,6 +159,115 @@ crate_target_kinds_at_rev() {
     echo "$kinds"
 }
 
+# Echo one tab-separated row per manifest fact about crate $1 at revision $2, read once
+# per revision for both manifest passes below:
+#
+#   dep      <name> <alias> <kind> <target> <req>   one per dependency a consumer resolves
+#   feature  <name> default|optional                one per declared feature
+#
+# Read via `cargo metadata` rather than the crate's own Cargo.toml, which would see
+# neither the version behind a `{ workspace = true }` inheritance marker nor the implicit
+# feature an `optional = true` dependency creates.
+#
+# <alias> is `.rename`, defaulting to the package name. It is in the row because a crate
+# may alias two versions of one package (`foo1`/`foo2` both `package = "foo"`), for which
+# cargo metadata reports an identical name, kind and target; keyed without it, the second
+# alias matches the first's baseline requirement and an unchanged pair reads as a raise.
+crate_manifest_facts_at_rev() {
+    local crate=$1 rev=$2
+    local tree meta cargo_status
+    tree=$(mktemp -d) || return 1
+    if ! git archive "$rev" | tar -x -C "$tree"; then
+        echo "Error: could not extract $rev to read the manifest for $crate" >&2
+        rm -rf "$tree"
+        return 1
+    fi
+    # Captured before jq: without pipefail a failing cargo would surface as jq's clean
+    # exit over empty input, and a broken manifest would read as "declares nothing".
+    meta=$(cargo metadata --format-version=1 --no-deps --manifest-path "$tree/Cargo.toml" 2>/dev/null)
+    cargo_status=$?
+    rm -rf "$tree"
+    if [[ $cargo_status -ne 0 || -z "$meta" ]]; then
+        echo "Error: could not read the manifest for $crate at $rev" >&2
+        return 1
+    fi
+    jq -r --arg crate "$crate" '
+        .packages[]
+        | select(.name == $crate)
+        | . as $p
+        | (
+            ( $p.dependencies[]
+              | select((.kind // "normal") != "dev")
+              | ["dep", .name, (.rename // .name), (.kind // "normal"), (.target // "any"), .req] ),
+            ( ($p.features // {}) as $f
+              | ($f.default // []) as $d
+              | ($f | keys[]) as $n
+              | select($n != "default")
+              | ["feature", $n, (if ($d | index($n)) then "default" else "optional" end)] )
+          )
+        | @tsv' <<< "$meta"
+}
+
+# version_gt A B — true when the dotted numeric tuple A is strictly greater than B.
+# Four components: req_min appends an exclusivity flag to the X.Y.Z triple.
+# Compared in the shell rather than with `sort -V`, a GNU extension.
+version_gt() {
+    local -a a=() b=()
+    local i x y
+    IFS='.' read -r -a a <<< "$1"
+    IFS='.' read -r -a b <<< "$2"
+    for i in 0 1 2 3; do
+        x=${a[i]:-0}
+        y=${b[i]:-0}
+        if (( 10#$x > 10#$y )); then
+            return 0
+        elif (( 10#$x < 10#$y )); then
+            return 1
+        fi
+    done
+    return 1
+}
+
+# Echo the lowest version requirement $1 admits, as `X.Y.Z.E` with E=1 when the bound
+# EXCLUDES that version. `>1.2.3` and `>=1.2.3` are different floors, so without E the
+# two compare equal and narrowing one into the other passes as a patch. E is an ordering
+# device only; the report quotes requirements verbatim.
+#
+# Echo nothing when there is no lower bound (`*`, `<2`) or it cannot be parsed: callers
+# treat that as "no opinion", so an exotic requirement can never invent a bump. A
+# pre-release bound is compared as its release version (`1.0.0-rc.1` -> `1.0.0`), which
+# can only understate a raise.
+req_min() {
+    local req=$1
+    local -a parts=() v=()
+    local part bound best="" exclusive
+    read -r -a parts <<< "${req//,/ }"
+    for part in "${parts[@]}"; do
+        exclusive=0
+        case "$part" in
+            ''|'*'|'<'*|'!='*) continue ;;
+            '>='*)  bound=${part#>=} ;;
+            '>'*)   bound=${part#>}; exclusive=1 ;;
+            '^'*)   bound=${part#^} ;;
+            '~'*)   bound=${part#\~} ;;
+            '='*)   bound=${part#=} ;;
+            [0-9]*) bound=$part ;;
+            *)      continue ;;
+        esac
+        bound=${bound%%[-+]*}   # drop pre-release and build metadata
+        bound=${bound//\*/0}    # `1.*` admits 1.0.0
+        [[ "$bound" =~ ^[0-9]+(\.[0-9]+)*$ ]] || continue
+        IFS='.' read -r -a v <<< "$bound"
+        bound="${v[0]:-0}.${v[1]:-0}.${v[2]:-0}.${exclusive}"
+        if [[ -z "$best" ]] || version_gt "$bound" "$best"; then
+            best=$bound
+        fi
+    done
+    if [[ -n "$best" ]]; then
+        printf '%s\n' "$best"
+    fi
+}
+
 compute_semver_results() {
     local crate=$1
     local baseline=$2
@@ -437,15 +546,175 @@ compute_semver_results() {
     fi
 
     # ----------------------------------------------------------------
-    # 3) Combine signals: take the higher of cargo-semver-checks and cargo-public-api.
+    # 2b) Dependency requirement floors
+    #
+    # Neither tool above reads a manifest. Raising the lowest version a requirement
+    # admits (`http = "1"` -> `"1.1"`) leaves every rustdoc signature byte-identical, so
+    # both report nothing and the level comes out patch — yet a consumer pinned to the
+    # old version can no longer resolve this crate, conventionally a minor.
+    #
+    # Deliberately NOT scored: dev-dependencies (not part of what a consumer resolves);
+    # a widened requirement; a dependency added or removed outright. Nor a raised MAJOR
+    # floor, capped at minor here on purpose — whether that forces the dependent to
+    # major is release-version-major-bumps.sh's call, made with the dependency graph
+    # this script cannot see, and max_level() lets it win from there.
+    # ----------------------------------------------------------------
+    local dep_level="none"
+    local dep_reason=""
+    local dep_details=""
+    local feature_level="none"
+    local feature_reason=""
+    local feature_details=""
+
+    # The passes have different ceilings, so they stop at different points: (2b) can
+    # only report minor, so minor ends it; (2c) can report major, so it runs on until
+    # major. They share one extraction per revision, gated by (2c)'s wider ceiling.
+    #
+    # Stopping (2c) at minor too would save that extraction, since (1)'s
+    # `feature_missing` / `feature_not_enabled_by_default` cover its major findings —
+    # but only while those lints exist, and the failure mode is silent. Second opinion
+    # kept on purpose.
+    local level_so_far
+    level_so_far=$(max_level "$semver_level" "$public_api_level")
+
+    local base_facts="" now_facts="" manifest_compared=false
+    if $crate_is_new; then
+        log_verbose "Skipping manifest diff: new crate (no baseline)"
+    elif [[ "$level_so_far" == "major" ]]; then
+        log_verbose "Skipping manifest diff: already at major"
+    else
+        if ! base_facts=$(crate_manifest_facts_at_rev "$crate" "$baseline"); then
+            exit 1
+        fi
+        if ! now_facts=$(crate_manifest_facts_at_rev "$crate" "$current"); then
+            exit 1
+        fi
+        manifest_compared=true
+    fi
+
+    if $manifest_compared && [[ "$level_so_far" == "minor" ]]; then
+        log_verbose "Skipping dependency requirement diff: already at minor, which is this pass's ceiling"
+    elif $manifest_compared; then
+        local base_reqs now_reqs raised=""
+        base_reqs=$(awk -F'\t' '$1 == "dep" { print substr($0, index($0, "\t") + 1) }' <<< "$base_facts")
+        now_reqs=$(awk -F'\t' '$1 == "dep" { print substr($0, index($0, "\t") + 1) }' <<< "$now_facts")
+
+        local dep_name dep_alias dep_kind dep_target dep_req dep_label old_req old_min new_min
+        while IFS=$'\t' read -r dep_name dep_alias dep_kind dep_target dep_req; do
+            [[ -z "$dep_name" ]] && continue
+            # Name, alias, kind and target together: see crate_manifest_facts_at_rev for
+            # why the alias belongs in the key.
+            old_req=$(awk -F'\t' -v n="$dep_name" -v a="$dep_alias" -v k="$dep_kind" -v t="$dep_target" \
+                '$1 == n && $2 == a && $3 == k && $4 == t { print $5; exit }' <<< "$base_reqs")
+            # Absent from the baseline: a dependency newly added, or one whose alias
+            # changed. Either way not a raised floor.
+            [[ -z "$old_req" ]] && continue
+            [[ "$old_req" == "$dep_req" ]] && continue
+
+            dep_label="$dep_name"
+            [[ "$dep_alias" != "$dep_name" ]] && dep_label="$dep_name as $dep_alias"
+
+            old_min=$(req_min "$old_req")
+            new_min=$(req_min "$dep_req")
+            if [[ -z "$old_min" || -z "$new_min" ]]; then
+                log_verbose "Not judging $dep_label: unparsed requirement ($old_req -> $dep_req)"
+                continue
+            fi
+            if version_gt "$new_min" "$old_min"; then
+                raised+="$dep_label ($dep_kind): $old_req -> $dep_req"$'\n'
+                log_verbose "$dep_label floor raised: $old_req -> $dep_req"
+            fi
+        done <<< "$now_reqs"
+
+        if [[ -n "$raised" ]]; then
+            dep_level="minor"
+            dep_reason="Dependency requirement floor raised"
+            dep_details=$(truncate_details 50 <<< "${raised%$'\n'}")
+        fi
+    fi
+
+    # ----------------------------------------------------------------
+    # 2c) Cargo feature surface
+    #
+    # Features are public API — downstream writes `features = ["x"]` — so adding one is
+    # a minor and removing one, or dropping it from the default set, breaks consumers
+    # that named it.
+    #
+    # An ADDED feature is the gap: cargo-semver-checks has no lint for it (0.47/0.48
+    # offer feature_missing, feature_not_enabled_by_default and the two
+    # *_enables_feature lints, nothing for an addition) and it adds no rustdoc item
+    # unless it gates one, so it used to come out patch.
+    #
+    # The removal cases are a backstop. For a library crate feature_missing and
+    # feature_not_enabled_by_default get there first (verified to fail the run, not
+    # merely warn) and this block is skipped once a pass said major; it earns its keep
+    # on a crate with no library target, where (1) is skipped entirely.
+    #
+    # Not scored: a change to what a feature *enables* — the two *_enables_feature
+    # lints' job, and judging it needs the feature graph rather than a name set.
+    # ----------------------------------------------------------------
+    if $manifest_compared; then
+        local base_features now_features
+        local feat_name feat_default removed="" added="" undefaulted=""
+        base_features=$(awk -F'\t' '$1 == "feature" { print $2 "\t" $3 }' <<< "$base_facts")
+        now_features=$(awk -F'\t' '$1 == "feature" { print $2 "\t" $3 }' <<< "$now_facts")
+
+        while IFS=$'\t' read -r feat_name feat_default; do
+            [[ -z "$feat_name" ]] && continue
+            if ! awk -F'\t' -v n="$feat_name" '$1 == n { found = 1 } END { exit !found }' <<< "$now_features"; then
+                removed+="$feat_name"$'\n'
+                continue
+            fi
+            # Still declared, but no longer reached by `default`.
+            if [[ "$feat_default" == "default" ]] \
+               && ! awk -F'\t' -v n="$feat_name" '$1 == n && $2 == "default" { found = 1 } END { exit !found }' <<< "$now_features"; then
+                undefaulted+="$feat_name"$'\n'
+            fi
+        done <<< "$base_features"
+
+        while IFS=$'\t' read -r feat_name feat_default; do
+            [[ -z "$feat_name" ]] && continue
+            if ! awk -F'\t' -v n="$feat_name" '$1 == n { found = 1 } END { exit !found }' <<< "$base_features"; then
+                added+="$feat_name"$'\n'
+            fi
+        done <<< "$now_features"
+
+        if [[ -n "$removed" || -n "$undefaulted" ]]; then
+            feature_level="major"
+            feature_reason="Cargo feature removed or no longer enabled by default"
+            feature_details=$(truncate_details 50 <<< "$(
+                [[ -n "$removed" ]] && printf 'removed: %s\n' "${removed//$'\n'/ }"
+                [[ -n "$undefaulted" ]] && printf 'no longer default: %s\n' "${undefaulted//$'\n'/ }"
+            )")
+            log_verbose "features removed: ${removed//$'\n'/ } undefaulted: ${undefaulted//$'\n'/ }"
+        elif [[ -n "$added" ]]; then
+            feature_level="minor"
+            feature_reason="Cargo feature added"
+            feature_details=$(truncate_details 50 <<< "added: ${added//$'\n'/ }")
+            log_verbose "features added: ${added//$'\n'/ }"
+        fi
+    fi
+
+    # ----------------------------------------------------------------
+    # 3) Combine: the highest level any pass reported. The reason comes from the pass
+    # that decided it, and on a tie from the one that describes the change most
+    # concretely — a removed item says more than "a dependency floor moved".
     # ----------------------------------------------------------------
     LEVEL=$(max_level "$semver_level" "$public_api_level")
-    if [[ "$LEVEL" == "$public_api_level" && "$public_api_level" != "$semver_level" ]]; then
-        REASON="$public_api_reason"
-        DETAILS="$public_api_details"
-    else
+    LEVEL=$(max_level "$LEVEL" "$feature_level")
+    LEVEL=$(max_level "$LEVEL" "$dep_level")
+    if [[ "$semver_level" == "$LEVEL" ]]; then
         REASON="$semver_reason"
         DETAILS="$semver_details"
+    elif [[ "$public_api_level" == "$LEVEL" ]]; then
+        REASON="$public_api_reason"
+        DETAILS="$public_api_details"
+    elif [[ "$feature_level" == "$LEVEL" ]]; then
+        REASON="$feature_reason"
+        DETAILS="$feature_details"
+    else
+        REASON="$dep_reason"
+        DETAILS="$dep_details"
     fi
 
     if [[ "$LEVEL" == "none" ]]; then

--- a/scripts/tests/README.md
+++ b/scripts/tests/README.md
@@ -40,6 +40,7 @@ CI runs the same suite plus `shellcheck` over `scripts/*.sh`
 | `publication-order.bats` | which crates a release includes, and the order they publish in |
 | `commits-since-release.bats` | which commits are attributed to each crate; tag/merge-base resolution; the exported `range`, `latest_tag` and `tag_in_local_branch`; exclusion rules |
 | `release-version-bumps.bats` | each crate's fate — released at a level, deferred, skipped, or a hard failure — and the version cargo-release actually lands on |
+| `release-version-major-bumps.bats` | which crates get forced to major by a dependency that went major in the same proposal, and which no-commit candidates are pulled back in or dropped |
 | `semver-level.bats` | the bump level fed to `cargo release version -x`, parsed out of cargo-semver-checks and cargo-public-api output |
 | `major-bumps-level.bats` | whether a direct `libdd-*` dependency going major forces a dependent to major |
 | `release-proposal-workflow.bats` | job-level `if:` gating, untrusted-`main_start_ref` defenses, branch prefixes, push path, PR contract |
@@ -58,12 +59,17 @@ parsing* `semver-level.sh` gets wrong when it regresses. The shim replays record
 output for those two subcommands and forwards everything else to the real cargo, so
 the script under test runs unmodified.
 
-**Real cargo-release** — `release-version-bumps.bats` runs `cargo release` against the
-fixture workspace rather than stubbing it, so the versions it asserts are the ones a
-release would land on. Only `semver-level.sh` is doubled there, by copying the script
-under test next to a stub sibling: it resolves `semver-level.sh` relative to itself, so
-no test-only hook is needed in the script. Install `cargo-release` to run those tests;
-without it they skip rather than fail.
+**Real cargo-release** — the two `release-version-*` suites run `cargo release` against
+the fixture workspace rather than stubbing it, so the versions they assert are the ones
+a release would land on. They also use it to *set up* state: driving the simulated
+previous release through cargo-release rewrites dependents' version requirements the way
+a real release does, which a hand-edited manifest does not. Install `cargo-release` to
+run them; without it they skip rather than fail.
+
+`release-version-major-bumps.bats` needs no doubles at all — `major-bumps-level.sh` only
+reads cargo metadata, with no compilation. `release-version-bumps.bats` doubles just
+`semver-level.sh`, by copying the script under test next to a stub sibling: it resolves
+`semver-level.sh` relative to itself, so no test-only hook is needed in the script.
 
 **Workflow guards** (`helpers/workflow-to-json.py`) — transcribes the workflow YAML to
 JSON so the tests can assert on it with `jq`. These are intentionally

--- a/scripts/tests/README.md
+++ b/scripts/tests/README.md
@@ -41,6 +41,7 @@ CI runs the same suite plus `shellcheck` over `scripts/*.sh`
 | `commits-since-release.bats` | which commits are attributed to each crate; tag/merge-base resolution; the exported `range`, `latest_tag` and `tag_in_local_branch`; exclusion rules |
 | `release-version-bumps.bats` | each crate's fate — released at a level, deferred, skipped, or a hard failure — and the version cargo-release actually lands on |
 | `release-version-major-bumps.bats` | which crates get forced to major by a dependency that went major in the same proposal, and which no-commit candidates are pulled back in or dropped |
+| `release-generate-changelogs.bats` | the CHANGELOG entry each crate gets — rendered by git-cliff, minimal, or none — and that only the crate's own commits reach it |
 | `semver-level.bats` | the bump level fed to `cargo release version -x`, parsed out of cargo-semver-checks and cargo-public-api output |
 | `major-bumps-level.bats` | whether a direct `libdd-*` dependency going major forces a dependent to major |
 | `release-proposal-workflow.bats` | job-level `if:` gating, untrusted-`main_start_ref` defenses, branch prefixes, push path, PR contract |
@@ -71,6 +72,11 @@ reads cargo metadata, with no compilation. `release-version-bumps.bats` doubles 
 `semver-level.sh`, by copying the script under test next to a stub sibling: it resolves
 `semver-level.sh` relative to itself, so no test-only hook is needed in the script.
 
+**Real git-cliff, real cliff.toml** — `release-generate-changelogs.bats` copies the
+repository's own `cliff.toml` into the fixture and lets git-cliff render, so the entries
+it asserts are the ones a release would publish rather than an approximation of them.
+Install `git-cliff` to run it; without it those tests skip.
+
 **Workflow guards** (`helpers/workflow-to-json.py`) — transcribes the workflow YAML to
 JSON so the tests can assert on it with `jq`. These are intentionally
 change-detectors: each states *why* the invariant exists, so changing the workflow
@@ -90,11 +96,14 @@ depends on it. Two properties worth preserving:
 
 ## Not covered
 
-What remains inline in `release-proposal-dispatch.yml` is untestable while it lives
-inside `run:` blocks: the libdd-* major-bump merge, CHANGELOG generation via git-cliff,
-and the PR body. Making those testable means the same move that produced
-`release-version-bumps.sh` — separate the decision from the side effects, so the
-decision takes JSON and git state and returns JSON.
+The four release stages now live in scripts and are covered above. What is still inline
+in `release-proposal-dispatch.yml`, and so still out of reach, is the PR body built in
+`create-pr` and the branch/ref plumbing in `cargo-release` — checking out the start ref,
+creating the ephemeral and proposal branches, and the guards around them.
+
+Making those testable is the same move that produced the four release scripts: lift the
+step into a script with its inputs as arguments, A/B it against the previous step body
+on a fixture repository, then cover it.
 
 The guards in `release-proposal-workflow.bats` are a holding measure for the
 security-critical parts of what is left, not a substitute.

--- a/scripts/tests/README.md
+++ b/scripts/tests/README.md
@@ -38,7 +38,8 @@ CI runs the same suite plus `shellcheck` over `scripts/*.sh`
 | Suite | Covers |
 | --- | --- |
 | `publication-order.bats` | which crates a release includes, and the order they publish in |
-| `commits-since-release.bats` | which commits are attributed to each crate; tag/merge-base resolution; the exported `range`; exclusion rules |
+| `commits-since-release.bats` | which commits are attributed to each crate; tag/merge-base resolution; the exported `range`, `latest_tag` and `tag_in_local_branch`; exclusion rules |
+| `release-version-bumps.bats` | each crate's fate — released at a level, deferred, skipped, or a hard failure — and the version cargo-release actually lands on |
 | `semver-level.bats` | the bump level fed to `cargo release version -x`, parsed out of cargo-semver-checks and cargo-public-api output |
 | `major-bumps-level.bats` | whether a direct `libdd-*` dependency going major forces a dependent to major |
 | `release-proposal-workflow.bats` | job-level `if:` gating, untrusted-`main_start_ref` defenses, branch prefixes, push path, PR contract |
@@ -56,6 +57,13 @@ scripts have to discriminate. Nothing touches the libdatadog checkout.
 parsing* `semver-level.sh` gets wrong when it regresses. The shim replays recorded
 output for those two subcommands and forwards everything else to the real cargo, so
 the script under test runs unmodified.
+
+**Real cargo-release** — `release-version-bumps.bats` runs `cargo release` against the
+fixture workspace rather than stubbing it, so the versions it asserts are the ones a
+release would land on. Only `semver-level.sh` is doubled there, by copying the script
+under test next to a stub sibling: it resolves `semver-level.sh` relative to itself, so
+no test-only hook is needed in the script. Install `cargo-release` to run those tests;
+without it they skip rather than fail.
 
 **Workflow guards** (`helpers/workflow-to-json.py`) — transcribes the workflow YAML to
 JSON so the tests can assert on it with `jq`. These are intentionally
@@ -76,9 +84,11 @@ depends on it. Two properties worth preserving:
 
 ## Not covered
 
-The inline bash in `release-proposal-dispatch.yml` — the bump-range computation, the
-"tag is not the latest" skip rule, the major-bump merge, CHANGELOG generation and the
-PR body — is untestable while it lives inside `run:` blocks. Making it testable means
-extracting the decision half of each step into a script that takes JSON and git state
-and returns JSON. The guards in `release-proposal-workflow.bats` are a holding
-measure for the security-critical parts of that logic, not a substitute.
+What remains inline in `release-proposal-dispatch.yml` is untestable while it lives
+inside `run:` blocks: the libdd-* major-bump merge, CHANGELOG generation via git-cliff,
+and the PR body. Making those testable means the same move that produced
+`release-version-bumps.sh` — separate the decision from the side effects, so the
+decision takes JSON and git state and returns JSON.
+
+The guards in `release-proposal-workflow.bats` are a holding measure for the
+security-critical parts of what is left, not a substitute.

--- a/scripts/tests/README.md
+++ b/scripts/tests/README.md
@@ -64,7 +64,7 @@ CI runs the same suite plus `shellcheck` over `scripts/*.sh`
 | `release-version-bumps.bats` | each crate's fate — released at a level, deferred, skipped, or a hard failure — and the version cargo-release actually lands on |
 | `release-version-major-bumps.bats` | which crates get forced to major by a dependency that went major in the same proposal, and which no-commit candidates are pulled back in or dropped |
 | `release-generate-changelogs.bats` | the CHANGELOG entry each crate gets — rendered by git-cliff, minimal, or none — and that only the crate's own commits reach it |
-| `semver-level.bats` | the bump level fed to `cargo release version -x`, parsed out of cargo-semver-checks and cargo-public-api output |
+| `semver-level.bats` | the bump level fed to `cargo release version -x`: parsed out of cargo-semver-checks and cargo-public-api output, plus the two manifest facts neither tool reads — dependency requirement floors and the package's cargo feature surface |
 | `major-bumps-level.bats` | whether a direct `libdd-*` dependency going major forces a dependent to major |
 | `release-proposal-workflow.bats` | job-level `if:` gating, untrusted-`main_start_ref` defenses, branch prefixes, push path, PR contract |
 
@@ -80,7 +80,9 @@ scripts have to discriminate. Nothing touches the libdatadog checkout.
 `cargo public-api` cost minutes per call and are precisely the tools whose *output
 parsing* `semver-level.sh` gets wrong when it regresses. The shim replays recorded
 output for those two subcommands and forwards everything else to the real cargo, so
-the script under test runs unmodified.
+the script under test runs unmodified. `cargo metadata` is deliberately among the
+forwarded calls: the dependency-floor pass is judged on requirements a real cargo
+resolved, which is the only way `{ workspace = true }` inheritance gets exercised.
 
 **Real cargo-release** — the two `release-version-*` suites run `cargo release` against
 the fixture workspace rather than stubbing it, so the versions they assert are the ones

--- a/scripts/tests/README.md
+++ b/scripts/tests/README.md
@@ -18,10 +18,32 @@ Requires [bats-core](https://github.com/bats-core/bats-core) >= 1.5.0, plus `jq`
 `git`, `cargo` and `python3` with PyYAML.
 
 ```bash
-./scripts/tests/run.sh                    # everything (~15s)
+./scripts/tests/run.sh                    # everything (~40s)
 ./scripts/tests/run.sh semver-level       # one suite
 ./scripts/tests/run.sh -f "merge-base"    # tests matching a regex
 ```
+
+## Running against another implementation
+
+Suites never name a script directly — they go through `run_tool NAME`, so the whole
+suite can be pointed somewhere else without touching an assertion:
+
+```bash
+RELEASE_TOOL_CMD='target/release/release-tool {name}' ./scripts/tests/run.sh
+RELEASE_TOOL_CMD='node dist/{name}.js'                ./scripts/tests/run.sh
+```
+
+`{name}` is the script's base name (`publication-order`, `release-version-bumps`, …);
+the template is split on whitespace, so it can carry a subcommand or flags. This is
+what makes the suite usable as a conformance harness if these scripts are ever
+rewritten in another language: run both implementations over it and diff.
+
+One suite opts out. `release-version-bumps.bats` doubles `semver-level.sh` by mirroring
+`scripts/` into a temp directory and swapping that one file, which relies on the script
+resolving siblings relative to how it was invoked. That does not generalise, so those
+tests `skip` with a stated reason under `RELEASE_TOOL_CMD` rather than silently running
+the real `semver-level.sh`. Giving the script a `--semver-level-cmd` option would close
+the gap.
 
 To install bats without root:
 
@@ -88,8 +110,19 @@ means updating the test and reading the reason first. They complement actionlint
 Assert on behaviour the workflow actually depends on, and say which workflow step
 depends on it. Two properties worth preserving:
 
-- Use `run --separate-stderr` so `$output` stays parseable JSON when a script logs
-  progress to stderr; assert diagnostics with `assert_stderr_contains`.
+- Invoke through `run_tool NAME` (or `tool NAME` for a setup step whose output you
+  need), never `${SCRIPTS_DIR}/name.sh`. That is what keeps the suite portable.
+- Both capture stdout and stderr separately, so `$output` stays parseable JSON when a
+  script logs progress. Assert diagnostics with `assert_stderr_mentions`, passing data
+  the test supplied — a crate name, a path, an option — rather than a phrase from the
+  message. Pinning our exact prose turns every reworded diagnostic into a failure, and
+  would force a reimplementation to reproduce the wording instead of the behaviour.
+  `assert_stderr_contains` is for text the test itself controls, such as a stub's
+  output being checked for forwarding.
+- Assert `assert_failure` without a code. The workflow only ever tests zero versus
+  non-zero, so a specific status is this implementation's convention, not a contract.
+  The exceptions are the tests whose *subject* is that a sub-process's own exit code
+  propagates; those name the code deliberately.
 - Prefer asserting invariants over golden output. `assert_topological_order` checks
   that every crate follows its dependencies rather than pinning one exact ordering,
   which would break on an irrelevant tie-breaking change.

--- a/scripts/tests/README.md
+++ b/scripts/tests/README.md
@@ -1,0 +1,84 @@
+<!--
+Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Release script tests
+
+Tests for the scripts that drive the release-proposal workflows, plus structural
+guards on `.github/workflows/release-proposal-dispatch.yml`.
+
+`release-proposal-dispatch.yml` can only be exercised end to end by running a real
+release (or a `bypass_standard_checks` run, which still pushes branches to the real
+repository). These tests are the only thing that catches a regression before it ships.
+
+## Running
+
+Requires [bats-core](https://github.com/bats-core/bats-core) >= 1.5.0, plus `jq`,
+`git`, `cargo` and `python3` with PyYAML.
+
+```bash
+./scripts/tests/run.sh                    # everything (~15s)
+./scripts/tests/run.sh semver-level       # one suite
+./scripts/tests/run.sh -f "merge-base"    # tests matching a regex
+```
+
+To install bats without root:
+
+```bash
+curl -sSfL https://github.com/bats-core/bats-core/archive/refs/tags/v1.11.1.tar.gz \
+  | tar xz && ./bats-core-1.11.1/install.sh "$HOME/.local"
+```
+
+CI runs the same suite plus `shellcheck` over `scripts/*.sh`
+(`.github/workflows/release-scripts.yml`).
+
+## What is covered
+
+| Suite | Covers |
+| --- | --- |
+| `publication-order.bats` | which crates a release includes, and the order they publish in |
+| `commits-since-release.bats` | which commits are attributed to each crate; tag/merge-base resolution; exclusion rules |
+| `semver-level.bats` | the bump level fed to `cargo release version -x`, parsed out of cargo-semver-checks and cargo-public-api output |
+| `major-bumps-level.bats` | whether a direct `libdd-*` dependency going major forces a dependent to major |
+| `release-proposal-workflow.bats` | job-level `if:` gating, untrusted-`main_start_ref` defenses, branch prefixes, push path, PR contract |
+
+## How the suites work
+
+**Fixture workspace** (`helpers/fixture.bash`) — a synthetic six-crate cargo workspace
+in a throwaway git repository, so `cargo metadata`, git tags and worktrees are all
+real. Its shape is deliberate: a dev-dependency cycle, a `publish = false` crate, a
+build-dependency edge and a non-`libdd-*` crate, because those are the cases the
+scripts have to discriminate. Nothing touches the libdatadog checkout.
+
+**Cargo shim** (`helpers/cargo-stub/cargo`) — `cargo semver-checks` and
+`cargo public-api` cost minutes per call and are precisely the tools whose *output
+parsing* `semver-level.sh` gets wrong when it regresses. The shim replays recorded
+output for those two subcommands and forwards everything else to the real cargo, so
+the script under test runs unmodified.
+
+**Workflow guards** (`helpers/workflow-to-json.py`) — transcribes the workflow YAML to
+JSON so the tests can assert on it with `jq`. These are intentionally
+change-detectors: each states *why* the invariant exists, so changing the workflow
+means updating the test and reading the reason first. They complement actionlint
+(in `lint.yml`), which checks syntax but not intent.
+
+## Adding a test
+
+Assert on behaviour the workflow actually depends on, and say which workflow step
+depends on it. Two properties worth preserving:
+
+- Use `run --separate-stderr` so `$output` stays parseable JSON when a script logs
+  progress to stderr; assert diagnostics with `assert_stderr_contains`.
+- Prefer asserting invariants over golden output. `assert_topological_order` checks
+  that every crate follows its dependencies rather than pinning one exact ordering,
+  which would break on an irrelevant tie-breaking change.
+
+## Not covered
+
+The inline bash in `release-proposal-dispatch.yml` — the bump-range computation, the
+"tag is not the latest" skip rule, the major-bump merge, CHANGELOG generation and the
+PR body — is untestable while it lives inside `run:` blocks. Making it testable means
+extracting the decision half of each step into a script that takes JSON and git state
+and returns JSON. The guards in `release-proposal-workflow.bats` are a holding
+measure for the security-critical parts of that logic, not a substitute.

--- a/scripts/tests/README.md
+++ b/scripts/tests/README.md
@@ -38,7 +38,7 @@ CI runs the same suite plus `shellcheck` over `scripts/*.sh`
 | Suite | Covers |
 | --- | --- |
 | `publication-order.bats` | which crates a release includes, and the order they publish in |
-| `commits-since-release.bats` | which commits are attributed to each crate; tag/merge-base resolution; exclusion rules |
+| `commits-since-release.bats` | which commits are attributed to each crate; tag/merge-base resolution; the exported `range`; exclusion rules |
 | `semver-level.bats` | the bump level fed to `cargo release version -x`, parsed out of cargo-semver-checks and cargo-public-api output |
 | `major-bumps-level.bats` | whether a direct `libdd-*` dependency going major forces a dependent to major |
 | `release-proposal-workflow.bats` | job-level `if:` gating, untrusted-`main_start_ref` defenses, branch prefixes, push path, PR contract |

--- a/scripts/tests/commits-since-release.bats
+++ b/scripts/tests/commits-since-release.bats
@@ -28,7 +28,7 @@ teardown() {
 }
 
 @test "reports no previous release when the crate has no tag" {
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" '[{"name":"libdd-beta","version":"0.5.0"}]'
+  run_tool commits-since-release '[{"name":"libdd-beta","version":"0.5.0"}]'
   assert_success
   assert_jq "$output" '.[0].tag_exists' "false"
   assert_jq "$output" '.[0].tag' "libdd-beta-v0.5.0"
@@ -37,7 +37,7 @@ teardown() {
 
 @test "reports an empty commit list when nothing changed since the tag" {
   fixture_touch_crate libdd-beta "feat(beta): unrelated"
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  run_tool commits-since-release "$ALPHA_INPUT"
   assert_success
   assert_jq "$output" '.[0].tag_exists' "true"
   assert_jq "$output" '.[0].commits | length' "0"
@@ -48,14 +48,14 @@ teardown() {
   fixture_touch_crate libdd-beta "feat(beta): not mine"
   fixture_commit_all "chore: empty commit touching nothing"
 
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  run_tool commits-since-release "$ALPHA_INPUT"
   assert_success
   assert_jq "$output" '.[0].commits | length' "1"
   assert_jq "$output" '.[0].commits[0].subject' "feat(alpha): mine"
 }
 
 @test "reports the crate path relative to the workspace root" {
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  run_tool commits-since-release "$ALPHA_INPUT"
   assert_success
   assert_jq "$output" '.[0].path' "libdd-alpha"
 }
@@ -67,7 +67,7 @@ teardown() {
   fixture_touch_crate libdd-alpha "feat(alpha): middle"
   fixture_touch_crate libdd-alpha "feat(alpha): newest"
 
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  run_tool commits-since-release "$ALPHA_INPUT"
   assert_success
   assert_jq "$output" '.[0].commits | map(.subject) | join("|")' \
     "feat(alpha): newest|feat(alpha): middle|feat(alpha): oldest"
@@ -79,7 +79,7 @@ teardown() {
   fixture_touch_crate libdd-alpha "Merge branch 'main' into topic"
   fixture_touch_crate libdd-alpha "Merge pull request #1 from someone/topic"
 
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  run_tool commits-since-release "$ALPHA_INPUT"
   assert_success
   assert_jq "$output" '.[0].commits | map(.subject) | join("|")' "feat(alpha): keep me"
 }
@@ -89,7 +89,7 @@ teardown() {
   fixture_touch_crate libdd-alpha "feat(alpha): human change"
   fixture_touch_crate libdd-alpha "feat(alpha): bot change" "dd-octo-sts[bot]" "bot@example.com"
 
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  run_tool commits-since-release "$ALPHA_INPUT"
   assert_success
   assert_jq "$output" '.[0].commits | map(.subject) | join("|")' "feat(alpha): human change"
 }
@@ -98,7 +98,7 @@ teardown() {
   fixture_touch_crate libdd-alpha "chore(release): bump"
   fixture_touch_crate libdd-alpha "feat(alpha): bot change" "dd-octo-sts[bot]" "bot@example.com"
 
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" --no-exclude "$ALPHA_INPUT"
+  run_tool commits-since-release --no-exclude "$ALPHA_INPUT"
   assert_success
   assert_jq "$output" '.[0].commits | map(.subject) | join("|")' "chore(release): bump"
 }
@@ -108,7 +108,7 @@ teardown() {
   fixture_touch_crate libdd-alpha "ci: drop me"
   fixture_touch_crate libdd-alpha "chore(release): also dropped"
 
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" --exclude='^ci:' "$ALPHA_INPUT"
+  run_tool commits-since-release --exclude='^ci:' "$ALPHA_INPUT"
   assert_success
   assert_jq "$output" '.[0].commits | map(.subject) | join("|")' "feat(alpha): keep me"
 }
@@ -120,7 +120,7 @@ teardown() {
   local nasty='fix(alpha): handle "quoted" \back\slash and — em dash $(whoami) `tick`'
   fixture_touch_crate libdd-alpha "$nasty"
 
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  run_tool commits-since-release "$ALPHA_INPUT"
   assert_success
   assert_valid_json "$output"
   assert_jq "$output" '.[0].commits[0].subject' "$nasty"
@@ -133,7 +133,7 @@ teardown() {
   fixture_tag "libdd-beta-v0.5.0" --annotated
   fixture_touch_crate libdd-beta "feat(beta): after the tag"
 
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" '[{"name":"libdd-beta","version":"0.5.0"}]'
+  run_tool commits-since-release '[{"name":"libdd-beta","version":"0.5.0"}]'
   assert_success
   assert_jq "$output" '.[0].tag_exists' "true"
   assert_jq "$output" '.[0].tag_ancestor' "true"
@@ -151,7 +151,7 @@ teardown() {
   git tag -f "libdd-alpha-v1.2.3" >/dev/null
   git checkout -q main
 
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  run_tool commits-since-release "$ALPHA_INPUT"
   assert_success
   assert_jq "$output" '.[0].tag_ancestor' "$fork_point"
   # The commit that only exists on the side branch must not be attributed to main.
@@ -162,7 +162,7 @@ teardown() {
 
 @test "reports the tagged commit as reachable from a local branch" {
   fixture_touch_crate libdd-alpha "feat(alpha): after the tag"
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  run_tool commits-since-release "$ALPHA_INPUT"
   assert_success
   assert_jq "$output" '.[0].tag_in_local_branch' "true"
   # A JSON boolean, not the string "true": the workflow compares it as one.
@@ -182,14 +182,14 @@ teardown() {
   git checkout -q main
   git branch -qD throwaway
 
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  run_tool commits-since-release "$ALPHA_INPUT"
   assert_success
   assert_jq "$output" '.[0].tag_exists' "true"
   assert_jq "$output" '.[0].tag_in_local_branch' "false"
 }
 
 @test "tag_in_local_branch is false when the crate has no tag" {
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" '[{"name":"libdd-beta","version":"0.5.0"}]'
+  run_tool commits-since-release '[{"name":"libdd-beta","version":"0.5.0"}]'
   assert_success
   assert_jq "$output" '.[0].tag_exists' "false"
   assert_jq "$output" '.[0].tag_in_local_branch' "false"
@@ -207,7 +207,7 @@ teardown() {
   fixture_tag "libdd-alpha-v1.9.0"
   fixture_tag "libdd-alpha-v1.10.0"
 
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  run_tool commits-since-release "$ALPHA_INPUT"
   assert_success
   # Version sort, not lexicographic: plain string ordering puts v1.9.0 above v1.10.0.
   assert_jq "$output" '.[0].latest_tag' "libdd-alpha-v1.10.0"
@@ -218,21 +218,21 @@ teardown() {
   # somewhere else, so the proposal must not re-release the older version.
   fixture_tag "libdd-alpha-v2.0.0"
 
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  run_tool commits-since-release "$ALPHA_INPUT"
   assert_success
   assert_jq "$output" '.[0].tag' "libdd-alpha-v1.2.3"
   assert_jq "$output" '.[0].latest_tag' "libdd-alpha-v2.0.0"
 }
 
 @test "latest_tag equals tag when the crate is at its most recent release" {
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  run_tool commits-since-release "$ALPHA_INPUT"
   assert_success
   assert_jq "$output" '.[0].latest_tag' "libdd-alpha-v1.2.3"
   assert_jq "$output" '.[0].tag' "libdd-alpha-v1.2.3"
 }
 
 @test "latest_tag is empty for a crate that was never released" {
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" '[{"name":"libdd-beta","version":"0.5.0"}]'
+  run_tool commits-since-release '[{"name":"libdd-beta","version":"0.5.0"}]'
   assert_success
   assert_jq "$output" '.[0].tag_exists' "false"
   assert_jq "$output" '.[0].latest_tag' ""
@@ -242,7 +242,7 @@ teardown() {
   # Manifest bumped without a release: no libdd-beta-v0.5.0 tag, but older ones exist.
   fixture_tag "libdd-beta-v0.4.0"
 
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" '[{"name":"libdd-beta","version":"0.5.0"}]'
+  run_tool commits-since-release '[{"name":"libdd-beta","version":"0.5.0"}]'
   assert_success
   assert_jq "$output" '.[0].tag_exists' "false"
   assert_jq "$output" '.[0].latest_tag' "libdd-beta-v0.4.0"
@@ -252,7 +252,7 @@ teardown() {
   # libdd-alpha and libdd-alpha-ffi share a prefix; the "-v" in the glob keeps them apart.
   fixture_tag "libdd-alpha-ffi-v9.9.9"
 
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  run_tool commits-since-release "$ALPHA_INPUT"
   assert_success
   assert_jq "$output" '.[0].latest_tag' "libdd-alpha-v1.2.3"
 }
@@ -270,7 +270,7 @@ teardown() {
   tag_commit="$(git rev-parse 'libdd-alpha-v1.2.3^{}')"
   head="$(git rev-parse HEAD)"
 
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  run_tool commits-since-release "$ALPHA_INPUT"
   assert_success
   assert_jq "$output" '.[0].tag_commit' "$tag_commit"
   assert_jq "$output" '.[0].range' "${tag_commit}..${head}"
@@ -284,7 +284,7 @@ teardown() {
   tag_commit="$(git rev-parse 'libdd-beta-v0.5.0^{}')"
   head="$(git rev-parse HEAD)"
 
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" '[{"name":"libdd-beta","version":"0.5.0"}]'
+  run_tool commits-since-release '[{"name":"libdd-beta","version":"0.5.0"}]'
   assert_success
   # The tag object's own SHA must not leak into the range.
   assert_not_contains "$(jq -r '.[0].range' <<< "$output")" "$(git rev-parse 'refs/tags/libdd-beta-v0.5.0')"
@@ -303,7 +303,7 @@ teardown() {
   local head
   head="$(git rev-parse HEAD)"
 
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  run_tool commits-since-release "$ALPHA_INPUT"
   assert_success
   assert_jq "$output" '.[0].range' "${fork_point}..${head}"
 }
@@ -335,7 +335,7 @@ tag_on_unrelated_history() {
 
   tag_on_unrelated_history "libdd-epsilon-v0.1.0"
 
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" '[{"name":"libdd-epsilon","version":"0.1.0"}]'
+  run_tool commits-since-release '[{"name":"libdd-epsilon","version":"0.1.0"}]'
   assert_success
   assert_jq "$output" '.[0].tag_ancestor' "no merge-base"
   assert_jq "$output" '.[0].range' "${range_start}..${head}"
@@ -354,7 +354,7 @@ tag_on_unrelated_history() {
   local tag_commit
   tag_commit="$(git rev-parse 'libdd-alpha-v1.2.3^{}')"
 
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  run_tool commits-since-release "$ALPHA_INPUT"
   assert_success
   assert_not_contains "$(jq -r '.[0].range' <<< "$output")" "^"
   assert_jq "$output" '.[0].range' "${tag_commit}..${head}"
@@ -363,7 +363,7 @@ tag_on_unrelated_history() {
 @test "leaves the range and tag_commit empty when the crate has no previous release tag" {
   # The workflow treats an empty range on a tagged crate as a hard error, so an
   # untagged crate must be distinguishable: it never reaches that check.
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" '[{"name":"libdd-beta","version":"0.5.0"}]'
+  run_tool commits-since-release '[{"name":"libdd-beta","version":"0.5.0"}]'
   assert_success
   assert_jq "$output" '.[0].tag_exists' "false"
   assert_jq "$output" '.[0].range' ""
@@ -380,7 +380,7 @@ tag_on_unrelated_history() {
   local head
   head="$(git rev-parse HEAD)"
 
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" \
+  run_tool commits-since-release \
     '[{"name":"libdd-alpha","version":"1.2.3"},{"name":"libdd-beta","version":"0.5.0"}]'
   assert_success
   assert_jq "$output" '[.[].range | split("..")[1]] | unique | join(",")' "$head"
@@ -388,7 +388,8 @@ tag_on_unrelated_history() {
 
 @test "reads the crate list from stdin" {
   fixture_touch_crate libdd-alpha "feat(alpha): via stdin"
-  run --separate-stderr bash -c "printf '%s' '$ALPHA_INPUT' | '${SCRIPTS_DIR}/commits-since-release.sh'"
+  release_tool_argv commits-since-release
+  run --separate-stderr bash -c 'printf "%s" "$1" | "${@:2}"' _ "$ALPHA_INPUT" "${RELEASE_TOOL_ARGV[@]}"
   assert_success
   assert_jq "$output" '.[0].commits[0].subject' "feat(alpha): via stdin"
 }
@@ -398,7 +399,7 @@ tag_on_unrelated_history() {
   fixture_touch_crate libdd-alpha "feat(alpha): a"
   fixture_touch_crate libdd-beta "feat(beta): b"
 
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" \
+  run_tool commits-since-release \
     '[{"name":"libdd-alpha","version":"1.2.3"},{"name":"libdd-beta","version":"0.5.0"}]'
   assert_success
   assert_jq "$output" 'length' "2"
@@ -407,24 +408,24 @@ tag_on_unrelated_history() {
 }
 
 @test "rejects invalid JSON input" {
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" 'not json'
-  assert_failure 1
-  assert_stderr_contains "Invalid JSON input"
+  run_tool commits-since-release 'not json'
+  assert_failure
+  assert_stderr_mentions "JSON"
 }
 
 @test "rejects an unknown option and an unknown format" {
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" --nope "$ALPHA_INPUT"
-  assert_failure 1
-  assert_stderr_contains "Unknown option: --nope"
+  run_tool commits-since-release --nope "$ALPHA_INPUT"
+  assert_failure
+  assert_stderr_mentions "--nope"
 
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" --format=yaml "$ALPHA_INPUT"
-  assert_failure 1
-  assert_stderr_contains "Unknown format: yaml"
+  run_tool commits-since-release --format=yaml "$ALPHA_INPUT"
+  assert_failure
+  assert_stderr_mentions "yaml"
 }
 
 @test "summary format lists the commits per crate" {
   fixture_touch_crate libdd-alpha "feat(alpha): summarised"
-  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" --format=summary "$ALPHA_INPUT"
+  run_tool commits-since-release --format=summary "$ALPHA_INPUT"
   assert_success
   assert_contains "$output" "libdd-alpha v1.2.3"
   assert_contains "$output" "feat(alpha): summarised"

--- a/scripts/tests/commits-since-release.bats
+++ b/scripts/tests/commits-since-release.bats
@@ -158,6 +158,135 @@ teardown() {
   assert_jq "$output" '.[0].commits | map(.subject) | join("|")' "feat(alpha): on main after fork"
 }
 
+# --- the exported range ------------------------------------------------------
+#
+# `range` is the commit span the listed commits came from, resolved to SHAs.
+# release-proposal-dispatch.yml carries it into api-changes.json and uses it as the
+# git-cliff range when the commit list cannot supply a tighter one, so a wrong start
+# point silently writes the wrong commits into a published CHANGELOG.
+
+@test "starts the range at the tag commit when the tag is an ancestor of HEAD" {
+  fixture_touch_crate libdd-alpha "feat(alpha): after the tag"
+  local tag_commit head
+  tag_commit="$(git rev-parse 'libdd-alpha-v1.2.3^{}')"
+  head="$(git rev-parse HEAD)"
+
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  assert_success
+  assert_jq "$output" '.[0].tag_commit' "$tag_commit"
+  assert_jq "$output" '.[0].range' "${tag_commit}..${head}"
+}
+
+@test "resolves an annotated tag to its commit in tag_commit and the range" {
+  fixture_touch_crate libdd-beta "feat(beta): released"
+  fixture_tag "libdd-beta-v0.5.0" --annotated
+  fixture_touch_crate libdd-beta "feat(beta): after the tag"
+  local tag_commit head
+  tag_commit="$(git rev-parse 'libdd-beta-v0.5.0^{}')"
+  head="$(git rev-parse HEAD)"
+
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" '[{"name":"libdd-beta","version":"0.5.0"}]'
+  assert_success
+  # The tag object's own SHA must not leak into the range.
+  assert_not_contains "$(jq -r '.[0].range' <<< "$output")" "$(git rev-parse 'refs/tags/libdd-beta-v0.5.0')"
+  assert_jq "$output" '.[0].range' "${tag_commit}..${head}"
+}
+
+@test "starts the range at the merge-base when the tag is not an ancestor of HEAD" {
+  local fork_point
+  fork_point="$(git rev-parse HEAD)"
+  fixture_touch_crate libdd-alpha "feat(alpha): on main after fork"
+
+  git checkout -q -b sidebranch "$fork_point"
+  fixture_touch_crate libdd-alpha "chore: release-only commit"
+  git tag -f "libdd-alpha-v1.2.3" >/dev/null
+  git checkout -q main
+  local head
+  head="$(git rev-parse HEAD)"
+
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  assert_success
+  assert_jq "$output" '.[0].range' "${fork_point}..${head}"
+}
+
+# Put a tag on history that shares no ancestor with main, so merge-base finds nothing.
+tag_on_unrelated_history() {
+  git checkout -q --orphan orphanbranch
+  git rm -rq --cached . 2>/dev/null || true
+  fixture_commit_all "chore: unrelated root"
+  git tag -f "$1" >/dev/null
+  git checkout -q -f main
+}
+
+@test "starts the range at the oldest commit's parent when the tag is on unrelated history" {
+  # A tag with no common ancestor makes `$TAG..HEAD` span all of HEAD's history. The
+  # range must instead cover exactly the commits that were found, or git-cliff walks
+  # years of unrelated history.
+  #
+  # libdd-epsilon is created after the root commit, so the oldest commit touching it
+  # has a parent to anchor the range at.
+  local range_start
+  range_start="$(git rev-parse HEAD)"
+  _fixture_crate libdd-epsilon 0.1.0
+  sed -i 's|    "other-tool",|    "other-tool",\n    "libdd-epsilon",|' "${FIXTURE_REPO}/Cargo.toml"
+  fixture_commit_all "feat(epsilon): add the crate"
+  fixture_touch_crate libdd-epsilon "feat(epsilon): a later change"
+  local head
+  head="$(git rev-parse HEAD)"
+
+  tag_on_unrelated_history "libdd-epsilon-v0.1.0"
+
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" '[{"name":"libdd-epsilon","version":"0.1.0"}]'
+  assert_success
+  assert_jq "$output" '.[0].tag_ancestor' "no merge-base"
+  assert_jq "$output" '.[0].range' "${range_start}..${head}"
+  assert_jq "$output" '.[0].commits | length' "2"
+}
+
+@test "falls back to the tag commit when the oldest commit is the repository root" {
+  # Same unrelated-history path, but the crate exists in the root commit so there is no
+  # parent to anchor at. `git rev-parse <root>^` prints "<sha>^" on stdout while exiting
+  # non-zero, so this guards against that string being used as a range start.
+  fixture_touch_crate libdd-alpha "feat(alpha): a change"
+  local head
+  head="$(git rev-parse HEAD)"
+
+  tag_on_unrelated_history "libdd-alpha-v1.2.3"
+  local tag_commit
+  tag_commit="$(git rev-parse 'libdd-alpha-v1.2.3^{}')"
+
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  assert_success
+  assert_not_contains "$(jq -r '.[0].range' <<< "$output")" "^"
+  assert_jq "$output" '.[0].range' "${tag_commit}..${head}"
+}
+
+@test "leaves the range and tag_commit empty when the crate has no previous release tag" {
+  # The workflow treats an empty range on a tagged crate as a hard error, so an
+  # untagged crate must be distinguishable: it never reaches that check.
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" '[{"name":"libdd-beta","version":"0.5.0"}]'
+  assert_success
+  assert_jq "$output" '.[0].tag_exists' "false"
+  assert_jq "$output" '.[0].range' ""
+  assert_jq "$output" '.[0].tag_commit' ""
+}
+
+@test "every crate's range ends at the same commit" {
+  # The workflow reuses these ranges after checking out the proposal branch, where HEAD
+  # has moved on; they must all be anchored to the release branch tip, not to whatever
+  # HEAD is at the time each one is read.
+  fixture_tag "libdd-beta-v0.5.0"
+  fixture_touch_crate libdd-alpha "feat(alpha): a"
+  fixture_touch_crate libdd-beta "feat(beta): b"
+  local head
+  head="$(git rev-parse HEAD)"
+
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" \
+    '[{"name":"libdd-alpha","version":"1.2.3"},{"name":"libdd-beta","version":"0.5.0"}]'
+  assert_success
+  assert_jq "$output" '[.[].range | split("..")[1]] | unique | join(",")' "$head"
+}
+
 @test "reads the crate list from stdin" {
   fixture_touch_crate libdd-alpha "feat(alpha): via stdin"
   run --separate-stderr bash -c "printf '%s' '$ALPHA_INPUT' | '${SCRIPTS_DIR}/commits-since-release.sh'"

--- a/scripts/tests/commits-since-release.bats
+++ b/scripts/tests/commits-since-release.bats
@@ -1,0 +1,203 @@
+#!/usr/bin/env bats
+
+# Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+
+# commits-since-release.sh decides which commits belong to each crate's release.
+# Its output drives three later decisions in release-proposal-dispatch.yml:
+#   * an empty `commits` array defers the crate to the libdd-* major-bump check
+#     (i.e. it is dropped from the release unless a dependency forces it back in),
+#   * `.commits[0]` / `.commits[-1]` become the git-cliff CHANGELOG range,
+#   * `commits` is rendered verbatim into the PR body.
+# A leaked or dropped commit therefore changes what gets released.
+
+load helpers/common
+load helpers/fixture
+
+ALPHA_INPUT='[{"name":"libdd-alpha","version":"1.2.3"}]'
+
+setup() {
+  setup_common
+  fixture_init
+  # Pretend libdd-alpha 1.2.3 was released at the initial commit.
+  fixture_tag "libdd-alpha-v1.2.3"
+}
+
+teardown() {
+  teardown_common
+}
+
+@test "reports no previous release when the crate has no tag" {
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" '[{"name":"libdd-beta","version":"0.5.0"}]'
+  assert_success
+  assert_jq "$output" '.[0].tag_exists' "false"
+  assert_jq "$output" '.[0].tag' "libdd-beta-v0.5.0"
+  assert_jq "$output" '.[0].commits | length' "0"
+}
+
+@test "reports an empty commit list when nothing changed since the tag" {
+  fixture_touch_crate libdd-beta "feat(beta): unrelated"
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  assert_success
+  assert_jq "$output" '.[0].tag_exists' "true"
+  assert_jq "$output" '.[0].commits | length' "0"
+}
+
+@test "collects only commits that touch the crate's directory" {
+  fixture_touch_crate libdd-alpha "feat(alpha): mine"
+  fixture_touch_crate libdd-beta "feat(beta): not mine"
+  fixture_commit_all "chore: empty commit touching nothing"
+
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  assert_success
+  assert_jq "$output" '.[0].commits | length' "1"
+  assert_jq "$output" '.[0].commits[0].subject' "feat(alpha): mine"
+}
+
+@test "reports the crate path relative to the workspace root" {
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  assert_success
+  assert_jq "$output" '.[0].path' "libdd-alpha"
+}
+
+@test "returns commits newest first" {
+  # The CHANGELOG range is built as `.commits[-1]^..\.commits[0]`, so the order is
+  # load-bearing: reversing it silently produces an empty or inverted range.
+  fixture_touch_crate libdd-alpha "feat(alpha): oldest"
+  fixture_touch_crate libdd-alpha "feat(alpha): middle"
+  fixture_touch_crate libdd-alpha "feat(alpha): newest"
+
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  assert_success
+  assert_jq "$output" '.[0].commits | map(.subject) | join("|")' \
+    "feat(alpha): newest|feat(alpha): middle|feat(alpha): oldest"
+}
+
+@test "excludes merge commits and chore(release) commits by default" {
+  fixture_touch_crate libdd-alpha "feat(alpha): keep me"
+  fixture_touch_crate libdd-alpha "chore(release): update CHANGELOG.md for libdd-alpha"
+  fixture_touch_crate libdd-alpha "Merge branch 'main' into topic"
+  fixture_touch_crate libdd-alpha "Merge pull request #1 from someone/topic"
+
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  assert_success
+  assert_jq "$output" '.[0].commits | map(.subject) | join("|")' "feat(alpha): keep me"
+}
+
+@test "excludes commits authored by the release bot" {
+  # Release automation commits must never be re-proposed as release content.
+  fixture_touch_crate libdd-alpha "feat(alpha): human change"
+  fixture_touch_crate libdd-alpha "feat(alpha): bot change" "dd-octo-sts[bot]" "bot@example.com"
+
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  assert_success
+  assert_jq "$output" '.[0].commits | map(.subject) | join("|")' "feat(alpha): human change"
+}
+
+@test "--no-exclude keeps subject-filtered commits but still drops the release bot" {
+  fixture_touch_crate libdd-alpha "chore(release): bump"
+  fixture_touch_crate libdd-alpha "feat(alpha): bot change" "dd-octo-sts[bot]" "bot@example.com"
+
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" --no-exclude "$ALPHA_INPUT"
+  assert_success
+  assert_jq "$output" '.[0].commits | map(.subject) | join("|")' "chore(release): bump"
+}
+
+@test "--exclude adds a subject pattern on top of the defaults" {
+  fixture_touch_crate libdd-alpha "feat(alpha): keep me"
+  fixture_touch_crate libdd-alpha "ci: drop me"
+  fixture_touch_crate libdd-alpha "chore(release): also dropped"
+
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" --exclude='^ci:' "$ALPHA_INPUT"
+  assert_success
+  assert_jq "$output" '.[0].commits | map(.subject) | join("|")' "feat(alpha): keep me"
+}
+
+@test "produces valid JSON for commit subjects with quotes, backslashes and unicode" {
+  # The script assembles JSON by string concatenation; only subject and author are
+  # escaped. A regression here yields a malformed PR body or a hard jq failure
+  # halfway through the release job.
+  local nasty='fix(alpha): handle "quoted" \back\slash and — em dash $(whoami) `tick`'
+  fixture_touch_crate libdd-alpha "$nasty"
+
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  assert_success
+  assert_valid_json "$output"
+  assert_jq "$output" '.[0].commits[0].subject' "$nasty"
+}
+
+@test "dereferences an annotated tag and still finds the commits after it" {
+  # git merge-base does not dereference annotated tag objects consistently across
+  # git versions, so the script resolves TAG^{} explicitly.
+  fixture_touch_crate libdd-beta "feat(beta): released"
+  fixture_tag "libdd-beta-v0.5.0" --annotated
+  fixture_touch_crate libdd-beta "feat(beta): after the tag"
+
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" '[{"name":"libdd-beta","version":"0.5.0"}]'
+  assert_success
+  assert_jq "$output" '.[0].tag_exists' "true"
+  assert_jq "$output" '.[0].tag_ancestor' "true"
+  assert_jq "$output" '.[0].commits | map(.subject) | join("|")' "feat(beta): after the tag"
+}
+
+@test "falls back to the merge-base when the tag is not an ancestor of HEAD" {
+  # Squash-merged release branches leave the tag on history that main never saw.
+  local fork_point
+  fork_point="$(git rev-parse HEAD)"
+  fixture_touch_crate libdd-alpha "feat(alpha): on main after fork"
+
+  git checkout -q -b sidebranch "$fork_point"
+  fixture_touch_crate libdd-alpha "chore: release-only commit"
+  git tag -f "libdd-alpha-v1.2.3" >/dev/null
+  git checkout -q main
+
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  assert_success
+  assert_jq "$output" '.[0].tag_ancestor' "$fork_point"
+  # The commit that only exists on the side branch must not be attributed to main.
+  assert_jq "$output" '.[0].commits | map(.subject) | join("|")' "feat(alpha): on main after fork"
+}
+
+@test "reads the crate list from stdin" {
+  fixture_touch_crate libdd-alpha "feat(alpha): via stdin"
+  run --separate-stderr bash -c "printf '%s' '$ALPHA_INPUT' | '${SCRIPTS_DIR}/commits-since-release.sh'"
+  assert_success
+  assert_jq "$output" '.[0].commits[0].subject' "feat(alpha): via stdin"
+}
+
+@test "handles several crates in one invocation" {
+  fixture_tag "libdd-beta-v0.5.0"
+  fixture_touch_crate libdd-alpha "feat(alpha): a"
+  fixture_touch_crate libdd-beta "feat(beta): b"
+
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" \
+    '[{"name":"libdd-alpha","version":"1.2.3"},{"name":"libdd-beta","version":"0.5.0"}]'
+  assert_success
+  assert_jq "$output" 'length' "2"
+  assert_jq "$output" '.[0].commits[0].subject' "feat(alpha): a"
+  assert_jq "$output" '.[1].commits[0].subject' "feat(beta): b"
+}
+
+@test "rejects invalid JSON input" {
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" 'not json'
+  assert_failure 1
+  assert_stderr_contains "Invalid JSON input"
+}
+
+@test "rejects an unknown option and an unknown format" {
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" --nope "$ALPHA_INPUT"
+  assert_failure 1
+  assert_stderr_contains "Unknown option: --nope"
+
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" --format=yaml "$ALPHA_INPUT"
+  assert_failure 1
+  assert_stderr_contains "Unknown format: yaml"
+}
+
+@test "summary format lists the commits per crate" {
+  fixture_touch_crate libdd-alpha "feat(alpha): summarised"
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" --format=summary "$ALPHA_INPUT"
+  assert_success
+  assert_contains "$output" "libdd-alpha v1.2.3"
+  assert_contains "$output" "feat(alpha): summarised"
+}

--- a/scripts/tests/commits-since-release.bats
+++ b/scripts/tests/commits-since-release.bats
@@ -158,6 +158,105 @@ teardown() {
   assert_jq "$output" '.[0].commits | map(.subject) | join("|")' "feat(alpha): on main after fork"
 }
 
+# --- reachability of the tagged commit -----------------------------------------
+
+@test "reports the tagged commit as reachable from a local branch" {
+  fixture_touch_crate libdd-alpha "feat(alpha): after the tag"
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  assert_success
+  assert_jq "$output" '.[0].tag_in_local_branch' "true"
+  # A JSON boolean, not the string "true": the workflow compares it as one.
+  assert_jq "$output" '.[0].tag_in_local_branch | type' "boolean"
+}
+
+@test "flags a tagged commit that no local branch contains" {
+  # What a squash-merged release leaves behind -- normal, but also what a tag pushed from an
+  # abandoned branch looks like, so the workflow surfaces it.
+  local fork_point
+  fork_point="$(git rev-parse HEAD)"
+  fixture_touch_crate libdd-alpha "feat(alpha): on main"
+
+  git checkout -q -b throwaway "$fork_point"
+  fixture_touch_crate libdd-alpha "chore: release-only commit"
+  git tag -f "libdd-alpha-v1.2.3" >/dev/null
+  git checkout -q main
+  git branch -qD throwaway
+
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  assert_success
+  assert_jq "$output" '.[0].tag_exists' "true"
+  assert_jq "$output" '.[0].tag_in_local_branch' "false"
+}
+
+@test "tag_in_local_branch is false when the crate has no tag" {
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" '[{"name":"libdd-beta","version":"0.5.0"}]'
+  assert_success
+  assert_jq "$output" '.[0].tag_exists' "false"
+  assert_jq "$output" '.[0].tag_in_local_branch' "false"
+}
+
+# --- the latest release tag ---------------------------------------------------
+#
+# `latest_tag` is the highest tag that exists for the crate, which is not necessarily the
+# tag matching the manifest version. release-proposal-dispatch.yml compares the two and
+# skips the crate when they differ -- main already holds a newer release -- unless the run
+# is a hotfix or a bypass. Getting it wrong either skips a crate that should ship or
+# re-releases a version that already went out.
+
+@test "reports the highest release tag for the crate" {
+  fixture_tag "libdd-alpha-v1.9.0"
+  fixture_tag "libdd-alpha-v1.10.0"
+
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  assert_success
+  # Version sort, not lexicographic: plain string ordering puts v1.9.0 above v1.10.0.
+  assert_jq "$output" '.[0].latest_tag' "libdd-alpha-v1.10.0"
+}
+
+@test "latest_tag differs from tag when the manifest version lags behind the tags" {
+  # This is the state the skip rule exists for: a release for this crate was already cut
+  # somewhere else, so the proposal must not re-release the older version.
+  fixture_tag "libdd-alpha-v2.0.0"
+
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  assert_success
+  assert_jq "$output" '.[0].tag' "libdd-alpha-v1.2.3"
+  assert_jq "$output" '.[0].latest_tag' "libdd-alpha-v2.0.0"
+}
+
+@test "latest_tag equals tag when the crate is at its most recent release" {
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  assert_success
+  assert_jq "$output" '.[0].latest_tag' "libdd-alpha-v1.2.3"
+  assert_jq "$output" '.[0].tag' "libdd-alpha-v1.2.3"
+}
+
+@test "latest_tag is empty for a crate that was never released" {
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" '[{"name":"libdd-beta","version":"0.5.0"}]'
+  assert_success
+  assert_jq "$output" '.[0].tag_exists' "false"
+  assert_jq "$output" '.[0].latest_tag' ""
+}
+
+@test "latest_tag is reported even when the crate's own tag does not exist" {
+  # Manifest bumped without a release: no libdd-beta-v0.5.0 tag, but older ones exist.
+  fixture_tag "libdd-beta-v0.4.0"
+
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" '[{"name":"libdd-beta","version":"0.5.0"}]'
+  assert_success
+  assert_jq "$output" '.[0].tag_exists' "false"
+  assert_jq "$output" '.[0].latest_tag' "libdd-beta-v0.4.0"
+}
+
+@test "latest_tag does not pick up tags belonging to a longer-named sibling crate" {
+  # libdd-alpha and libdd-alpha-ffi share a prefix; the "-v" in the glob keeps them apart.
+  fixture_tag "libdd-alpha-ffi-v9.9.9"
+
+  run --separate-stderr "${SCRIPTS_DIR}/commits-since-release.sh" "$ALPHA_INPUT"
+  assert_success
+  assert_jq "$output" '.[0].latest_tag' "libdd-alpha-v1.2.3"
+}
+
 # --- the exported range ------------------------------------------------------
 #
 # `range` is the commit span the listed commits came from, resolved to SHAs.

--- a/scripts/tests/helpers/cargo-stub/cargo
+++ b/scripts/tests/helpers/cargo-stub/cargo
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+
+# A `cargo` shim placed first on PATH by the semver-level.bats suite.
+#
+# `cargo semver-checks` and `cargo public-api` need a full build of two revisions of a
+# real crate — minutes per invocation, and the very tools whose OUTPUT PARSING is what
+# semver-level.sh gets wrong when it regresses. The shim replays recorded output for
+# those two subcommands and forwards everything else to the real cargo, so the script
+# under test runs unmodified.
+#
+#   STUB_SEMVER_CHECKS_OUT / STUB_SEMVER_CHECKS_RC   canned `cargo semver-checks` result
+#   STUB_PUBLIC_API_OUT    / STUB_PUBLIC_API_RC      canned `cargo public-api` result
+#   STUB_CALL_LOG                                    file receiving one line per call
+#   STUB_REAL_CARGO                                  path to the real cargo binary
+
+set -uo pipefail
+
+if [[ -n "${STUB_CALL_LOG:-}" ]]; then
+  printf '%s\n' "$*" >> "$STUB_CALL_LOG"
+fi
+
+case "${1:-}" in
+  semver-checks)
+    [[ -n "${STUB_SEMVER_CHECKS_OUT:-}" ]] && cat "$STUB_SEMVER_CHECKS_OUT"
+    exit "${STUB_SEMVER_CHECKS_RC:-0}"
+    ;;
+  public-api)
+    [[ -n "${STUB_PUBLIC_API_OUT:-}" ]] && cat "$STUB_PUBLIC_API_OUT"
+    exit "${STUB_PUBLIC_API_RC:-0}"
+    ;;
+esac
+
+exec "${STUB_REAL_CARGO:?STUB_REAL_CARGO is not set}" "$@"

--- a/scripts/tests/helpers/common.bash
+++ b/scripts/tests/helpers/common.bash
@@ -103,6 +103,19 @@ assert_jq() {
   fi
 }
 
+# --- test doubles -----------------------------------------------------------
+
+# use_failing_stream_jq — put a jq on PATH that fails the `jq -c '.[]' FILE` call the
+# release scripts read their rows from, and forwards everything else to the real jq.
+# Call it immediately before the `run` under test: assertions that shell out to jq
+# themselves keep working, since only that one argument shape is intercepted.
+use_failing_stream_jq() {
+  STUB_REAL_JQ="$(command -v jq)"
+  export STUB_REAL_JQ
+  PATH="${TESTS_DIR}/helpers/jq-stub:${PATH}"
+  export PATH
+}
+
 # Fail unless the string is parseable JSON. Guards the scripts that build JSON by
 # string concatenation, where an unescaped commit subject can produce garbage.
 assert_valid_json() {

--- a/scripts/tests/helpers/common.bash
+++ b/scripts/tests/helpers/common.bash
@@ -36,6 +36,52 @@ teardown_common() {
   fi
 }
 
+# --- the implementation under test ------------------------------------------
+#
+# Suites never name a script directly. They go through `run_tool NAME` (or `tool NAME`
+# for setup steps whose output they need), so the whole suite can be pointed at a
+# different implementation without touching a single assertion:
+#
+#   RELEASE_TOOL_CMD='target/release/release-tool {name}' ./scripts/tests/run.sh
+#   RELEASE_TOOL_CMD='node dist/{name}.js'                ./scripts/tests/run.sh
+#
+# {name} is the script's base name -- "publication-order", "release-version-bumps" and
+# so on. The template is split on whitespace, so it can carry a subcommand or flags.
+# Unset, it resolves to the shell scripts in scripts/.
+#
+# Sets RELEASE_TOOL_ARGV rather than echoing, so arguments containing spaces survive.
+release_tool_argv() {
+  local name="$1" word
+  RELEASE_TOOL_ARGV=()
+  if [[ -n "${RELEASE_TOOL_CMD:-}" ]]; then
+    # shellcheck disable=SC2206  # deliberate word splitting: the template is a command
+    local words=(${RELEASE_TOOL_CMD})
+    for word in "${words[@]}"; do
+      RELEASE_TOOL_ARGV+=("${word//\{name\}/$name}")
+    done
+  else
+    RELEASE_TOOL_ARGV=("${SCRIPTS_DIR}/${name}.sh")
+  fi
+}
+
+# run_tool NAME ARGS... — run the implementation under bats' `run`, with stdout and
+# stderr captured separately so $output stays parseable JSON.
+run_tool() {
+  local name="$1"
+  shift
+  release_tool_argv "$name"
+  run --separate-stderr "${RELEASE_TOOL_ARGV[@]}" "$@"
+}
+
+# tool NAME ARGS... — invoke the implementation directly, for setup steps that need its
+# output rather than assertions about it.
+tool() {
+  local name="$1"
+  shift
+  release_tool_argv "$name"
+  "${RELEASE_TOOL_ARGV[@]}" "$@"
+}
+
 # --- assertions -------------------------------------------------------------
 #
 # bats-assert is deliberately not vendored: these few helpers keep the suite to a
@@ -67,8 +113,26 @@ assert_failure() {
 
 # Assert on the diagnostics a script writes to stderr. Tests use
 # `run --separate-stderr`, so $output holds stdout only.
+#
+# Reserve this for text the test itself controls -- a stub's output being forwarded,
+# say. For a script's own diagnostics prefer assert_stderr_mentions: pinning our exact
+# prose makes every reworded message a test failure, and would force a reimplementation
+# to reproduce the wording rather than the behaviour.
 assert_stderr_contains() {
   assert_contains "${stderr:-}" "$1"
+}
+
+# assert_stderr_mentions [TOKEN...] — the script reported something, and named the
+# thing it was reporting about. Tokens should be data the caller passed in (a crate
+# name, a path, an option, a version), not a phrase from the message.
+assert_stderr_mentions() {
+  local token
+  if [[ -z "${stderr:-}" ]]; then
+    fail_with "expected a diagnostic on stderr, got nothing" "--- stdout ---" "${output:-}"
+  fi
+  for token in "$@"; do
+    assert_contains "${stderr}" "$token"
+  done
 }
 
 assert_eq() {

--- a/scripts/tests/helpers/common.bash
+++ b/scripts/tests/helpers/common.bash
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+# Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+
+# Shared assertions and paths for the scripts/tests bats suites.
+# Loaded from every .bats file via `load helpers/common`.
+
+# $status, $output and $stderr are set by bats' own `run`, not by this file.
+# shellcheck disable=SC2154
+
+# `run --separate-stderr` (used throughout so that $output stays parseable JSON even
+# when a script logs progress to stderr) requires bats 1.5.0 or newer.
+bats_require_minimum_version 1.5.0
+
+# Absolute path to scripts/ (the directory under test) and to scripts/tests/.
+TESTS_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd)"
+export TESTS_DIR
+SCRIPTS_DIR="$(cd -- "${TESTS_DIR}/.." >/dev/null 2>&1 && pwd)"
+export SCRIPTS_DIR
+REPO_ROOT="$(cd -- "${SCRIPTS_DIR}/.." >/dev/null 2>&1 && pwd)"
+export REPO_ROOT
+
+# Per-test scratch directory, removed by teardown_common.
+setup_common() {
+  TEST_TMP="$(mktemp -d "${BATS_TMPDIR:-/tmp}/libdd-scripts-test.XXXXXX")"
+  export TEST_TMP
+}
+
+teardown_common() {
+  if [[ -n "${TEST_TMP:-}" && -d "$TEST_TMP" ]]; then
+    # Fixture repos may contain git worktrees registered elsewhere; plain rm is enough
+    # because every worktree lives inside TEST_TMP too.
+    chmod -R u+w "$TEST_TMP" 2>/dev/null || true
+    rm -rf "$TEST_TMP"
+  fi
+}
+
+# --- assertions -------------------------------------------------------------
+#
+# bats-assert is deliberately not vendored: these few helpers keep the suite to a
+# single dependency (bats-core itself).
+
+fail_with() {
+  printf '%s\n' "$@" >&2
+  return 1
+}
+
+assert_success() {
+  if [[ "$status" -ne 0 ]]; then
+    fail_with "expected success, got exit status $status" \
+      "--- stdout ---" "$output" "--- stderr ---" "${stderr:-}"
+  fi
+}
+
+assert_failure() {
+  local expected="${1:-}"
+  if [[ "$status" -eq 0 ]]; then
+    fail_with "expected failure, got exit status 0" \
+      "--- stdout ---" "$output" "--- stderr ---" "${stderr:-}"
+  fi
+  if [[ -n "$expected" && "$status" -ne "$expected" ]]; then
+    fail_with "expected exit status $expected, got $status" \
+      "--- stdout ---" "$output" "--- stderr ---" "${stderr:-}"
+  fi
+}
+
+# Assert on the diagnostics a script writes to stderr. Tests use
+# `run --separate-stderr`, so $output holds stdout only.
+assert_stderr_contains() {
+  assert_contains "${stderr:-}" "$1"
+}
+
+assert_eq() {
+  local actual="$1" expected="$2"
+  if [[ "$actual" != "$expected" ]]; then
+    fail_with "values differ" "--- expected ---" "$expected" "--- actual ---" "$actual"
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    fail_with "expected to find: $needle" "--- in ---" "$haystack"
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    fail_with "expected NOT to find: $needle" "--- in ---" "$haystack"
+  fi
+}
+
+# assert_jq JSON FILTER EXPECTED — run `jq -r FILTER` over JSON and compare.
+assert_jq() {
+  local json="$1" filter="$2" expected="$3" actual
+  if ! actual="$(jq -r "$filter" <<< "$json" 2>&1)"; then
+    fail_with "jq failed for filter: $filter" "--- error ---" "$actual" "--- json ---" "$json"
+  fi
+  if [[ "$actual" != "$expected" ]]; then
+    fail_with "jq filter: $filter" "--- expected ---" "$expected" "--- actual ---" "$actual" "--- json ---" "$json"
+  fi
+}
+
+# Fail unless the string is parseable JSON. Guards the scripts that build JSON by
+# string concatenation, where an unescaped commit subject can produce garbage.
+assert_valid_json() {
+  local json="$1" err
+  if ! err="$(jq empty <<< "$json" 2>&1)"; then
+    fail_with "not valid JSON: $err" "--- value ---" "$json"
+  fi
+}

--- a/scripts/tests/helpers/fixture.bash
+++ b/scripts/tests/helpers/fixture.bash
@@ -133,10 +133,73 @@ fixture_touch_crate() {
   fixture_commit_all "$message" "$author" "$email"
 }
 
-# fixture_set_dep_req CRATE DEP REQ — rewrite a dependency's version requirement.
+# fixture_set_dep_req CRATE DEP REQ — rewrite a dependency's version requirement. DEP is
+# the key as written in the manifest, which for an aliased dependency is the alias.
 fixture_set_dep_req() {
   local crate="$1" dep="$2" req="$3"
-  sed -i -E "s|^(${dep} = \{ path = \"[^\"]*\", version = )\"[^\"]*\"|\1\"${req}\"|" \
+  sed -i -E "s|^(${dep} = \{ (package = \"[^\"]*\", )?path = \"[^\"]*\", version = )\"[^\"]*\"|\1\"${req}\"|" \
+    "${FIXTURE_REPO}/${crate}/Cargo.toml"
+}
+
+# fixture_alias_dep CRATE DEP ALIAS — re-declare CRATE's dependency on DEP under the local
+# name ALIAS, via `package = "DEP"`. cargo metadata then reports DEP in .name and ALIAS in
+# .rename, which is the only thing separating two aliases of one package.
+fixture_alias_dep() {
+  local crate="$1" dep="$2" alias="$3"
+  sed -i -E "s|^${dep} = \{ path = (\"[^\"]*\"), version = (\"[^\"]*\") \}|${alias} = { package = \"${dep}\", path = \1, version = \2 }|" \
+    "${FIXTURE_REPO}/${crate}/Cargo.toml"
+}
+
+# fixture_publish_tag TAG — tag HEAD and push it to origin. semver-level.sh runs
+# `git fetch origin <baseline>` before resolving a baseline, so a tag created after
+# fixture_add_origin has to be published for it to be usable as one.
+fixture_publish_tag() {
+  fixture_tag "$1"
+  git push -q origin "refs/tags/$1"
+}
+
+# fixture_set_features CRATE ENTRY... — replace CRATE's [features] table with ENTRYs,
+# each a raw TOML line: fixture_set_features libdd-beta 'default = ["std"]' 'std = []'
+#
+# Only this helper ever writes a [features] table and it always appends, so the table
+# is last in the manifest and deleting to end-of-file is a safe way to replace it.
+fixture_set_features() {
+  local crate="$1"
+  shift
+  local manifest="${FIXTURE_REPO}/${crate}/Cargo.toml"
+  sed -i '/^\[features\]$/,$d' "$manifest"
+  {
+    printf '\n[features]\n'
+    printf '%s\n' "$@"
+  } >> "$manifest"
+}
+
+# fixture_set_dep_optional CRATE DEP — mark CRATE's dependency on DEP optional. Cargo
+# then derives an implicit feature of the same name, which is part of the package's
+# feature surface while appearing nowhere in its [features] table.
+fixture_set_dep_optional() {
+  local crate="$1" dep="$2"
+  sed -i -E "s|^(${dep} = \{ path = \"[^\"]*\", version = \"[^\"]*\")( \})|\1, optional = true\2|" \
+    "${FIXTURE_REPO}/${crate}/Cargo.toml"
+}
+
+# fixture_use_workspace_dep CRATE DEP REQ — move CRATE's dependency on DEP into
+# [workspace.dependencies] at REQ, leaving the crate manifest carrying only
+# `{ workspace = true }`.
+#
+# Reproduces the shape of a "migrate deps to workspace level" refactor: the crate's own
+# manifest diff no longer mentions a version at all, so anything reading Cargo.toml
+# directly sees no version change while the resolved requirement has moved.
+#
+# Appends the table, so call it at most once per fixture.
+fixture_use_workspace_dep() {
+  local crate="$1" dep="$2" req="$3"
+  cat >> "${FIXTURE_REPO}/Cargo.toml" <<EOF
+
+[workspace.dependencies]
+${dep} = { path = "${dep}", version = "${req}" }
+EOF
+  sed -i -E "s|^(${dep}) = \{ path = \"[^\"]*\", version = \"[^\"]*\" \}|\1 = { workspace = true }|" \
     "${FIXTURE_REPO}/${crate}/Cargo.toml"
 }
 

--- a/scripts/tests/helpers/fixture.bash
+++ b/scripts/tests/helpers/fixture.bash
@@ -133,12 +133,6 @@ fixture_touch_crate() {
   fixture_commit_all "$message" "$author" "$email"
 }
 
-# fixture_set_version CRATE VERSION — rewrite the [package] version in place.
-fixture_set_version() {
-  local crate="$1" version="$2"
-  sed -i -E "0,/^version = \".*\"$/s//version = \"${version}\"/" "${FIXTURE_REPO}/${crate}/Cargo.toml"
-}
-
 # fixture_set_dep_req CRATE DEP REQ — rewrite a dependency's version requirement.
 fixture_set_dep_req() {
   local crate="$1" dep="$2" req="$3"

--- a/scripts/tests/helpers/fixture.bash
+++ b/scripts/tests/helpers/fixture.bash
@@ -150,6 +150,19 @@ fixture_tag() {
   fi
 }
 
+# fixture_add_cliff_config — copy the repository's real cliff.toml into the fixture, so
+# git-cliff renders with the same template the release actually uses.
+fixture_add_cliff_config() {
+  cp "${REPO_ROOT}/cliff.toml" "${FIXTURE_REPO}/cliff.toml"
+  fixture_commit_all "chore: add cliff.toml"
+}
+
+# fixture_commits_json RANGE [-- PATH...] — the commit list shape that
+# commits-since-release.sh produces, for handing to a script under test.
+fixture_commits_json() {
+  git log --format='{"hash":"%H","subject":"%s","author":"%an","date":"%aI"}' "$@" | jq -s '.'
+}
+
 # fixture_add_origin — publish the fixture to a bare repo and wire it as `origin`,
 # for scripts that run `git fetch origin` or resolve `origin/<branch>`.
 fixture_add_origin() {

--- a/scripts/tests/helpers/fixture.bash
+++ b/scripts/tests/helpers/fixture.bash
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+
+# Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+
+# Builds a synthetic cargo workspace inside a throwaway git repository so the
+# release scripts can be exercised against real `cargo metadata` output and real
+# git history, without touching the libdatadog checkout.
+#
+# The fixture is intentionally small but covers the shapes the release scripts
+# have to reason about:
+#
+#   libdd-alpha    1.2.3   no workspace deps; dev-depends on libdd-gamma
+#                          (a dev-dependency CYCLE — publication order must ignore it)
+#   libdd-beta     0.5.0   depends on libdd-alpha
+#   libdd-gamma    2.0.1   depends on libdd-alpha and libdd-beta
+#   libdd-delta    0.1.0   build-depends on libdd-beta, dev-depends on libdd-alpha
+#                          (kind filters: build counts for publication order, dev never does;
+#                           major-bumps-level.sh must ignore both)
+#   libdd-private  0.9.0   publish = false (must be excluded unless asked for)
+#   other-tool     0.3.0   depends on libdd-alpha but is not libdd-* itself
+#                          (major-bumps-level.sh only tracks libdd-* dependencies)
+
+# Offline everywhere: the fixture has path dependencies only, so cargo never needs
+# the network, and an accidental registry hit would make the suite flaky.
+export CARGO_NET_OFFLINE=true
+
+# fixture_init [DIR] — create the workspace and an initial commit. Leaves the shell
+# in the repository root and exports FIXTURE_REPO.
+fixture_init() {
+  FIXTURE_REPO="${1:-${TEST_TMP}/workspace}"
+  export FIXTURE_REPO
+  mkdir -p "$FIXTURE_REPO"
+
+  cat > "${FIXTURE_REPO}/Cargo.toml" <<'EOF'
+[workspace]
+resolver = "2"
+members = [
+    "libdd-alpha",
+    "libdd-beta",
+    "libdd-gamma",
+    "libdd-delta",
+    "libdd-private",
+    "other-tool",
+]
+EOF
+
+  _fixture_crate libdd-alpha 1.2.3
+  cat >> "${FIXTURE_REPO}/libdd-alpha/Cargo.toml" <<'EOF'
+
+[dev-dependencies]
+libdd-gamma = { path = "../libdd-gamma", version = "2.0" }
+EOF
+
+  _fixture_crate libdd-beta 0.5.0
+  cat >> "${FIXTURE_REPO}/libdd-beta/Cargo.toml" <<'EOF'
+
+[dependencies]
+libdd-alpha = { path = "../libdd-alpha", version = "1.2" }
+EOF
+
+  _fixture_crate libdd-gamma 2.0.1
+  cat >> "${FIXTURE_REPO}/libdd-gamma/Cargo.toml" <<'EOF'
+
+[dependencies]
+libdd-alpha = { path = "../libdd-alpha", version = "1.2" }
+libdd-beta = { path = "../libdd-beta", version = "0.5" }
+EOF
+
+  _fixture_crate libdd-delta 0.1.0
+  cat >> "${FIXTURE_REPO}/libdd-delta/Cargo.toml" <<'EOF'
+
+[build-dependencies]
+libdd-beta = { path = "../libdd-beta", version = "0.5" }
+
+[dev-dependencies]
+libdd-alpha = { path = "../libdd-alpha", version = "1.2" }
+EOF
+  # A build script is not needed for cargo metadata, but keep the manifest honest.
+  printf 'fn main() {}\n' > "${FIXTURE_REPO}/libdd-delta/build.rs"
+
+  _fixture_crate libdd-private 0.9.0 'publish = false'
+  cat >> "${FIXTURE_REPO}/libdd-private/Cargo.toml" <<'EOF'
+
+[dependencies]
+libdd-alpha = { path = "../libdd-alpha", version = "1.2" }
+EOF
+
+  _fixture_crate other-tool 0.3.0
+  cat >> "${FIXTURE_REPO}/other-tool/Cargo.toml" <<'EOF'
+
+[dependencies]
+libdd-alpha = { path = "../libdd-alpha", version = "1.2" }
+EOF
+
+  cd "$FIXTURE_REPO" || return 1
+  git init -q -b main .
+  git config user.name "Fixture Author"
+  git config user.email "fixture@example.com"
+  git config commit.gpgsign false
+  git config tag.gpgsign false
+  fixture_commit_all "chore: initial workspace"
+}
+
+_fixture_crate() {
+  local name="$1" version="$2" extra="${3:-}"
+  mkdir -p "${FIXTURE_REPO}/${name}/src"
+  {
+    printf '[package]\n'
+    printf 'name = "%s"\n' "$name"
+    printf 'version = "%s"\n' "$version"
+    printf 'edition = "2021"\n'
+    [[ -n "$extra" ]] && printf '%s\n' "$extra"
+  } > "${FIXTURE_REPO}/${name}/Cargo.toml"
+  printf '// %s\n' "$name" > "${FIXTURE_REPO}/${name}/src/lib.rs"
+}
+
+# fixture_commit_all MESSAGE [AUTHOR_NAME] [AUTHOR_EMAIL]
+fixture_commit_all() {
+  local message="$1" author="${2:-Fixture Author}" email="${3:-fixture@example.com}"
+  git add -A
+  GIT_AUTHOR_NAME="$author" GIT_AUTHOR_EMAIL="$email" \
+    GIT_COMMITTER_NAME="Fixture Author" GIT_COMMITTER_EMAIL="fixture@example.com" \
+    git commit -q --allow-empty -m "$message"
+}
+
+# fixture_touch_crate CRATE MESSAGE [AUTHOR_NAME] [AUTHOR_EMAIL]
+# Make a commit that changes only CRATE's directory, so path-filtered git log
+# picks it up for that crate and no other.
+fixture_touch_crate() {
+  local crate="$1" message="$2" author="${3:-Fixture Author}" email="${4:-fixture@example.com}"
+  printf '// %s\n' "$message" >> "${FIXTURE_REPO}/${crate}/src/lib.rs"
+  fixture_commit_all "$message" "$author" "$email"
+}
+
+# fixture_set_version CRATE VERSION — rewrite the [package] version in place.
+fixture_set_version() {
+  local crate="$1" version="$2"
+  sed -i -E "0,/^version = \".*\"$/s//version = \"${version}\"/" "${FIXTURE_REPO}/${crate}/Cargo.toml"
+}
+
+# fixture_set_dep_req CRATE DEP REQ — rewrite a dependency's version requirement.
+fixture_set_dep_req() {
+  local crate="$1" dep="$2" req="$3"
+  sed -i -E "s|^(${dep} = \{ path = \"[^\"]*\", version = )\"[^\"]*\"|\1\"${req}\"|" \
+    "${FIXTURE_REPO}/${crate}/Cargo.toml"
+}
+
+# fixture_tag TAG [--annotated] — tag HEAD.
+fixture_tag() {
+  local tag="$1" kind="${2:-}"
+  if [[ "$kind" == "--annotated" ]]; then
+    git tag -a "$tag" -m "release $tag"
+  else
+    git tag "$tag"
+  fi
+}
+
+# fixture_add_origin — publish the fixture to a bare repo and wire it as `origin`,
+# for scripts that run `git fetch origin` or resolve `origin/<branch>`.
+fixture_add_origin() {
+  local bare="${TEST_TMP}/origin.git"
+  git init -q --bare "$bare"
+  git remote add origin "$bare"
+  git push -q origin main --tags
+  git fetch -q origin
+}
+
+# --- topological-order assertion --------------------------------------------
+
+# assert_topological_order ORDER_LINES DEPS_SPEC
+# ORDER_LINES: newline-separated crate names, in claimed publication order.
+# DEPS_SPEC:   newline-separated "crate:dep1,dep2" entries.
+#
+# Asserting the exact list would pin Kahn's tie-breaking, which is an
+# implementation detail. Assert the property the workflow actually relies on:
+# every crate is published after all of its workspace dependencies.
+assert_topological_order() {
+  local order="$1" deps_spec="$2"
+  local -a seen=()
+  local line crate dep spec_crate spec_deps found
+
+  while IFS= read -r crate; do
+    [[ -z "$crate" ]] && continue
+    while IFS= read -r line; do
+      [[ -z "$line" ]] && continue
+      spec_crate="${line%%:*}"
+      [[ "$spec_crate" != "$crate" ]] && continue
+      spec_deps="${line#*:}"
+      while IFS= read -r dep; do
+        [[ -z "$dep" ]] && continue
+        found=false
+        for s in "${seen[@]:-}"; do
+          [[ "$s" == "$dep" ]] && found=true && break
+        done
+        if [[ "$found" != true ]]; then
+          fail_with "publication order violated: '$crate' is listed before its dependency '$dep'" \
+            "--- order ---" "$order"
+          return 1
+        fi
+      done < <(tr ',' '\n' <<< "$spec_deps")
+    done <<< "$deps_spec"
+    seen+=("$crate")
+  done <<< "$order"
+}

--- a/scripts/tests/helpers/jq-stub/jq
+++ b/scripts/tests/helpers/jq-stub/jq
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+
+# A `jq` shim that fails only the streaming row read -- `jq -c '.[]' FILE` -- and
+# forwards every other invocation to the real jq.
+#
+# The release scripts loop over their input with that one call. It used to be wired up
+# as `done < <(jq -c '.[]' FILE)`, and a process substitution's exit status is reported
+# by nothing: neither set -e nor pipefail sees it. A jq that died mid-stream left the
+# loop with no input and the script exited 0 having done nothing at all. This shim makes
+# that failure reproducible so the loops can be held to surfacing it.
+#
+#   STUB_JQ_STREAM_RC  exit code for the streaming call (default 5)
+#   STUB_REAL_JQ       path to the real jq
+
+set -uo pipefail
+
+if [ "${1:-}" = "-c" ] && [ "${2:-}" = ".[]" ]; then
+  echo "jq: simulated failure on the streaming read" >&2
+  exit "${STUB_JQ_STREAM_RC:-5}"
+fi
+
+exec "${STUB_REAL_JQ:?STUB_REAL_JQ is not set}" "$@"

--- a/scripts/tests/helpers/workflow-to-json.py
+++ b/scripts/tests/helpers/workflow-to-json.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+# Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+
+"""Print a GitHub Actions workflow as JSON so bats tests can assert on it with jq.
+
+Only a YAML-to-JSON transcription; no interpretation of the workflow itself.
+"""
+
+import json
+import sys
+
+import yaml
+
+
+def normalize(node):
+    """Undo YAML 1.1 boolean keys.
+
+    `on:` — the trigger block every workflow has — is parsed as the boolean True by
+    PyYAML, and so are `off:`/`yes:`/`no:`. Map those keys back to the words that
+    were written in the file so queries can use them.
+    """
+    if isinstance(node, dict):
+        out = {}
+        for key, value in node.items():
+            if key is True:
+                key = "on"
+            elif key is False:
+                key = "off"
+            elif not isinstance(key, str):
+                key = str(key)
+            out[key] = normalize(value)
+        return out
+    if isinstance(node, list):
+        return [normalize(item) for item in node]
+    return node
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} WORKFLOW_YAML", file=sys.stderr)
+        return 2
+    with open(sys.argv[1], encoding="utf-8") as handle:
+        json.dump(normalize(yaml.safe_load(handle)), sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/major-bumps-level.bats
+++ b/scripts/tests/major-bumps-level.bats
@@ -1,0 +1,220 @@
+#!/usr/bin/env bats
+
+# Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+
+# major-bumps-level.sh answers: "did a direct libdd-* dependency of this crate go to a
+# new major version since its last release?" In release-proposal-dispatch.yml a
+# non-empty `major_bumps` forces the crate to a major bump, and pulls crates with no
+# commits of their own back into the release. A false positive ships an unnecessary
+# major; a false negative ships a crate whose dependency broke underneath it.
+
+load helpers/common
+load helpers/fixture
+
+# Build an api-changes.json row the way the workflow does.
+row() {
+  local name="$1" prev_tag="$2" level="${3:-patch}" initial="${4:-false}"
+  jq -nc --arg name "$name" --arg prev_tag "$prev_tag" --arg level "$level" \
+    --arg initial "$initial" \
+    '{name: $name, level: $level, tag: "", prev_tag: $prev_tag, version: "0.0.0",
+      range: "", commits: [], path: $name, initial_release: $initial}'
+}
+
+# Write rows to a file and run the script against it.
+run_major_bumps() {
+  printf '%s\n' "$@" | jq -s '.' > "${TEST_TMP}/api-changes.json"
+  run --separate-stderr "${SCRIPTS_DIR}/major-bumps-level.sh" "${TEST_TMP}/api-changes.json"
+}
+
+setup() {
+  setup_common
+  fixture_init
+  fixture_tag "libdd-beta-v0.5.0"
+  fixture_tag "libdd-gamma-v2.0.1"
+  fixture_tag "libdd-delta-v0.1.0"
+  fixture_tag "other-tool-v0.3.0"
+}
+
+teardown() {
+  teardown_common
+}
+
+@test "records a direct libdd-* dependency that moved to a new major" {
+  fixture_set_dep_req libdd-beta libdd-alpha "2.0"
+  run_major_bumps "$(row libdd-beta libdd-beta-v0.5.0)"
+  assert_success
+  assert_jq "$output" '.[0].major_bumps | length' "1"
+  assert_jq "$output" '.[0].major_bumps[0].dependency' "libdd-alpha"
+  assert_jq "$output" '.[0].major_bumps[0].previous_req' "^1.2"
+  assert_jq "$output" '.[0].major_bumps[0].current_req' "^2.0"
+}
+
+@test "ignores a minor bump of a direct dependency" {
+  fixture_set_dep_req libdd-beta libdd-alpha "1.3"
+  run_major_bumps "$(row libdd-beta libdd-beta-v0.5.0)"
+  assert_success
+  assert_jq "$output" '.[0].major_bumps' "[]"
+}
+
+@test "ignores an unchanged dependency" {
+  run_major_bumps "$(row libdd-beta libdd-beta-v0.5.0)"
+  assert_success
+  assert_jq "$output" '.[0].major_bumps' "[]"
+}
+
+@test "known limitation: a 0.x to 0.y bump is not treated as major" {
+  # `first_num` compares only the leading integer of the requirement, so 0.5 -> 0.6
+  # scores 0 vs 0. Under cargo's semver rules that IS a breaking change for a 0.x
+  # dependency. This test pins the current behaviour so a change to it is deliberate.
+  fixture_set_dep_req libdd-gamma libdd-beta "0.6"
+  run_major_bumps "$(row libdd-gamma libdd-gamma-v2.0.1)"
+  assert_success
+  assert_jq "$output" '.[0].major_bumps' "[]"
+}
+
+@test "ignores dependencies that are not libdd-*" {
+  cat >> "${FIXTURE_REPO}/libdd-beta/Cargo.toml" <<'EOF'
+other-tool = { path = "../other-tool", version = "0.3" }
+EOF
+  fixture_commit_all "chore: add a non-libdd dependency"
+  git tag -f "libdd-beta-v0.5.0" >/dev/null
+
+  fixture_set_dep_req libdd-beta other-tool "1.0"
+  run_major_bumps "$(row libdd-beta libdd-beta-v0.5.0)"
+  assert_success
+  assert_jq "$output" '.[0].major_bumps' "[]"
+}
+
+@test "ignores dev-dependency and build-dependency major bumps" {
+  # libdd-delta build-depends on libdd-beta and dev-depends on libdd-alpha. Neither
+  # affects what a consumer of libdd-delta links against, so neither forces a major.
+  fixture_set_dep_req libdd-delta libdd-beta "1.0"
+  fixture_set_dep_req libdd-delta libdd-alpha "9.0"
+  run_major_bumps "$(row libdd-delta libdd-delta-v0.1.0)"
+  assert_success
+  assert_jq "$output" '.[0].major_bumps' "[]"
+}
+
+@test "prefers a concrete requirement over a wildcard when a dependency appears twice" {
+  # A target-specific edge duplicates the dependency with req "*"; taking the wildcard
+  # would make every comparison unparseable and hide real bumps.
+  cat >> "${FIXTURE_REPO}/libdd-beta/Cargo.toml" <<'EOF'
+
+[target.'cfg(unix)'.dependencies]
+libdd-alpha = { path = "../libdd-alpha" }
+EOF
+  fixture_commit_all "chore: add a target-specific duplicate dependency"
+  git tag -f "libdd-beta-v0.5.0" >/dev/null
+
+  fixture_set_dep_req libdd-beta libdd-alpha "3.0"
+  run_major_bumps "$(row libdd-beta libdd-beta-v0.5.0)"
+  assert_success
+  assert_jq "$output" '.[0].major_bumps | length' "1"
+  assert_jq "$output" '.[0].major_bumps[0].previous_req' "^1.2"
+  assert_jq "$output" '.[0].major_bumps[0].current_req' "^3.0"
+}
+
+@test "ignores a dependency that did not exist at the previous tag" {
+  cat >> "${FIXTURE_REPO}/other-tool/Cargo.toml" <<'EOF'
+libdd-beta = { path = "../libdd-beta", version = "0.5" }
+EOF
+  run_major_bumps "$(row other-tool other-tool-v0.3.0)"
+  assert_success
+  assert_jq "$output" '.[0].major_bumps' "[]"
+}
+
+@test "ignores a dependency that was removed since the previous tag" {
+  sed -i '/^libdd-alpha = /d' "${FIXTURE_REPO}/libdd-beta/Cargo.toml"
+  run_major_bumps "$(row libdd-beta libdd-beta-v0.5.0)"
+  assert_success
+  assert_jq "$output" '.[0].major_bumps' "[]"
+}
+
+@test "skips crates flagged as an initial release" {
+  # There is no previous tag to diff against; the crate is new.
+  fixture_set_dep_req libdd-beta libdd-alpha "2.0"
+  run_major_bumps "$(row libdd-beta "" patch true)"
+  assert_success
+  assert_jq "$output" '.[0].major_bumps' "[]"
+}
+
+@test "skips crates with an empty or null prev_tag" {
+  fixture_set_dep_req libdd-beta libdd-alpha "2.0"
+  run_major_bumps "$(row libdd-beta "")"
+  assert_success
+  assert_jq "$output" '.[0].major_bumps' "[]"
+
+  run_major_bumps "$(row libdd-beta "null")"
+  assert_success
+  assert_jq "$output" '.[0].major_bumps' "[]"
+}
+
+@test "passes the original row through unchanged apart from major_bumps" {
+  # The workflow re-reads level, prev_tag, version, path and commits from this output.
+  fixture_set_dep_req libdd-beta libdd-alpha "2.0"
+  run_major_bumps "$(row libdd-beta libdd-beta-v0.5.0 minor)"
+  assert_success
+  assert_jq "$output" '.[0].level' "minor"
+  assert_jq "$output" '.[0].prev_tag' "libdd-beta-v0.5.0"
+  assert_jq "$output" '.[0].path' "libdd-beta"
+  assert_jq "$output" '.[0].initial_release' "false"
+  assert_jq "$output" '.[0] | has("major_bumps")' "true"
+}
+
+@test "preserves extra fields such as pending_release" {
+  # The workflow tags no-commit candidates with pending_release and relies on the
+  # flag surviving the audit to decide whether to keep them out of the release.
+  local pending
+  pending="$(row libdd-beta libdd-beta-v0.5.0 none | jq -c '. + {pending_release: "true"}')"
+  run_major_bumps "$pending"
+  assert_success
+  assert_jq "$output" '.[0].pending_release' "true"
+}
+
+@test "handles several crates and reports each independently" {
+  fixture_set_dep_req libdd-beta libdd-alpha "2.0"
+  run_major_bumps "$(row libdd-beta libdd-beta-v0.5.0)" "$(row libdd-gamma libdd-gamma-v2.0.1)"
+  assert_success
+  assert_jq "$output" 'length' "2"
+  assert_jq "$output" '.[0].major_bumps | length' "1"
+  assert_jq "$output" '.[1].major_bumps' "[]"
+}
+
+@test "reports the bump on stderr so the job log explains the forced major" {
+  fixture_set_dep_req libdd-beta libdd-alpha "2.0"
+  run_major_bumps "$(row libdd-beta libdd-beta-v0.5.0)"
+  assert_success
+  assert_stderr_contains "libdd-alpha: ^1.2 -> ^2.0"
+}
+
+@test "fails when the crate manifest is missing from the current tree" {
+  run_major_bumps "$(row libdd-nonexistent libdd-beta-v0.5.0)"
+  assert_failure 2
+  assert_stderr_contains "missing manifest libdd-nonexistent/Cargo.toml"
+}
+
+@test "fails when the crate manifest is missing at the previous tag" {
+  _fixture_crate libdd-epsilon 0.1.0
+  sed -i 's|    "other-tool",|    "other-tool",\n    "libdd-epsilon",|' "${FIXTURE_REPO}/Cargo.toml"
+  run_major_bumps "$(row libdd-epsilon libdd-beta-v0.5.0)"
+  assert_failure 2
+  assert_stderr_contains "missing manifest"
+}
+
+@test "rejects a missing or non-file argument" {
+  run --separate-stderr "${SCRIPTS_DIR}/major-bumps-level.sh"
+  assert_failure 2
+  assert_stderr_contains "Usage:"
+
+  run --separate-stderr "${SCRIPTS_DIR}/major-bumps-level.sh" "${TEST_TMP}/does-not-exist.json"
+  assert_failure 2
+  assert_stderr_contains "Not a file:"
+}
+
+@test "returns an empty array for an empty input list" {
+  echo '[]' > "${TEST_TMP}/api-changes.json"
+  run --separate-stderr "${SCRIPTS_DIR}/major-bumps-level.sh" "${TEST_TMP}/api-changes.json"
+  assert_success
+  assert_jq "$output" 'length' "0"
+}

--- a/scripts/tests/major-bumps-level.bats
+++ b/scripts/tests/major-bumps-level.bats
@@ -24,7 +24,7 @@ row() {
 # Write rows to a file and run the script against it.
 run_major_bumps() {
   printf '%s\n' "$@" | jq -s '.' > "${TEST_TMP}/api-changes.json"
-  run --separate-stderr "${SCRIPTS_DIR}/major-bumps-level.sh" "${TEST_TMP}/api-changes.json"
+  run_tool major-bumps-level "${TEST_TMP}/api-changes.json"
 }
 
 setup() {
@@ -185,36 +185,36 @@ EOF
   fixture_set_dep_req libdd-beta libdd-alpha "2.0"
   run_major_bumps "$(row libdd-beta libdd-beta-v0.5.0)"
   assert_success
-  assert_stderr_contains "libdd-alpha: ^1.2 -> ^2.0"
+  assert_stderr_mentions "libdd-alpha" "^1.2" "^2.0"
 }
 
 @test "fails when the crate manifest is missing from the current tree" {
   run_major_bumps "$(row libdd-nonexistent libdd-beta-v0.5.0)"
-  assert_failure 2
-  assert_stderr_contains "missing manifest libdd-nonexistent/Cargo.toml"
+  assert_failure
+  assert_stderr_mentions "libdd-nonexistent"
 }
 
 @test "fails when the crate manifest is missing at the previous tag" {
   _fixture_crate libdd-epsilon 0.1.0
   sed -i 's|    "other-tool",|    "other-tool",\n    "libdd-epsilon",|' "${FIXTURE_REPO}/Cargo.toml"
   run_major_bumps "$(row libdd-epsilon libdd-beta-v0.5.0)"
-  assert_failure 2
-  assert_stderr_contains "missing manifest"
+  assert_failure
+  assert_stderr_mentions "libdd-epsilon"
 }
 
 @test "rejects a missing or non-file argument" {
-  run --separate-stderr "${SCRIPTS_DIR}/major-bumps-level.sh"
-  assert_failure 2
-  assert_stderr_contains "Usage:"
+  run_tool major-bumps-level
+  assert_failure
+  assert_stderr_mentions
 
-  run --separate-stderr "${SCRIPTS_DIR}/major-bumps-level.sh" "${TEST_TMP}/does-not-exist.json"
-  assert_failure 2
-  assert_stderr_contains "Not a file:"
+  run_tool major-bumps-level "${TEST_TMP}/does-not-exist.json"
+  assert_failure
+  assert_stderr_mentions "does-not-exist.json"
 }
 
 @test "returns an empty array for an empty input list" {
   echo '[]' > "${TEST_TMP}/api-changes.json"
-  run --separate-stderr "${SCRIPTS_DIR}/major-bumps-level.sh" "${TEST_TMP}/api-changes.json"
+  run_tool major-bumps-level "${TEST_TMP}/api-changes.json"
   assert_success
   assert_jq "$output" 'length' "0"
 }

--- a/scripts/tests/publication-order.bats
+++ b/scripts/tests/publication-order.bats
@@ -1,0 +1,150 @@
+#!/usr/bin/env bats
+
+# Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+
+# publication-order.sh feeds the release-proposal-dispatch workflow the set of crates
+# to release (the requested crates plus their workspace dependencies) in dependency
+# order. Getting the set or the order wrong means publishing a crate before the
+# dependency it needs, or silently dropping a crate from the release.
+
+load helpers/common
+load helpers/fixture
+
+setup() {
+  setup_common
+  fixture_init
+}
+
+teardown() {
+  teardown_common
+}
+
+# Dependency edges the publication order must respect (build-dependencies count,
+# dev-dependencies do not — see helpers/fixture.bash for the fixture layout).
+DEPS_SPEC='libdd-beta:libdd-alpha
+libdd-gamma:libdd-alpha,libdd-beta
+libdd-delta:libdd-beta
+other-tool:libdd-alpha
+libdd-private:libdd-alpha'
+
+@test "orders every crate after its workspace dependencies" {
+  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=simple
+  assert_success
+  assert_topological_order "$output" "$DEPS_SPEC"
+}
+
+@test "a dev-dependency cycle does not trip the cycle detector" {
+  # libdd-alpha dev-depends on libdd-gamma, which depends on libdd-alpha. If dev
+  # edges leaked into the graph this would abort with "Circular dependency detected".
+  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=simple
+  assert_success
+  assert_not_contains "$output" "Circular dependency"
+  assert_contains "$output" "libdd-alpha"
+}
+
+@test "excludes publish = false crates by default" {
+  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=simple
+  assert_success
+  assert_not_contains "$output" "libdd-private"
+}
+
+@test "--include-unpublishable and --all add publish = false crates back" {
+  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=simple --include-unpublishable
+  assert_success
+  assert_contains "$output" "libdd-private"
+
+  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=simple --all
+  assert_success
+  assert_contains "$output" "libdd-private"
+}
+
+@test "json format reports name and version for each crate" {
+  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=json
+  assert_success
+  assert_valid_json "$output"
+  assert_jq "$output" '[.[] | select(.name == "libdd-alpha")] | length' "1"
+  assert_jq "$output" '.[] | select(.name == "libdd-gamma") | .version' "2.0.1"
+  # The workflow pipes this straight into commits-since-release.sh, which reads
+  # exactly these two fields.
+  assert_jq "$output" '[.[] | keys] | flatten | unique | join(",")' "name,version"
+}
+
+@test "filtering by a crate includes its transitive dependencies and nothing else" {
+  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=simple libdd-gamma
+  assert_success
+  assert_eq "$(sort <<< "$output")" "$(printf 'libdd-alpha\nlibdd-beta\nlibdd-gamma')"
+  assert_topological_order "$output" "$DEPS_SPEC"
+}
+
+@test "filtering by a leaf crate returns only that crate" {
+  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=simple libdd-alpha
+  assert_success
+  assert_eq "$output" "libdd-alpha"
+}
+
+@test "filtering by several crates unions their dependency closures" {
+  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=simple libdd-delta other-tool
+  assert_success
+  assert_eq "$(sort <<< "$output")" \
+    "$(printf 'libdd-alpha\nlibdd-beta\nlibdd-delta\nother-tool')"
+  assert_topological_order "$output" "$DEPS_SPEC"
+}
+
+@test "a dev-dependency is not pulled into the dependency closure" {
+  # libdd-delta dev-depends on libdd-alpha and build-depends on libdd-beta.
+  # libdd-alpha still appears, but only because libdd-beta depends on it.
+  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=simple libdd-delta
+  assert_success
+  assert_eq "$(sort <<< "$output")" "$(printf 'libdd-alpha\nlibdd-beta\nlibdd-delta')"
+}
+
+@test "requesting a repeated crate is idempotent" {
+  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=simple libdd-beta libdd-beta
+  assert_success
+  assert_eq "$(sort <<< "$output")" "$(printf 'libdd-alpha\nlibdd-beta')"
+}
+
+@test "output is deterministic across runs" {
+  # The workflow branch name and the PR body are derived from this order; churn
+  # between runs would make proposals non-reproducible.
+  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=json
+  assert_success
+  local first="$output"
+  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=json
+  assert_success
+  assert_eq "$output" "$first"
+}
+
+@test "rejects an unknown crate" {
+  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=json libdd-nope
+  assert_failure 1
+  assert_stderr_contains "Unknown crate 'libdd-nope'"
+}
+
+@test "rejects a publish = false crate as a target unless unpublishable crates are included" {
+  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=simple libdd-private
+  assert_failure 1
+  assert_stderr_contains "Unknown crate 'libdd-private'"
+
+  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=simple --all libdd-private
+  assert_success
+  assert_contains "$output" "libdd-private"
+}
+
+@test "rejects an unknown format and an unknown option" {
+  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=yaml
+  assert_failure 1
+  assert_stderr_contains "Unknown format: yaml"
+
+  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --nope
+  assert_failure 1
+  assert_stderr_contains "Unknown option: --nope"
+}
+
+@test "list format annotates unpublishable crates and shows dependencies" {
+  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=list --all
+  assert_success
+  assert_contains "$output" "libdd-private (0.9.0) [unpublishable]"
+  assert_contains "$output" "Dependencies: libdd-alpha (1.2.3)"
+}

--- a/scripts/tests/publication-order.bats
+++ b/scripts/tests/publication-order.bats
@@ -29,7 +29,7 @@ other-tool:libdd-alpha
 libdd-private:libdd-alpha'
 
 @test "orders every crate after its workspace dependencies" {
-  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=simple
+  run_tool publication-order --format=simple
   assert_success
   assert_topological_order "$output" "$DEPS_SPEC"
 }
@@ -37,30 +37,30 @@ libdd-private:libdd-alpha'
 @test "a dev-dependency cycle does not trip the cycle detector" {
   # libdd-alpha dev-depends on libdd-gamma, which depends on libdd-alpha. If dev
   # edges leaked into the graph this would abort with "Circular dependency detected".
-  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=simple
+  run_tool publication-order --format=simple
   assert_success
   assert_not_contains "$output" "Circular dependency"
   assert_contains "$output" "libdd-alpha"
 }
 
 @test "excludes publish = false crates by default" {
-  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=simple
+  run_tool publication-order --format=simple
   assert_success
   assert_not_contains "$output" "libdd-private"
 }
 
 @test "--include-unpublishable and --all add publish = false crates back" {
-  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=simple --include-unpublishable
+  run_tool publication-order --format=simple --include-unpublishable
   assert_success
   assert_contains "$output" "libdd-private"
 
-  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=simple --all
+  run_tool publication-order --format=simple --all
   assert_success
   assert_contains "$output" "libdd-private"
 }
 
 @test "json format reports name and version for each crate" {
-  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=json
+  run_tool publication-order --format=json
   assert_success
   assert_valid_json "$output"
   assert_jq "$output" '[.[] | select(.name == "libdd-alpha")] | length' "1"
@@ -71,20 +71,20 @@ libdd-private:libdd-alpha'
 }
 
 @test "filtering by a crate includes its transitive dependencies and nothing else" {
-  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=simple libdd-gamma
+  run_tool publication-order --format=simple libdd-gamma
   assert_success
   assert_eq "$(sort <<< "$output")" "$(printf 'libdd-alpha\nlibdd-beta\nlibdd-gamma')"
   assert_topological_order "$output" "$DEPS_SPEC"
 }
 
 @test "filtering by a leaf crate returns only that crate" {
-  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=simple libdd-alpha
+  run_tool publication-order --format=simple libdd-alpha
   assert_success
   assert_eq "$output" "libdd-alpha"
 }
 
 @test "filtering by several crates unions their dependency closures" {
-  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=simple libdd-delta other-tool
+  run_tool publication-order --format=simple libdd-delta other-tool
   assert_success
   assert_eq "$(sort <<< "$output")" \
     "$(printf 'libdd-alpha\nlibdd-beta\nlibdd-delta\nother-tool')"
@@ -94,13 +94,13 @@ libdd-private:libdd-alpha'
 @test "a dev-dependency is not pulled into the dependency closure" {
   # libdd-delta dev-depends on libdd-alpha and build-depends on libdd-beta.
   # libdd-alpha still appears, but only because libdd-beta depends on it.
-  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=simple libdd-delta
+  run_tool publication-order --format=simple libdd-delta
   assert_success
   assert_eq "$(sort <<< "$output")" "$(printf 'libdd-alpha\nlibdd-beta\nlibdd-delta')"
 }
 
 @test "requesting a repeated crate is idempotent" {
-  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=simple libdd-beta libdd-beta
+  run_tool publication-order --format=simple libdd-beta libdd-beta
   assert_success
   assert_eq "$(sort <<< "$output")" "$(printf 'libdd-alpha\nlibdd-beta')"
 }
@@ -108,42 +108,42 @@ libdd-private:libdd-alpha'
 @test "output is deterministic across runs" {
   # The workflow branch name and the PR body are derived from this order; churn
   # between runs would make proposals non-reproducible.
-  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=json
+  run_tool publication-order --format=json
   assert_success
   local first="$output"
-  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=json
+  run_tool publication-order --format=json
   assert_success
   assert_eq "$output" "$first"
 }
 
 @test "rejects an unknown crate" {
-  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=json libdd-nope
-  assert_failure 1
-  assert_stderr_contains "Unknown crate 'libdd-nope'"
+  run_tool publication-order --format=json libdd-nope
+  assert_failure
+  assert_stderr_mentions "libdd-nope"
 }
 
 @test "rejects a publish = false crate as a target unless unpublishable crates are included" {
-  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=simple libdd-private
-  assert_failure 1
-  assert_stderr_contains "Unknown crate 'libdd-private'"
+  run_tool publication-order --format=simple libdd-private
+  assert_failure
+  assert_stderr_mentions "libdd-private"
 
-  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=simple --all libdd-private
+  run_tool publication-order --format=simple --all libdd-private
   assert_success
   assert_contains "$output" "libdd-private"
 }
 
 @test "rejects an unknown format and an unknown option" {
-  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=yaml
-  assert_failure 1
-  assert_stderr_contains "Unknown format: yaml"
+  run_tool publication-order --format=yaml
+  assert_failure
+  assert_stderr_mentions "yaml"
 
-  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --nope
-  assert_failure 1
-  assert_stderr_contains "Unknown option: --nope"
+  run_tool publication-order --nope
+  assert_failure
+  assert_stderr_mentions "--nope"
 }
 
 @test "list format annotates unpublishable crates and shows dependencies" {
-  run --separate-stderr "${SCRIPTS_DIR}/publication-order.sh" --format=list --all
+  run_tool publication-order --format=list --all
   assert_success
   assert_contains "$output" "libdd-private (0.9.0) [unpublishable]"
   assert_contains "$output" "Dependencies: libdd-alpha (1.2.3)"

--- a/scripts/tests/release-generate-changelogs.bats
+++ b/scripts/tests/release-generate-changelogs.bats
@@ -40,7 +40,7 @@ run_changelogs() {
   local -a flags=()
   while [[ "${1:-}" == --* ]]; do flags+=("$1" "$2"); shift 2; done
   printf '%s\n' "$@" | jq -s '.' > "${TEST_TMP}/api-changes.json"
-  run --separate-stderr "${SCRIPTS_DIR}/release-generate-changelogs.sh" \
+  run_tool release-generate-changelogs \
     --api-changes "${TEST_TMP}/api-changes.json" "${flags[@]}"
 }
 
@@ -238,7 +238,7 @@ MB='[{"dependency":"libdd-core","previous_req":"^1.0","current_req":"^2.0"}]'
     | jq -s '.' > "${TEST_TMP}/api-changes.json"
 
   use_failing_stream_jq
-  run --separate-stderr "${SCRIPTS_DIR}/release-generate-changelogs.sh" \
+  run_tool release-generate-changelogs \
     --api-changes "${TEST_TMP}/api-changes.json"
   assert_failure 5
   assert_stderr_contains "simulated failure on the streaming read"
@@ -246,20 +246,20 @@ MB='[{"dependency":"libdd-core","previous_req":"^1.0","current_req":"^2.0"}]'
 }
 
 @test "rejects a missing, non-file or non-array input" {
-  run --separate-stderr "${SCRIPTS_DIR}/release-generate-changelogs.sh"
-  assert_failure 1
-  assert_stderr_contains "--api-changes is required"
+  run_tool release-generate-changelogs
+  assert_failure
+  assert_stderr_mentions "--api-changes"
 
-  run --separate-stderr "${SCRIPTS_DIR}/release-generate-changelogs.sh" --api-changes "${TEST_TMP}/nope.json"
-  assert_failure 1
-  assert_stderr_contains "not a file"
+  run_tool release-generate-changelogs --api-changes "${TEST_TMP}/nope.json"
+  assert_failure
+  assert_stderr_mentions "nope.json"
 
   echo '{"not":"an array"}' > "${TEST_TMP}/bad.json"
-  run --separate-stderr "${SCRIPTS_DIR}/release-generate-changelogs.sh" --api-changes "${TEST_TMP}/bad.json"
-  assert_failure 1
-  assert_stderr_contains "is not a JSON array"
+  run_tool release-generate-changelogs --api-changes "${TEST_TMP}/bad.json"
+  assert_failure
+  assert_stderr_mentions "bad.json" "array"
 
-  run --separate-stderr "${SCRIPTS_DIR}/release-generate-changelogs.sh" --nope
-  assert_failure 1
-  assert_stderr_contains "Unknown option: --nope"
+  run_tool release-generate-changelogs --nope
+  assert_failure
+  assert_stderr_mentions "--nope"
 }

--- a/scripts/tests/release-generate-changelogs.bats
+++ b/scripts/tests/release-generate-changelogs.bats
@@ -1,0 +1,244 @@
+#!/usr/bin/env bats
+
+# Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+
+# release-generate-changelogs.sh writes the CHANGELOG.md entries that ship with the
+# release. Unlike the version bumps, a mistake here is not caught by anything
+# downstream -- a wrong or missing entry is published and stays published.
+#
+# git-cliff runs for real, against the repository's own cliff.toml, so the rendered
+# output is what a release would actually publish.
+
+load helpers/common
+load helpers/fixture
+
+setup() {
+  setup_common
+  if ! git cliff --version >/dev/null 2>&1; then
+    skip "git-cliff is not installed (cargo install git-cliff)"
+  fi
+  fixture_init
+  fixture_add_cliff_config
+  git checkout -q -b proposal
+  RELEASE_DATE="$(date +%Y-%m-%d)"
+}
+
+teardown() {
+  teardown_common
+}
+
+# row NAME VERSION PREV_TAG TAG COMMITS_JSON MAJOR_BUMPS_JSON INITIAL_RELEASE
+row() {
+  jq -nc --arg n "$1" --arg v "$2" --arg pt "$3" --arg t "$4" \
+     --argjson c "$5" --argjson mb "$6" --arg ir "$7" \
+    '{name: $n, level: "minor", tag: $t, prev_tag: $pt, version: $v, range: "",
+      commits: $c, path: $n, initial_release: $ir, major_bumps: $mb}'
+}
+
+run_changelogs() {
+  local -a flags=()
+  while [[ "${1:-}" == --* ]]; do flags+=("$1" "$2"); shift 2; done
+  printf '%s\n' "$@" | jq -s '.' > "${TEST_TMP}/api-changes.json"
+  run --separate-stderr "${SCRIPTS_DIR}/release-generate-changelogs.sh" \
+    --api-changes "${TEST_TMP}/api-changes.json" "${flags[@]}"
+}
+
+seed_changelog() {
+  printf '# Changelog\n\n\n## [%s] - 2020-01-01\n\n### Added\n\n- an older release\n' "$2" \
+    > "${FIXTURE_REPO}/$1/CHANGELOG.md"
+  fixture_commit_all "chore: seed $1 changelog"
+}
+
+changelog() { cat "${FIXTURE_REPO}/$1/CHANGELOG.md"; }
+release_commits() { git log --format='%s' proposal --not main; }
+
+MB='[{"dependency":"libdd-core","previous_req":"^1.0","current_req":"^2.0"}]'
+
+# --- the git-cliff path -----------------------------------------------------
+
+@test "renders an entry from the crate's commits" {
+  seed_changelog libdd-alpha 1.0.0
+  fixture_touch_crate libdd-alpha "feat(alpha): add a thing"
+  fixture_touch_crate libdd-alpha "fix(alpha): fix a thing"
+  local commits
+  commits="$(fixture_commits_json HEAD~2..HEAD -- libdd-alpha)"
+
+  run_changelogs "$(row libdd-alpha 1.1.0 libdd-alpha-v1.0.0 libdd-alpha-v1.1.0 "$commits" '[]' false)"
+  assert_success
+  local out; out="$(changelog libdd-alpha)"
+  assert_contains "$out" "Add a thing"
+  assert_contains "$out" "Fix a thing"
+  # Conventional-commit types become the sections cliff.toml defines.
+  assert_contains "$out" "### Added"
+  assert_contains "$out" "### Fixed"
+}
+
+@test "links the new version to a compare view against the previous tag" {
+  seed_changelog libdd-alpha 1.0.0
+  fixture_touch_crate libdd-alpha "feat(alpha): add a thing"
+  local commits; commits="$(fixture_commits_json HEAD~1..HEAD -- libdd-alpha)"
+
+  run_changelogs "$(row libdd-alpha 1.1.0 libdd-alpha-v1.0.0 libdd-alpha-v1.1.0 "$commits" '[]' false)"
+  assert_success
+  assert_contains "$(changelog libdd-alpha)" \
+    "compare/libdd-alpha-v1.0.0..libdd-alpha-v1.1.0"
+}
+
+@test "includes only the crate's own commits, not everything in the range" {
+  # This is why the generation is two-pass. git-cliff's own path filter works on
+  # cumulative tree diffs, so an unrelated commit sitting between the oldest and
+  # newest of this crate's commits would otherwise be swept into the entry.
+  seed_changelog libdd-alpha 1.0.0
+  fixture_touch_crate libdd-alpha "feat(alpha): mine first"
+  local first; first="$(git rev-parse HEAD)"
+  fixture_touch_crate libdd-beta "feat(beta): NOT MINE"
+  fixture_touch_crate libdd-alpha "fix(alpha): mine second"
+  local commits
+  commits="$(fixture_commits_json "${first}^..HEAD" -- libdd-alpha)"
+
+  run_changelogs "$(row libdd-alpha 1.1.0 libdd-alpha-v1.0.0 libdd-alpha-v1.1.0 "$commits" '[]' false)"
+  assert_success
+  local out; out="$(changelog libdd-alpha)"
+  assert_contains "$out" "Mine first"
+  assert_contains "$out" "Mine second"
+  assert_not_contains "$out" "NOT MINE"
+}
+
+@test "prepends the new entry and leaves earlier releases intact" {
+  seed_changelog libdd-alpha 1.0.0
+  fixture_touch_crate libdd-alpha "feat(alpha): add a thing"
+  local commits; commits="$(fixture_commits_json HEAD~1..HEAD -- libdd-alpha)"
+
+  run_changelogs "$(row libdd-alpha 1.1.0 libdd-alpha-v1.0.0 libdd-alpha-v1.1.0 "$commits" '[]' false)"
+  assert_success
+  local out; out="$(changelog libdd-alpha)"
+  assert_contains "$out" "an older release"
+  # Newest first: the new section must come before the one it was seeded with.
+  local new_at old_at
+  new_at="$(grep -n '\[1.1.0\]' <<< "$out" | head -1 | cut -d: -f1)"
+  old_at="$(grep -n '\[1.0.0\]' <<< "$out" | head -1 | cut -d: -f1)"
+  [ "$new_at" -lt "$old_at" ] || fail_with "new section is not above the old one" "$out"
+}
+
+@test "commits each generated CHANGELOG" {
+  seed_changelog libdd-alpha 1.0.0
+  fixture_touch_crate libdd-alpha "feat(alpha): add a thing"
+  local commits; commits="$(fixture_commits_json HEAD~1..HEAD -- libdd-alpha)"
+  local before; before="$(git rev-parse HEAD)"
+
+  run_changelogs "$(row libdd-alpha 1.1.0 libdd-alpha-v1.0.0 libdd-alpha-v1.1.0 "$commits" '[]' false)"
+  assert_success
+  assert_eq "$(git rev-list --count "${before}..HEAD")" "1"
+  assert_eq "$(git log -1 --format=%s)" "chore(release): update CHANGELOG.md for libdd-alpha"
+  # Nothing left uncommitted.
+  assert_eq "$(git status --porcelain -- libdd-alpha)" ""
+}
+
+# --- initial releases -------------------------------------------------------
+
+@test "creates a minimal CHANGELOG for an initial release that has none" {
+  run_changelogs "$(row libdd-delta 0.1.0 "" libdd-delta-v0.1.0 '[]' '[]' true)"
+  assert_success
+  assert_eq "$(changelog libdd-delta)" \
+    "$(printf '# Changelog\n\n\n## 0.1.0 - %s\n\nInitial release.' "$RELEASE_DATE")"
+  assert_contains "$(release_commits)" "chore(release): update CHANGELOG.md for libdd-delta"
+}
+
+@test "leaves an initial release's existing CHANGELOG untouched" {
+  printf '# Changelog\n\nhand written\n' > "${FIXTURE_REPO}/libdd-delta/CHANGELOG.md"
+  fixture_commit_all "chore: hand-written changelog"
+  local before; before="$(git rev-parse HEAD)"
+
+  run_changelogs "$(row libdd-delta 0.1.0 "" libdd-delta-v0.1.0 '[]' '[]' true)"
+  assert_success
+  assert_eq "$(changelog libdd-delta)" "$(printf '# Changelog\n\nhand written')"
+  assert_eq "$(git rev-list --count "${before}..HEAD")" "0"
+  assert_contains "$output" "Using existing CHANGELOG.md"
+}
+
+# --- dependency-only releases -----------------------------------------------
+
+@test "writes a minimal entry for a crate released only for a dependency major bump" {
+  seed_changelog libdd-beta 0.9.0
+  run_changelogs "$(row libdd-beta 1.0.0 libdd-beta-v0.9.0 libdd-beta-v1.0.0 '[]' "$MB" false)"
+  assert_success
+  local out; out="$(changelog libdd-beta)"
+  assert_contains "$out" '- Bump `libdd-core` to a new major version (`^1.0` → `^2.0`)'
+  assert_contains "$out" "### Changed"
+  # Same header shape git-cliff would have produced.
+  assert_contains "$out" "## [1.0.0](https://github.com/datadog/libdatadog/compare/libdd-beta-v0.9.0..libdd-beta-v1.0.0) - ${RELEASE_DATE}"
+  assert_contains "$out" "an older release"
+}
+
+@test "creates the file when a dependency-only release has no CHANGELOG yet" {
+  run_changelogs "$(row libdd-beta 1.0.0 libdd-beta-v0.9.0 libdd-beta-v1.0.0 '[]' "$MB" false)"
+  assert_success
+  local out; out="$(changelog libdd-beta)"
+  assert_contains "$out" "# Changelog"
+  assert_contains "$out" '- Bump `libdd-core` to a new major version'
+}
+
+@test "omits the compare link when there is no previous tag" {
+  run_changelogs "$(row libdd-beta 1.0.0 "" libdd-beta-v1.0.0 '[]' "$MB" false)"
+  assert_success
+  local out; out="$(changelog libdd-beta)"
+  assert_contains "$out" "## [1.0.0] - ${RELEASE_DATE}"
+  assert_not_contains "$out" "compare/"
+}
+
+@test "--remote-url changes the generated compare link" {
+  run_changelogs --remote-url "https://example.invalid/org/repo" \
+    "$(row libdd-beta 1.0.0 libdd-beta-v0.9.0 libdd-beta-v1.0.0 '[]' "$MB" false)"
+  assert_success
+  assert_contains "$(changelog libdd-beta)" "https://example.invalid/org/repo/compare/"
+}
+
+# --- nothing to say ---------------------------------------------------------
+
+@test "writes nothing for a crate with no commits and no dependency bumps" {
+  local before; before="$(git rev-parse HEAD)"
+  run_changelogs "$(row libdd-beta 0.6.0 libdd-beta-v0.5.0 libdd-beta-v0.6.0 '[]' '[]' false)"
+  assert_success
+  [ ! -f "${FIXTURE_REPO}/libdd-beta/CHANGELOG.md" ] \
+    || fail_with "a CHANGELOG was created for a crate with nothing to report"
+  assert_eq "$(git rev-list --count "${before}..HEAD")" "0"
+  assert_contains "$output" "skipping CHANGELOG generation"
+}
+
+@test "treats a missing major_bumps field as no bumps" {
+  # Rows that never went through the audit have no major_bumps key at all.
+  local no_mb
+  no_mb="$(row libdd-beta 0.6.0 libdd-beta-v0.5.0 libdd-beta-v0.6.0 '[]' '[]' false | jq -c 'del(.major_bumps)')"
+  run_changelogs "$no_mb"
+  assert_success
+  [ ! -f "${FIXTURE_REPO}/libdd-beta/CHANGELOG.md" ] || fail_with "unexpected CHANGELOG"
+}
+
+@test "does nothing for an empty release set" {
+  local before; before="$(git rev-parse HEAD)"
+  run_changelogs
+  assert_success
+  assert_eq "$(git rev-list --count "${before}..HEAD")" "0"
+}
+
+# --- argument handling ------------------------------------------------------
+
+@test "rejects a missing, non-file or non-array input" {
+  run --separate-stderr "${SCRIPTS_DIR}/release-generate-changelogs.sh"
+  assert_failure 1
+  assert_stderr_contains "--api-changes is required"
+
+  run --separate-stderr "${SCRIPTS_DIR}/release-generate-changelogs.sh" --api-changes "${TEST_TMP}/nope.json"
+  assert_failure 1
+  assert_stderr_contains "not a file"
+
+  echo '{"not":"an array"}' > "${TEST_TMP}/bad.json"
+  run --separate-stderr "${SCRIPTS_DIR}/release-generate-changelogs.sh" --api-changes "${TEST_TMP}/bad.json"
+  assert_failure 1
+  assert_stderr_contains "is not a JSON array"
+
+  run --separate-stderr "${SCRIPTS_DIR}/release-generate-changelogs.sh" --nope
+  assert_failure 1
+  assert_stderr_contains "Unknown option: --nope"
+}

--- a/scripts/tests/release-generate-changelogs.bats
+++ b/scripts/tests/release-generate-changelogs.bats
@@ -224,6 +224,27 @@ MB='[{"dependency":"libdd-core","previous_req":"^1.0","current_req":"^2.0"}]'
 
 # --- argument handling ------------------------------------------------------
 
+@test "fails when the jq that streams the rows fails" {
+  # Regression, and the worst of the three: the caller's guard after this step is
+  # `git diff --quiet "$EPHEMERAL_BRANCH"`, which still sees the version-bump commits
+  # from the earlier step. A run that generated no CHANGELOG at all therefore looked
+  # exactly like a healthy one, and the proposal shipped without changelogs.
+  seed_changelog libdd-alpha 1.0.0
+  fixture_touch_crate libdd-alpha "feat(alpha): add a thing"
+  local commits before
+  commits="$(fixture_commits_json HEAD~1..HEAD -- libdd-alpha)"
+  before="$(git rev-parse HEAD)"
+  printf '%s\n' "$(row libdd-alpha 1.1.0 libdd-alpha-v1.0.0 libdd-alpha-v1.1.0 "$commits" '[]' false)" \
+    | jq -s '.' > "${TEST_TMP}/api-changes.json"
+
+  use_failing_stream_jq
+  run --separate-stderr "${SCRIPTS_DIR}/release-generate-changelogs.sh" \
+    --api-changes "${TEST_TMP}/api-changes.json"
+  assert_failure 5
+  assert_stderr_contains "simulated failure on the streaming read"
+  assert_eq "$(git rev-list --count "${before}..HEAD")" "0"
+}
+
 @test "rejects a missing, non-file or non-array input" {
   run --separate-stderr "${SCRIPTS_DIR}/release-generate-changelogs.sh"
   assert_failure 1

--- a/scripts/tests/release-proposal-workflow.bats
+++ b/scripts/tests/release-proposal-workflow.bats
@@ -1,0 +1,282 @@
+#!/usr/bin/env bats
+
+# Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+
+# Structural guards on .github/workflows/release-proposal-dispatch.yml.
+#
+# Most of that workflow's logic is inline bash and is only exercised by running a real
+# release. What CANNOT be exercised any other way is its job-level gating: the `if:`
+# expressions that decide whether a release proceeds, and the steps that reject an
+# untrusted `main_start_ref`. Those are one careless edit away from silently letting a
+# release through without the membership check, or running attacker-controlled code
+# with the job's OIDC token.
+#
+# These tests are deliberately change-detectors — each one states WHY the invariant
+# exists, so a deliberate change means updating the test and reading the reason first.
+# They complement actionlint (lint.yml), which checks syntax but not intent.
+
+load helpers/common
+
+WORKFLOW=".github/workflows/release-proposal-dispatch.yml"
+TEST_WORKFLOW=".github/workflows/release-proposal-test.yml"
+
+setup() {
+  setup_common
+  WF="$(python3 "${TESTS_DIR}/helpers/workflow-to-json.py" "${REPO_ROOT}/${WORKFLOW}")"
+  TEST_WF="$(python3 "${TESTS_DIR}/helpers/workflow-to-json.py" "${REPO_ROOT}/${TEST_WORKFLOW}")"
+}
+
+teardown() {
+  teardown_common
+}
+
+# job_if JOB — the job's `if:` expression, with runs of whitespace collapsed to a
+# single space so line wrapping in the YAML does not affect the assertions.
+job_if() {
+  jq -r --arg job "$1" '.jobs[$job].if // ""' <<< "$WF" \
+    | tr -s '[:space:]' ' ' | sed -e 's/^ //' -e 's/ $//'
+}
+
+# step_run JOB STEP_NAME — the `run:` body of a named step.
+step_run() {
+  jq -r --arg job "$1" --arg name "$2" \
+    '.jobs[$job].steps[] | select(.name == $name) | .run // ""' <<< "$WF"
+}
+
+# step_if JOB STEP_NAME — the `if:` of a named step.
+step_if() {
+  jq -r --arg job "$1" --arg name "$2" \
+    '.jobs[$job].steps[] | select(.name == $name) | .if // ""' <<< "$WF"
+}
+
+# --- privilege gating -------------------------------------------------------
+
+@test "the membership check is skipped only when bypassing standard checks" {
+  assert_eq "$(job_if check-membership)" '${{ !inputs.bypass_standard_checks }}'
+}
+
+@test "cargo-release requires the ongoing-proposal guard to have succeeded" {
+  # check-membership is skipped on bypass runs, so cargo-release accepts a skipped
+  # membership. Without this second condition, a membership skipped because
+  # check-proposal-ongoing FAILED would also satisfy the gate and release anyway.
+  assert_contains "$(job_if cargo-release)" "needs.check-proposal-ongoing.result == 'success'"
+}
+
+@test "cargo-release requires validated inputs" {
+  assert_contains "$(job_if cargo-release)" "needs.validate-inputs.result == 'success'"
+}
+
+@test "cargo-release accepts a skipped membership check only under bypass" {
+  # The skipped-membership escape hatch must stay welded to the bypass input.
+  local expr
+  expr="$(job_if cargo-release)"
+  assert_contains "$expr" "needs.check-membership.result == 'success'"
+  assert_contains "$expr" "(inputs.bypass_standard_checks && needs.check-membership.result == 'skipped')"
+}
+
+@test "cargo-release depends on every job whose result it gates on" {
+  # `needs.<job>.result` is empty for a job that is not in `needs`, which would make
+  # each gate above silently unsatisfiable — or, with !cancelled(), simply wrong.
+  local needs
+  needs="$(jq -r '.jobs["cargo-release"].needs | sort | join(",")' <<< "$WF")"
+  assert_eq "$needs" "check-membership,check-proposal-ongoing,validate-inputs"
+}
+
+@test "create-pr gates on cargo-release directly rather than on transitive status" {
+  # A skipped check-membership propagates 'skipped' transitively through cargo-release,
+  # so create-pr must name cargo-release's own result.
+  assert_contains "$(job_if create-pr)" "needs.cargo-release.result == 'success'"
+  assert_contains "$(job_if create-pr)" "needs.validate-inputs.result == 'success'"
+  local needs
+  needs="$(jq -r '.jobs["create-pr"].needs | sort | join(",")' <<< "$WF")"
+  assert_eq "$needs" "cargo-release,validate-inputs"
+}
+
+@test "only the membership job may mint an org-read token" {
+  # dd-octo-sts with the self.read.members policy must not spread to other jobs.
+  local jobs
+  jobs="$(jq -r '[.jobs | to_entries[]
+                 | select(any(.value.steps[]?; (.with.policy? // "") == "self.read.members"))
+                 | .key] | join(",")' <<< "$WF")"
+  assert_eq "$jobs" "check-membership"
+}
+
+# --- untrusted main_start_ref ----------------------------------------------
+
+@test "the checked-out tree is rejected if it configures cargo-release hooks" {
+  # cargo-release's pre-release-hook / pre-release-replacements run arbitrary commands.
+  # main_start_ref chooses the tree, so without this guard a crafted ref executes code
+  # in a job that holds an OIDC minting capability.
+  local body
+  body="$(step_run cargo-release "Reject untrusted cargo-release configuration")"
+  assert_contains "$body" "pre-release-hook"
+  assert_contains "$body" "pre-release-replacements"
+  assert_contains "$body" "exit 1"
+}
+
+@test "pull-request refs are rejected as main_start_ref" {
+  # Anyone with a fork can push refs/pull/*.
+  local body
+  body="$(step_run cargo-release "Optionally checkout at a specific git ref")"
+  assert_contains "$body" "refs/pull/*|pull/*)"
+  assert_contains "$body" "refs/pull/* refs are not allowed"
+}
+
+@test "main_start_ref must resolve to a commit reachable from a trusted branch" {
+  local body
+  body="$(step_run cargo-release "Optionally checkout at a specific git ref")"
+  assert_contains "$body" 'git merge-base --is-ancestor "$COMMIT" "origin/${{ env.MAIN_BRANCH }}"'
+  assert_contains "$body" 'TRUSTED=false'
+  assert_contains "$body" 'if [ "$TRUSTED" != "true" ]; then'
+}
+
+@test "the hotfix ref pattern is anchored" {
+  # An unanchored pattern would let any ref containing a hotfix-looking substring take
+  # the hotfix path, which skips the ephemeral-branch creation and the latest-tag guard.
+  local pattern
+  pattern="$(jq -r '.env.HOTFIX_REF_PATTERN' <<< "$WF")"
+  assert_eq "$pattern" '^hotfix/[^/]+/[0-9]+\.x\.x$'
+}
+
+@test "hotfix releases are limited to a single crate" {
+  # The hotfix path releases onto the hotfix branch itself; bundling several crates
+  # there would publish unrelated crates from an old base.
+  local body
+  body="$(step_run validate-inputs "Normalize and validate crate list")"
+  assert_contains "$body" "hotfix releases (main_start_ref=\$REF) accept only a single crate"
+}
+
+@test "only publishable crates can be requested" {
+  local body
+  body="$(step_run validate-inputs "Normalize and validate crate list")"
+  assert_contains "$body" "unknown or unpublishable crate(s)"
+  assert_contains "$body" 'select(.publish == null or (.publish | type == "array" and length > 0))'
+}
+
+@test "release tooling is snapshotted from the workflow revision, not from main_start_ref" {
+  # main_start_ref may be an old or crafted tree; the scripts that run with the job's
+  # privileges must come from the revision the workflow file itself was read from.
+  local body
+  body="$(step_run cargo-release "Snapshot scripts from workflow revision")"
+  assert_contains "$body" 'WF_SHA="${{ github.sha }}"'
+  assert_contains "$body" 'git archive "$WF_SHA" scripts'
+  assert_contains "$body" "WORKFLOW_SCRIPTS_ROOT="
+
+  # And every release script call must go through that snapshot.
+  local calls
+  calls="$(jq -r '[.jobs[].steps[]?.run // ""] | join("\n")' <<< "$WF" \
+    | grep -oE '[^ "]*scripts?/[a-z-]+\.sh' | sort -u)"
+  while IFS= read -r call; do
+    [[ -z "$call" ]] && continue
+    case "$call" in
+      '${WORKFLOW_SCRIPTS_ROOT}/'*) ;;
+      ./scripts/exclude-from-green-ci.sh) ;;  # runs in validate-inputs, before any ref switch
+      *) fail_with "release script invoked outside the pinned snapshot: $call" ;;
+    esac
+  done <<< "$calls"
+}
+
+# --- branch prefixes --------------------------------------------------------
+
+@test "bypass runs use separate branch prefixes so they cannot collide with real releases" {
+  assert_eq "$(jq -r '.env.RELEASE_BRANCH_PREFIX' <<< "$WF")" \
+    "\${{ inputs.bypass_standard_checks && 'release-testing' || 'release' }}"
+  assert_eq "$(jq -r '.env.PROPOSAL_BRANCH_PREFIX' <<< "$WF")" \
+    "\${{ inputs.bypass_standard_checks && 'release-proposal-testing' || 'release-proposal' }}"
+}
+
+@test "release-proposal-test.yml triggers on both the real and the testing prefixes" {
+  # The two workflows are coupled by branch name only. Renaming a prefix in the
+  # dispatch workflow without updating the triggers here silently stops the
+  # dd-trace-rs compatibility check from ever running on a proposal.
+  assert_eq "$(jq -r '.on.push.branches | sort | join(",")' <<< "$TEST_WF")" \
+    "release-proposal-testing/**,release-proposal/**"
+  assert_eq "$(jq -r '.on.pull_request.branches | sort | join(",")' <<< "$TEST_WF")" \
+    "release-testing/**,release/**"
+}
+
+@test "the ongoing-proposal guard looks for both proposal and ephemeral release branches" {
+  local body
+  body="$(step_run check-proposal-ongoing "Check if a release proposal is ongoing")"
+  assert_contains "$body" 'origin/${{ env.PROPOSAL_BRANCH_PREFIX }}/*'
+  assert_contains "$body" 'origin/${{ env.RELEASE_BRANCH_PREFIX }}/*/*'
+  assert_contains "$body" "A release proposal is ongoing"
+}
+
+# --- pushing ----------------------------------------------------------------
+
+@test "real runs push through the verified-commit action and bypass runs push plainly" {
+  # Swapping these conditions would push unverified commits onto a real release branch.
+  assert_eq "$(step_if cargo-release "Push commits (verified)")" \
+    '${{ !inputs.bypass_standard_checks }}'
+  assert_eq "$(step_if cargo-release "Push commits (plain, testing only)")" \
+    '${{ inputs.bypass_standard_checks }}'
+
+  local uses
+  uses="$(jq -r '.jobs["cargo-release"].steps[] | select(.name == "Push commits (verified)") | .uses' <<< "$WF")"
+  assert_contains "$uses" "DataDog/commit-headless"
+}
+
+@test "the verified push is given commits oldest-first" {
+  # commit-headless replays commits in the order given; newest-first (plain `git log`)
+  # would fail to apply or reorder history.
+  local body
+  body="$(step_run cargo-release "Generate CHANGELOGS")"
+  assert_contains "$body" 'git log --reverse "$ORIGINAL_HEAD"..'
+}
+
+@test "both branch-creating jobs clean up their branches on failure" {
+  # A failed run that leaves branches behind trips the ongoing-proposal guard and
+  # blocks every subsequent release until someone deletes them by hand.
+  for job in cargo-release create-pr; do
+    local cleanup
+    cleanup="$(jq -r --arg job "$job" \
+      '.jobs[$job].steps[] | select(.name == "Cleanup on failure") | .if' <<< "$WF")"
+    assert_contains "$cleanup" "failure()"
+    local body
+    body="$(step_run "$job" "Cleanup on failure")"
+    assert_contains "$body" "git push origin --delete"
+    # The hotfix base branch is a real long-lived branch, not an ephemeral one.
+    assert_contains "$body" "Hotfix mode: not deleting ephemeral base branch"
+  done
+}
+
+# --- downstream contracts ---------------------------------------------------
+
+@test "the PR title keeps the prefix downstream tooling matches on" {
+  local body
+  body="$(step_run create-pr "Create a PR")"
+  assert_contains "$body" 'PR_TITLE="chore(release): proposal for'
+  # GitHub rejects titles over 256 chars; the workflow truncates well below that.
+  assert_contains "$body" 'if [ "${#PR_TITLE}" -gt 100 ]; then'
+}
+
+@test "the proposal PR is opened as a draft with the release-proposal label" {
+  local body
+  body="$(step_run create-pr "Create a PR")"
+  assert_contains "$body" '--label "release-proposal"'
+  assert_contains "$body" "--draft"
+  assert_contains "$body" '--base "${{ needs.cargo-release.outputs.ephemeral_branch }}"'
+}
+
+@test "a failed PR creation fails the run unless it is a bypass run" {
+  # Otherwise the branches survive and block the next release.
+  local body
+  body="$(step_run create-pr "Create a PR")"
+  assert_contains "$body" '::error::Failed to create the release proposal PR.'
+  assert_contains "$body" "exit 1"
+}
+
+# --- run safety -------------------------------------------------------------
+
+@test "concurrent dispatches queue instead of cancelling each other" {
+  # Cancelling a run mid-release leaves pushed branches and a half-applied proposal.
+  assert_eq "$(jq -r '.concurrency.group' <<< "$WF")" "release-proposal-dispatch-group"
+  assert_eq "$(jq -r '.concurrency["cancel-in-progress"]' <<< "$WF")" "false"
+}
+
+@test "the workflow is dispatch-only" {
+  # It pushes branches and mints tokens; it must never become push- or PR-triggered.
+  assert_eq "$(jq -r '.on | keys | join(",")' <<< "$WF")" "workflow_dispatch"
+}

--- a/scripts/tests/release-proposal-workflow.bats
+++ b/scripts/tests/release-proposal-workflow.bats
@@ -166,7 +166,20 @@ step_if() {
   # And every release script call must go through that snapshot.
   local calls
   calls="$(jq -r '[.jobs[].steps[]?.run // ""] | join("\n")' <<< "$WF" \
-    | grep -oE '[^ "]*scripts?/[a-z-]+\.sh' | sort -u)"
+    | grep -oE '(\$\{WORKFLOW_SCRIPTS_ROOT\}|\./scripts)/[a-z-]+\.sh' | sort -u)"
+
+  # Keep this assertion from passing vacuously if the invocation syntax changes in
+  # a way the matcher above no longer recognises.
+  local expected
+  for expected in \
+    commits-since-release.sh \
+    publication-order.sh \
+    release-generate-changelogs.sh \
+    release-version-bumps.sh \
+    release-version-major-bumps.sh; do
+    assert_contains "$calls" "\${WORKFLOW_SCRIPTS_ROOT}/$expected"
+  done
+
   while IFS= read -r call; do
     [[ -z "$call" ]] && continue
     case "$call" in
@@ -262,10 +275,20 @@ step_if() {
 
 @test "a failed PR creation fails the run unless it is a bypass run" {
   # Otherwise the branches survive and block the next release.
-  local body
+  local body bypass_marker standard_marker bypass_body standard_body
   body="$(step_run create-pr "Create a PR")"
-  assert_contains "$body" '::error::Failed to create the release proposal PR.'
-  assert_contains "$body" "exit 1"
+  bypass_marker='elif [ "$BYPASS_STANDARD_CHECKS" = "true" ]; then'
+  standard_marker='# Standard run: PR creation must succeed.'
+  assert_contains "$body" "$bypass_marker"
+  assert_contains "$body" "$standard_marker"
+
+  bypass_body="${body#*"$bypass_marker"}"
+  bypass_body="${bypass_body%%"$standard_marker"*}"
+  assert_not_contains "$bypass_body" "exit 1"
+
+  standard_body="${body#*"$standard_marker"}"
+  assert_contains "$standard_body" '::error::Failed to create the release proposal PR.'
+  assert_contains "$standard_body" "exit 1"
 }
 
 # --- run safety -------------------------------------------------------------

--- a/scripts/tests/release-version-bumps.bats
+++ b/scripts/tests/release-version-bumps.bats
@@ -47,11 +47,28 @@ teardown() {
 
 # Copy the script under test next to a semver-level.sh stub. The script resolves that
 # sibling relative to itself, so no test-only hook is needed in the script.
+#
+# This is the one seam that does not generalise: pointing the suite at another
+# implementation via RELEASE_TOOL_CMD cannot work until the script takes the
+# semver-level command as an argument, because "copy the executable next to a fake
+# sibling" assumes sibling resolution. Skip loudly rather than silently running the
+# real semver-level.sh, which would build crates for minutes and then disagree.
 install_release_tool() {
+  if [[ -n "${RELEASE_TOOL_CMD:-}" ]]; then
+    skip "needs a --semver-level-cmd override to run against a non-default implementation"
+  fi
+  # A mirror of scripts/, with semver-level.sh swapped for a stub. Symlinks are enough:
+  # the script resolves its siblings from the directory it was *invoked* through, which
+  # is this one. Mirroring everything keeps the other scripts the suite drives (namely
+  # commits-since-release.sh) reachable through the same directory.
   RELEASE_BIN="${TEST_TMP}/bin"
   export RELEASE_BIN
   mkdir -p "$RELEASE_BIN"
-  install -m 0755 "${SCRIPTS_DIR}/release-version-bumps.sh" "$RELEASE_BIN/"
+  local script
+  for script in "${SCRIPTS_DIR}"/*.sh; do
+    ln -sf "$script" "${RELEASE_BIN}/$(basename "$script")"
+  done
+  rm -f "${RELEASE_BIN}/semver-level.sh"
   cat > "${RELEASE_BIN}/semver-level.sh" <<'STUB'
 #!/usr/bin/env bash
 printf '%s\n' "$1" >> "${STUB_SEMVER_CALLS:-/dev/null}"
@@ -63,6 +80,9 @@ jq -nc --arg n "$1" --arg l "${STUB_SEMVER_LEVEL:-minor}" \
   '{name: $n, level: $l, reason: "stub", details: ""}'
 STUB
   chmod +x "${RELEASE_BIN}/semver-level.sh"
+  # Point the resolver at the copy, so the tests below read like every other suite.
+  RELEASE_TOOL_CMD="${RELEASE_BIN}/{name}.sh"
+  export RELEASE_TOOL_CMD
   STUB_SEMVER_CALLS="${TEST_TMP}/semver-level-calls"
   export STUB_SEMVER_CALLS
   : > "$STUB_SEMVER_CALLS"
@@ -80,8 +100,8 @@ crates_input() {
 run_bumps() {
   local -a flags=()
   while [[ "${1:-}" == --* ]]; do flags+=("$1"); shift; done
-  "${SCRIPTS_DIR}/commits-since-release.sh" "$1" > "${TEST_TMP}/commits-by-crate.json"
-  run --separate-stderr "${RELEASE_BIN}/release-version-bumps.sh" \
+  tool commits-since-release "$1" > "${TEST_TMP}/commits-by-crate.json"
+  run_tool release-version-bumps \
     --commits-by-crate "${TEST_TMP}/commits-by-crate.json" \
     --out "${TEST_TMP}/api-changes.json" \
     --branch proposal "${flags[@]}"
@@ -203,8 +223,8 @@ crate_version() {
   # A missing tag on a crate that is not brand new means something is wrong with the
   # tags, not that the crate is new; releasing it as 1.0.0 would be wrong.
   run_bumps "$(crates_input libdd-private:0.9.0)"
-  assert_failure 1
-  assert_stderr_contains "libdd-private is not a 0.1.0 release"
+  assert_failure
+  assert_stderr_mentions "libdd-private" "0.1.0"
 }
 
 # --- failure paths ----------------------------------------------------------
@@ -214,19 +234,19 @@ crate_version() {
   # run aborted with nothing in the log.
   STUB_SEMVER_RC=3 run_bumps "$(crates_input libdd-alpha:1.2.3)"
   assert_failure
-  assert_stderr_contains "semver-level.sh failed for libdd-alpha"
+  assert_stderr_mentions "libdd-alpha"
   assert_stderr_contains "cargo semver-checks blew up"
 }
 
 @test "fails when a tagged crate has no usable range" {
   # tag_commit/range empty means commits-since-release.sh could not resolve the tag.
-  "${SCRIPTS_DIR}/commits-since-release.sh" "$(crates_input libdd-alpha:1.2.3)" \
+  tool commits-since-release "$(crates_input libdd-alpha:1.2.3)" \
     | jq '[.[] | .range = "" | .tag_commit = ""]' > "${TEST_TMP}/commits-by-crate.json"
-  run --separate-stderr "${RELEASE_BIN}/release-version-bumps.sh" \
+  run_tool release-version-bumps \
     --commits-by-crate "${TEST_TMP}/commits-by-crate.json" \
     --out "${TEST_TMP}/api-changes.json" --branch proposal
-  assert_failure 1
-  assert_stderr_contains "Could not dereference tag libdd-alpha-v1.2.3 to a commit"
+  assert_failure
+  assert_stderr_mentions "libdd-alpha-v1.2.3"
 }
 
 @test "fails when the jq that streams the rows fails" {
@@ -234,11 +254,11 @@ crate_version() {
   # substitution's exit status is reported by neither set -e nor pipefail, so a jq
   # that died mid-stream left the loop with no input and the script exited 0 having
   # released nothing at all.
-  "${SCRIPTS_DIR}/commits-since-release.sh" "$(crates_input libdd-alpha:1.2.3)" \
+  tool commits-since-release "$(crates_input libdd-alpha:1.2.3)" \
     > "${TEST_TMP}/commits-by-crate.json"
 
   use_failing_stream_jq
-  run --separate-stderr "${RELEASE_BIN}/release-version-bumps.sh" \
+  run_tool release-version-bumps \
     --commits-by-crate "${TEST_TMP}/commits-by-crate.json" \
     --out "${TEST_TMP}/api-changes.json" \
     --branch proposal
@@ -249,34 +269,34 @@ crate_version() {
 }
 
 @test "rejects a missing, unreadable or non-array input" {
-  run --separate-stderr "${RELEASE_BIN}/release-version-bumps.sh" \
+  run_tool release-version-bumps \
     --commits-by-crate "${TEST_TMP}/nope.json" --out "${TEST_TMP}/out.json" --branch proposal
-  assert_failure 1
-  assert_stderr_contains "not a file"
+  assert_failure
+  assert_stderr_mentions "nope.json"
 
   echo '{"not":"an array"}' > "${TEST_TMP}/bad.json"
-  run --separate-stderr "${RELEASE_BIN}/release-version-bumps.sh" \
+  run_tool release-version-bumps \
     --commits-by-crate "${TEST_TMP}/bad.json" --out "${TEST_TMP}/out.json" --branch proposal
-  assert_failure 1
-  assert_stderr_contains "is not a JSON array"
+  assert_failure
+  assert_stderr_mentions "bad.json" "array"
 }
 
 @test "requires its three mandatory options" {
-  run --separate-stderr "${RELEASE_BIN}/release-version-bumps.sh" --out /dev/null --branch b
-  assert_failure 1
-  assert_stderr_contains "--commits-by-crate is required"
+  run_tool release-version-bumps --out /dev/null --branch b
+  assert_failure
+  assert_stderr_mentions "--commits-by-crate"
 
-  run --separate-stderr "${RELEASE_BIN}/release-version-bumps.sh" --commits-by-crate /dev/null --branch b
-  assert_failure 1
-  assert_stderr_contains "--out is required"
+  run_tool release-version-bumps --commits-by-crate /dev/null --branch b
+  assert_failure
+  assert_stderr_mentions "--out"
 
-  run --separate-stderr "${RELEASE_BIN}/release-version-bumps.sh" --commits-by-crate /dev/null --out /dev/null
-  assert_failure 1
-  assert_stderr_contains "--branch is required"
+  run_tool release-version-bumps --commits-by-crate /dev/null --out /dev/null
+  assert_failure
+  assert_stderr_mentions "--branch"
 
-  run --separate-stderr "${RELEASE_BIN}/release-version-bumps.sh" --nope
-  assert_failure 1
-  assert_stderr_contains "Unknown option: --nope"
+  run_tool release-version-bumps --nope
+  assert_failure
+  assert_stderr_mentions "--nope"
 }
 
 # --- several crates at once -------------------------------------------------
@@ -296,7 +316,7 @@ crate_version() {
 
 @test "writes an empty array when there are no candidates" {
   echo '[]' > "${TEST_TMP}/commits-by-crate.json"
-  run --separate-stderr "${RELEASE_BIN}/release-version-bumps.sh" \
+  run_tool release-version-bumps \
     --commits-by-crate "${TEST_TMP}/commits-by-crate.json" \
     --out "${TEST_TMP}/api-changes.json" --branch proposal
   assert_success

--- a/scripts/tests/release-version-bumps.bats
+++ b/scripts/tests/release-version-bumps.bats
@@ -229,6 +229,25 @@ crate_version() {
   assert_stderr_contains "Could not dereference tag libdd-alpha-v1.2.3 to a commit"
 }
 
+@test "fails when the jq that streams the rows fails" {
+  # Regression: this loop used to read from `done < <(jq -c '.[]' ...)`. A process
+  # substitution's exit status is reported by neither set -e nor pipefail, so a jq
+  # that died mid-stream left the loop with no input and the script exited 0 having
+  # released nothing at all.
+  "${SCRIPTS_DIR}/commits-since-release.sh" "$(crates_input libdd-alpha:1.2.3)" \
+    > "${TEST_TMP}/commits-by-crate.json"
+
+  use_failing_stream_jq
+  run --separate-stderr "${RELEASE_BIN}/release-version-bumps.sh" \
+    --commits-by-crate "${TEST_TMP}/commits-by-crate.json" \
+    --out "${TEST_TMP}/api-changes.json" \
+    --branch proposal
+  assert_failure 5
+  assert_stderr_contains "simulated failure on the streaming read"
+  # Nothing was released on the way out.
+  assert_eq "$(crate_version libdd-alpha)" "1.2.3"
+}
+
 @test "rejects a missing, unreadable or non-array input" {
   run --separate-stderr "${RELEASE_BIN}/release-version-bumps.sh" \
     --commits-by-crate "${TEST_TMP}/nope.json" --out "${TEST_TMP}/out.json" --branch proposal

--- a/scripts/tests/release-version-bumps.bats
+++ b/scripts/tests/release-version-bumps.bats
@@ -1,0 +1,302 @@
+#!/usr/bin/env bats
+
+# Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+
+# release-version-bumps.sh turns commits-since-release.sh output into api-changes.json.
+# It is where a crate's fate is decided: released at a level, deferred to the libdd-*
+# major-bump check, skipped because a newer release already exists, or the whole run
+# failed. Everything downstream -- the version bumps committed to the proposal branch,
+# the CHANGELOGs, the PR body -- follows from what this produces.
+#
+# cargo-release runs for real against a throwaway workspace, so the versions asserted
+# here are the ones a release would actually land on. Only semver-level.sh is stubbed:
+# the real one builds two revisions of a crate with cargo-semver-checks and
+# cargo-public-api, which is minutes per crate and orthogonal to what is under test.
+
+load helpers/common
+load helpers/fixture
+
+setup() {
+  setup_common
+  if ! cargo release --version >/dev/null 2>&1; then
+    skip "cargo-release is not installed (cargo install cargo-release)"
+  fi
+  fixture_init
+
+  # libdd-alpha  1.2.3  tagged, tag is the latest, has commits  -> released
+  # libdd-beta   0.5.0  tagged, but v0.9.0 also exists          -> skipped
+  # libdd-gamma  2.0.1  tagged, no commits of its own           -> deferred
+  # libdd-delta  0.1.0  never tagged                            -> initial release
+  # libdd-private 0.9.0 never tagged, not 0.1.0                 -> hard error
+  fixture_tag "libdd-alpha-v1.2.3"
+  fixture_tag "libdd-beta-v0.5.0"
+  fixture_tag "libdd-beta-v0.9.0"
+  fixture_tag "libdd-gamma-v2.0.1"
+  fixture_touch_crate libdd-alpha "feat(alpha): a change"
+  fixture_touch_crate libdd-beta "feat(beta): a change"
+  fixture_touch_crate libdd-delta "feat(delta): a change"
+  git checkout -q -b proposal
+
+  install_release_tool
+}
+
+teardown() {
+  teardown_common
+}
+
+# Copy the script under test next to a semver-level.sh stub. The script resolves that
+# sibling relative to itself, so no test-only hook is needed in the script.
+install_release_tool() {
+  RELEASE_BIN="${TEST_TMP}/bin"
+  export RELEASE_BIN
+  mkdir -p "$RELEASE_BIN"
+  install -m 0755 "${SCRIPTS_DIR}/release-version-bumps.sh" "$RELEASE_BIN/"
+  cat > "${RELEASE_BIN}/semver-level.sh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$1" >> "${STUB_SEMVER_CALLS:-/dev/null}"
+if [ "${STUB_SEMVER_RC:-0}" != "0" ]; then
+  echo "cargo semver-checks blew up for $1" >&2
+  exit "${STUB_SEMVER_RC}"
+fi
+jq -nc --arg n "$1" --arg l "${STUB_SEMVER_LEVEL:-minor}" \
+  '{name: $n, level: $l, reason: "stub", details: ""}'
+STUB
+  chmod +x "${RELEASE_BIN}/semver-level.sh"
+  STUB_SEMVER_CALLS="${TEST_TMP}/semver-level-calls"
+  export STUB_SEMVER_CALLS
+  : > "$STUB_SEMVER_CALLS"
+}
+
+# crates_input NAME:VERSION... — the shape publication-order.sh feeds downstream.
+crates_input() {
+  local spec
+  for spec in "$@"; do
+    jq -nc --arg n "${spec%%:*}" --arg v "${spec##*:}" '{name: $n, version: $v}'
+  done | jq -s -c '.'
+}
+
+# run_bumps [--flags...] — resolve the crate list, then run the script over it.
+run_bumps() {
+  local -a flags=()
+  while [[ "${1:-}" == --* ]]; do flags+=("$1"); shift; done
+  "${SCRIPTS_DIR}/commits-since-release.sh" "$1" > "${TEST_TMP}/commits-by-crate.json"
+  run --separate-stderr "${RELEASE_BIN}/release-version-bumps.sh" \
+    --commits-by-crate "${TEST_TMP}/commits-by-crate.json" \
+    --out "${TEST_TMP}/api-changes.json" \
+    --branch proposal "${flags[@]}"
+  API_CHANGES="$(cat "${TEST_TMP}/api-changes.json" 2>/dev/null || echo 'null')"
+}
+
+crate_version() {
+  cargo metadata --format-version=1 --no-deps \
+    | jq -r --arg n "$1" '.packages[] | select(.name == $n) | .version'
+}
+
+# --- releasing --------------------------------------------------------------
+
+@test "releases a tagged crate that has commits, at the level semver-level.sh reports" {
+  STUB_SEMVER_LEVEL=minor run_bumps "$(crates_input libdd-alpha:1.2.3)"
+  assert_success
+  assert_jq "$API_CHANGES" 'length' "1"
+  assert_jq "$API_CHANGES" '.[0].name' "libdd-alpha"
+  assert_jq "$API_CHANGES" '.[0].level' "minor"
+  assert_jq "$API_CHANGES" '.[0].version' "1.3.0"
+  assert_jq "$API_CHANGES" '.[0].tag' "libdd-alpha-v1.3.0"
+  assert_jq "$API_CHANGES" '.[0].prev_tag' "libdd-alpha-v1.2.3"
+  assert_jq "$API_CHANGES" '.[0].initial_release' "false"
+  assert_jq "$API_CHANGES" '.[0].commits | map(.subject) | join("|")' "feat(alpha): a change"
+  # The manifest really was rewritten, not just the JSON.
+  assert_eq "$(crate_version libdd-alpha)" "1.3.0"
+}
+
+@test "a major level bumps the major version" {
+  STUB_SEMVER_LEVEL=major run_bumps "$(crates_input libdd-alpha:1.2.3)"
+  assert_success
+  assert_jq "$API_CHANGES" '.[0].level' "major"
+  assert_jq "$API_CHANGES" '.[0].version' "2.0.0"
+}
+
+@test "a patch level bumps the patch version" {
+  STUB_SEMVER_LEVEL=patch run_bumps "$(crates_input libdd-alpha:1.2.3)"
+  assert_success
+  assert_jq "$API_CHANGES" '.[0].level' "patch"
+  assert_jq "$API_CHANGES" '.[0].version' "1.2.4"
+}
+
+@test "commits the version bump to the proposal branch" {
+  local before
+  before="$(git rev-parse HEAD)"
+  STUB_SEMVER_LEVEL=minor run_bumps "$(crates_input libdd-alpha:1.2.3)"
+  assert_success
+  assert_eq "$(git rev-list --count "${before}..HEAD")" "1"
+  assert_contains "$(git log -1 --format=%s)" "Release"
+}
+
+@test "carries the range through from commits-since-release.sh" {
+  # The range is what git-cliff falls back to when generating the CHANGELOG.
+  STUB_SEMVER_LEVEL=minor run_bumps "$(crates_input libdd-alpha:1.2.3)"
+  assert_success
+  local expected
+  expected="$(jq -r '.[0].range' "${TEST_TMP}/commits-by-crate.json")"
+  assert_jq "$API_CHANGES" '.[0].range' "$expected"
+}
+
+# --- deferring --------------------------------------------------------------
+
+@test "defers a tagged crate with no commits of its own" {
+  run_bumps "$(crates_input libdd-gamma:2.0.1)"
+  assert_success
+  assert_jq "$API_CHANGES" '.[0].pending_release' "true"
+  assert_jq "$API_CHANGES" '.[0].level' "none"
+  assert_jq "$API_CHANGES" '.[0].version' "2.0.1"
+  assert_jq "$API_CHANGES" '.[0].commits' "[]"
+  assert_jq "$API_CHANGES" '.[0].range' ""
+  # Deferred means untouched: no bump, no commit, and semver-level.sh never ran.
+  assert_eq "$(crate_version libdd-gamma)" "2.0.1"
+  assert_eq "$(cat "$STUB_SEMVER_CALLS")" ""
+}
+
+# --- skipping ---------------------------------------------------------------
+
+@test "skips a crate whose tag is not the latest for that crate" {
+  # libdd-beta-v0.9.0 exists, so a newer release was already cut elsewhere.
+  run_bumps "$(crates_input libdd-beta:0.5.0)"
+  assert_success
+  assert_jq "$API_CHANGES" 'length' "0"
+  assert_eq "$(crate_version libdd-beta)" "0.5.0"
+  assert_contains "$output" "Skipping release for libdd-beta"
+}
+
+@test "--hotfix releases a crate whose tag is not the latest" {
+  STUB_SEMVER_LEVEL=patch run_bumps --hotfix "$(crates_input libdd-beta:0.5.0)"
+  assert_success
+  assert_jq "$API_CHANGES" 'length' "1"
+  assert_jq "$API_CHANGES" '.[0].version' "0.5.1"
+  assert_contains "$output" "because it is a hotfix"
+}
+
+@test "--bypass-standard-checks releases a crate whose tag is not the latest" {
+  STUB_SEMVER_LEVEL=patch run_bumps --bypass-standard-checks "$(crates_input libdd-beta:0.5.0)"
+  assert_success
+  assert_jq "$API_CHANGES" 'length' "1"
+  assert_jq "$API_CHANGES" '.[0].version' "0.5.1"
+  assert_contains "$output" "because bypass_standard_checks is true"
+}
+
+# --- initial releases -------------------------------------------------------
+
+@test "treats a crate with no tag as an initial release" {
+  run_bumps "$(crates_input libdd-delta:0.1.0)"
+  assert_success
+  assert_jq "$API_CHANGES" '.[0].initial_release' "true"
+  assert_jq "$API_CHANGES" '.[0].level' "major"
+  assert_jq "$API_CHANGES" '.[0].prev_tag' ""
+  assert_jq "$API_CHANGES" '.[0].range' ""
+  assert_jq "$API_CHANGES" '.[0].version' "1.0.0"
+  assert_jq "$API_CHANGES" '.[0].tag' "libdd-delta-v1.0.0"
+  # An initial release has no baseline to diff against.
+  assert_eq "$(cat "$STUB_SEMVER_CALLS")" ""
+}
+
+@test "refuses an untagged crate that is not at 0.1.0" {
+  # A missing tag on a crate that is not brand new means something is wrong with the
+  # tags, not that the crate is new; releasing it as 1.0.0 would be wrong.
+  run_bumps "$(crates_input libdd-private:0.9.0)"
+  assert_failure 1
+  assert_stderr_contains "libdd-private is not a 0.1.0 release"
+}
+
+# --- failure paths ----------------------------------------------------------
+
+@test "fails, with the reason, when semver-level.sh fails" {
+  # The output used to be captured into a variable that errexit then discarded, so the
+  # run aborted with nothing in the log.
+  STUB_SEMVER_RC=3 run_bumps "$(crates_input libdd-alpha:1.2.3)"
+  assert_failure
+  assert_stderr_contains "semver-level.sh failed for libdd-alpha"
+  assert_stderr_contains "cargo semver-checks blew up"
+}
+
+@test "fails when a tagged crate has no usable range" {
+  # tag_commit/range empty means commits-since-release.sh could not resolve the tag.
+  "${SCRIPTS_DIR}/commits-since-release.sh" "$(crates_input libdd-alpha:1.2.3)" \
+    | jq '[.[] | .range = "" | .tag_commit = ""]' > "${TEST_TMP}/commits-by-crate.json"
+  run --separate-stderr "${RELEASE_BIN}/release-version-bumps.sh" \
+    --commits-by-crate "${TEST_TMP}/commits-by-crate.json" \
+    --out "${TEST_TMP}/api-changes.json" --branch proposal
+  assert_failure 1
+  assert_stderr_contains "Could not dereference tag libdd-alpha-v1.2.3 to a commit"
+}
+
+@test "rejects a missing, unreadable or non-array input" {
+  run --separate-stderr "${RELEASE_BIN}/release-version-bumps.sh" \
+    --commits-by-crate "${TEST_TMP}/nope.json" --out "${TEST_TMP}/out.json" --branch proposal
+  assert_failure 1
+  assert_stderr_contains "not a file"
+
+  echo '{"not":"an array"}' > "${TEST_TMP}/bad.json"
+  run --separate-stderr "${RELEASE_BIN}/release-version-bumps.sh" \
+    --commits-by-crate "${TEST_TMP}/bad.json" --out "${TEST_TMP}/out.json" --branch proposal
+  assert_failure 1
+  assert_stderr_contains "is not a JSON array"
+}
+
+@test "requires its three mandatory options" {
+  run --separate-stderr "${RELEASE_BIN}/release-version-bumps.sh" --out /dev/null --branch b
+  assert_failure 1
+  assert_stderr_contains "--commits-by-crate is required"
+
+  run --separate-stderr "${RELEASE_BIN}/release-version-bumps.sh" --commits-by-crate /dev/null --branch b
+  assert_failure 1
+  assert_stderr_contains "--out is required"
+
+  run --separate-stderr "${RELEASE_BIN}/release-version-bumps.sh" --commits-by-crate /dev/null --out /dev/null
+  assert_failure 1
+  assert_stderr_contains "--branch is required"
+
+  run --separate-stderr "${RELEASE_BIN}/release-version-bumps.sh" --nope
+  assert_failure 1
+  assert_stderr_contains "Unknown option: --nope"
+}
+
+# --- several crates at once -------------------------------------------------
+
+@test "handles a mixed batch, giving each crate its own outcome" {
+  # One release, one skip, one defer, one initial release, in publication order.
+  STUB_SEMVER_LEVEL=minor run_bumps \
+    "$(crates_input libdd-alpha:1.2.3 libdd-beta:0.5.0 libdd-gamma:2.0.1 libdd-delta:0.1.0)"
+  assert_success
+  assert_jq "$API_CHANGES" 'map(.name) | join(",")' "libdd-alpha,libdd-gamma,libdd-delta"
+  assert_jq "$API_CHANGES" '.[] | select(.name == "libdd-alpha") | .level' "minor"
+  assert_jq "$API_CHANGES" '.[] | select(.name == "libdd-gamma") | .pending_release' "true"
+  assert_jq "$API_CHANGES" '.[] | select(.name == "libdd-delta") | .initial_release' "true"
+  # Only the crate that needed a level asked for one.
+  assert_eq "$(cat "$STUB_SEMVER_CALLS")" "libdd-alpha"
+}
+
+@test "writes an empty array when there are no candidates" {
+  echo '[]' > "${TEST_TMP}/commits-by-crate.json"
+  run --separate-stderr "${RELEASE_BIN}/release-version-bumps.sh" \
+    --commits-by-crate "${TEST_TMP}/commits-by-crate.json" \
+    --out "${TEST_TMP}/api-changes.json" --branch proposal
+  assert_success
+  assert_jq "$(cat "${TEST_TMP}/api-changes.json")" 'length' "0"
+}
+
+@test "warns when the tagged commit is not in any local branch" {
+  # Re-tag onto history no branch points at -- what a squash-merged release leaves --
+  # while keeping the crate's own commits after the fork point so it still gets released.
+  local tag_point
+  tag_point="$(git rev-parse 'libdd-alpha-v1.2.3^{}')"
+  git checkout -q -b throwaway "$tag_point"
+  fixture_touch_crate libdd-alpha "chore: release-only commit"
+  git tag -f "libdd-alpha-v1.2.3" >/dev/null
+  git checkout -q proposal
+  git branch -qD throwaway
+
+  STUB_SEMVER_LEVEL=patch run_bumps "$(crates_input libdd-alpha:1.2.3)"
+  assert_success
+  assert_jq "$API_CHANGES" 'length' "1"
+  assert_contains "$output" "is not in any local branch"
+}

--- a/scripts/tests/release-version-major-bumps.bats
+++ b/scripts/tests/release-version-major-bumps.bats
@@ -1,0 +1,233 @@
+#!/usr/bin/env bats
+
+# Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+
+# release-version-major-bumps.sh decides the final shape of a release: which crates get
+# forced to major because a direct libdd-* dependency went to a new major inside this
+# same proposal, and which no-commit candidates are pulled back in or dropped entirely.
+# Get it wrong and a crate ships a compatible-looking version against an incompatible
+# dependency, or silently disappears from the release.
+#
+# Nothing is stubbed here. major-bumps-level.sh only reads cargo metadata in a worktree
+# -- no compilation -- and cargo-release is fast, so the whole step runs for real and the
+# versions asserted are the ones a release would land on.
+
+load helpers/common
+load helpers/fixture
+
+setup() {
+  setup_common
+  if ! cargo release --version >/dev/null 2>&1; then
+    skip "cargo-release is not installed (cargo install cargo-release)"
+  fi
+  fixture_init
+
+  # State at the last release: beta, gamma and other-tool all depend on libdd-alpha ^1.2,
+  # libdd-delta only build- and dev-depends on its siblings.
+  fixture_tag "libdd-alpha-v1.2.3"
+  fixture_tag "libdd-beta-v0.5.0"
+  fixture_tag "libdd-gamma-v2.0.1"
+  fixture_tag "libdd-delta-v0.1.0"
+  fixture_tag "other-tool-v0.3.0"
+  git checkout -q -b proposal
+
+  simulate_previous_release
+}
+
+teardown() {
+  teardown_common
+}
+
+# What the "Release version bumps" step would have left behind: libdd-alpha released at
+# major (1.2.3 -> 2.0.0) and libdd-beta at minor (0.5.0 -> 0.6.0). Driven through
+# cargo-release rather than by editing manifests, so dependents' requirements are
+# rewritten the same way a real release rewrites them and the workspace still resolves.
+# Committed, because the audit reads the proposal branch tip.
+simulate_previous_release() {
+  cargo release version -p libdd-alpha --allow-branch proposal -x major --no-confirm >/dev/null
+  cargo release version -p libdd-beta --allow-branch proposal -x minor --no-confirm >/dev/null
+  fixture_commit_all "chore: Release"
+}
+
+# row NAME LEVEL PREV_VERSION VERSION [pending]
+row() {
+  jq -nc --arg n "$1" --arg l "$2" --arg pv "$3" --arg v "$4" --argjson p "${5:-false}" \
+    '{name: $n, level: $l, tag: ($n + "-v" + $v), prev_tag: ($n + "-v" + $pv),
+      version: $v, range: "", commits: [], path: $n, initial_release: "false"}
+     + (if $p then {pending_release: "true"} else {} end)'
+}
+
+# run_major_bumps ROW... — feed rows in and run the script over them.
+run_major_bumps() {
+  printf '%s\n' "$@" | jq -s '.' > "${TEST_TMP}/api-changes.json"
+  run --separate-stderr "${SCRIPTS_DIR}/release-version-major-bumps.sh" \
+    --api-changes "${TEST_TMP}/api-changes.json" \
+    --out "${TEST_TMP}/api-changes-with-major-bumps.json" \
+    --branch proposal
+  RESULT="$(cat "${TEST_TMP}/api-changes-with-major-bumps.json" 2>/dev/null || echo 'null')"
+}
+
+crate_version() {
+  cargo metadata --format-version=1 --no-deps \
+    | jq -r --arg n "$1" '.packages[] | select(.name == $n) | .version'
+}
+
+# --- promoting --------------------------------------------------------------
+
+@test "promotes a released crate below major when a direct dependency went major" {
+  run_major_bumps "$(row libdd-beta minor 0.5.0 0.6.0)"
+  assert_success
+  assert_jq "$RESULT" 'length' "1"
+  assert_jq "$RESULT" '.[0].level' "major"
+  assert_jq "$RESULT" '.[0].version' "1.0.0"
+  assert_jq "$RESULT" '.[0].tag' "libdd-beta-v1.0.0"
+  assert_eq "$(crate_version libdd-beta)" "1.0.0"
+  assert_contains "$output" "Bumping libdd-beta to major"
+}
+
+@test "records why the crate was promoted" {
+  run_major_bumps "$(row libdd-beta minor 0.5.0 0.6.0)"
+  assert_success
+  assert_jq "$RESULT" '.[0].major_bumps[0].dependency' "libdd-alpha"
+  assert_jq "$RESULT" '.[0].major_bumps[0].previous_req' "^1.2"
+  assert_jq "$RESULT" '.[0].major_bumps[0].current_req' "^2.0"
+}
+
+@test "commits one version bump per promoted crate" {
+  local before
+  before="$(git rev-parse HEAD)"
+  run_major_bumps "$(row libdd-beta minor 0.5.0 0.6.0)" "$(row libdd-gamma minor 2.0.1 2.1.0)"
+  assert_success
+  assert_eq "$(git rev-list --count "${before}..HEAD")" "2"
+  assert_contains "$(git log -1 --format=%s)" "chore(release): update version for"
+}
+
+@test "leaves a crate already bumped to major alone" {
+  # It cannot go higher, so the audit must not bump it a second time.
+  run_major_bumps "$(row libdd-beta major 0.5.0 1.0.0)"
+  assert_success
+  assert_jq "$RESULT" '.[0].level' "major"
+  assert_jq "$RESULT" '.[0].version' "1.0.0"
+  assert_eq "$(crate_version libdd-beta)" "0.6.0"
+  assert_contains "$output" "Skipping libdd-beta: already bumped at major level"
+}
+
+@test "leaves a crate with no libdd-* dependency alone" {
+  # libdd-alpha is the dependency that moved; it depends on nothing itself.
+  run_major_bumps "$(row libdd-alpha major 1.2.3 2.0.0)"
+  assert_success
+  assert_jq "$RESULT" '.[0].version' "2.0.0"
+  assert_jq "$RESULT" '.[0].major_bumps' "[]"
+  assert_eq "$(crate_version libdd-alpha)" "2.0.0"
+}
+
+@test "ignores dev-dependency and build-dependency major bumps" {
+  # libdd-delta only build- and dev-depends on its siblings, so nothing a consumer of
+  # libdd-delta links against changed.
+  run_major_bumps "$(row libdd-delta minor 0.1.0 0.2.0)"
+  assert_success
+  assert_jq "$RESULT" '.[0].level' "minor"
+  assert_jq "$RESULT" '.[0].major_bumps' "[]"
+  assert_eq "$(crate_version libdd-delta)" "0.1.0"
+}
+
+# --- pending candidates -----------------------------------------------------
+
+@test "pulls a pending crate into the release when its dependency went major" {
+  run_major_bumps "$(row libdd-gamma none 2.0.1 2.0.1 true)"
+  assert_success
+  assert_jq "$RESULT" 'length' "1"
+  assert_jq "$RESULT" '.[0].name' "libdd-gamma"
+  assert_jq "$RESULT" '.[0].level' "major"
+  assert_jq "$RESULT" '.[0].version' "3.0.0"
+  assert_eq "$(crate_version libdd-gamma)" "3.0.0"
+}
+
+@test "drops a pending crate that earns no major bump" {
+  # No commits of its own and nothing forcing it: it stays out of the release entirely.
+  run_major_bumps "$(row libdd-delta none 0.1.0 0.1.0 true)"
+  assert_success
+  assert_jq "$RESULT" 'length' "0"
+  assert_eq "$(crate_version libdd-delta)" "0.1.0"
+  assert_contains "$output" "keeping it out of the release"
+}
+
+@test "never leaks pending_release into the result" {
+  # Downstream steps treat every row in this file as a crate being released.
+  run_major_bumps "$(row libdd-beta minor 0.5.0 0.6.0)" \
+                  "$(row libdd-gamma none 2.0.1 2.0.1 true)" \
+                  "$(row libdd-delta none 0.1.0 0.1.0 true)"
+  assert_success
+  assert_jq "$RESULT" 'any(.[]; has("pending_release"))' "false"
+}
+
+# --- ordering and batches ---------------------------------------------------
+
+@test "handles a mixed batch, giving each crate its own outcome" {
+  run_major_bumps "$(row libdd-alpha major 1.2.3 2.0.0)" \
+                  "$(row libdd-beta minor 0.5.0 0.6.0)" \
+                  "$(row libdd-gamma none 2.0.1 2.0.1 true)" \
+                  "$(row libdd-delta none 0.1.0 0.1.0 true)"
+  assert_success
+  # Released crates keep their order; the promoted pending crate is appended after them.
+  assert_jq "$RESULT" 'map("\(.name):\(.level):\(.version)") | join(" ")' \
+    "libdd-alpha:major:2.0.0 libdd-beta:major:1.0.0 libdd-gamma:major:3.0.0"
+}
+
+@test "writes an empty array when there are no candidates" {
+  run_major_bumps
+  assert_success
+  assert_jq "$RESULT" 'length' "0"
+}
+
+# --- hygiene and failure paths ----------------------------------------------
+
+@test "removes the throwaway audit worktree" {
+  # It is created inside the caller's repository; leaving it behind would make later
+  # `git worktree add` calls in the same job collide.
+  run_major_bumps "$(row libdd-beta minor 0.5.0 0.6.0)"
+  assert_success
+  assert_eq "$(git worktree list | tail -n +2 | wc -l)" "0"
+}
+
+@test "fails, with the audit output, when major-bumps-level.sh fails" {
+  # A prev_tag that does not exist: the audit cannot check the crate out to compare
+  # against. Failing loudly beats releasing on an unaudited row.
+  run_major_bumps "$(row libdd-beta minor 9.9.9 0.6.0)"
+  assert_failure
+  assert_contains "$output" "Major bumps level script failed with code"
+  # And it still cleaned up after itself.
+  assert_eq "$(git worktree list | tail -n +2 | wc -l)" "0"
+}
+
+@test "rejects a missing or non-array input" {
+  run --separate-stderr "${SCRIPTS_DIR}/release-version-major-bumps.sh" \
+    --api-changes "${TEST_TMP}/nope.json" --out "${TEST_TMP}/out.json" --branch proposal
+  assert_failure 1
+  assert_stderr_contains "not a file"
+
+  echo '{"not":"an array"}' > "${TEST_TMP}/bad.json"
+  run --separate-stderr "${SCRIPTS_DIR}/release-version-major-bumps.sh" \
+    --api-changes "${TEST_TMP}/bad.json" --out "${TEST_TMP}/out.json" --branch proposal
+  assert_failure 1
+  assert_stderr_contains "is not a JSON array"
+}
+
+@test "requires its three mandatory options" {
+  run --separate-stderr "${SCRIPTS_DIR}/release-version-major-bumps.sh" --out /dev/null --branch b
+  assert_failure 1
+  assert_stderr_contains "--api-changes is required"
+
+  run --separate-stderr "${SCRIPTS_DIR}/release-version-major-bumps.sh" --api-changes /dev/null --branch b
+  assert_failure 1
+  assert_stderr_contains "--out is required"
+
+  run --separate-stderr "${SCRIPTS_DIR}/release-version-major-bumps.sh" --api-changes /dev/null --out /dev/null
+  assert_failure 1
+  assert_stderr_contains "--branch is required"
+
+  run --separate-stderr "${SCRIPTS_DIR}/release-version-major-bumps.sh" --nope
+  assert_failure 1
+  assert_stderr_contains "Unknown option: --nope"
+}

--- a/scripts/tests/release-version-major-bumps.bats
+++ b/scripts/tests/release-version-major-bumps.bats
@@ -201,6 +201,24 @@ crate_version() {
   assert_eq "$(git worktree list | tail -n +2 | wc -l)" "0"
 }
 
+@test "accepts relative --api-changes and --out paths" {
+  # Regression: --api-changes was validated in the caller's directory and then passed
+  # unchanged into `( cd "$MAJOR_BUMPS_WT" && major-bumps-level.sh ... )`, so a relative
+  # path was looked up from the throwaway worktree and failed there with "Not a file"
+  # after validating fine a few lines earlier. The workflow passes absolute /tmp paths,
+  # but the documented interface takes a generic FILE.
+  printf '%s\n' "$(row libdd-beta minor 0.5.0 0.6.0)" | jq -s '.' > "${FIXTURE_REPO}/rel-in.json"
+
+  run --separate-stderr "${SCRIPTS_DIR}/release-version-major-bumps.sh" \
+    --api-changes rel-in.json \
+    --out rel-out.json \
+    --branch proposal
+  assert_success
+  # --out is resolved from the caller's directory, which is where it must land.
+  assert_jq "$(cat "${FIXTURE_REPO}/rel-out.json")" '.[0].version' "1.0.0"
+  assert_jq "$(cat "${FIXTURE_REPO}/rel-out.json")" '.[0].level' "major"
+}
+
 @test "fails when the jq that streams the audited rows fails" {
   # Regression: see release-version-bumps.bats. The audit itself succeeds here; the
   # failure is in the read of its output, which used to be a process substitution and

--- a/scripts/tests/release-version-major-bumps.bats
+++ b/scripts/tests/release-version-major-bumps.bats
@@ -61,7 +61,7 @@ row() {
 # run_major_bumps ROW... — feed rows in and run the script over them.
 run_major_bumps() {
   printf '%s\n' "$@" | jq -s '.' > "${TEST_TMP}/api-changes.json"
-  run --separate-stderr "${SCRIPTS_DIR}/release-version-major-bumps.sh" \
+  run_tool release-version-major-bumps \
     --api-changes "${TEST_TMP}/api-changes.json" \
     --out "${TEST_TMP}/api-changes-with-major-bumps.json" \
     --branch proposal
@@ -209,7 +209,7 @@ crate_version() {
   # but the documented interface takes a generic FILE.
   printf '%s\n' "$(row libdd-beta minor 0.5.0 0.6.0)" | jq -s '.' > "${FIXTURE_REPO}/rel-in.json"
 
-  run --separate-stderr "${SCRIPTS_DIR}/release-version-major-bumps.sh" \
+  run_tool release-version-major-bumps \
     --api-changes rel-in.json \
     --out rel-out.json \
     --branch proposal
@@ -226,7 +226,7 @@ crate_version() {
   printf '%s\n' "$(row libdd-beta minor 0.5.0 0.6.0)" | jq -s '.' > "${TEST_TMP}/api-changes.json"
 
   use_failing_stream_jq
-  run --separate-stderr "${SCRIPTS_DIR}/release-version-major-bumps.sh" \
+  run_tool release-version-major-bumps \
     --api-changes "${TEST_TMP}/api-changes.json" \
     --out "${TEST_TMP}/api-changes-with-major-bumps.json" \
     --branch proposal
@@ -238,32 +238,32 @@ crate_version() {
 }
 
 @test "rejects a missing or non-array input" {
-  run --separate-stderr "${SCRIPTS_DIR}/release-version-major-bumps.sh" \
+  run_tool release-version-major-bumps \
     --api-changes "${TEST_TMP}/nope.json" --out "${TEST_TMP}/out.json" --branch proposal
-  assert_failure 1
-  assert_stderr_contains "not a file"
+  assert_failure
+  assert_stderr_mentions "nope.json"
 
   echo '{"not":"an array"}' > "${TEST_TMP}/bad.json"
-  run --separate-stderr "${SCRIPTS_DIR}/release-version-major-bumps.sh" \
+  run_tool release-version-major-bumps \
     --api-changes "${TEST_TMP}/bad.json" --out "${TEST_TMP}/out.json" --branch proposal
-  assert_failure 1
-  assert_stderr_contains "is not a JSON array"
+  assert_failure
+  assert_stderr_mentions "bad.json" "array"
 }
 
 @test "requires its three mandatory options" {
-  run --separate-stderr "${SCRIPTS_DIR}/release-version-major-bumps.sh" --out /dev/null --branch b
-  assert_failure 1
-  assert_stderr_contains "--api-changes is required"
+  run_tool release-version-major-bumps --out /dev/null --branch b
+  assert_failure
+  assert_stderr_mentions "--api-changes"
 
-  run --separate-stderr "${SCRIPTS_DIR}/release-version-major-bumps.sh" --api-changes /dev/null --branch b
-  assert_failure 1
-  assert_stderr_contains "--out is required"
+  run_tool release-version-major-bumps --api-changes /dev/null --branch b
+  assert_failure
+  assert_stderr_mentions "--out"
 
-  run --separate-stderr "${SCRIPTS_DIR}/release-version-major-bumps.sh" --api-changes /dev/null --out /dev/null
-  assert_failure 1
-  assert_stderr_contains "--branch is required"
+  run_tool release-version-major-bumps --api-changes /dev/null --out /dev/null
+  assert_failure
+  assert_stderr_mentions "--branch"
 
-  run --separate-stderr "${SCRIPTS_DIR}/release-version-major-bumps.sh" --nope
-  assert_failure 1
-  assert_stderr_contains "Unknown option: --nope"
+  run_tool release-version-major-bumps --nope
+  assert_failure
+  assert_stderr_mentions "--nope"
 }

--- a/scripts/tests/release-version-major-bumps.bats
+++ b/scripts/tests/release-version-major-bumps.bats
@@ -201,6 +201,24 @@ crate_version() {
   assert_eq "$(git worktree list | tail -n +2 | wc -l)" "0"
 }
 
+@test "fails when the jq that streams the audited rows fails" {
+  # Regression: see release-version-bumps.bats. The audit itself succeeds here; the
+  # failure is in the read of its output, which used to be a process substitution and
+  # so exited 0 with nothing promoted.
+  printf '%s\n' "$(row libdd-beta minor 0.5.0 0.6.0)" | jq -s '.' > "${TEST_TMP}/api-changes.json"
+
+  use_failing_stream_jq
+  run --separate-stderr "${SCRIPTS_DIR}/release-version-major-bumps.sh" \
+    --api-changes "${TEST_TMP}/api-changes.json" \
+    --out "${TEST_TMP}/api-changes-with-major-bumps.json" \
+    --branch proposal
+  assert_failure 5
+  assert_stderr_contains "simulated failure on the streaming read"
+  assert_eq "$(crate_version libdd-beta)" "0.6.0"
+  # The audit worktree is still cleaned up on the way out.
+  assert_eq "$(git worktree list | tail -n +2 | wc -l)" "0"
+}
+
 @test "rejects a missing or non-array input" {
   run --separate-stderr "${SCRIPTS_DIR}/release-version-major-bumps.sh" \
     --api-changes "${TEST_TMP}/nope.json" --out "${TEST_TMP}/out.json" --branch proposal

--- a/scripts/tests/run.sh
+++ b/scripts/tests/run.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+
+# Run the release-script test suite.
+#
+#   ./scripts/tests/run.sh                          # everything
+#   ./scripts/tests/run.sh semver-level             # one suite (by file stem)
+#   ./scripts/tests/run.sh -f "merge-base"          # tests whose name matches a regex
+#
+# Requires bats-core >= 1.5.0 on PATH:
+#   curl -sSfL https://github.com/bats-core/bats-core/archive/refs/tags/v1.11.1.tar.gz \
+#     | tar xz && ./bats-core-1.11.1/install.sh "$HOME/.local"
+
+set -euo pipefail
+
+TESTS_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+REPO_ROOT="$(cd -- "${TESTS_DIR}/../.." >/dev/null 2>&1 && pwd)"
+
+missing=()
+for tool in bats jq git cargo python3; do
+  command -v "$tool" >/dev/null 2>&1 || missing+=("$tool")
+done
+if [ "${#missing[@]}" -gt 0 ]; then
+  echo "Error: missing required tool(s): ${missing[*]}" >&2
+  if [[ " ${missing[*]} " == *" bats "* ]]; then
+    echo "Install bats-core >= 1.5.0; see the header of this script." >&2
+  fi
+  exit 1
+fi
+
+if ! python3 -c 'import yaml' >/dev/null 2>&1; then
+  echo "Error: python3 is missing the PyYAML module (needed to parse the workflow YAML)." >&2
+  echo "Install it with: python3 -m pip install pyyaml" >&2
+  exit 1
+fi
+
+# Suites resolve paths relative to the repository root.
+cd "$REPO_ROOT"
+
+declare -a suites=()
+declare -a bats_args=()
+for arg in "$@"; do
+  if [[ "$arg" == -* || "${#bats_args[@]}" -gt 0 && "${bats_args[-1]}" == "-f" ]]; then
+    bats_args+=("$arg")
+  else
+    suites+=("${TESTS_DIR}/${arg%.bats}.bats")
+  fi
+done
+if [ "${#suites[@]}" -eq 0 ]; then
+  mapfile -t suites < <(find "$TESTS_DIR" -maxdepth 1 -name '*.bats' | sort)
+fi
+
+exec bats --print-output-on-failure "${bats_args[@]}" "${suites[@]}"

--- a/scripts/tests/semver-level.bats
+++ b/scripts/tests/semver-level.bats
@@ -76,7 +76,7 @@ EOF
 }
 
 run_semver_level() {
-  run --separate-stderr "${SCRIPTS_DIR}/semver-level.sh" libdd-alpha "refs/tags/libdd-alpha-v1.2.3" HEAD
+  run_tool semver-level libdd-alpha "refs/tags/libdd-alpha-v1.2.3" HEAD
 }
 
 @test "no API change at all is a patch release" {
@@ -201,22 +201,22 @@ EOF
   # as a patch release.
   stub_semver_checks 1 "error: could not compile \`libdd-alpha\`"
   run_semver_level
-  assert_failure 1
-  assert_stderr_contains "Error running cargo-semver-checks"
+  assert_failure
+  assert_stderr_mentions "cargo-semver-checks"
 }
 
 @test "fails on an unexpected cargo-semver-checks exit code" {
   stub_semver_checks 101 "thread 'main' panicked"
   run_semver_level
   assert_failure 101
-  assert_stderr_contains "Unexpected exit code from cargo-semver-checks"
+  assert_stderr_mentions "cargo-semver-checks"
 }
 
 @test "fails when cargo-public-api errors out" {
   stub_public_api 1 "error: failed to build rustdoc JSON"
   run_semver_level
-  assert_failure 1
-  assert_stderr_contains "Unexpected error from cargo-public-api"
+  assert_failure
+  assert_stderr_mentions "cargo-public-api"
 }
 
 @test "passes the tag baseline through unprefixed and diffs baseline..current" {
@@ -231,19 +231,19 @@ EOF
 }
 
 @test "prefixes a bare branch baseline with origin/" {
-  run --separate-stderr "${SCRIPTS_DIR}/semver-level.sh" libdd-alpha main HEAD
+  run_tool semver-level libdd-alpha main HEAD
   assert_success
   assert_contains "$(cat "$STUB_CALL_LOG")" "--baseline-rev origin/main"
 }
 
 @test "defaults the current ref to HEAD and requires a crate name" {
-  run --separate-stderr "${SCRIPTS_DIR}/semver-level.sh" libdd-alpha main
+  run_tool semver-level libdd-alpha main
   assert_success
   assert_contains "$(cat "$STUB_CALL_LOG")" "diff origin/main..HEAD"
 
-  run --separate-stderr "${SCRIPTS_DIR}/semver-level.sh"
+  run_tool semver-level
   assert_failure
-  assert_stderr_contains "CRATE is required"
+  assert_stderr_mentions
 }
 
 @test "emits a single JSON object with the fields the workflow reads" {

--- a/scripts/tests/semver-level.bats
+++ b/scripts/tests/semver-level.bats
@@ -79,6 +79,18 @@ run_semver_level() {
   run_tool semver-level libdd-alpha "refs/tags/libdd-alpha-v1.2.3" HEAD
 }
 
+# run_semver_level_for CRATE — same baseline, for the crates that carry dependencies.
+# The baseline is just a revision, so libdd-alpha's tag serves for any crate.
+run_semver_level_for() {
+  run_tool semver-level "$1" "refs/tags/libdd-alpha-v1.2.3" HEAD
+}
+
+# run_semver_level_since CRATE BASELINE — for the cases that need state established in
+# the baseline itself, and so tag their own.
+run_semver_level_since() {
+  run_tool semver-level "$1" "$2" HEAD
+}
+
 @test "no API change at all is a patch release" {
   # Every crate with commits gets released, so 'none' is deliberately floored to patch.
   run_semver_level
@@ -244,6 +256,257 @@ EOF
   run_tool semver-level
   assert_failure
   assert_stderr_mentions
+}
+
+# --- dependency requirement floors -----------------------------------------
+#
+# Neither cargo-semver-checks nor cargo-public-api reads a manifest, so raising the
+# lowest version a dependency admits is invisible to both and used to come out patch.
+# Both tools stay stubbed clean throughout this section: the level under test can only
+# have come from the manifest pass.
+
+@test "raising a dependency requirement floor is a minor, not a patch" {
+  fixture_set_dep_req libdd-beta libdd-alpha "1.3"
+  fixture_commit_all "chore: require libdd-alpha 1.3"
+  run_semver_level_for libdd-beta
+  assert_success
+  assert_jq "$output" '.level' "minor"
+  assert_jq "$output" '.reason' "Dependency requirement floor raised"
+  assert_contains "$(jq -r '.details' <<< "$output")" "libdd-alpha"
+}
+
+@test "a floor raised only inside [workspace.dependencies] is still seen" {
+  # The libdd-capabilities case from release proposal #2482: `http = "1"` became
+  # `http = { workspace = true }` with the root manifest at "1.1". The crate's own
+  # Cargo.toml diff shows no version, so only a resolved view catches the raise.
+  fixture_use_workspace_dep libdd-beta libdd-alpha "1.3"
+  fixture_commit_all "refactor: migrate libdd-alpha to workspace level"
+  # Guard the premise: the crate manifest really has no version left to read.
+  assert_not_contains "$(cat "${FIXTURE_REPO}/libdd-beta/Cargo.toml")" 'version = "1.2"'
+  run_semver_level_for libdd-beta
+  assert_success
+  assert_jq "$output" '.level' "minor"
+  assert_jq "$output" '.reason' "Dependency requirement floor raised"
+}
+
+@test "widening a requirement is not a raise and stays a patch" {
+  # `bytes = "1.11.1"` -> `"1.11"` lowers the floor: every consumer that resolved
+  # before still resolves.
+  fixture_set_dep_req libdd-beta libdd-alpha "1.0"
+  fixture_commit_all "chore: accept older libdd-alpha"
+  run_semver_level_for libdd-beta
+  assert_success
+  assert_jq "$output" '.level' "patch"
+  assert_jq "$output" '.reason' "No public API changes detected"
+}
+
+@test "a dependency is identified by its alias, not just its package name" {
+  # cargo metadata reports the package name in .name and the local alias in .rename, so a
+  # crate aliasing two versions of one package emits an identical name, kind and target
+  # for both. Keyed without the alias, the second is looked up against the first's
+  # baseline requirement and an unchanged pair reads as a raised floor.
+  #
+  # That exact pair needs a registry source — cargo refuses two same-named path packages
+  # even in separate workspaces — and this fixture is deliberately offline, so assert
+  # instead that the alias reaches the row, the lookup key and the report. Dropping it
+  # from the emitted row shifts every later field and the raise stops being detected.
+  fixture_alias_dep libdd-beta libdd-alpha alpha_next
+  fixture_commit_all "refactor: alias libdd-alpha"
+  fixture_publish_tag "beta-aliased"
+  fixture_set_dep_req libdd-beta alpha_next "1.3"
+  fixture_commit_all "chore: require libdd-alpha 1.3"
+  run_semver_level_since libdd-beta "refs/tags/beta-aliased"
+  assert_success
+  assert_jq "$output" '.level' "minor"
+  assert_contains "$(jq -r '.details' <<< "$output")" "libdd-alpha as alpha_next"
+}
+
+@test "a dev-dependency floor raise stays a patch" {
+  # libdd-tinybytes in #2482: its whole diff was a [dev-dependencies] entry. A consumer
+  # never resolves those, so it must not be promoted.
+  fixture_set_dep_req libdd-alpha libdd-gamma "2.0.1"
+  fixture_commit_all "chore: bump the dev-dependency"
+  run_semver_level
+  assert_success
+  assert_jq "$output" '.level' "patch"
+}
+
+@test "a build-dependency floor raise is a minor" {
+  # libdd-delta build-depends on libdd-beta and dev-depends on libdd-alpha: the build
+  # kind counts, and the dev one alongside it must not confuse the match.
+  fixture_set_dep_req libdd-delta libdd-beta "0.5.1"
+  fixture_commit_all "chore: require libdd-beta 0.5.1"
+  run_semver_level_for libdd-delta
+  assert_success
+  assert_jq "$output" '.level' "minor"
+  assert_contains "$(jq -r '.details' <<< "$output")" "libdd-beta"
+}
+
+@test "a raised major floor is capped at minor here" {
+  # Whether a dependent must itself go major is release-version-major-bumps.sh's call,
+  # made with the dependency graph this script cannot see. Reporting major here would
+  # pre-empt it.
+  fixture_set_dep_req libdd-beta libdd-alpha "2.0"
+  fixture_commit_all "chore: require libdd-alpha 2.0"
+  run_semver_level_for libdd-beta
+  assert_success
+  assert_jq "$output" '.level' "minor"
+}
+
+@test "tightening an inclusive bound into an exclusive one is a raise" {
+  # `>=1.2` and `>1.2` are different floors — the second stops admitting 1.2 itself — so
+  # comparing the bare version either side of the operator would call them equal and pass
+  # a narrowed requirement off as a patch.
+  fixture_set_dep_req libdd-beta libdd-alpha ">=1.2"
+  fixture_commit_all "chore: require libdd-alpha >=1.2"
+  fixture_publish_tag "beta-bounded"
+  fixture_set_dep_req libdd-beta libdd-alpha ">1.2"
+  fixture_commit_all "chore: stop admitting libdd-alpha 1.2"
+  run_semver_level_since libdd-beta "refs/tags/beta-bounded"
+  assert_success
+  assert_jq "$output" '.level' "minor"
+  assert_jq "$output" '.reason' "Dependency requirement floor raised"
+}
+
+@test "relaxing an exclusive bound into an inclusive one is not a raise" {
+  fixture_set_dep_req libdd-beta libdd-alpha ">1.2"
+  fixture_commit_all "chore: require libdd-alpha >1.2"
+  fixture_publish_tag "beta-bounded"
+  fixture_set_dep_req libdd-beta libdd-alpha ">=1.2"
+  fixture_commit_all "chore: admit libdd-alpha 1.2 again"
+  run_semver_level_since libdd-beta "refs/tags/beta-bounded"
+  assert_success
+  assert_jq "$output" '.level' "patch"
+}
+
+@test "a requirement with no lower bound yields no opinion" {
+  # `*` admits everything, so nothing was raised — and an unparsed requirement must
+  # never be guessed into a bump.
+  fixture_set_dep_req libdd-beta libdd-alpha "*"
+  fixture_commit_all "chore: accept any libdd-alpha"
+  run_semver_level_for libdd-beta
+  assert_success
+  assert_jq "$output" '.level' "patch"
+}
+
+@test "an unchanged manifest reports nothing from the dependency pass" {
+  fixture_touch_crate libdd-beta "feat: something internal"
+  run_semver_level_for libdd-beta
+  assert_success
+  assert_jq "$output" '.level' "patch"
+  assert_jq "$output" '.reason' "No public API changes detected"
+}
+
+@test "an API signal of the same level keeps its more specific reason" {
+  # Added items and a raised floor are both minor; the API explanation describes the
+  # change better than "a dependency floor moved".
+  stub_public_api 0 "$(public_api_diff '(none)' '(none)' 'pub fn libdd_beta::added()')"
+  fixture_set_dep_req libdd-beta libdd-alpha "1.3"
+  fixture_commit_all "chore: require libdd-alpha 1.3"
+  run_semver_level_for libdd-beta
+  assert_success
+  assert_jq "$output" '.level' "minor"
+  assert_jq "$output" '.reason' "cargo-public-api detected new public API items"
+}
+
+@test "a major API signal outranks a raised floor" {
+  stub_public_api 0 "$(public_api_diff 'pub fn libdd_beta::gone()' '(none)' '(none)')"
+  fixture_set_dep_req libdd-beta libdd-alpha "1.3"
+  fixture_commit_all "chore: require libdd-alpha 1.3"
+  run_semver_level_for libdd-beta
+  assert_success
+  assert_jq "$output" '.level' "major"
+  assert_jq "$output" '.reason' "cargo-public-api detected removed public API items"
+}
+
+# --- cargo feature surface --------------------------------------------------
+#
+# Features are public API — downstream writes `features = ["x"]` against them — but
+# cargo-semver-checks has no lint for an ADDED feature, and an added feature adds no
+# rustdoc item unless it gates one, so it used to come out patch. Both tools stay
+# stubbed clean here, which also stands in for the crate shape where
+# cargo-semver-checks is skipped outright (no library target) and this pass is the
+# only thing watching the feature table.
+
+@test "adding a feature is a minor" {
+  fixture_set_features libdd-beta 'extra = []'
+  fixture_commit_all "feat: add an extra feature"
+  run_semver_level_for libdd-beta
+  assert_success
+  assert_jq "$output" '.level' "minor"
+  assert_jq "$output" '.reason' "Cargo feature added"
+  assert_contains "$(jq -r '.details' <<< "$output")" "extra"
+}
+
+@test "removing a feature is a major" {
+  fixture_set_features libdd-beta 'default = ["std"]' 'std = []' 'extra = []'
+  fixture_commit_all "feat: declare features"
+  fixture_publish_tag "beta-featured"
+  fixture_set_features libdd-beta 'default = ["std"]' 'std = []'
+  fixture_commit_all "chore!: drop the extra feature"
+  run_semver_level_since libdd-beta "refs/tags/beta-featured"
+  assert_success
+  assert_jq "$output" '.level' "major"
+  assert_jq "$output" '.reason' "Cargo feature removed or no longer enabled by default"
+  assert_contains "$(jq -r '.details' <<< "$output")" "extra"
+}
+
+@test "dropping a feature from the default set is a major" {
+  # The feature is still declared, so a name-set comparison alone would miss it — but
+  # every consumer relying on default features loses whatever it enabled.
+  fixture_set_features libdd-beta 'default = ["std"]' 'std = []'
+  fixture_commit_all "feat: declare features"
+  fixture_publish_tag "beta-featured"
+  fixture_set_features libdd-beta 'default = []' 'std = []'
+  fixture_commit_all "chore!: stop enabling std by default"
+  run_semver_level_since libdd-beta "refs/tags/beta-featured"
+  assert_success
+  assert_jq "$output" '.level' "major"
+  assert_jq "$output" '.reason' "Cargo feature removed or no longer enabled by default"
+  assert_contains "$(jq -r '.details' <<< "$output")" "std"
+}
+
+@test "the implicit feature of a newly optional dependency counts as added" {
+  # `optional = true` derives a feature of the dependency's name that appears in no
+  # [features] table, so only a resolved view of the manifest sees it.
+  fixture_set_dep_optional libdd-beta libdd-alpha
+  fixture_commit_all "refactor: make libdd-alpha optional"
+  assert_not_contains "$(cat "${FIXTURE_REPO}/libdd-beta/Cargo.toml")" "[features]"
+  run_semver_level_for libdd-beta
+  assert_success
+  assert_jq "$output" '.level' "minor"
+  assert_jq "$output" '.reason' "Cargo feature added"
+  assert_contains "$(jq -r '.details' <<< "$output")" "libdd-alpha"
+}
+
+@test "a removed feature outranks added public items" {
+  # Also pins the asymmetry between the two manifest passes: the dependency pass stops
+  # once the level is minor because minor is its ceiling, but this one must keep going,
+  # or a feature removal on a crate whose cargo-semver-checks pass was skipped (no
+  # library target) would ship as a minor.
+  stub_public_api 0 "$(public_api_diff '(none)' '(none)' 'pub fn libdd_beta::added()')"
+  fixture_set_features libdd-beta 'extra = []'
+  fixture_commit_all "feat: declare features"
+  fixture_publish_tag "beta-featured"
+  fixture_set_features libdd-beta
+  fixture_commit_all "chore!: drop the extra feature"
+  run_semver_level_since libdd-beta "refs/tags/beta-featured"
+  assert_success
+  assert_jq "$output" '.level' "major"
+  assert_jq "$output" '.reason' "Cargo feature removed or no longer enabled by default"
+}
+
+@test "renaming a feature reports the removal, not just the addition" {
+  # A rename is an addition and a removal at once; the breaking half must win.
+  fixture_set_features libdd-beta 'old_name = []'
+  fixture_commit_all "feat: declare features"
+  fixture_publish_tag "beta-featured"
+  fixture_set_features libdd-beta 'new_name = []'
+  fixture_commit_all "chore!: rename the feature"
+  run_semver_level_since libdd-beta "refs/tags/beta-featured"
+  assert_success
+  assert_jq "$output" '.level' "major"
+  assert_contains "$(jq -r '.details' <<< "$output")" "old_name"
 }
 
 @test "emits a single JSON object with the fields the workflow reads" {

--- a/scripts/tests/semver-level.bats
+++ b/scripts/tests/semver-level.bats
@@ -1,0 +1,255 @@
+#!/usr/bin/env bats
+
+# Copyright 2026-Present Datadog, Inc. https://www.datadoghq.com/
+# SPDX-License-Identifier: Apache-2.0
+
+# semver-level.sh picks the bump level (major/minor/patch) that
+# release-proposal-dispatch.yml passes to `cargo release version -x`. It combines two
+# tools whose output it parses textually:
+#   * cargo-semver-checks, which has known false negatives at signature level, and
+#   * cargo-public-api, whose "Changed items" section it normalizes before judging.
+# The parsing IS the logic, so these tests replay recorded tool output through a
+# `cargo` shim (helpers/cargo-stub/cargo) instead of building crates for real.
+
+load helpers/common
+load helpers/fixture
+
+setup() {
+  setup_common
+  fixture_init
+  fixture_tag "libdd-alpha-v1.2.3"
+  # semver-level.sh runs `git fetch origin <baseline>`; give it a real remote so the
+  # fetch is a no-op rather than an error.
+  fixture_add_origin
+
+  STUB_REAL_CARGO="$(command -v cargo)"
+  export STUB_REAL_CARGO
+  PATH="${TESTS_DIR}/helpers/cargo-stub:${PATH}"
+  export PATH
+  STUB_CALL_LOG="${TEST_TMP}/cargo-calls.log"
+  export STUB_CALL_LOG
+  : > "$STUB_CALL_LOG"
+
+  # Default: both tools clean. Individual tests override.
+  stub_semver_checks 0 ""
+  stub_public_api 0 "$(public_api_diff '(none)' '(none)' '(none)')"
+}
+
+teardown() {
+  teardown_common
+}
+
+# stub_semver_checks RC OUTPUT
+stub_semver_checks() {
+  STUB_SEMVER_CHECKS_RC="$1"
+  export STUB_SEMVER_CHECKS_RC
+  STUB_SEMVER_CHECKS_OUT="${TEST_TMP}/semver-checks.out"
+  export STUB_SEMVER_CHECKS_OUT
+  printf '%s\n' "$2" > "$STUB_SEMVER_CHECKS_OUT"
+}
+
+# stub_public_api RC OUTPUT
+stub_public_api() {
+  STUB_PUBLIC_API_RC="$1"
+  export STUB_PUBLIC_API_RC
+  STUB_PUBLIC_API_OUT="${TEST_TMP}/public-api.out"
+  export STUB_PUBLIC_API_OUT
+  printf '%s\n' "$2" > "$STUB_PUBLIC_API_OUT"
+}
+
+# public_api_diff REMOVED CHANGED ADDED — reproduce cargo-public-api's diff layout,
+# including the `===` underlines the script's `grep -A 2` checks depend on.
+public_api_diff() {
+  cat <<EOF
+Removed items from the public API
+=================================
+$1
+
+Changed items in the public API
+===============================
+$2
+
+Added items to the public API
+=============================
+$3
+EOF
+}
+
+run_semver_level() {
+  run --separate-stderr "${SCRIPTS_DIR}/semver-level.sh" libdd-alpha "refs/tags/libdd-alpha-v1.2.3" HEAD
+}
+
+@test "no API change at all is a patch release" {
+  # Every crate with commits gets released, so 'none' is deliberately floored to patch.
+  run_semver_level
+  assert_success
+  assert_jq "$output" '.level' "patch"
+  assert_jq "$output" '.name' "libdd-alpha"
+  assert_jq "$output" '.reason' "No public API changes detected"
+}
+
+@test "cargo-semver-checks reporting a breaking change is major" {
+  stub_semver_checks 1 "$(cat <<'EOF'
+--- failure struct_missing: pub struct removed or renamed ---
+Description: A publicly-visible struct cannot be imported by its prior path.
+     Summary semver requires new major version: 1 major and 0 minor checks failed
+EOF
+)"
+  run_semver_level
+  assert_success
+  assert_jq "$output" '.level' "major"
+  assert_jq "$output" '.reason' "cargo-semver-checks detected breaking changes"
+  assert_contains "$(jq -r '.details' <<< "$output")" "struct_missing"
+}
+
+@test "cargo-public-api is skipped once cargo-semver-checks already says major" {
+  # It cannot raise the level any further, and it is the expensive half.
+  stub_semver_checks 1 "     Summary semver requires new major version: 1 major and 0 minor checks failed"
+  run_semver_level
+  assert_success
+  assert_jq "$output" '.level' "major"
+  assert_not_contains "$(cat "$STUB_CALL_LOG")" "public-api"
+}
+
+@test "a crate missing from the baseline is a new crate and is treated as minor" {
+  stub_semver_checks 1 "error: package \`libdd-alpha\` not found"
+  run_semver_level
+  assert_success
+  assert_jq "$output" '.level' "minor"
+  assert_jq "$output" '.reason' "New crate (not present in baseline)"
+  # There is no baseline to diff against, so cargo-public-api must not run either.
+  assert_not_contains "$(cat "$STUB_CALL_LOG")" "public-api"
+}
+
+@test "removed public items are major even when cargo-semver-checks is clean" {
+  stub_public_api 0 "$(public_api_diff 'pub fn libdd_alpha::gone()' '(none)' '(none)')"
+  run_semver_level
+  assert_success
+  assert_jq "$output" '.level' "major"
+  assert_jq "$output" '.reason' "cargo-public-api detected removed public API items"
+}
+
+@test "added public items are minor" {
+  stub_public_api 0 "$(public_api_diff '(none)' '(none)' 'pub fn libdd_alpha::added()')"
+  run_semver_level
+  assert_success
+  assert_jq "$output" '.level' "minor"
+  assert_jq "$output" '.reason' "cargo-public-api detected new public API items"
+}
+
+@test "a changed signature is major — the case cargo-semver-checks misses" {
+  # A parameter type change on a non-generic fn keeps the item path, so semver-checks
+  # stays silent and only the -old/+new pair under "Changed items" reveals it.
+  stub_public_api 0 "$(public_api_diff '(none)' \
+    "$(printf -- '-pub fn libdd_alpha::convert(u32) -> u32\n+pub fn libdd_alpha::convert(u64) -> u32')" \
+    '(none)')"
+  run_semver_level
+  assert_success
+  assert_jq "$output" '.level' "major"
+  assert_jq "$output" '.reason' "cargo-public-api detected breaking signature changes"
+}
+
+@test "a changed item that only gained an attribute is not breaking" {
+  stub_public_api 0 "$(public_api_diff '(none)' \
+    "$(printf -- '-pub struct libdd_alpha::Config\n+#[repr(C)] pub struct libdd_alpha::Config')" \
+    '(none)')"
+  run_semver_level
+  assert_success
+  assert_jq "$output" '.level' "patch"
+  assert_jq "$output" '.reason' "No public API changes detected"
+}
+
+@test "a changed item that only gained const/async/unsafe qualifiers is not breaking" {
+  stub_public_api 0 "$(public_api_diff '(none)' \
+    "$(printf -- '-pub fn libdd_alpha::build() -> Config\n+pub const fn libdd_alpha::build() -> Config')" \
+    '(none)')"
+  run_semver_level
+  assert_success
+  assert_jq "$output" '.level' "patch"
+}
+
+@test "a non-breaking change alongside added items still reports minor" {
+  stub_public_api 0 "$(public_api_diff '(none)' \
+    "$(printf -- '-pub fn libdd_alpha::build() -> Config\n+pub const fn libdd_alpha::build() -> Config')" \
+    'pub fn libdd_alpha::added()')"
+  run_semver_level
+  assert_success
+  assert_jq "$output" '.level' "minor"
+}
+
+@test "takes the higher of the two signals" {
+  # cargo-semver-checks says minor, cargo-public-api says major: major wins, and the
+  # reported reason comes from the tool that decided the level.
+  stub_semver_checks 1 "     Summary semver requires new minor version: 0 major and 1 minor checks failed"
+  stub_public_api 0 "$(public_api_diff 'pub fn libdd_alpha::gone()' '(none)' '(none)')"
+  run_semver_level
+  assert_success
+  assert_jq "$output" '.level' "major"
+  assert_jq "$output" '.reason' "cargo-public-api detected removed public API items"
+}
+
+@test "keeps the cargo-semver-checks level when cargo-public-api finds less" {
+  stub_semver_checks 1 "     Summary semver requires new minor version: 0 major and 1 minor checks failed"
+  run_semver_level
+  assert_success
+  assert_jq "$output" '.level' "minor"
+  assert_jq "$output" '.reason' "cargo-semver-checks detected minor breaking changes"
+}
+
+@test "fails loudly on an unrecognised cargo-semver-checks failure" {
+  # Silently downgrading an unparsed failure to patch would ship a breaking change
+  # as a patch release.
+  stub_semver_checks 1 "error: could not compile \`libdd-alpha\`"
+  run_semver_level
+  assert_failure 1
+  assert_stderr_contains "Error running cargo-semver-checks"
+}
+
+@test "fails on an unexpected cargo-semver-checks exit code" {
+  stub_semver_checks 101 "thread 'main' panicked"
+  run_semver_level
+  assert_failure 101
+  assert_stderr_contains "Unexpected exit code from cargo-semver-checks"
+}
+
+@test "fails when cargo-public-api errors out" {
+  stub_public_api 1 "error: failed to build rustdoc JSON"
+  run_semver_level
+  assert_failure 1
+  assert_stderr_contains "Unexpected error from cargo-public-api"
+}
+
+@test "passes the tag baseline through unprefixed and diffs baseline..current" {
+  # The workflow calls this with refs/tags/<tag>. Prefixing that with origin/ (as the
+  # script does for branch names) would resolve to nothing.
+  run_semver_level
+  assert_success
+  local calls
+  calls="$(cat "$STUB_CALL_LOG")"
+  assert_contains "$calls" "semver-checks -p libdd-alpha --color=never --all-features --baseline-rev refs/tags/libdd-alpha-v1.2.3"
+  assert_contains "$calls" "diff refs/tags/libdd-alpha-v1.2.3..HEAD"
+}
+
+@test "prefixes a bare branch baseline with origin/" {
+  run --separate-stderr "${SCRIPTS_DIR}/semver-level.sh" libdd-alpha main HEAD
+  assert_success
+  assert_contains "$(cat "$STUB_CALL_LOG")" "--baseline-rev origin/main"
+}
+
+@test "defaults the current ref to HEAD and requires a crate name" {
+  run --separate-stderr "${SCRIPTS_DIR}/semver-level.sh" libdd-alpha main
+  assert_success
+  assert_contains "$(cat "$STUB_CALL_LOG")" "diff origin/main..HEAD"
+
+  run --separate-stderr "${SCRIPTS_DIR}/semver-level.sh"
+  assert_failure
+  assert_stderr_contains "CRATE is required"
+}
+
+@test "emits a single JSON object with the fields the workflow reads" {
+  # The workflow does `jq -r '.level'` on this; extra chatter on stdout breaks it.
+  run_semver_level
+  assert_success
+  assert_valid_json "$output"
+  assert_jq "$output" 'keys | join(",")' "details,level,name,reason"
+}


### PR DESCRIPTION
# What does this PR do?

Adds a bats suite for the scripts that drive the release-proposal workflows, and wires it into CI alongside `shellcheck` over `scripts/*.sh` (`.github/workflows/release-scripts.yml`).

Coverage, one suite per script — see `scripts/tests/README.md` for the full table:

| suite | covers |
| --- | --- |
| `publication-order.bats` | which crates a release includes, and the order they publish in |
| `commits-since-release.bats` | commit attribution, tag/merge-base resolution, exclusion rules |
| `release-version-bumps.bats` | each crate's fate — released, deferred, skipped, hard failure — and the version cargo-release lands on |
| `release-version-major-bumps.bats` | which crates are forced to major by a dependency that went major in the same proposal |
| `release-generate-changelogs.bats` | the CHANGELOG entry each crate gets, and that only its own commits reach it |
| `semver-level.bats` | the bump level fed to `cargo release version -x` |
| `major-bumps-level.bats` | whether a direct `libdd-*` dependency going major forces a dependent to major |
| `release-proposal-workflow.bats` | job-level `if:` gating, untrusted-`main_start_ref` defenses, branch prefixes, push path, PR contract |

The final commit adds 19 cases and 5 fixture helpers for the dependency-floor and cargo-feature passes introduced in the base PR.

# Motivation

`scripts/*.sh` and `.github/workflows/release-proposal-dispatch.yml` decide version numbers, changelog contents and publication order for every crate in the workspace, and a real release is otherwise the only way to exercise them. A regression there is discovered by shipping it.

# Additional Notes

⚠️ **Stacked PR.** The base is `igor/versioning/semver-level-dep-and-feat` (#2506), not `main`, because the last commit's tests exercise the passes that PR adds. Review #2506 first; this one should be retargeted to `main` once it lands.

How the suites work, in case it affects how you read them:

- **Fixture workspace** (`helpers/fixture.bash`) — a synthetic cargo workspace in a throwaway git repository, so `cargo metadata`, git tags and worktrees are all real. Its shape is deliberate: a dev-dependency cycle, a `publish = false` crate, a build-dependency edge and a non-`libdd-*` crate, because those are the cases the scripts have to discriminate. Nothing touches the libdatadog checkout.
- **Real `cargo-release` and real `git-cliff`**, not stubs, so the versions and changelog entries asserted are the ones a release would produce. Both are also used to *set up* state — driving a simulated previous release through cargo-release rewrites dependents' requirements the way a real release does, which a hand-edited manifest does not. Without those tools installed the affected tests skip rather than fail.
- **A `cargo` shim** (`helpers/cargo-stub/cargo`) replays recorded `cargo semver-checks` / `cargo public-api` output, because those cost minutes per call and their *output parsing* is what `semver-level.sh` gets wrong when it regresses. `cargo metadata` is deliberately forwarded to the real cargo.
- **Implementation-agnostic**: suites never name a script directly, they go through `run_tool NAME`, so the whole suite can be pointed at a reimplementation with `RELEASE_TOOL_CMD='target/release/release-tool {name}'`. One suite opts out with a stated reason — `release-version-bumps.bats` doubles `semver-level.sh` by mirroring `scripts/` into a temp directory, which does not generalise.
- **Workflow guards** (`helpers/workflow-to-json.py`) transcribe the workflow YAML to JSON so tests can assert on it with `jq`. These are intentional change-detectors: each states *why* the invariant exists, so changing the workflow means reading the reason first. They complement actionlint, which checks syntax but not intent.

# How to test the change?

```bash
./scripts/tests/run.sh                 # whole suite; needs bats-core >= 1.5.0
./scripts/tests/run.sh semver-level    # one suite
./scripts/tests/run.sh -f "merge-base" # tests matching a regex
```

Without root, bats installs with:

```bash
curl -sSfL https://github.com/bats-core/bats-core/archive/refs/tags/v1.11.1.tar.gz \
  | tar xz && ./bats-core-1.11.1/install.sh "$HOME/.local"
```

CI runs the same suite plus shellcheck via the new `release-scripts.yml`. On this PR that runs against the merge of head into base, so the 19 new cases have the `semver-level.sh` passes they exercise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

