### PR TITLE
fix(ipc): prevent possible divide by zero

### DIFF
--- a/libdd-ipc/src/rate_limiter.rs
+++ b/libdd-ipc/src/rate_limiter.rs
@@ -114,13 +114,15 @@ impl<Inner> ShmLimiterMemory<Inner> {
             memory: self.clone(),
         };
         let limiter = reference.limiter();
-        limiter.rc.store(1, Ordering::Relaxed);
-        // SAFETY: we initialize the struct here
+        // Initialize the limiter before publishing it through the reference count. Otherwise a
+        // reader can acquire the entry while its zero-filled granularity is still being reset.
+        // SAFETY: this entry is not visible while its reference count is zero.
         unsafe {
             (*(limiter as *const _ as *mut ShmLimiterData<Inner>))
                 .limiter
                 .reset(seconds)
         };
+        limiter.rc.store(1, Ordering::Release);
         reference
     }
 
@@ -153,14 +155,14 @@ impl<Inner> ShmLimiterMemory<Inner> {
             memory: self.clone(),
         };
         let limiter = reference.limiter();
-        let mut rc = limiter.rc.load(Ordering::Relaxed);
+        let mut rc = limiter.rc.load(Ordering::Acquire);
         loop {
             if rc == 0 {
                 return None;
             }
             match limiter
                 .rc
-                .compare_exchange(rc, rc + 1, Ordering::Release, Ordering::Relaxed)
+                .compare_exchange(rc, rc + 1, Ordering::AcqRel, Ordering::Acquire)
             {
                 Ok(_) => return Some(reference),
                 Err(found) => rc = found,


### PR DESCRIPTION
# What does this PR do?

Initializes a shared-memory rate limiter before publishing its reference count. Readers use acquire ordering when obtaining the limiter.

# Motivation

Fixes a divide-by-zero panic in `LocalLimiter::inc()` if a reader observes a published limiter before its granularity was initialized.

# Additional Notes

The failure was observed in a live-debugger log-probe test using the shared limiter in PHP.

# How to test the change?

Run the focused IPC tests:

```sh
cargo test -p libdd-ipc rate_limiter --lib
```

Then run the dd-trace-php live-debugger PHPT suite after updating the submodule to this branch.