### PR TITLE
fix(libdd-ipc)!: detect liveness in macos IPC recv mechanism

### DIFF
--- a/libdd-ipc/src/platform/unix/sockets/macos.rs
+++ b/libdd-ipc/src/platform/unix/sockets/macos.rs
@@ -22,8 +22,8 @@
 //! - Success → live server.  `ECONNRESET` → stale socket file.
 
 use super::{
-    create_unix_socket, max_message_size, sendmsg, set_nonblocking, ControlMessage, MsgFlags,
-    SeqpacketConn, SeqpacketListener, UnixAddr,
+    create_unix_socket, max_message_size, poll_with_timeout, sendmsg, set_nonblocking,
+    ControlMessage, MsgFlags, SeqpacketConn, SeqpacketListener, UnixAddr,
 };
 use crate::PeerCredentials;
 use nix::sys::socket::{bind, AddressFamily, SockFlag, SockType};
@@ -36,6 +36,7 @@ use std::{
         io::{AsRawFd, FromRawFd, OwnedFd},
     },
     path::Path,
+    time::Duration,
 };
 use tracing::error;
 
@@ -256,6 +257,56 @@ impl SeqpacketConn {
         Ok(())
     }
 
+    /// Like [`poll_with_timeout`] for `POLLIN` on the data socket, but also watches the
+    /// liveness pipe for `POLLHUP` so a peer that disconnects *while we're waiting for a
+    /// response* is detected immediately as `BrokenPipe`, instead of only after the full
+    /// `timeout` elapses with a generic `TimedOut`.
+    ///
+    /// This matters because `SOCK_DGRAM` (macOS's SOCK_SEQPACKET emulation, see the module
+    /// docs) has no connection state: unlike Linux, where the peer closing a real
+    /// SOCK_SEQPACKET socket makes an in-flight `recv()` return immediately (EOF/ECONNRESET),
+    /// here the daemon closing its end (e.g. after failing to decode a garbled message, see
+    /// the IPC serve loop) is invisible to a plain `recv()` wait — only the liveness pipe
+    /// (checked here) reflects it.
+    pub(super) fn poll_readable_with_liveness(&self, timeout: Option<Duration>) -> io::Result<()> {
+        let Some(ref lw) = self.liveness else {
+            return poll_with_timeout(self.inner.as_raw_fd(), libc::POLLIN, timeout);
+        };
+        let timeout_ms: i32 = match timeout {
+            None => -1,
+            Some(d) => d.as_millis().min(i32::MAX as u128) as i32,
+        };
+        let mut pfds = [
+            libc::pollfd {
+                fd: self.inner.as_raw_fd(),
+                events: libc::POLLIN,
+                revents: 0,
+            },
+            libc::pollfd {
+                fd: lw.as_raw_fd(),
+                events: libc::POLLHUP as libc::c_short,
+                revents: 0,
+            },
+        ];
+        loop {
+            let ret =
+                unsafe { libc::poll(pfds.as_mut_ptr(), pfds.len() as libc::nfds_t, timeout_ms) };
+            if ret > 0 {
+                if pfds[1].revents & (libc::POLLHUP | libc::POLLERR) != 0 {
+                    return Err(io::Error::from(io::ErrorKind::BrokenPipe));
+                }
+                return Ok(());
+            }
+            if ret == 0 {
+                return Err(io::Error::from(io::ErrorKind::TimedOut));
+            }
+            let e = io::Error::last_os_error();
+            if e.kind() != io::ErrorKind::Interrupted {
+                return Err(e);
+            }
+        }
+    }
+
     /// Create from a connected fd plus a peer fd that must be kept alive.
     ///
     /// On macOS, the peer fd must be kept open locally to maintain the SOCK_DGRAM
@@ -370,6 +421,47 @@ mod tests {
         assert!(
             conn0.try_send_raw(&mut vec![42u8; 10], &[]).is_err(),
             "expected send error after dropping peer on macOS"
+        );
+    }
+
+    /// A peer that disconnects while we're blocked in `recv_raw_blocking` must be detected
+    /// immediately (via the liveness pipe) rather than only once the whole read_timeout
+    /// elapses. This reproduces the real-world scenario in `broken_pipe.phpt`: the daemon
+    /// closes its connection after failing to decode a garbled message (see the IPC serve
+    /// loop's `Ok((Err(_), _)) => break` arm), and the client is waiting on a `call()`'s
+    /// `recv_raw_blocking` for the response that will now never arrive. Before this fix,
+    /// `recv_raw_blocking` only polled the data socket, so it had no way to learn the peer
+    /// was gone and just blocked for the full timeout, then returned a generic `TimedOut`
+    /// (which `with_retry` treats as non-reconnectable) instead of `BrokenPipe`.
+    #[test]
+    fn test_recv_blocking_detects_peer_disconnect_promptly() {
+        let tmpdir = tempfile::tempdir().expect("tempdir");
+        let path = tmpdir.path().join("test.sock");
+        let listener = SeqpacketListener::bind(&path).expect("bind");
+        let mut client = SeqpacketConn::connect(&path).expect("connect");
+        let server = listener.try_accept().expect("try_accept");
+
+        // Generous timeout: if the fix regresses, this test would otherwise have to wait out
+        // this whole duration before failing, so keep it well above scheduling jitter but far
+        // below what a CI timeout would tolerate for a passing run.
+        client
+            .set_read_timeout(Some(Duration::from_secs(5)))
+            .expect("set_read_timeout");
+
+        // Simulate the daemon closing its connection (e.g. after a decode failure).
+        drop(server);
+
+        let start = std::time::Instant::now();
+        let err = client
+            .recv_raw_blocking(&mut [0u8; 64])
+            .expect_err("expected recv to fail after peer disconnect");
+        let elapsed = start.elapsed();
+
+        assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "recv_raw_blocking took {elapsed:?} to notice the disconnect; \
+             expected near-immediate detection via the liveness pipe, not a timeout wait"
         );
     }
 }

--- a/libdd-ipc/src/platform/unix/sockets/macos.rs
+++ b/libdd-ipc/src/platform/unix/sockets/macos.rs
@@ -464,4 +464,39 @@ mod tests {
              expected near-immediate detection via the liveness pipe, not a timeout wait"
         );
     }
+
+    /// Async counterpart of `test_recv_blocking_detects_peer_disconnect_promptly`, covering
+    /// `recv_raw_async` (used by the macro-generated server dispatch loop) rather than the
+    /// client-side `recv_raw_blocking`. This reproduces the real-world
+    /// `pcntl_fork_thread_mode_orphan.phpt` hang: in thread mode, the main PHP thread connects
+    /// to its own in-process sidecar listener as a worker, and `datadog_sidecar_shutdown()`
+    /// drops that connection from the client side. Before this fix, the server-side task
+    /// handling that connection only polled the data socket via `fd.readable()`, so it never
+    /// learned the client was gone and awaited forever instead of the listener's shutdown
+    /// completing (`shutdown_complete_rx` never resolved).
+    #[tokio::test]
+    async fn test_recv_async_detects_peer_disconnect_promptly() {
+        let tmpdir = tempfile::tempdir().expect("tempdir");
+        let path = tmpdir.path().join("test.sock");
+        let listener = SeqpacketListener::bind(&path).expect("bind");
+        let client = SeqpacketConn::connect(&path).expect("connect");
+        let server = listener.try_accept().expect("try_accept");
+        let server = server.into_async_conn().expect("into_async_conn");
+
+        // Simulate the client (e.g. the main PHP thread) disconnecting.
+        drop(client);
+
+        let start = std::time::Instant::now();
+        let err = crate::recv_raw_async(&server, |buf: &[u8]| buf.to_vec())
+            .await
+            .expect_err("expected recv to fail after peer disconnect");
+        let elapsed = start.elapsed();
+
+        assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "recv_raw_async took {elapsed:?} to notice the disconnect; \
+             expected near-immediate detection via the liveness pipe, not an indefinite wait"
+        );
+    }
 }

--- a/libdd-ipc/src/platform/unix/sockets/mod.rs
+++ b/libdd-ipc/src/platform/unix/sockets/mod.rs
@@ -213,6 +213,22 @@ impl IntoRawFd for SeqpacketListener {
     }
 }
 
+/// Exposes an optional secondary fd that should also be watched for hangup alongside a
+/// connection's primary data fd.
+///
+/// `SOCK_DGRAM` (macOS's `SOCK_SEQPACKET` emulation, see the module docs) has no connection
+/// state: unlike Linux, where the peer closing a real `SOCK_SEQPACKET` socket makes an in-flight
+/// `recv()`/`readable()` wait return immediately (EOF/ECONNRESET), a peer here can drop its end
+/// without that ever being visible on the data fd. The liveness pipe (see `SeqpacketConn`) is a
+/// side-channel built specifically to make that visible; this trait lets generic recv helpers
+/// (`recv_raw_async`, `recv_raw_blocking`) poll it without depending on the concrete connection
+/// type. The default no-op impl covers types (or platforms) with no such side-channel.
+pub trait LivenessAware {
+    fn liveness_raw_fd(&self) -> Option<RawFd> {
+        None
+    }
+}
+
 /// A connected socket providing message-boundary-preserving IPC.
 ///
 /// - Linux: `AF_UNIX SOCK_SEQPACKET`.
@@ -232,6 +248,15 @@ pub struct SeqpacketConn {
     liveness: Option<OwnedFd>,
     read_timeout: Option<Duration>,
     write_timeout: Option<Duration>,
+}
+
+impl LivenessAware for SeqpacketConn {
+    #[cfg(target_os = "macos")]
+    fn liveness_raw_fd(&self) -> Option<RawFd> {
+        self.liveness.as_ref().map(|l| l.as_raw_fd())
+    }
+    // On Linux, SOCK_SEQPACKET already surfaces peer disconnection as ordinary readiness
+    // (EOF/ECONNRESET), so the default (no secondary fd to watch) applies.
 }
 
 impl SeqpacketConn {
@@ -480,7 +505,7 @@ pub type AsyncConn = AsyncFd<SeqpacketConn>;
 pub async fn recv_raw_async<F, T, C>(fd: &AsyncFd<C>, decode: F) -> io::Result<(T, Vec<OwnedFd>)>
 where
     F: FnOnce(&[u8]) -> T,
-    C: AsRawFd,
+    C: AsRawFd + LivenessAware,
 {
     thread_local! {
         /// Reusable receive buffer. Grows on first use; never shrinks.
@@ -488,8 +513,37 @@ where
     }
     // Wrap in Option to satisfy FnMut (take() is only called on successful receive).
     let mut decode = Some(decode);
+
+    // If the connection exposes a liveness fd (see `LivenessAware`'s docs -- macOS only), watch
+    // it alongside the data fd so a peer that disconnects while we're waiting for the next
+    // message is detected immediately as `BrokenPipe`, instead of waiting forever for a message
+    // that will now never arrive.
+    let liveness_async = match fd.get_ref().liveness_raw_fd() {
+        // SAFETY: `raw` is owned by `*fd.get_ref()`, which outlives this function's `fd`
+        // borrow; the BorrowedFd built from it is only used (and dropped) within that same
+        // lifetime, never after `fd` itself could have been dropped.
+        Some(raw) => Some(AsyncFd::new(unsafe {
+            std::os::fd::BorrowedFd::borrow_raw(raw)
+        })?),
+        None => None,
+    };
+
     loop {
-        let mut guard = fd.readable().await?;
+        let mut guard = match &liveness_async {
+            Some(liveness_async) => {
+                tokio::select! {
+                    guard = fd.readable() => guard?,
+                    liveness = liveness_async.readable() => {
+                        // Peer's liveness pipe write end closed: it disconnected. Consume the
+                        // readiness guard so a future poll of this fd doesn't see stale
+                        // "not ready" state, then report the connection as gone.
+                        drop(liveness?);
+                        return Err(io::Error::from(io::ErrorKind::BrokenPipe));
+                    }
+                }
+            }
+            None => fd.readable().await?,
+        };
         match guard.try_io(|inner| {
             RECV_BUF.with_borrow_mut(|buf| {
                 let size = max_message_size();

--- a/libdd-ipc/src/platform/unix/sockets/mod.rs
+++ b/libdd-ipc/src/platform/unix/sockets/mod.rs
@@ -388,6 +388,14 @@ impl SeqpacketConn {
             match recvmsg_raw(fd, buf, MsgFlags::empty()) {
                 Ok(r) => return Ok(r),
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                    // On macOS, also watch the liveness pipe so a peer that disconnects while
+                    // we're waiting for a response is detected immediately (BrokenPipe) rather
+                    // than only after the full read_timeout elapses (see
+                    // poll_readable_with_liveness's docs: SOCK_DGRAM has no connection state,
+                    // so a plain poll on the data socket alone can't see the peer is gone).
+                    #[cfg(target_os = "macos")]
+                    self.poll_readable_with_liveness(self.read_timeout)?;
+                    #[cfg(not(target_os = "macos"))]
                     poll_with_timeout(fd, libc::POLLIN, self.read_timeout)?;
                 }
                 Err(e) => return Err(e),


### PR DESCRIPTION
Always poll the liveness probe alongside the datagram connection.